### PR TITLE
Clean up phase-1 TypeScript test noise

### DIFF
--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/.openspec.yaml
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-04-10

--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/design.md
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/design.md
@@ -1,0 +1,189 @@
+## Context
+
+- Relevant architecture:
+  The failures are limited to repo test code and test helpers under `tests/`.
+  The affected suites exercise combat utilities, route helpers, import routes,
+  server-side D&D import fetch wrappers, and monster upload validation. The
+  source contracts they rely on live in `lib/types.ts`,
+  `lib/dndBeyondCharacterImport.ts`, and `lib/validation/monsterUpload.ts`.
+- Dependencies:
+  TypeScript strict mode in `tsconfig.json`, Jest test suites, Next.js request
+  and response types, and existing OpenSpec issue split between #135 and #138.
+- Interfaces/contracts touched:
+  `CombatantState`, `ActiveDamageEffect`, route handler helper signatures,
+  `AuthPayload`, safe `Response` mock patterns, and optional `CreatureStats`
+  properties used in tests. Phase 1 does not change D&D Beyond fixture
+  contracts; that remains in #138.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Remove the non-D&D `tsc --noEmit` failures tracked in #135
+- Keep the cleanup limited to test files and test-only helper patterns
+- Preserve existing behavioral intent while aligning tests to current exported
+  contracts
+- Leave the remaining D&D Beyond fixture failures clearly isolated to #138
+
+### Non-Goals
+
+- Making repo-wide `tsc --noEmit` fully green in this change
+- Reworking the shared D&D Beyond fixtures or
+  `tests/unit/import/dndBeyondCharacterImport.test.ts`
+- Loosening production types to accommodate stale tests
+
+## Decisions
+
+### Decision 1: Fix stale non-D&D tests by aligning them to current exported types
+
+- Chosen:
+  Update the affected tests to match the current domain contracts instead of
+  changing production code.
+- Alternatives considered:
+  Relax production types or suppress type errors in tests.
+- Rationale:
+  The failures reflect test drift, not product behavior changes. Production
+  contracts should remain the source of truth.
+- Trade-offs:
+  Test fixtures may become slightly more explicit, but the typecheck signal
+  becomes more trustworthy.
+
+### Decision 2: Restrict phase 1 to a bounded non-D&D failure set
+
+- Chosen:
+  Phase 1 resolves only the failures in the listed non-D&D files and leaves the
+  D&D Beyond fixture-contract work to #138.
+- Alternatives considered:
+  Keep one broad change that also includes the D&D Beyond fixture cleanup.
+- Rationale:
+  The D&D Beyond bucket dominates the remaining errors and has different design
+  concerns. Splitting the work reduces review ambiguity and shortens the path to
+  a cleaner typecheck signal.
+- Trade-offs:
+  `tsc --noEmit` may still fail after phase 1, but the remaining failures are
+  deliberate and easier to reason about.
+
+### Decision 3: Use safer test-only patterns for env overrides, async handlers,
+and response mocks
+
+- Chosen:
+  Replace direct read-only env mutation patterns, broad handler unions, and
+  structural `Response` casts with patterns that satisfy current platform and
+  TypeScript constraints.
+- Alternatives considered:
+  Continue using ad hoc casts or `as any`.
+- Rationale:
+  These failures are mechanical and should be fixed with test-only hygiene, not
+  by weakening type safety.
+- Trade-offs:
+  Some helper code becomes slightly more verbose, but it centralizes safe test
+  conventions.
+
+## Proposal to Design Mapping
+
+- Proposal element: Remove non-D&D test noise only
+  - Design decision: Decision 2
+  - Validation approach: `npx tsc --noEmit` should no longer report the bounded
+    non-D&D failures listed in #135
+- Proposal element: Keep production types strict
+  - Design decision: Decision 1
+  - Validation approach: test files change without corresponding type loosening
+    in `lib/`
+- Proposal element: Replace unsafe test patterns
+  - Design decision: Decision 3
+  - Validation approach: targeted tests/helpers compile cleanly under strict
+    TypeScript
+
+## Functional Requirements Mapping
+
+- Requirement:
+  Non-D&D test fixtures and helpers match current exported contracts
+  - Design element:
+    Decisions 1 and 3
+  - Acceptance criteria reference:
+    `specs/typecheck-validation/spec.md`
+  - Testability notes:
+    Verified by `npx tsc --noEmit` and targeted unit/integration tests for the
+    touched suites
+- Requirement:
+  Phase 1 stops before D&D Beyond fixture alignment
+  - Design element:
+    Decision 2
+  - Acceptance criteria reference:
+    `specs/typecheck-validation/spec.md`
+  - Testability notes:
+    Remaining failures, if any, should be attributable to the D&D Beyond work
+    tracked in #138
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement:
+    TypeScript output remains a dependable signal for unrelated changes
+  - Design element:
+    Decisions 1 and 2
+  - Acceptance criteria reference:
+    `specs/typecheck-validation/spec.md`
+  - Testability notes:
+    Verify the bounded failure reduction via repo-wide typecheck
+- Requirement category: operability
+  - Requirement:
+    Test-only patterns for env overrides and mocks remain maintainable
+  - Design element:
+    Decision 3
+  - Acceptance criteria reference:
+    `specs/typecheck-validation/spec.md`
+  - Testability notes:
+    Review helper readability and targeted suite pass/fail behavior
+
+## Risks / Trade-offs
+
+- Risk/trade-off:
+  Narrow phase 1 may be misread as promising a fully green typecheck.
+  - Impact:
+    Reviewers may think the work is incomplete even when it matches the approved
+    issue split.
+  - Mitigation:
+    Keep proposal/spec/tasks explicit that phase 1 removes only the non-D&D
+    failures and defers the rest to #138.
+- Risk/trade-off:
+  Test fixture cleanup could accidentally alter behavioral coverage.
+  - Impact:
+    Tests may compile while no longer protecting the original scenario.
+  - Mitigation:
+    Preserve assertions, change only the minimum needed fixture/helper typing,
+    and run the targeted suites in addition to typecheck.
+
+## Rollback / Mitigation
+
+- Rollback trigger:
+  The cleanup changes production behavior, meaningfully weakens assertions, or
+  causes new regressions in the touched suites.
+- Rollback steps:
+  Revert the phase 1 test/helper changes as a unit, restore the previous test
+  files, and reopen the cleanup under a narrower patch if needed.
+- Data migration considerations:
+  None. This change is limited to tests and test helpers.
+- Verification after rollback:
+  Re-run the targeted test suites and `npx tsc --noEmit` to confirm the repo is
+  back to the pre-change state.
+
+## Operational Blocking Policy
+
+- If CI checks fail:
+  Stop and fix the failing test/helper cleanup before merging. Do not treat
+  unrelated D&D Beyond failures as phase 1 regressions if they are already
+  tracked in #138.
+- If security checks fail:
+  Investigate whether the failure is introduced by the change; remediate before
+  merge or pause the PR if the finding is unrelated but blocking.
+- If required reviews are blocked/stale:
+  Clarify whether the review is objecting to scope, implementation quality, or
+  the #135/#138 split, and update artifacts before continuing.
+- Escalation path and timeout:
+  Escalate to the human reviewer/requester if the implementation drifts toward
+  D&D Beyond fixture work or if the phase boundary becomes contested.
+
+## Open Questions
+
+- None. Phase 1 scope is explicitly limited to removing the non-D&D failures.

