### PR TITLE
test(import): align dnd beyond fixtures with contracts

### DIFF
--- a/openspec/changes/align-dnd-beyond-fixture-contracts/.openspec.yaml
+++ b/openspec/changes/align-dnd-beyond-fixture-contracts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-04-11

--- a/openspec/changes/align-dnd-beyond-fixture-contracts/design.md
+++ b/openspec/changes/align-dnd-beyond-fixture-contracts/design.md
@@ -1,0 +1,201 @@
+## Context
+
+- Relevant architecture:
+  `lib/dndBeyondCharacterImport.ts` defines the current import contracts and
+  normalization logic;
+  `tests/fixtures/dndBeyondCharacter.ts` provides the shared source fixture;
+  `tests/unit/import/dndBeyondCharacterImport.test.ts` performs extensive
+  spread-based overrides against that fixture.
+- Dependencies:
+  The change depends on the current exported TypeScript contracts for
+  `DndBeyondCharacterData` and the normalized `Character` shape.
+- Interfaces/contracts touched:
+  Test-facing use of `DndBeyondCharacterData`, modifier/action entry unions, and
+  optional normalized fields such as `senses`, `savingThrows`, and `skills`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Make the shared D&D Beyond fixture satisfy the current import contracts
+  directly
+- Preserve strict union typing for modifier and action overrides used in tests
+- Keep test assertions explicit and type-safe when normalized fields are
+  optional
+- Remove the D&D Beyond fixture-related `tsc --noEmit` failures without changing
+  runtime behavior
+
+### Non-Goals
+
+- Change production normalization behavior
+- Relax the current import contract definitions
+- Broaden scope to unrelated TypeScript cleanup outside the D&D Beyond failure
+  cluster
+
+## Decisions
+
+### Decision 1: Type the shared fixture at the source contract boundary
+
+- Chosen:
+  Type the shared fixture data in `tests/fixtures/dndBeyondCharacter.ts`
+  directly against the current import contract rather than relying on broad
+  object-literal inference.
+- Alternatives considered:
+  Add per-test casts at each call site; loosen production contracts to accept
+  wider shapes.
+- Rationale:
+  The shared fixture is the root of most failures. Fixing its type boundary once
+  keeps the suite aligned with the source-of-truth contract and avoids repeated
+  local workarounds.
+- Trade-offs:
+  The fixture file becomes slightly more explicit about contract details, but
+  the rest of the tests become simpler and safer.
+
+### Decision 2: Preserve nested unions through typed override helpers or aliases
+
+- Chosen:
+  Refactor test-local modifier/action overrides to use typed aliases derived
+  from `DndBeyondCharacterData` instead of relying on object spread inference.
+- Alternatives considered:
+  Continue using inline literals and patch errors with `as const` or ad hoc
+  casts throughout the suite.
+- Rationale:
+  Most TS2322/TS2345 failures come from nested literals widening from
+  `"bonus"`/`"set"` to `string`. A typed helper or alias keeps override-heavy
+  tests readable while preserving the intended unions.
+- Trade-offs:
+  The suite may gain a small amount of helper structure, but it removes a large
+  amount of repeated type noise.
+
+### Decision 3: Narrow optional normalized fields at assertion sites
+
+- Chosen:
+  Where tests assert on `result.character.senses`, `savingThrows`, or `skills`,
+  introduce explicit narrowing before property access.
+- Alternatives considered:
+  Change `Character` to make those fields required everywhere; suppress errors
+  with non-null assertions.
+- Rationale:
+  These properties are intentionally optional in the domain model. The tests
+  should reflect that contract instead of forcing a stronger type than
+  production guarantees.
+- Trade-offs:
+  Assertions become slightly more verbose, but the test intent remains aligned
+  with the real API shape.
+
+## Proposal to Design Mapping
+
+- Proposal element: Re-type the shared fixture source
+  - Design decision: Decision 1
+  - Validation approach: targeted typecheck and import test runs
+- Proposal element: Standardize modifier/action override patterns
+  - Design decision: Decision 2
+  - Validation approach: targeted unit tests that cover custom modifier/action
+    overrides
+- Proposal element: Replace unsafe optional-field assertions
+  - Design decision: Decision 3
+  - Validation approach: targeted unit tests plus `npx tsc --noEmit`
+- Proposal element: Remove the D&D Beyond typecheck failure cluster
+  - Design decision: Decisions 1 through 3
+  - Validation approach: repo-wide typecheck filtered against the issue #138
+    failure set
+
+## Functional Requirements Mapping
+
+- Requirement:
+  D&D Beyond fixtures and helpers must match the current import contracts
+  - Design element:
+    Decisions 1 and 2
+  - Acceptance criteria reference:
+    `openspec/changes/align-dnd-beyond-fixture-contracts/specs/typecheck-validation/spec.md`
+  - Testability notes:
+    Validate through targeted import tests and repo-wide typecheck
+- Requirement:
+  Optional normalized fields must be asserted safely
+  - Design element:
+    Decision 3
+  - Acceptance criteria reference:
+    `openspec/changes/align-dnd-beyond-fixture-contracts/specs/typecheck-validation/spec.md`
+  - Testability notes:
+    Ensure assertions compile without non-null shortcuts and still verify the
+    expected values
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement:
+    Repo-wide typecheck should produce a materially cleaner and more attributable
+    failure signal after this change
+  - Design element:
+    Decisions 1 through 3
+  - Acceptance criteria reference:
+    Non-functional reliability criteria in the spec delta
+  - Testability notes:
+    Run `npx tsc --noEmit` and confirm the D&D Beyond fixture-related failures
+    are removed
+- Requirement category: operability
+  - Requirement:
+    Test maintenance should remain localized and readable rather than spread
+    across many ad hoc casts
+  - Design element:
+    Decisions 1 and 2
+  - Acceptance criteria reference:
+    modified contract-alignment requirement in the spec delta
+  - Testability notes:
+    Review changed tests for a shared typed pattern rather than repeated
+    one-off casts
+
+## Risks / Trade-offs
+
+- Risk/trade-off:
+  Deriving nested helper types from `DndBeyondCharacterData` may be slightly
+  awkward because modifier/action records are nullable and index-based.
+  - Impact:
+    Helper definitions may become harder to read if over-engineered.
+  - Mitigation:
+    Keep aliases minimal and colocated with the tests that use them.
+- Risk/trade-off:
+  The suite may still contain a few call-site-specific contract adjustments even
+  after the shared fixture is typed.
+  - Impact:
+    The final cleanup may span more than one file despite having a single root
+    cause.
+  - Mitigation:
+    Treat the fixture as the primary boundary fix, then only add local typing
+    where a test intentionally constructs a contract edge case.
+
+## Rollback / Mitigation
+
+- Rollback trigger:
+  The proposed cleanup makes the tests substantially less readable, or targeted
+  import tests regress behavior while only attempting type cleanup.
+- Rollback steps:
+  Revert the fixture/test typing changes in this change set.
+- Data migration considerations:
+  None. This is test-only and should not affect persisted data.
+- Verification after rollback:
+  Re-run the targeted import tests and `npx tsc --noEmit` to confirm the repo is
+  back to its prior state.
+
+## Operational Blocking Policy
+
+- If CI checks fail:
+  Diagnose whether the failure is caused by the fixture cleanup or by an
+  unrelated pre-existing issue, fix fixture/test regressions within scope, and
+  document unrelated failures separately if discovered.
+- If security checks fail:
+  Treat as unexpected for a test-only change, verify no production code or data
+  handling behavior was broadened, and resolve before merge.
+- If required reviews are blocked/stale:
+  Request maintainer review and pause apply until a human explicitly approves
+  the proposal and subsequent implementation.
+- Escalation path and timeout:
+  Escalate to the repository maintainer if scope expands beyond fixture/test
+  alignment or if repo-wide typecheck reveals a new unrelated blocker that
+  meaningfully changes the change set.
+
+## Open Questions
+
+- None at proposal time. If implementation reveals a real production-contract
+  inconsistency rather than stale test typing, the change must be paused and the
+  proposal/specs/tasks updated before continuing.