--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/proposal.md
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/proposal.md
@@ -1,0 +1,115 @@
+## GitHub Issues
+
+- #135
+- #138
+
+## Why
+
+- Problem statement:
+  `npx tsc --noEmit` currently reports a mixed set of unrelated test typing
+  failures, which makes TypeScript output noisy and less useful as a validation
+  signal for current work.
+- Why now:
+  The issue was identified during follow-up to PR #133, and the current failure
+  set has a clear split between straightforward non-D&D cleanup and a larger
+  D&D Beyond fixture-contract alignment effort.
+- Business/user impact:
+  Restoring a cleaner typecheck signal reduces review friction, makes regressions
+  easier to spot, and lowers the cost of using `tsc --noEmit` as a routine
+  quality gate.
+
+## Problem Space
+
+- Current behavior:
+  The repository-wide typecheck fails on several stale tests and test helpers.
+  Some failures are small fixture or helper drifts, while a larger cluster comes
+  from D&D Beyond import fixtures that are inferred too broadly for the current
+  contracts.
+- Desired behavior:
+  Phase 1 should remove the non-D&D test noise so the remaining TypeScript
+  failures are smaller, more focused, and mostly isolated to the D&D Beyond
+  fixture work tracked separately.
+- Constraints:
+  Production types must not be loosened just to silence tests. The cleanup
+  should stay limited to test code, test helpers, and safe test-only patterns.
+- Assumptions:
+  The non-D&D failures are mechanically fixable without design changes to
+  production behavior. The D&D Beyond fixture alignment remains a separate
+  follow-up tracked in #138.
+- Edge cases considered:
+  Optional normalized fields must still be asserted safely after cleanup; auth
+  mocks must satisfy the current `AuthPayload` shape; env overrides in tests
+  must avoid direct mutation patterns that TypeScript now rejects.
+
+## Scope
+
+### In Scope
+
+- Clean up non-D&D typecheck failures in:
+  `tests/unit/combat/conditionExpiry.test.ts`,
+  `tests/unit/combat/damageResistance.test.ts`,
+  `tests/unit/helpers/route.test.helpers.ts`,
+  `tests/unit/import/characterImportRoute.test.ts`,
+  `tests/unit/import/charactersPageImport.test.ts`,
+  `tests/unit/import/dndBeyondCharacterServer.test.ts`, and
+  `tests/integration/monsterUpload.test.ts`
+- Update stale combat fixtures to match current exported domain types
+- Tighten test helper return types where callers now expect narrower async
+  behavior
+- Refactor read-only env handling in tests to a safe pattern
+- Replace unsafe optional-property assertions and partial `Response` casts with
+  type-safe test patterns
+
+### Out of Scope
+
+- Narrowing shared D&D Beyond fixtures to the current
+  `DndBeyondCharacterData` contract
+- The bulk of failures in `tests/unit/import/dndBeyondCharacterImport.test.ts`
+- Any production behavior changes unrelated to test/type hygiene
+
+## What Changes
+
+- Isolate issue #135 to the non-D&D cleanup phase and leave D&D Beyond fixture
+  alignment to dependent issue #138
+- Update the affected non-D&D tests and helpers so they match current exported
+  contracts
+- Re-establish `npx tsc --noEmit` as a more actionable signal by removing the
+  straightforward noise first
+
+## Risks
+
+- Risk:
+  Cleanup work could accidentally change test intent rather than just fixing
+  typing drift.
+  - Impact:
+    Tests may still compile but stop guarding the behavior they were meant to
+    cover.
+  - Mitigation:
+    Keep changes narrowly aligned to current domain contracts and retain the
+    original behavioral assertions.
+- Risk:
+  The issue split could leave ambiguity about whether phase 1 is considered
+  complete before repo-wide typecheck is fully green.
+  - Impact:
+    Reviewers may expect `tsc --noEmit` to pass completely when phase 1 only
+    reduces the failure set.
+  - Mitigation:
+    Be explicit in specs and tasks that phase 1 removes the non-D&D failures and
+    isolates the remaining D&D Beyond work to #138.
+
+## Open Questions
+
+- No unresolved scope questions remain. Phase 1 is defined as removing the
+  non-D&D failures only, with the remaining D&D Beyond fixture-contract work
+  delegated to #138.
+
+## Non-Goals
+
+- Solving the D&D Beyond fixture-contract alignment in the same change
+- Weakening strict typing in production code to make tests compile
+- Refactoring unrelated test suites while touching these files
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/specs/typecheck-validation/spec.md
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/specs/typecheck-validation/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the
+`design.md` document, not a replacement.
+
+### Requirement: ADDED phase-bounded typecheck cleanup
+
+The system SHALL allow the phase 1 cleanup to remove the non-D&D typecheck
+failures without requiring the D&D Beyond fixture-contract failures to be solved
+in the same change.
+
+#### Scenario: Non-D&D failures are removed from the repo-wide typecheck
+
+- **Given** the repository contains the phase 1 cleanup changes
+- **When** `npx tsc --noEmit` is run from the project root
+- **Then** TypeScript no longer reports failures from
+  `tests/unit/combat/conditionExpiry.test.ts`,
+  `tests/unit/combat/damageResistance.test.ts`,
+  `tests/unit/helpers/route.test.helpers.ts`,
+  `tests/unit/import/characterImportRoute.test.ts`,
+  `tests/unit/import/charactersPageImport.test.ts`,
+  `tests/unit/import/dndBeyondCharacterServer.test.ts`, or
+  `tests/integration/monsterUpload.test.ts`
+
+#### Scenario: Remaining D&D Beyond failures do not block phase 1 scope
+
+- **Given** D&D Beyond fixture-contract failures remain tracked in #138
+- **When** the phase 1 change is reviewed
+- **Then** those D&D Beyond failures are treated as out of scope for this change
+- **And** the change is evaluated against the non-D&D failure set only
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED test fixtures and helpers must match current exported contracts
+
+The system SHALL keep the affected non-D&D tests and test helpers aligned with
+the current exported application types and platform contracts.
+
+#### Scenario: Combat tests use current combatant and damage-effect shapes
+
+- **Given** the combat tests construct `CombatantState` and
+  `ActiveDamageEffect` fixtures
+- **When** the tests are typechecked
+- **Then** those fixtures use the current property names, required fields, and
+  argument ordering from the exported combat contracts
+
+#### Scenario: Helper and import tests use current auth, async, env, and response patterns
+
+- **Given** the touched route/import/helper tests rely on `AuthPayload`,
+  handler wrappers, `process.env`, optional properties, and mocked responses
+- **When** the tests are typechecked
+- **Then** auth mocks satisfy the current auth contract
+- **And** handler helper wrappers return the async shape their callers expect
+- **And** env overrides avoid direct read-only mutations
+- **And** optional properties are narrowed before assertion
+- **And** mocked `Response` objects use a type-safe pattern
+
+## REMOVED Requirements
+
+### Requirement: REMOVED tolerance for stale non-D&D test typing drift
+
+Reason for removal:
+The repo should no longer tolerate known stale non-D&D test fixtures and helper
+patterns that obscure TypeScript regressions unrelated to current work.
+
+#### Scenario: Legacy stale test patterns are no longer accepted in phase 1 files
+
+- **Given** one of the phase 1 files uses a removed property name, mismatched
+  helper signature, unsafe env mutation, or unsafe optional-property assertion
+- **When** `npx tsc --noEmit` is run
+- **Then** the file is treated as a failure until it matches the current
+  contract rather than being excused as pre-existing noise
+
+## Traceability
+
+- Proposal element -> Requirement:
+  remove non-D&D noise first -> ADDED phase-bounded typecheck cleanup
+- Design decision -> Requirement:
+  Decision 1 and Decision 3 -> MODIFIED test fixtures and helpers must match
+  current exported contracts
+- Design decision -> Requirement:
+  Decision 2 -> ADDED phase-bounded typecheck cleanup
+- Requirement -> Task(s):
+  ADDED/MODIFIED/REMOVED requirements -> tasks 3.1 through 4.2 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Latency budget
+
+- **Given** the phase 1 change updates only tests and test helpers
+- **When** `npx tsc --noEmit` and the targeted suites are run
+- **Then** the change does not introduce new production runtime work
+- **And** any validation cost increase is limited to the normal cost of the
+  touched tests compiling and running
+
+### Requirement: Security
+
+#### Scenario: Access control
+
+- **Given** phase 1 modifies only tests and test helpers
+- **When** auth-related test fixtures are updated
+- **Then** the change aligns them to the current exported auth contract
+- **And** does not weaken production auth enforcement or route behavior
+
+### Requirement: Reliability
+
+#### Scenario: Recovery behavior
+
+- **Given** a maintainer runs repo-wide typecheck after phase 1
+- **When** a failure remains
+- **Then** the remaining failure set should be materially smaller and easier to
+  attribute
+- **And** D&D Beyond fixture-related failures can be routed to #138 without
+  ambiguity