--- a/openspec/changes/align-dnd-beyond-fixture-contracts/proposal.md
+++ b/openspec/changes/align-dnd-beyond-fixture-contracts/proposal.md
@@ -1,0 +1,124 @@
+## GitHub Issues
+
+- #138
+
+## Why
+
+- Problem statement:
+  `npx tsc --noEmit` still reports a concentrated block of failures in the
+  D&D Beyond import fixtures and tests because shared fixture objects are
+  inferred too broadly for the current import contracts.
+- Why now:
+  Phase 1 cleanup isolated this remaining failure cluster, and issue #138 now
+  defines a focused follow-up instead of leaving the repo-wide typecheck noisy.
+- Business/user impact:
+  A clean, trustworthy typecheck signal reduces review friction, makes strict
+  typing sustainable in import code, and prevents test maintenance from pushing
+  pressure back onto production contracts.
+
+## Problem Space
+
+- Current behavior:
+  The shared fixture in `tests/fixtures/dndBeyondCharacter.ts` and many
+  spread-based test overrides in
+  `tests/unit/import/dndBeyondCharacterImport.test.ts` no longer satisfy the
+  current `DndBeyondCharacterData` shape. Nested modifier and action literals
+  widen to `string`, and assertions against optional normalized fields do not
+  narrow before access.
+- Desired behavior:
+  Shared D&D Beyond fixtures should satisfy the current import contracts
+  directly, test-local overrides should preserve those contracts without
+  scattered unsafe casts, and `npx tsc --noEmit` should stop reporting this
+  D&D Beyond fixture-related failure set.
+- Constraints:
+  The fix must stay centered on tests and fixtures. Production contracts in
+  `lib/dndBeyondCharacterImport.ts` and `lib/types.ts` must not be loosened to
+  silence type errors.
+- Assumptions:
+  The current import contracts are the source of truth, and the failures are
+  due to test drift rather than an unresolved product requirement.
+- Edge cases considered:
+  Optional normalized fields such as `senses`, `savingThrows`, and `skills`
+  remain intentionally optional on `Character`; shared fixture typing must still
+  support override-heavy test cases; modifier/action groups may include custom
+  keys while still requiring current entry unions.
+
+## Scope
+
+### In Scope
+
+- Align `tests/fixtures/dndBeyondCharacter.ts` to the current
+  `DndBeyondCharacterData` contract
+- Refactor D&D Beyond import tests to preserve modifier/action unions when
+  overriding nested fixture data
+- Replace unsafe optional-field assertions in
+  `tests/unit/import/dndBeyondCharacterImport.test.ts` with explicit narrowing
+- Re-run repo-wide typecheck and targeted D&D Beyond import tests to confirm the
+  failure cluster is removed
+
+### Out of Scope
+
+- Any production behavior change in the D&D Beyond import flow
+- Loosening `DndBeyondCharacterData`, `DndBeyondModifier`, or
+  `DndBeyondActionEntry` to accommodate stale tests
+- Broader TypeScript cleanup outside the D&D Beyond fixture-related failures
+- New D&D Beyond feature support beyond what the current import contracts
+  already describe
+
+## What Changes
+
+- Introduce a dedicated OpenSpec change for the remaining D&D Beyond
+  fixture-contract cleanup tracked in #138
+- Re-type the shared D&D Beyond fixture source so it satisfies current import
+  contracts directly
+- Standardize test-local helper patterns for modifier/action overrides and
+  optional normalized-field assertions
+- Restore repo-wide typecheck clarity by removing the D&D Beyond fixture-related
+  failure cluster isolated by phase 1
+
+## Risks
+
+- Risk:
+  The cleanup could accidentally hide a real contract mismatch by overusing
+  casts in tests.
+  - Impact:
+    Tests may compile while no longer validating the current import contracts.
+  - Mitigation:
+    Center the fix on typed shared fixtures and typed helpers, and treat
+    repeated `as` casts as a design smell to avoid.
+- Risk:
+  Optional-field narrowing could become verbose and reduce test readability.
+  - Impact:
+    The tests may become harder to maintain even if they are correct.
+  - Mitigation:
+    Use small local variables or helper assertions that keep narrowing explicit
+    without repeating boilerplate throughout the suite.
+- Risk:
+  Repo-wide typecheck may still surface unrelated failures after the D&D Beyond
+  cluster is fixed.
+  - Impact:
+    Reviewers may assume #138 guarantees a fully green typecheck.
+  - Mitigation:
+    Define acceptance around removing the D&D Beyond fixture-related failures
+    while still recording any newly discovered unrelated failures separately.
+
+## Open Questions
+
+- No unresolved scope questions remain. The change is limited to fixture/test
+  alignment for the failure set described in #138, and production contracts stay
+  unchanged.
+
+## Non-Goals
+
+- Refactoring the D&D Beyond importer beyond what is required for test-fixture
+  alignment
+- Reworking unrelated test suites while touching the import tests
+- Weakening strict typing in production code to reduce maintenance cost in tests
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.
+
+Proposal must be reviewed and explicitly approved by a human before design,
+specs, tasks, or apply proceed.

--- a/openspec/changes/align-dnd-beyond-fixture-contracts/specs/typecheck-validation/spec.md
+++ b/openspec/changes/align-dnd-beyond-fixture-contracts/specs/typecheck-validation/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the
+`design.md` document, not a replacement.
+
+### Requirement: ADDED D&D Beyond fixture-contract cleanup can complete as a
+focused typecheck change
+
+The system SHALL allow the D&D Beyond fixture-contract cleanup tracked in #138
+to be completed as a focused test-maintenance change without requiring
+production import behavior changes.
+
+#### Scenario: D&D Beyond fixture-related typecheck failures are removed
+
+- **Given** the repository contains the #138 cleanup changes
+- **When** `npx tsc --noEmit` is run from the project root
+- **Then** TypeScript no longer reports the D&D Beyond fixture-related failures
+  from `tests/fixtures/dndBeyondCharacter.ts` or
+  `tests/unit/import/dndBeyondCharacterImport.test.ts`
+
+#### Scenario: Production contracts remain the source of truth
+
+- **Given** the D&D Beyond fixture cleanup is implemented
+- **When** the change is reviewed
+- **Then** the fix is centered on fixture and test alignment
+- **And** `lib/dndBeyondCharacterImport.ts` contract definitions are not widened
+  solely to silence test failures
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED test fixtures and helpers must match current exported
+contracts
+
+The system SHALL keep D&D Beyond import fixtures and tests aligned with the
+current exported import and normalized-character contracts.
+
+#### Scenario: Shared D&D Beyond fixtures satisfy the current import contract
+
+- **Given** the shared fixture file constructs a representative imported
+  character payload
+- **When** the fixture is consumed by import tests
+- **Then** the fixture satisfies `DndBeyondCharacterData` directly
+- **And** nested modifier and action entries use the current allowed unions
+  rather than widened `string` values
+
+#### Scenario: Import tests preserve contract safety in override-heavy cases
+
+- **Given** the import unit tests override nested modifier, action, race, stat,
+  or inventory data from the shared fixture
+- **When** those tests are typechecked
+- **Then** the overrides preserve the current contract shape without repeated
+  unsafe casts
+- **And** optional normalized fields are narrowed explicitly before property
+  assertions
+
+## REMOVED Requirements
+
+### Requirement: REMOVED tolerance for stale D&D Beyond fixture typing drift
+
+Reason for removal:
+The repository should no longer tolerate known stale D&D Beyond fixture and
+test patterns that obscure whether import-contract regressions are real.
+
+#### Scenario: Stale D&D Beyond fixture drift is treated as a failure
+
+- **Given** a D&D Beyond import test uses a fixture shape that no longer matches
+  the exported import contract
+- **When** `npx tsc --noEmit` is run
+- **Then** the mismatch is treated as a failure to be corrected in fixtures or
+  tests rather than excused as pre-existing noise
+
+## Traceability
+
+- Proposal element -> Requirement:
+  re-type the shared fixture source -> MODIFIED test fixtures and helpers must
+  match current exported contracts
+- Proposal element -> Requirement:
+  remove the D&D Beyond failure cluster -> ADDED D&D Beyond fixture-contract
+  cleanup can complete as a focused typecheck change
+- Design decision -> Requirement:
+  Decision 1 -> shared fixtures satisfy the current import contract
+- Design decision -> Requirement:
+  Decision 2 -> override-heavy tests preserve current unions
+- Design decision -> Requirement:
+  Decision 3 -> optional normalized fields are narrowed explicitly
+- Requirement -> Task(s):
+  ADDED/MODIFIED/REMOVED requirements -> tasks 1 through 6 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: No new runtime work is introduced
+
+- **Given** this change touches fixtures and tests only
+- **When** the project is built and typechecked
+- **Then** the change introduces no new production runtime behavior
+- **And** validation cost remains limited to normal compile and test execution
+
+### Requirement: Security
+
+#### Scenario: Contract cleanup does not weaken import enforcement
+
+- **Given** the change updates only fixtures, tests, and typed helper patterns
+- **When** the import flow is reviewed
+- **Then** no auth, fetch, or normalization guard in production code is weakened
+  to accommodate the tests
+
+### Requirement: Reliability
+
+#### Scenario: Typecheck output becomes more attributable
+
+- **Given** a maintainer runs repo-wide typecheck after the #138 cleanup
+- **When** a failure remains
+- **Then** the D&D Beyond fixture-related failure cluster is no longer part of
+  the output
+- **And** any remaining failures are easier to attribute to separate work