--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/tasks.md
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/tasks.md
@@ -4,7 +4,7 @@
 
 - [ ] **Step 1 — Sync default branch:** `git checkout main` and
   `git pull --ff-only`
-- [ ] **Step 2 — Create and publish working branch:**
+- [x] **Step 2 — Create and publish working branch:**
   `git checkout -b cleanup-typescript-test-noise-phase-1` then immediately
   `git push -u origin cleanup-typescript-test-noise-phase-1`
 
@@ -64,10 +64,10 @@ Use the project's documented commands for each of the above (see `README.md`,
 
 ## PR and Merge
 
-- [ ] Run the required pre-PR self-review from
+- [x] Run the required pre-PR self-review from
   `.github/openspec-shared/.codex/skills/openspec-apply-change/SKILL.md` before
   committing
-- [ ] Commit all changes to the working branch and push to remote
+- [x] Commit all changes to the working branch and push to remote
 - [ ] Open PR from working branch to `main`
 - [ ] Wait for 120 seconds for the Agentic reviewers to post their comments
 - [ ] **Monitor PR comments** — when comments appear, address them, commit

--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/tasks.md
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/tasks.md
@@ -1,0 +1,123 @@
+# Tasks
+
+## Preparation
+
+- [ ] **Step 1 — Sync default branch:** `git checkout main` and
+  `git pull --ff-only`
+- [ ] **Step 2 — Create and publish working branch:**
+  `git checkout -b cleanup-typescript-test-noise-phase-1` then immediately
+  `git push -u origin cleanup-typescript-test-noise-phase-1`
+
+## Execution
+
+- [x] **3.1 Define failing tests first for the combat fixture drift**
+  in `tests/unit/combat/conditionExpiry.test.ts` and
+  `tests/unit/combat/damageResistance.test.ts`, then update those tests to match
+  current exported combat contracts without changing production code
+- [x] **3.2 Define failing tests first for helper and import-route typing drift**
+  in `tests/unit/helpers/route.test.helpers.ts`,
+  `tests/unit/import/characterImportRoute.test.ts`, and
+  `tests/unit/import/charactersPageImport.test.ts`, then replace stale auth,
+  async, and response-mock patterns with type-safe test-only patterns
+- [x] **3.3 Define failing tests first for env and optional-property hygiene**
+  in `tests/unit/import/dndBeyondCharacterServer.test.ts` and
+  `tests/integration/monsterUpload.test.ts`, then refactor the tests to avoid
+  direct read-only env mutations and unsafe optional-property assertions
+- [x] **3.4 Review the touched files for duplication and unnecessary complexity**
+  and confirm the cleanup stays strictly within the non-D&D phase 1 boundary
+- [x] **3.5 Confirm acceptance criteria are covered** and that no work from
+  issue `#138` is pulled into this branch
+
+Suggested start-of-work commands: `git checkout main` →
+`git pull --ff-only` →
+`git checkout -b cleanup-typescript-test-noise-phase-1` →
+`git push -u origin cleanup-typescript-test-noise-phase-1`
+
+## Validation
+
+- [x] **4.1 Run the targeted non-D&D suites** needed to confirm the touched
+  tests still protect their intended behavior
+- [x] **4.2 Run `npx tsc --noEmit`** and confirm the bounded non-D&D failures
+  from phase 1 no longer appear
+- [x] **4.3 Run `npm run lint`** for repository lint validation
+- [x] **4.4 Run any additional focused validation required by the touched files**
+  and record the exact commands/results in the PR
+- [x] **4.5 All completed tasks marked as complete**
+- [x] **4.6 All steps in [Remote push validation]**
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — run the relevant Jest unit suites for the touched files; all
+  tests must pass
+- **Integration tests** — run the relevant integration suite for
+  `tests/integration/monsterUpload.test.ts`; all tests must pass
+- **Regression / E2E tests** — not required unless a touched helper change
+  expands beyond unit/integration scope
+- **Build** — not required for this test-only cleanup unless the touched changes
+  surface a build regression during validation
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+Use the project's documented commands for each of the above (see `README.md`,
+`CONTRIBUTING.md`, and `AGENTS.md`).
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review from
+  `.github/openspec-shared/.codex/skills/openspec-apply-change/SKILL.md` before
+  committing
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from working branch to `main`
+- [ ] Wait for 120 seconds for the Agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — when comments appear, address them, commit
+  fixes, follow all steps in [Remote push validation] then push to the same
+  working branch; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — when any CI check fails, diagnose and fix the
+  failure, commit fixes, follow all steps in [Remote push validation] then push
+  to the same working branch; repeat until all checks pass
+- [ ] Wait for the PR to merge — **never force-merge**; if a human force-merges,
+  continue to Post-Merge
+
+The comment and CI resolution loops are iterative: address → validate locally →
+push → sleep for 120 seconds → re-check → repeat until the PR is fully clean.
+If a human force-merges before the PR is clean, proceed directly to Post-Merge
+steps.
+
+Ownership metadata:
+
+- Implementer: AI agent plus human reviewer
+- Reviewer(s): repository maintainer(s)
+- Required approvals: explicit human approval before apply, then normal PR
+  review approval before merge
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm
+  resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change, if any
+- [ ] Sync approved spec deltas into `openspec/specs/` if this change is
+  approved for long-term global spec retention
+- [ ] Archive the change: move
+  `openspec/changes/cleanup-typescript-test-noise-phase-1/` to
+  `openspec/changes/archive/YYYY-MM-DD-cleanup-typescript-test-noise-phase-1/`
+  **and stage both the new location and the deletion of the old location in a
+  single commit** — do not commit the copy and delete separately
+- [ ] Confirm the archive location exists and the original change directory is
+  gone
+- [ ] Commit and push the archive to `main` in one commit
+- [ ] Prune merged local feature branches:
+  `git fetch --prune` and
+  `git branch -d cleanup-typescript-test-noise-phase-1`
+
+Required cleanup after archive: `git fetch --prune` and
+`git branch -d cleanup-typescript-test-noise-phase-1`

--- a/openspec/changes/cleanup-typescript-test-noise-phase-1/tests.md
+++ b/openspec/changes/cleanup-typescript-test-noise-phase-1/tests.md
@@ -1,0 +1,55 @@
+---
+name: tests
+description: Tests for the change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the
+`cleanup-typescript-test-noise-phase-1` change. All work should follow a strict
+TDD (Test-Driven Development) process.
+
+Phase 1 test coverage is limited to the non-D&D failure set. The D&D Beyond
+fixture-contract work tracked in `#138` is not part of this test plan.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing any implementation code, write or
+   adjust a test that captures the current type or behavioral requirement. Run
+   the relevant command and ensure it fails.
+2. **Write code to pass the test:** Write the smallest possible test/helper
+   change to make the failure pass.
+3. **Refactor:** Improve clarity and remove duplication while keeping the test
+   green and the typecheck clean.
+
+## Test Cases
+
+- [x] **Task 3.1 / Spec MODIFIED combat contracts**
+  Add or adjust failing checks so
+  `tests/unit/combat/conditionExpiry.test.ts` and
+  `tests/unit/combat/damageResistance.test.ts` reflect the current
+  `CombatantState` and `ActiveDamageEffect` contracts, then confirm the suites
+  pass and the typecheck errors disappear.
+- [x] **Task 3.2 / Spec MODIFIED helper and import-route contracts**
+  Add or adjust failing checks so
+  `tests/unit/helpers/route.test.helpers.ts`,
+  `tests/unit/import/characterImportRoute.test.ts`, and
+  `tests/unit/import/charactersPageImport.test.ts` use the current auth, async,
+  and response-mock contracts, then confirm the suites pass and the typecheck
+  errors disappear.
+- [x] **Task 3.3 / Spec MODIFIED env and optional-property hygiene**
+  Add or adjust failing checks so
+  `tests/unit/import/dndBeyondCharacterServer.test.ts` avoids direct read-only
+  env mutation and `tests/integration/monsterUpload.test.ts` narrows optional
+  properties safely, then confirm the suites pass and the typecheck errors
+  disappear.
+- [x] **Task 4.2 / Spec ADDED phase-bounded cleanup**
+  Run `npx tsc --noEmit` and verify that the phase 1 non-D&D failures are gone
+  while any remaining D&D Beyond fixture failures are attributable to `#138`.
+- [x] **Task 4.3 / Non-functional reliability**
+  Run `npm run lint` and any targeted validation commands used for the touched
+  suites, then record the commands and outcomes for PR traceability.