--- a/openspec/changes/align-dnd-beyond-fixture-contracts/tasks.md
+++ b/openspec/changes/align-dnd-beyond-fixture-contracts/tasks.md
@@ -1,0 +1,105 @@
+# Tasks
+
+## Preparation
+
+- [ ] **Step 1 — Sync default branch:** `git checkout main` and
+  `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b fix/align-dnd-beyond-fixture-contracts`
+  then immediately `git push -u origin fix/align-dnd-beyond-fixture-contracts`
+
+## Execution
+
+- [x] 1. Reproduce the current issue #138 failure set with `npx tsc --noEmit`
+  and record the D&D Beyond-specific failures that define scope
+- [x] 2. Update `tests/fixtures/dndBeyondCharacter.ts` so the shared fixture
+  source satisfies the current `DndBeyondCharacterData` contract directly
+- [x] 3. Refactor
+  `tests/unit/import/dndBeyondCharacterImport.test.ts` to preserve
+  modifier/action unions in override-heavy test cases without repeated unsafe
+  casts
+- [x] 4. Replace direct optional-property assertions for normalized fields with
+  explicit narrowing where required
+- [x] 5. Review the touched tests for duplication and simplify any helper shape
+  introduced during the cleanup
+- [x] 6. Confirm the change remains limited to fixture/test alignment and does
+  not loosen production contracts
+
+Suggested start-of-work commands:
+`git checkout main` → `git pull --ff-only` →
+`git checkout -b fix/align-dnd-beyond-fixture-contracts` →
+`git push -u origin fix/align-dnd-beyond-fixture-contracts`
+
+## Validation
+
+- [x] Run targeted unit tests:
+  `npm run test:unit -- tests/unit/import/dndBeyondCharacterImport.test.ts`
+- [ ] Run any directly related import integration tests if fixture changes touch
+  shared import helpers
+- [x] Run repo-wide typecheck: `npx tsc --noEmit`
+- [x] Run lint: `npm run lint`
+- [x] Run build: `npm run build`
+- [ ] Run security/code quality checks required by project standards
+- [ ] All completed tasks marked as complete
+- [ ] All steps in [Remote push validation]
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — run the project's unit test suite; all tests must pass
+- **Integration tests** — run the project's integration test suite for any
+  directly affected import flows; all tests must pass
+- **Regression / E2E tests** — run the project's end-to-end or regression suite
+  if the touched import flow is covered there; all tests must pass
+- **Build** — run the project's build script; build must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+Use the project's documented commands for each of the above.
+
+## PR and Merge
+
+- [x] Run the required pre-PR self-review from
+  `skills/openspec-apply-change/SKILL.md` before committing
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from working branch to `main`
+- [ ] Wait for 120 seconds for the Agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — when comments appear, address them, commit
+  fixes, follow all steps in [Remote push validation] then push to the same
+  working branch; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — when any CI check fails, diagnose and fix the
+  failure, commit fixes, follow all steps in [Remote push validation] then push
+  to the same working branch; repeat until all checks pass
+- [ ] Wait for the PR to merge — **never force-merge**; if a human force-merges,
+  continue to Post-Merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s):
+- Required approvals: 1 human approval before apply and merge
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm
+  resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change
+- [ ] Sync approved spec deltas into `openspec/specs/`
+- [ ] Archive the change: move
+  `openspec/changes/align-dnd-beyond-fixture-contracts/` to
+  `openspec/changes/archive/YYYY-MM-DD-align-dnd-beyond-fixture-contracts/`
+  **and stage both the new location and the deletion of the old location in a
+  single commit**
+- [ ] Confirm the archived path exists and the original change directory is gone
+- [ ] Commit and push the archive to `main` in one commit
+- [ ] Prune merged local feature branches:
+  `git fetch --prune` and
+  `git branch -d fix/align-dnd-beyond-fixture-contracts`