--- a/tests/integration/monsterUpload.test.ts
+++ b/tests/integration/monsterUpload.test.ts
@@ -347,8 +347,9 @@ describe("Monster Upload Validation", () => {
       expect(result.source).toBe("SRD");
       expect(result.abilityScores.strength).toBe(21);
       expect(result.languages).toHaveLength(1);
-      expect(result.traits).toHaveLength(1);
-      expect(result.traits[0].name).toBe("Amphibious");
+      const traits = result.traits ?? [];
+      expect(traits).toHaveLength(1);
+      expect(traits[0]?.name).toBe("Amphibious");
     });
 
     it("should clamp hp to maxHp if provided value is higher", () => {

--- a/tests/unit/combat/conditionExpiry.test.ts
+++ b/tests/unit/combat/conditionExpiry.test.ts
@@ -2,16 +2,27 @@ import { describe, test, expect } from '@jest/globals';
 import { getExpiringConditions, tickConditions, processRoundEnd } from '@/lib/combat/conditionExpiry';
 import { CombatantState } from '@/lib/types';
 
-function makeCombatant(overrides: Partial<CombatantState> & { name: string }): CombatantState {
+function makeCombatant({
+  name,
+  ...overrides
+}: Partial<CombatantState> & { name: string }): CombatantState {
   return {
-    id: overrides.name,
-    name: overrides.name,
+    id: name,
+    name,
     type: 'player',
     initiative: 10,
     initiativeRoll: { roll: 10, bonus: 0, total: 10, method: 'manual' },
     maxHp: 10,
-    currentHp: 10,
-    armorClass: 10,
+    hp: 10,
+    ac: 10,
+    abilityScores: {
+      strength: 10,
+      dexterity: 10,
+      constitution: 10,
+      intelligence: 10,
+      wisdom: 10,
+      charisma: 10,
+    },
     conditions: [],
     ...overrides,
   };

--- a/tests/unit/combat/damageResistance.test.ts
+++ b/tests/unit/combat/damageResistance.test.ts
@@ -5,7 +5,7 @@ import type { ActiveDamageEffect } from '@/lib/types';
 const eff = (
   type: ActiveDamageEffect['type'],
   kind: ActiveDamageEffect['kind'],
-  label = kind,
+  label: string = kind,
 ): ActiveDamageEffect => ({ type, kind, label });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/helpers/route.test.helpers.ts
+++ b/tests/unit/helpers/route.test.helpers.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { AuthPayload } from "@/lib/types";
 
 /** Shared auth payload used across route unit tests */
-export const MOCK_AUTH = { userId: "user-123", email: "user@example.com" };
+export const MOCK_AUTH: AuthPayload = {
+  userId: "user-123",
+  email: "user@example.com",
+};
 
 /** Admin auth payload — userId must be a valid 24-char hex string for MongoDB ObjectId */
-export const ADMIN_AUTH = { userId: "507f1f77bcf86cd799439011", email: "admin@example.com" };
+export const ADMIN_AUTH: AuthPayload = {
+  userId: "507f1f77bcf86cd799439011",
+  email: "admin@example.com",
+};
 
 /** Configure a mocked requireAuth/verifyAuth to return a 401 Unauthorized response */
 export function mockUnauthorized(mockedFn: jest.Mock): void {
@@ -47,13 +54,13 @@ export function makeRouteRequest(
 // describe() block. Use them to avoid repeating the identical 401/404/500
 // boilerplate in every describe block.
 
-type RouteHandler = (req: NextRequest) => Promise<Response> | Response;
+type RouteHandler = (req: NextRequest) => Promise<Response>;
 // Note: params is Promise<...> because Next.js 15 App Router made route params
 // async. Route handlers await params before reading id.
 type ContextHandler = (
   req: NextRequest,
   ctx: { params: Promise<{ id: string }> }
-) => Promise<Response> | Response;
+) => Promise<Response>;
 
 /** Register: returns 401 when requireAuth returns Unauthorized (no route params) */
 export function itReturns401(

--- a/tests/unit/import/characterImportRoute.test.ts
+++ b/tests/unit/import/characterImportRoute.test.ts
@@ -11,6 +11,7 @@ import {
   EXISTING_IMPORTED_CHARACTER_ID,
   IMPORT_WARNING,
 } from "@/tests/helpers/dndBeyondImport";
+import { MOCK_AUTH } from "@/tests/unit/helpers/route.test.helpers";
 
 jest.mock("@/lib/middleware", () => ({
   requireAuth: jest.fn(),
@@ -49,7 +50,7 @@ describe("character import route", () => {
     mockedSaveCharacter.mockReset();
     mockedImportCharacter.mockReset();
 
-    mockedRequireAuth.mockReturnValue({ userId: "user-123" });
+    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedLoadCharacters.mockResolvedValue([]);
     mockedSaveCharacter.mockResolvedValue(undefined);
     mockedImportCharacter.mockResolvedValue(createNormalizedImportResult());

--- a/tests/unit/import/charactersPageImport.test.ts
+++ b/tests/unit/import/charactersPageImport.test.ts
@@ -11,6 +11,7 @@ import {
 import React from "react";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
+import { Response as FetchResponse } from "node-fetch";
 import { CharactersContent } from "@/app/characters/page";
 import {
   CONFLICT_WARNING,
@@ -19,6 +20,13 @@ import {
   DND_BEYOND_CHARACTER_URL,
   IMPORT_WARNING,
 } from "@/tests/helpers/dndBeyondImport";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  }) as unknown as Response;
+}
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -60,47 +68,24 @@ describe("Characters page import UI", () => {
         const url = input.toString();
 
         if (url === "/api/characters" && (!init || init.method === undefined)) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => [],
-          } as Response;
+          return jsonResponse([], 200);
         }
 
         if (url === "/api/characters/import") {
           const body = JSON.parse(String(init?.body || "{}"));
 
           if (!body.overwrite) {
-            return {
-              ok: false,
-              status: 409,
-              headers: new Headers({ "Content-Type": "application/json" }),
-              json: async () => createDuplicateNameConflictPayload(),
-            } as Response;
+            return jsonResponse(createDuplicateNameConflictPayload(), 409);
           }
 
-          return {
-            ok: true,
-            status: 200,
-            headers: new Headers({ "Content-Type": "application/json" }),
-            json: async () => createImportedCharacterApiPayload(),
-          } as Response;
+          return jsonResponse(createImportedCharacterApiPayload(), 200);
         }
 
         if (url.startsWith("/api/characters/") && init?.method === "DELETE") {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({}),
-          } as Response;
+          return jsonResponse({}, 200);
         }
 
-        return {
-          ok: false,
-          status: 404,
-          headers: new Headers({ "Content-Type": "application/json" }),
-          json: async () => ({ error: "not found" }),
-        } as Response;
+        return jsonResponse({ error: "not found" }, 404);
       },
     ) as typeof fetch;
   });
@@ -243,32 +228,17 @@ describe("Characters page import UI", () => {
         const url = input.toString();
 
         if (url === "/api/characters" && (!init || init.method === undefined)) {
-          return {
-            ok: true,
-            status: 200,
-            headers: new Headers({ "Content-Type": "application/json" }),
-            json: async () => [],
-          } as Response;
+          return jsonResponse([], 200);
         }
 
         if (url === "/api/characters/import") {
-          return {
-            ok: false,
+          return new FetchResponse("gateway timeout", {
             status: 502,
-            headers: new Headers({ "Content-Type": "text/plain" }),
-            text: async () => "gateway timeout",
-            json: async () => {
-              throw new Error("not json");
-            },
-          } as Response;
+            headers: { "Content-Type": "text/plain" },
+          }) as unknown as Response;
         }
 
-        return {
-          ok: false,
-          status: 404,
-          headers: new Headers({ "Content-Type": "application/json" }),
-          json: async () => ({ error: "not found" }),
-        } as Response;
+        return jsonResponse({ error: "not found" }, 404);
       },
     ) as typeof fetch;
 

--- a/tests/unit/import/dndBeyondCharacterServer.test.ts
+++ b/tests/unit/import/dndBeyondCharacterServer.test.ts
@@ -11,30 +11,17 @@ import {
 } from "@/tests/helpers/dndBeyondImport";
 
 describe("dndBeyondCharacterImport server module", () => {
-  const originalBaseUrl = process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-  const originalNodeEnv = process.env.NODE_ENV;
-  const originalAllowInsecure =
-    process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
+  const originalEnv = { ...process.env };
+
+  function setEnv(overrides: Partial<NodeJS.ProcessEnv>): void {
+    process.env = {
+      ...process.env,
+      ...overrides,
+    };
+  }
 
   afterEach(() => {
-    if (typeof originalBaseUrl === "string") {
-      process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL = originalBaseUrl;
-    } else {
-      delete process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-    }
-
-    if (typeof originalNodeEnv === "string") {
-      process.env.NODE_ENV = originalNodeEnv;
-    } else {
-      delete process.env.NODE_ENV;
-    }
-
-    if (typeof originalAllowInsecure === "string") {
-      process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL =
-        originalAllowInsecure;
-    } else {
-      delete process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-    }
+    process.env = { ...originalEnv };
   });
 
   test("fetches the public character-service payload", async () => {
@@ -93,9 +80,11 @@ describe("dndBeyondCharacterImport server module", () => {
   });
 
   test("rejects insecure upstream base URLs outside tests", async () => {
-    process.env.NODE_ENV = "production";
-    process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL =
-      "http://character-service.dndbeyond.test/character/v5";
+    setEnv({
+      NODE_ENV: "production",
+      DND_BEYOND_CHARACTER_SERVICE_BASE_URL:
+        "http://character-service.dndbeyond.test/character/v5",
+    });
     const fetchImpl = jest.fn() as unknown as typeof fetch;
 
     await expect(
@@ -105,9 +94,11 @@ describe("dndBeyondCharacterImport server module", () => {
   });
 
   test("allows insecure upstream base URLs during tests", async () => {
-    process.env.NODE_ENV = "test";
-    process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL =
-      "http://character-service.dndbeyond.test/character/v5";
+    setEnv({
+      NODE_ENV: "test",
+      DND_BEYOND_CHARACTER_SERVICE_BASE_URL:
+        "http://character-service.dndbeyond.test/character/v5",
+    });
     const fetchImpl = jest.fn(async (url: string) => ({
       ok: true,
       status: 200,

--- a/tests/unit/import/dndBeyondCharacterServer.test.ts
+++ b/tests/unit/import/dndBeyondCharacterServer.test.ts
@@ -14,14 +14,17 @@ describe("dndBeyondCharacterImport server module", () => {
   const originalEnv = { ...process.env };
 
   function setEnv(overrides: Partial<NodeJS.ProcessEnv>): void {
-    process.env = {
-      ...process.env,
-      ...overrides,
-    };
+    Object.assign(process.env, overrides);
   }
 
   afterEach(() => {
-    process.env = { ...originalEnv };
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+
+    Object.assign(process.env, originalEnv);
   });
 
   test("fetches the public character-service payload", async () => {


### PR DESCRIPTION
## Summary
- align the phase-1 combat, route helper, import, and monster upload tests with the current exported TypeScript contracts
- replace stale auth, async handler, response mock, env override, and optional-property test patterns with stricter test-only equivalents
- record the OpenSpec change artifacts and mark the completed implementation and validation tasks

## Why
This removes the non-D&D TypeScript noise from issue #135 without pulling the larger D&D Beyond fixture-contract cleanup from #138 into the same branch.

## Validation
- `npx jest --runInBand tests/unit/combat/conditionExpiry.test.ts tests/unit/combat/damageResistance.test.ts tests/unit/import/characterImportRoute.test.ts tests/unit/import/charactersPageImport.test.ts tests/unit/import/dndBeyondCharacterServer.test.ts`
- `npx jest --config=jest.integration.config.js --runInBand tests/integration/monsterUpload.test.ts`
- `npx tsc --noEmit --pretty false` (phase-1 files no longer appear; remaining failures are confined to `tests/unit/import/dndBeyondCharacterImport.test.ts` and belong to #138)
- `npm run lint`

## Notes
- The working tree still contains an unrelated dirty `.github/openspec-shared` submodule, which was intentionally left out of this PR.