--- a/openspec/changes/align-dnd-beyond-fixture-contracts/tests.md
+++ b/openspec/changes/align-dnd-beyond-fixture-contracts/tests.md
@@ -1,0 +1,48 @@
+---
+name: tests
+description: Tests for the change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the
+`align-dnd-beyond-fixture-contracts` change. All work should follow a strict
+TDD (Test-Driven Development) process.
+
+This change is limited to the D&D Beyond fixture-contract failures tracked in
+`#138`. It must not rely on weakening production types to make the tests pass.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing implementation changes, reproduce
+   the current typing failure with `npx tsc --noEmit` or a targeted import test.
+2. **Write code to pass the test:** Make the smallest fixture/test-only change
+   that restores contract alignment.
+3. **Refactor:** Reduce duplication and keep type-safe patterns readable without
+   changing runtime behavior.
+
+## Test Cases
+
+- [ ] **Task 2 / shared fixture contract**
+  Reproduce that the shared fixture in `tests/fixtures/dndBeyondCharacter.ts`
+  fails assignability against the current import contract, then update the
+  fixture typing and confirm targeted import tests still pass.
+- [ ] **Task 3 / modifier and action override unions**
+  Reproduce the current widening failures in
+  `tests/unit/import/dndBeyondCharacterImport.test.ts` for modifier and action
+  overrides, then confirm the suite compiles and preserves the intended
+  assertions after refactoring.
+- [ ] **Task 4 / optional normalized-field narrowing**
+  Reproduce the `TS18048` failures for `senses`, `savingThrows`, and `skills`,
+  then confirm the updated assertions narrow explicitly and keep the same
+  expected values.
+- [ ] **Task 6 / repo-wide typecheck validation**
+  Run `npx tsc --noEmit` and confirm the D&D Beyond fixture-related failures
+  described in #138 no longer appear.
+- [ ] **Validation / lint and build**
+  Run `npm run lint` and `npm run build` after the cleanup to confirm the
+  fixture/test alignment does not create broader project regressions.

--- a/tests/fixtures/dndBeyondCharacter.ts
+++ b/tests/fixtures/dndBeyondCharacter.ts
@@ -8,7 +8,7 @@ type DndBeyondFixtureResponse = {
   pagination: null;
 };
 
-export const sampleDndBeyondCharacterResponse = {
+export const sampleDndBeyondCharacterResponse: DndBeyondFixtureResponse = {
   id: 91913267,
   success: true,
   message: "OK",
@@ -279,9 +279,9 @@ export const sampleDndBeyondCharacterResponse = {
     },
   },
   pagination: null,
-} satisfies DndBeyondFixtureResponse;
+};
 
-export const unsupportedDndBeyondCharacterResponse = {
+export const unsupportedDndBeyondCharacterResponse: DndBeyondFixtureResponse = {
   ...sampleDndBeyondCharacterResponse,
   data: {
     ...sampleDndBeyondCharacterResponse.data,
@@ -291,9 +291,9 @@ export const unsupportedDndBeyondCharacterResponse = {
       fullName: "Warforged",
     },
   },
-} satisfies DndBeyondFixtureResponse;
+};
 
-export const mountainDwarfCharacterResponse = {
+export const mountainDwarfCharacterResponse: DndBeyondFixtureResponse = {
   ...sampleDndBeyondCharacterResponse,
   data: {
     ...sampleDndBeyondCharacterResponse.data,
@@ -302,9 +302,9 @@ export const mountainDwarfCharacterResponse = {
       fullName: "Mountain Dwarf",
     },
   },
-} satisfies DndBeyondFixtureResponse;
+};
 
-export const aasimarArtificerCharacterResponse = {
+export const aasimarArtificerCharacterResponse: DndBeyondFixtureResponse = {
   ...sampleDndBeyondCharacterResponse,
   data: {
     ...sampleDndBeyondCharacterResponse.data,
@@ -321,4 +321,4 @@ export const aasimarArtificerCharacterResponse = {
       },
     ],
   },
-} satisfies DndBeyondFixtureResponse;
+};

--- a/tests/fixtures/dndBeyondCharacter.ts
+++ b/tests/fixtures/dndBeyondCharacter.ts
@@ -291,7 +291,7 @@ export const unsupportedDndBeyondCharacterResponse = {
       fullName: "Warforged",
     },
   },
-};
+} satisfies DndBeyondFixtureResponse;
 
 export const mountainDwarfCharacterResponse = {
   ...sampleDndBeyondCharacterResponse,
@@ -302,7 +302,7 @@ export const mountainDwarfCharacterResponse = {
       fullName: "Mountain Dwarf",
     },
   },
-};
+} satisfies DndBeyondFixtureResponse;
 
 export const aasimarArtificerCharacterResponse = {
   ...sampleDndBeyondCharacterResponse,
@@ -321,4 +321,4 @@ export const aasimarArtificerCharacterResponse = {
       },
     ],
   },
-};
+} satisfies DndBeyondFixtureResponse;

--- a/tests/fixtures/dndBeyondCharacter.ts
+++ b/tests/fixtures/dndBeyondCharacter.ts
@@ -1,3 +1,13 @@
+import type { DndBeyondCharacterData } from "@/lib/dndBeyondCharacterImport";
+
+type DndBeyondFixtureResponse = {
+  id: number;
+  success: boolean;
+  message: string;
+  data: DndBeyondCharacterData;
+  pagination: null;
+};
+
 export const sampleDndBeyondCharacterResponse = {
   id: 91913267,
   success: true,
@@ -41,10 +51,6 @@ export const sampleDndBeyondCharacterResponse = {
       weightSpeeds: {
         normal: {
           walk: 30,
-          fly: 0,
-          swim: 0,
-          climb: 0,
-          burrow: 0,
         },
       },
     },
@@ -255,7 +261,6 @@ export const sampleDndBeyondCharacterResponse = {
       {
         equipped: true,
         definition: {
-          name: "Lucky Leather Armor",
           armorClass: 12,
           armorTypeId: 1,
           baseArmorName: "Studded Leather",
@@ -274,7 +279,7 @@ export const sampleDndBeyondCharacterResponse = {
     },
   },
   pagination: null,
-};
+} satisfies DndBeyondFixtureResponse;
 
 export const unsupportedDndBeyondCharacterResponse = {
   ...sampleDndBeyondCharacterResponse,

--- a/tests/helpers/dndBeyondImport.ts
+++ b/tests/helpers/dndBeyondImport.ts
@@ -57,7 +57,7 @@ export function createNormalizedImportResult(
     character: createImportedCharacterDraft(),
     warnings: [IMPORT_WARNING],
     sourceCharacterId: String(sampleDndBeyondCharacterResponse.data.id),
-    sourceUrl: sampleDndBeyondCharacterResponse.data.readonlyUrl,
+    sourceUrl: sampleDndBeyondCharacterResponse.data.readonlyUrl ?? undefined,
     ...overrides,
   };
 }

--- a/tests/unit/import/dndBeyondCharacterImport.test.ts
+++ b/tests/unit/import/dndBeyondCharacterImport.test.ts
@@ -9,6 +9,14 @@ import {
   unsupportedDndBeyondCharacterResponse,
 } from "@/tests/fixtures/dndBeyondCharacter";
 
+function expectDefined<T>(value: T | undefined, label: string): T {
+  expect(value).toBeDefined();
+  if (value === undefined) {
+    throw new Error(`${label} should be defined`);
+  }
+  return value;
+}
+
 describe("dndBeyondCharacterImport", () => {
   test("rejects a non-URL string", () => {
     expect(() => parseDndBeyondCharacterUrl("not-a-url")).toThrow(
@@ -95,7 +103,8 @@ describe("dndBeyondCharacterImport", () => {
         description: "Use your reaction to halve the attack's damage.",
       },
     ]);
-    expect(result.character.senses["passive perception"]).toBe("18");
+    const senses = expectDefined(result.character.senses, "senses");
+    expect(senses["passive perception"]).toBe("18");
     expect(result.warnings).toEqual([]);
   });
 
@@ -366,7 +375,8 @@ describe("dndBeyondCharacterImport", () => {
     expect(result.character.languages).toEqual(
       expect.arrayContaining(["Common", "Infernal", "Deep Speech"]),
     );
-    expect(result.character.senses).toMatchObject({
+    const senses = expectDefined(result.character.senses, "senses");
+    expect(senses).toMatchObject({
       blindsight: "15 ft.",
       darkvision: "60 ft.",
       speed: "30 ft.",
@@ -376,8 +386,13 @@ describe("dndBeyondCharacterImport", () => {
     expect(result.character.conditionImmunities).toContain("Poisoned");
     expect(result.character.damageResistances).toContain("fire");
     expect(result.character.damageVulnerabilities).toContain("cold");
-    expect(result.character.savingThrows.wisdom).toBe(5);
-    expect(result.character.skills.stealth).toBe(9);
+    const savingThrows = expectDefined(
+      result.character.savingThrows,
+      "savingThrows",
+    );
+    const skills = expectDefined(result.character.skills, "skills");
+    expect(savingThrows.wisdom).toBe(5);
+    expect(skills.stealth).toBe(9);
     expect(result.character.actions).toEqual(
       expect.arrayContaining([
         {
@@ -418,9 +433,10 @@ describe("dndBeyondCharacterImport", () => {
       },
     });
 
-    expect(result.character.senses.speed).toBeUndefined();
-    expect(result.character.senses["passive insight"]).toBe("10");
-    expect(result.character.senses["passive investigation"]).toBe("13");
+    const senses = expectDefined(result.character.senses, "senses");
+    expect(senses.speed).toBeUndefined();
+    expect(senses["passive insight"]).toBe("10");
+    expect(senses["passive investigation"]).toBe("13");
   });
 
   test("omits actions whose sanitized descriptions are empty", () => {

--- a/tests/unit/import/dndBeyondCharacterImport.test.ts
+++ b/tests/unit/import/dndBeyondCharacterImport.test.ts
@@ -9,10 +9,11 @@ import {
   unsupportedDndBeyondCharacterResponse,
 } from "@/tests/fixtures/dndBeyondCharacter";
 
-function expectDefined<T>(value: T | undefined, label: string): T {
+function expectDefined<T>(value: T | undefined | null, label: string): T {
   expect(value).toBeDefined();
-  if (value === undefined) {
-    throw new Error(`${label} should be defined`);
+  expect(value).not.toBeNull();
+  if (value === undefined || value === null) {
+    throw new Error(`${label} should be defined and not null`);
   }
   return value;
 }

--- a/tests/unit/import/dndBeyondCharacterImport.test.ts
+++ b/tests/unit/import/dndBeyondCharacterImport.test.ts
@@ -9,12 +9,15 @@ import {
   unsupportedDndBeyondCharacterResponse,
 } from "@/tests/fixtures/dndBeyondCharacter";
 
-function expectDefined<T>(value: T | undefined | null, label: string): T {
-  expect(value).toBeDefined();
-  expect(value).not.toBeNull();
+function expectDefined<T>(
+  value: T | undefined | null,
+  label: string,
+): NonNullable<T> {
   if (value === undefined || value === null) {
     throw new Error(`${label} should be defined and not null`);
   }
+  expect(value).toBeDefined();
+  expect(value).not.toBeNull();
   return value;
 }
 

--- a/tests/unit/import/dndBeyondCharacterImport.test.ts
+++ b/tests/unit/import/dndBeyondCharacterImport.test.ts
@@ -21,6 +21,27 @@ function expectDefined<T>(
   return value;
 }
 
+const sampleStats = expectDefined(
+  sampleDndBeyondCharacterResponse.data.stats,
+  "sample stats",
+);
+const sampleBonusStats = expectDefined(
+  sampleDndBeyondCharacterResponse.data.bonusStats,
+  "sample bonus stats",
+);
+const sampleOverrideStats = expectDefined(
+  sampleDndBeyondCharacterResponse.data.overrideStats,
+  "sample override stats",
+);
+const sampleModifiers = expectDefined(
+  sampleDndBeyondCharacterResponse.data.modifiers,
+  "sample modifiers",
+);
+const sampleClassModifiers = expectDefined(
+  sampleModifiers.class,
+  "sample class modifiers",
+);
+
 describe("dndBeyondCharacterImport", () => {
   test("rejects a non-URL string", () => {
     expect(() => parseDndBeyondCharacterUrl("not-a-url")).toThrow(
@@ -201,9 +222,7 @@ describe("dndBeyondCharacterImport", () => {
     expect(() =>
       normalizeDndBeyondCharacter({
         ...sampleDndBeyondCharacterResponse.data,
-        stats: sampleDndBeyondCharacterResponse.data.stats.filter(
-          (stat) => stat.id !== 6,
-        ),
+        stats: sampleStats.filter((stat) => stat.id !== 6),
       }),
     ).toThrow(/missing charisma data/i);
   });
@@ -254,17 +273,16 @@ describe("dndBeyondCharacterImport", () => {
       currentHitPoints: 31,
       overrideHitPoints: 44,
       bonusHitPoints: 6,
-      bonusStats: sampleDndBeyondCharacterResponse.data.bonusStats.map(
-        (stat) => (stat.id === 2 ? { ...stat, value: 5 } : stat),
+      bonusStats: sampleBonusStats.map((stat) =>
+        stat.id === 2 ? { ...stat, value: 5 } : stat,
       ),
-      overrideStats: sampleDndBeyondCharacterResponse.data.overrideStats.map(
-        (stat) =>
-          stat.id === 2
-            ? {
-                ...stat,
-                value: 20,
-              }
-            : stat,
+      overrideStats: sampleOverrideStats.map((stat) =>
+        stat.id === 2
+          ? {
+              ...stat,
+              value: 20,
+            }
+          : stat,
       ),
     });
 
@@ -564,9 +582,9 @@ describe("dndBeyondCharacterImport", () => {
     const result = normalizeDndBeyondCharacter({
       ...sampleDndBeyondCharacterResponse.data,
       modifiers: {
-        ...sampleDndBeyondCharacterResponse.data.modifiers,
+        ...sampleModifiers,
         class: [
-          ...sampleDndBeyondCharacterResponse.data.modifiers.class,
+          ...sampleClassModifiers,
           {
             type: "bonus",
             subType: "hit-points-per-level",
@@ -586,7 +604,7 @@ describe("dndBeyondCharacterImport", () => {
     const result = normalizeDndBeyondCharacter({
       ...sampleDndBeyondCharacterResponse.data,
       modifiers: {
-        ...sampleDndBeyondCharacterResponse.data.modifiers,
+        ...sampleModifiers,
         item: [
           {
             type: "bonus",
@@ -607,9 +625,9 @@ describe("dndBeyondCharacterImport", () => {
     const result = normalizeDndBeyondCharacter({
       ...sampleDndBeyondCharacterResponse.data,
       modifiers: {
-        ...sampleDndBeyondCharacterResponse.data.modifiers,
+        ...sampleModifiers,
         class: [
-          ...sampleDndBeyondCharacterResponse.data.modifiers.class,
+          ...sampleClassModifiers,
           {
             type: "bonus",
             subType: "hit-points-per-level",
@@ -638,9 +656,9 @@ describe("dndBeyondCharacterImport", () => {
       ...sampleDndBeyondCharacterResponse.data,
       overrideHitPoints: 50,
       modifiers: {
-        ...sampleDndBeyondCharacterResponse.data.modifiers,
+        ...sampleModifiers,
         class: [
-          ...sampleDndBeyondCharacterResponse.data.modifiers.class,
+          ...sampleClassModifiers,
           {
             type: "bonus",
             subType: "hit-points-per-level",


### PR DESCRIPTION
## Summary
- align the shared D&D Beyond fixture with the current `DndBeyondCharacterData` contract
- remove stale fixture-only fields that no longer exist on the import contract
- replace direct optional normalized-field assertions with explicit narrowing in the D&D Beyond import tests

## Validation
- `npx tsc --noEmit`
- `npm run test:unit -- tests/unit/import/dndBeyondCharacterImport.test.ts`
- `npm run lint`
- `npm run build`

## Blocked In This Environment
- `npm run test:integration -- tests/integration/import/characterImport.integration.test.ts`
- `npx playwright test tests/e2e/combat.spec.ts --grep "import a D&D Beyond character"`

Both blocked commands fail because `testcontainers` cannot find a working container runtime in this environment, so MongoDB-backed integration/E2E tests cannot start.

## Scope Notes
- no production import contracts were loosened
- the change is limited to fixtures and tests for issue #138