### PR TITLE
feat: extract isUserAdmin to lib/permissions with null sentinel for DB errors

### DIFF
--- a/app/api/monsters/global/[id]/route.ts
+++ b/app/api/monsters/global/[id]/route.ts
@@ -1,21 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ObjectId } from 'mongodb';
 import { requireAuth } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
 import { MonsterTemplate, normalizeAlignment } from '@/lib/types';
-import { getDatabase } from '@/lib/db';
-
-// Helper to check if user is admin
-async function isUserAdmin(userId: string): Promise<boolean> {
-  try {
-    const db = await getDatabase();
-    const user = await db.collection('users').findOne({ _id: new ObjectId(userId) });
-    return user?.isAdmin === true;
-  } catch (error) {
-    console.error('Error checking admin status:', error);
-    return false;
-  }
-}
+import { isUserAdmin } from '@/lib/permissions';
 
 export async function GET(
   request: NextRequest,
@@ -55,8 +42,10 @@ export async function PUT(
     return auth;
   }
 
-  // Check if user is admin
   const admin = await isUserAdmin(auth.userId);
+  if (admin === null) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
   if (!admin) {
     return NextResponse.json(
       { error: 'Only administrators can modify global monster templates' },
@@ -185,8 +174,10 @@ export async function DELETE(
     return auth;
   }
 
-  // Check if user is admin
   const admin = await isUserAdmin(auth.userId);
+  if (admin === null) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
   if (!admin) {
     return NextResponse.json(
       { error: 'Only administrators can delete global monster templates' },

--- a/app/api/monsters/global/route.ts
+++ b/app/api/monsters/global/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ObjectId } from 'mongodb';
 import { requireAuth } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
 import { MonsterTemplate, normalizeAlignment } from '@/lib/types';
@@ -7,18 +6,7 @@ import { GLOBAL_USER_ID } from '@/lib/constants';
 import { getDatabase } from '@/lib/db';
 import { ALL_SRD_MONSTERS } from '@/lib/data/monsters';
 import { randomUUID } from 'crypto';
-
-// Helper to check if user is admin
-async function isUserAdmin(userId: string): Promise<boolean> {
-  try {
-    const db = await getDatabase();
-    const user = await db.collection('users').findOne({ _id: new ObjectId(userId) });
-    return user?.isAdmin === true;
-  } catch (error) {
-    console.error('Error checking admin status:', error);
-    return false;
-  }
-}
+import { isUserAdmin } from '@/lib/permissions';
 
 export async function GET(request: NextRequest) {
   try {
@@ -40,8 +28,10 @@ export async function POST(request: NextRequest) {
     return auth;
   }
 
-  // Check if user is admin
   const admin = await isUserAdmin(auth.userId);
+  if (admin === null) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
   if (!admin) {
     return NextResponse.json(
       { error: 'Only administrators can create global monster templates' },
@@ -163,8 +153,10 @@ export async function PUT(request: NextRequest) {
     return auth;
   }
 
-  // Check if user is admin
   const admin = await isUserAdmin(auth.userId);
+  if (admin === null) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
   if (!admin) {
     return NextResponse.json(
       { error: 'Only administrators can seed the monster library' },

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,0 +1,15 @@
+import { ObjectId } from 'mongodb';
+import { getDatabase } from '@/lib/db';
+
+export async function isUserAdmin(userId: string): Promise<boolean | null> {
+  try {
+    const db = await getDatabase();
+    const user = await db.collection('users').findOne({ _id: new ObjectId(userId) });
+    return user?.isAdmin === true;
+  } catch (err) {
+    if (err instanceof Error && err.name !== 'BSONError') {
+      console.error('isUserAdmin: DB error for userId', userId, err);
+    }
+    return null;
+  }
+}

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -7,9 +7,7 @@ export async function isUserAdmin(userId: string): Promise<boolean | null> {
     const user = await db.collection('users').findOne({ _id: new ObjectId(userId) });
     return user?.isAdmin === true;
   } catch (err) {
-    if (err instanceof Error && err.name !== 'BSONError') {
-      console.error('isUserAdmin: DB error for userId', userId, err);
-    }
+    console.error('isUserAdmin: error checking admin status for userId', userId, err);
     return null;
   }
 }

--- a/openspec/changes/extract-isuseradmin-permissions-helper/.openspec.yaml
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-04-16

--- a/openspec/changes/extract-isuseradmin-permissions-helper/design.md
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/design.md
@@ -1,0 +1,119 @@
+## Context
+
+- Relevant architecture: Next.js API routes with JWT auth (`lib/middleware.ts`), MongoDB via `lib/db.ts`. Auth/authz deliberately separated: `requireAuth` verifies identity (returns 401), `isUserAdmin` checks role (returns boolean). Routes compose both.
+- Dependencies: `lib/db.ts` (`getDatabase`), `mongodb` (`ObjectId`), `@testcontainers/mongodb` (integration tests).
+- Interfaces/contracts touched: `app/api/monsters/global/route.ts` (POST, GET-seed), `app/api/monsters/global/[id]/route.ts` (PUT, DELETE). No external API contract changes — same HTTP status codes for successful admin/non-admin paths.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Single canonical `isUserAdmin` in `lib/permissions.ts`
+- Null sentinel return on DB error → callers surface 500
+- Real MongoDB integration test
+- No behavior change for successful admin/non-admin checks
+
+### Non-Goals
+
+- RequireAdmin UI component (tracked in #143)
+- Permission matrix or user tier system
+- Changes to authentication layer
+
+## Decisions
+
+### Decision 1: Return type `Promise<boolean | null>`
+
+- Chosen: `null` sentinel for DB errors; `true`/`false` for resolved admin status.
+- Alternatives considered: (a) throw on error — caller must try/catch at every call site; (b) return `false` always — silent 403 masks DB failures.
+- Rationale: Null sentinel is type-safe (TypeScript enforces handling), avoids hidden control flow from throws, and keeps caller logic flat (`if (admin === null)` → 500).
+- Trade-offs: Callers must check three states instead of two. Acceptable given only two call sites, both updated together.
+
+### Decision 2: `lib/permissions.ts` as new home
+
+- Chosen: New dedicated file for authorization logic.
+- Alternatives considered: (a) `lib/auth.ts` — wrong layer, handles JWT/password; (b) `lib/middleware.ts` — HTTP request layer, wrong abstraction level.
+- Rationale: Authorization is a distinct concern. Dedicated file positions cleanly for future role/tier expansion without touching auth or middleware.
+- Trade-offs: New file vs. slightly larger existing files. Net positive — clear conceptual boundary.
+
+### Decision 3: Integration test seeds via direct MongoDB write
+
+- Chosen: After user registration via API, directly update `users` collection to set `isAdmin: true`.
+- Alternatives considered: Expose admin-grant API endpoint (out of scope, security risk), mock DB (defeats purpose).
+- Rationale: Follows existing pattern in `auth.test.helpers.ts`. Testcontainer lifecycle already established.
+- Trade-offs: Test couples to DB schema field name `isAdmin`. Acceptable — schema is stable and the field is the very thing under test.
+
+## Proposal to Design Mapping
+
+- Proposal element: Extract `isUserAdmin` to `lib/permissions.ts`
+  - Design decision: Decision 2 (new dedicated file)
+  - Validation approach: TypeScript import resolves; existing callers updated
+- Proposal element: Surface DB errors as null → 500
+  - Design decision: Decision 1 (null sentinel)
+  - Validation approach: Integration test with DB failure simulation OR type-checking enforces null handling
+- Proposal element: Real MongoDB integration test
+  - Design decision: Decision 3 (direct collection write for seeding)
+  - Validation approach: `permissions.test.ts` passes in Docker CI environment
+
+## Functional Requirements Mapping
+
+- Requirement: `isUserAdmin` returns `true` for admin user
+  - Design element: `lib/permissions.ts` → DB lookup → `user.isAdmin === true`
+  - Acceptance criteria reference: specs/permissions/spec.md
+  - Testability notes: Integration test seeds admin user, asserts return value
+
+- Requirement: `isUserAdmin` returns `false` for non-admin user
+  - Design element: `user.isAdmin !== true` or user not found
+  - Acceptance criteria reference: specs/permissions/spec.md
+  - Testability notes: Integration test uses registered user without isAdmin flag
+
+- Requirement: `isUserAdmin` returns `null` on DB error
+  - Design element: catch block returns `null` instead of `false`
+  - Acceptance criteria reference: specs/permissions/spec.md
+  - Testability notes: Unit test with mocked `getDatabase` that throws
+
+- Requirement: Routes return 500 on null from `isUserAdmin`
+  - Design element: Call sites in both route files check `admin === null`
+  - Acceptance criteria reference: specs/routes/spec.md
+  - Testability notes: Integration test or manual verification of route response
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: DB errors must not silently return wrong HTTP status
+  - Design element: Null sentinel + 500 at call sites
+  - Acceptance criteria reference: specs/permissions/spec.md
+  - Testability notes: Error path must be covered by test
+
+- Requirement category: security
+  - Requirement: No change to admin check logic — same DB field, same truthiness test
+  - Design element: Extracted function is character-for-character equivalent to current implementation (minus error swallowing)
+  - Acceptance criteria reference: specs/permissions/spec.md
+  - Testability notes: Code review; existing route behavior tests unchanged
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Null check missed at a call site
+  - Impact: DB error returns 403 (existing behavior, not regression)
+  - Mitigation: TypeScript `boolean | null` return type forces explicit handling at both call sites
+
+- Risk/trade-off: Testcontainer startup time in CI
+  - Impact: Slower integration test suite
+  - Mitigation: Reuse existing container lifecycle from `monsters.integration.test.ts`
+
+## Rollback / Mitigation
+
+- Rollback trigger: Integration test failures in CI; route regression in staging
+- Rollback steps: Revert `lib/permissions.ts` creation and route edits; restore local `isUserAdmin` definitions in both route files
+- Data migration considerations: None — no schema changes
+- Verification after rollback: Existing monster route tests pass; admin operations behave as before
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Investigate test failure root cause — do not bypass or skip integration tests.
+- If security checks fail: Do not merge. Authorization logic changes require clean security scan.
+- If required reviews are blocked/stale: Ping reviewer after 24h; escalate to maintainer after 48h.
+- Escalation path and timeout: Maintainer (dougis) has final call. No auto-merge.
+
+## Open Questions
+
+No unresolved questions. All design decisions finalized during exploration for #134.

--- a/openspec/changes/extract-isuseradmin-permissions-helper/proposal.md
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/proposal.md
@@ -1,0 +1,71 @@
+## GitHub Issues
+
+- #134
+
+## Why
+
+- Problem statement: `isUserAdmin` is defined verbatim in two production files (`app/api/monsters/global/route.ts` and `app/api/monsters/global/[id]/route.ts`). Bodies are character-for-character identical. Duplication creates drift risk and no canonical home for authorization logic.
+- Why now: Blocker #141 (test suite cleanup) is closed. Integration test infrastructure is honest. Safe to add real authorization test.
+- Business/user impact: Silent DB error swallowing means a MongoDB failure silently masquerades as a 403 — admin ops fail with wrong status code and no server-side signal. Fix surfaces these as 500.
+
+## Problem Space
+
+- Current behavior: Both route files define `isUserAdmin` locally. On DB error, function catches, logs, returns `false` — caller returns 403 instead of 500.
+- Desired behavior: Single `lib/permissions.ts` export. DB errors surface as `null` return → callers return 500. No behavior change for successful admin/non-admin checks.
+- Constraints: Must not change existing auth/authz separation. `requireAuth` (middleware) handles identity; `isUserAdmin` (permissions) handles role. Routes compose both independently.
+- Assumptions: No other callers of `isUserAdmin` exist (confirmed — only these two route files).
+- Edge cases considered: DB error during admin check → null sentinel → 500 (not silent 403). User not found → `false` (not admin). ObjectId parse error on malformed userId → null sentinel → 500.
+
+## Scope
+
+### In Scope
+
+- New `lib/permissions.ts` with exported `isUserAdmin(userId): Promise<boolean | null>`
+- Remove local `isUserAdmin` from `app/api/monsters/global/route.ts`
+- Remove local `isUserAdmin` from `app/api/monsters/global/[id]/route.ts`
+- Update both route files to import from `lib/permissions` and handle null → 500
+- New `tests/integration/permissions.test.ts` using real MongoDB via testcontainer
+
+### Out of Scope
+
+- `RequireAdmin` page-level component (tracked in #143)
+- `getUserTier` or `hasPermission` future extensions (noted as future shape only)
+- Any changes to `lib/middleware.ts` or `requireAuth`
+- Frontend changes
+
+## What Changes
+
+- `lib/permissions.ts` — NEW: exports `isUserAdmin`
+- `app/api/monsters/global/route.ts` — EDIT: remove local fn, import from lib/permissions, handle null
+- `app/api/monsters/global/[id]/route.ts` — EDIT: same
+- `tests/integration/permissions.test.ts` — NEW: real MongoDB integration test
+
+## Risks
+
+- Risk: Null sentinel changes call-site logic — missed null check returns 403 instead of 500 on DB error.
+  - Impact: Wrong status code; existing behavior (silent 403) rather than regression.
+  - Mitigation: Both call sites updated in same PR. TypeScript forces handling of `boolean | null` return type.
+
+- Risk: Integration test flakiness from testcontainer startup.
+  - Impact: CI noise.
+  - Mitigation: Pattern already established in `monsters.integration.test.ts` — reuse same container lifecycle.
+
+## Open Questions
+
+No unresolved ambiguity. All decisions finalized during exploration session for #134:
+- Extract location: `lib/permissions.ts` ✓
+- Error surfacing: null sentinel → 500 ✓
+- Test approach: real MongoDB via testcontainer ✓
+- `RequireAdmin` component: deferred to #143 ✓
+
+## Non-Goals
+
+- Changing authentication logic (`lib/middleware.ts`, `requireAuth`)
+- Adding user tier or permission matrix system
+- Frontend redirect behavior for non-admin users (deferred to #143)
+- Changing error messages returned to clients
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/extract-isuseradmin-permissions-helper/specs/permissions/spec.md
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/specs/permissions/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Shared `isUserAdmin` authorization helper
+
+The system SHALL export `isUserAdmin(userId: string): Promise<boolean | null>` from `lib/permissions.ts`, returning `true` for admin users, `false` for non-admin users, and `null` on DB error.
+
+#### Scenario: Admin user lookup succeeds
+
+- **Given** a MongoDB user document exists with `isAdmin: true` for the given userId
+- **When** `isUserAdmin(userId)` is called
+- **Then** the function returns `true`
+
+#### Scenario: Non-admin user lookup succeeds
+
+- **Given** a MongoDB user document exists without `isAdmin: true` for the given userId
+- **When** `isUserAdmin(userId)` is called
+- **Then** the function returns `false`
+
+#### Scenario: User not found
+
+- **Given** no MongoDB user document exists for the given userId
+- **When** `isUserAdmin(userId)` is called
+- **Then** the function returns `false`
+
+#### Scenario: DB error during lookup
+
+- **Given** the MongoDB connection fails or throws during the query
+- **When** `isUserAdmin(userId)` is called
+- **Then** the function returns `null` (not `false`, not throws)
+
+#### Scenario: Invalid ObjectId format
+
+- **Given** the userId string cannot be parsed as a valid MongoDB ObjectId
+- **When** `isUserAdmin(userId)` is called
+- **Then** the function returns `null`
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Admin check in global monster routes
+
+The system SHALL check admin status by importing `isUserAdmin` from `lib/permissions.ts` instead of using a locally-defined function.
+
+#### Scenario: Behavior unchanged for admin user
+
+- **Given** an authenticated user who is an admin
+- **When** a POST to `/api/monsters/global` or PUT/DELETE to `/api/monsters/global/[id]` is made
+- **Then** the route proceeds identically to current behavior (no HTTP-visible change)
+
+#### Scenario: Behavior unchanged for non-admin user
+
+- **Given** an authenticated user who is not an admin
+- **When** a POST to `/api/monsters/global` or PUT/DELETE to `/api/monsters/global/[id]` is made
+- **Then** the route returns 403 identically to current behavior
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Local `isUserAdmin` definitions in route files
+
+Reason for removal: Duplication eliminated by extraction to `lib/permissions.ts`. Local definitions in `app/api/monsters/global/route.ts` and `app/api/monsters/global/[id]/route.ts` are removed.
+
+## Traceability
+
+- Proposal element "Extract isUserAdmin to lib/permissions.ts" → Requirement: ADDED Shared helper
+- Proposal element "Surface DB errors as null → 500" → Requirement: ADDED (null on DB error scenario)
+- Design decision 1 (null sentinel) → ADDED scenarios: "DB error" and "Invalid ObjectId"
+- Design decision 2 (lib/permissions.ts) → MODIFIED requirement: admin check in routes
+- Requirement ADDED → Task: Create lib/permissions.ts, Write permissions.test.ts
+- Requirement MODIFIED → Task: Update route.ts and [id]/route.ts imports
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: DB failure does not silently return wrong status
+
+- **Given** MongoDB is unavailable
+- **When** an admin-protected route is called
+- **Then** the route returns HTTP 500 (not 403)
+
+### Requirement: Security
+
+#### Scenario: Admin check uses same field and logic as before
+
+- **Given** the extracted `isUserAdmin` implementation
+- **When** compared to the original local implementations
+- **Then** the DB field checked (`isAdmin`), the collection queried (`users`), and the truthiness test (`=== true`) are identical — no behavior change for the success path

--- a/openspec/changes/extract-isuseradmin-permissions-helper/specs/routes/spec.md
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/specs/routes/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Routes handle null from `isUserAdmin` as 500
+
+The system SHALL return HTTP 500 with `{ error: 'Internal server error' }` when `isUserAdmin` returns `null`.
+
+#### Scenario: DB error during admin check on POST /api/monsters/global
+
+- **Given** an authenticated request to POST `/api/monsters/global`
+- **When** `isUserAdmin` returns `null` due to a DB error
+- **Then** the route returns HTTP 500
+
+#### Scenario: DB error during admin check on PUT /api/monsters/global/[id]
+
+- **Given** an authenticated request to PUT `/api/monsters/global/[id]`
+- **When** `isUserAdmin` returns `null` due to a DB error
+- **Then** the route returns HTTP 500
+
+#### Scenario: DB error during admin check on DELETE /api/monsters/global/[id]
+
+- **Given** an authenticated request to DELETE `/api/monsters/global/[id]`
+- **When** `isUserAdmin` returns `null` due to a DB error
+- **Then** the route returns HTTP 500
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Routes import `isUserAdmin` from shared module
+
+The system SHALL import `isUserAdmin` from `lib/permissions` rather than defining it locally.
+
+#### Scenario: Import resolves correctly
+
+- **Given** `lib/permissions.ts` exists and exports `isUserAdmin`
+- **When** TypeScript compiles the route files
+- **Then** no import errors; function signature matches expected `Promise<boolean | null>`
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Locally-defined `isUserAdmin` in route files
+
+Reason for removal: Both local definitions deleted. Import from `lib/permissions` replaces them.
+
+## Traceability
+
+- Proposal element "Update both route files to import from lib/permissions and handle null → 500" → Requirement: ADDED null → 500 handling
+- Design decision 1 (null sentinel) → ADDED scenarios for each route
+- Requirement ADDED → Task: Update route.ts, Update [id]/route.ts
+- Requirement MODIFIED → Task: Update route.ts, Update [id]/route.ts
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No silent status code downgrade
+
+- **Given** DB failure during admin check
+- **When** any admin-protected route is called
+- **Then** caller receives 500, never a silent 403 masking the infrastructure failure

--- a/openspec/changes/extract-isuseradmin-permissions-helper/tasks.md
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/tasks.md
@@ -1,0 +1,99 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/extract-isuseradmin-permissions` then immediately `git push -u origin feat/extract-isuseradmin-permissions`
+
+## Execution
+
+### 1. Create `lib/permissions.ts`
+
+- [x] Create `lib/permissions.ts` exporting `isUserAdmin(userId: string): Promise<boolean | null>`
+- [x] Implement: `getDatabase()` → `users` collection → `findOne({ _id: new ObjectId(userId) })` → return `user?.isAdmin === true`
+- [x] On catch (including ObjectId parse error): return `null`
+- [x] Verify TypeScript compiles: `npx tsc --noEmit`
+
+### 2. Write integration test (TDD — before touching routes)
+
+- [x] Create `tests/integration/permissions.test.ts`
+- [x] Reuse testcontainer + Next.js server lifecycle from `tests/integration/monsters.integration.test.ts`
+- [x] Seed admin user: register via API, then directly set `isAdmin: true` in `users` collection
+- [x] Test: admin user → `isUserAdmin` returns `true`
+- [x] Test: non-admin user → `isUserAdmin` returns `false`
+- [x] Test: unknown userId → `isUserAdmin` returns `false`
+- [x] Run: `npm run test:integration` — confirm tests pass
+
+### 3. Update `app/api/monsters/global/route.ts`
+
+- [x] Remove local `isUserAdmin` function definition (lines ~11–22)
+- [x] Add import: `import { isUserAdmin } from '@/lib/permissions';`
+- [x] At each call site (`admin = await isUserAdmin(...)`), add null check: `if (admin === null) return NextResponse.json({ error: 'Internal server error' }, { status: 500 });`
+- [x] Verify TypeScript compiles: `npx tsc --noEmit`
+
+### 4. Update `app/api/monsters/global/[id]/route.ts`
+
+- [x] Remove local `isUserAdmin` function definition (lines ~8–19)
+- [x] Add import: `import { isUserAdmin } from '@/lib/permissions';`
+- [x] At each call site, add null check → 500 (same pattern as above)
+- [x] Verify TypeScript compiles: `npx tsc --noEmit`
+
+### 5. Review for duplication and unnecessary complexity
+
+- [x] Confirm no other `isUserAdmin` definitions remain: `grep -r "isUserAdmin" app/`
+- [x] Confirm single export in `lib/permissions.ts`
+- [x] Confirm all acceptance criteria covered (specs/permissions/spec.md, specs/routes/spec.md)
+
+## Validation
+
+- [x] `npx tsc --noEmit` — no type errors
+- [x] `npm run test:unit` — all unit tests pass
+- [x] `npm run test:integration` — `permissions.test.ts` passes alongside existing integration tests
+- [x] `npm run build` — production build succeeds
+- [x] `grep -r "function isUserAdmin" app/` returns empty (no local definitions remain)
+- [ ] All completed tasks marked as complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [ ] Run required pre-PR self-review before committing
+- [ ] Commit all changes to `feat/extract-isuseradmin-permissions` and push to remote
+- [ ] Open PR from `feat/extract-isuseradmin-permissions` to `main`; reference `#134` in PR body
+- [ ] Wait 120 seconds for agentic reviewers to post comments
+- [ ] **Monitor PR comments** — address each comment, commit fixes, validate locally (remote push validation), push; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — if any check fails, diagnose, fix, commit, validate locally, push; repeat until all checks pass
+- [ ] Wait for PR to merge — **never force-merge**; if human force-merges, continue to Post-Merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): agentic reviewers + dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No doc updates required (no public API change)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec) if applicable
+- [ ] Archive: move `openspec/changes/extract-isuseradmin-permissions-helper/` to `openspec/changes/archive/YYYY-MM-DD-extract-isuseradmin-permissions-helper/` — stage both copy and deletion in a single commit
+- [ ] Confirm archive exists and original path is gone
+- [ ] Commit and push archive to `main` in one commit
+- [ ] Prune: `git fetch --prune` and `git branch -d feat/extract-isuseradmin-permissions`
+- [ ] Close GitHub issue #134

--- a/openspec/changes/extract-isuseradmin-permissions-helper/tests.md
+++ b/openspec/changes/extract-isuseradmin-permissions-helper/tests.md
@@ -1,0 +1,79 @@
+---
+name: tests
+description: Tests for extract-isuseradmin-permissions-helper
+---
+
+# Tests
+
+## Overview
+
+Tests for extracting `isUserAdmin` into `lib/permissions.ts`. All work follows strict TDD: failing test first, implement to pass, refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2. **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3. **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### Task 2 — Integration test for `isUserAdmin` (write BEFORE implementation)
+
+File: `tests/integration/permissions.test.ts`
+Maps to: specs/permissions/spec.md (all ADDED scenarios)
+
+- [ ] **Admin user returns `true`**
+  - Seed: register user via API, set `isAdmin: true` directly in MongoDB `users` collection
+  - Call `isUserAdmin(userId)` directly
+  - Assert: returns `true`
+  - Spec: "Admin user lookup succeeds"
+
+- [ ] **Non-admin user returns `false`**
+  - Seed: register user via API (no `isAdmin` flag)
+  - Call `isUserAdmin(userId)`
+  - Assert: returns `false`
+  - Spec: "Non-admin user lookup succeeds"
+
+- [ ] **Unknown userId returns `false`**
+  - Use a valid ObjectId that does not exist in the `users` collection
+  - Call `isUserAdmin(userId)`
+  - Assert: returns `false`
+  - Spec: "User not found"
+
+- [ ] **Invalid ObjectId format returns `null`**
+  - Call `isUserAdmin("not-a-valid-objectid")`
+  - Assert: returns `null`
+  - Spec: "Invalid ObjectId format"
+
+### Task 1 — `lib/permissions.ts` (implement against failing tests above)
+
+- [ ] TypeScript compiles with `boolean | null` return type
+  - Run: `npx tsc --noEmit`
+  - Assert: no errors on `lib/permissions.ts` import in route files
+
+### Tasks 3 & 4 — Route files (verify no regression)
+
+File: `tests/integration/monsters.integration.test.ts` (existing)
+Maps to: specs/routes/spec.md (MODIFIED requirement)
+
+- [ ] **Existing monster route integration tests still pass after route edits**
+  - Run: `npm run test:integration`
+  - Assert: all tests in `monsters.integration.test.ts` pass unchanged
+  - Spec: "Behavior unchanged for admin/non-admin user"
+
+- [ ] **No local `isUserAdmin` definitions remain**
+  - Run: `grep -r "function isUserAdmin" app/`
+  - Assert: empty output
+  - Spec: REMOVED requirement
+
+### Validation commands (run in order)
+
+```bash
+npx tsc --noEmit
+npm run test:unit
+npm run test:integration
+npm run build
+grep -r "function isUserAdmin" app/    # must return empty
+```

--- a/tests/integration/permissions.test.ts
+++ b/tests/integration/permissions.test.ts
@@ -1,0 +1,68 @@
+import { MongoClient, ObjectId } from "mongodb";
+import { startTestServer, registerAndGetCookie, TestServer } from "./helpers/server";
+
+describe("isUserAdmin Integration Tests", () => {
+  let server: TestServer;
+  let baseUrl: string;
+  let mongoClient: MongoClient;
+  let isUserAdmin: (userId: string) => Promise<boolean | null>;
+
+  beforeAll(async () => {
+    server = await startTestServer();
+    baseUrl = server.baseUrl;
+
+    // Must follow startTestServer() so MONGODB_URI is set before the module-level constant runs
+    jest.resetModules();
+    const mod = await import("@/lib/permissions");
+    isUserAdmin = mod.isUserAdmin;
+
+    mongoClient = new MongoClient(process.env.MONGODB_URI!);
+    await mongoClient.connect();
+  }, 120000);
+
+  afterAll(async () => {
+    await mongoClient.close();
+    await server.cleanup();
+  }, 30000);
+
+  async function registerUser(emailSuffix: string): Promise<{ userId: string }> {
+    const email = `permissions-test-${emailSuffix}-${Date.now()}@example.com`;
+    await registerAndGetCookie(baseUrl, email, "TestPassword123!");
+
+    const db = mongoClient.db(process.env.MONGODB_DB);
+    const user = await db.collection("users").findOne({ email });
+    if (!user) throw new Error(`User not found after registration: ${email}`);
+
+    return { userId: user._id.toString() };
+  }
+
+  it("returns true for admin user", async () => {
+    const { userId } = await registerUser("admin");
+
+    const db = mongoClient.db(process.env.MONGODB_DB);
+    await db.collection("users").updateOne(
+      { _id: new ObjectId(userId) },
+      { $set: { isAdmin: true } }
+    );
+
+    const result = await isUserAdmin(userId);
+    expect(result).toBe(true);
+  });
+
+  it("returns false for non-admin user", async () => {
+    const { userId } = await registerUser("nonadmin");
+    const result = await isUserAdmin(userId);
+    expect(result).toBe(false);
+  });
+
+  it("returns false for unknown userId", async () => {
+    const unknownId = new ObjectId().toString();
+    const result = await isUserAdmin(unknownId);
+    expect(result).toBe(false);
+  });
+
+  it("returns null for malformed userId", async () => {
+    const result = await isUserAdmin("not-a-valid-object-id");
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/api/monsters/global.id.route.test.ts
+++ b/tests/unit/api/monsters/global.id.route.test.ts
@@ -1,4 +1,4 @@
-import { PUT } from "@/app/api/monsters/global/[id]/route";
+import { PUT, DELETE } from "@/app/api/monsters/global/[id]/route";
 import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import { getDatabase } from "@/lib/db";
@@ -45,4 +45,43 @@ describe("PUT /api/monsters/global/[id] — alignment validation", () => {
   });
 
   itValidatesAlignmentFieldWithParams(PUT, makeReqWith, PARAMS, 200);
+});
+
+describe("PUT /api/monsters/global/[id] — DB error during admin check", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
+  });
+
+  it("returns 500 when isUserAdmin returns null", async () => {
+    const req = makeRouteRequest(
+      `http://localhost/api/monsters/global/${EXISTING_GLOBAL_MONSTER.id}`,
+      "PUT",
+      { name: "x", maxHp: 10 }
+    );
+    const res = await PUT(req, { params: PARAMS });
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Internal server error");
+  });
+});
+
+describe("DELETE /api/monsters/global/[id] — DB error during admin check", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
+  });
+
+  it("returns 500 when isUserAdmin returns null", async () => {
+    const req = makeRouteRequest(
+      `http://localhost/api/monsters/global/${EXISTING_GLOBAL_MONSTER.id}`,
+      "DELETE"
+    );
+    const res = await DELETE(req, { params: PARAMS });
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Internal server error");
+  });
 });

--- a/tests/unit/api/monsters/global.route.test.ts
+++ b/tests/unit/api/monsters/global.route.test.ts
@@ -1,4 +1,4 @@
-import { POST } from "@/app/api/monsters/global/route";
+import { POST, PUT } from "@/app/api/monsters/global/route";
 import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import { getDatabase } from "@/lib/db";
@@ -43,4 +43,36 @@ describe("POST /api/monsters/global — alignment validation", () => {
   });
 
   itValidatesAlignmentField(POST, makeReqWith, 201);
+});
+
+describe("POST /api/monsters/global — DB error during admin check", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
+  });
+
+  it("returns 500 when isUserAdmin returns null", async () => {
+    const req = makeRouteRequest("http://localhost/api/monsters/global", "POST", BASE_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Internal server error");
+  });
+});
+
+describe("PUT /api/monsters/global — DB error during admin check", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
+  });
+
+  it("returns 500 when isUserAdmin returns null", async () => {
+    const req = makeRouteRequest("http://localhost/api/monsters/global", "PUT", {});
+    const res = await PUT(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Internal server error");
+  });
 });

--- a/tests/unit/lib/permissions.test.ts
+++ b/tests/unit/lib/permissions.test.ts
@@ -1,0 +1,56 @@
+import { isUserAdmin } from "@/lib/permissions";
+import { getDatabase } from "@/lib/db";
+
+jest.mock("@/lib/db", () => ({ getDatabase: jest.fn() }));
+jest.mock("mongodb", () => ({ ObjectId: jest.fn((id: string) => ({ id })) }));
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+function mockCollection(methods: Record<string, jest.Mock>) {
+  mockedGetDatabase.mockResolvedValue({
+    collection: jest.fn().mockReturnValue(methods),
+  } as any);
+}
+
+describe("isUserAdmin", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns true when user has isAdmin: true", async () => {
+    mockCollection({ findOne: jest.fn().mockResolvedValue({ isAdmin: true }) });
+    expect(await isUserAdmin("507f1f77bcf86cd799439011")).toBe(true);
+  });
+
+  it("returns false when user has isAdmin: false", async () => {
+    mockCollection({ findOne: jest.fn().mockResolvedValue({ isAdmin: false }) });
+    expect(await isUserAdmin("507f1f77bcf86cd799439011")).toBe(false);
+  });
+
+  it("returns false when user exists without isAdmin field", async () => {
+    mockCollection({ findOne: jest.fn().mockResolvedValue({ email: "x@example.com" }) });
+    expect(await isUserAdmin("507f1f77bcf86cd799439011")).toBe(false);
+  });
+
+  it("returns false when user not found", async () => {
+    mockCollection({ findOne: jest.fn().mockResolvedValue(null) });
+    expect(await isUserAdmin("507f1f77bcf86cd799439011")).toBe(false);
+  });
+
+  it("returns null when getDatabase throws", async () => {
+    mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
+    expect(await isUserAdmin("507f1f77bcf86cd799439011")).toBeNull();
+  });
+
+  it("returns null when findOne throws", async () => {
+    mockCollection({ findOne: jest.fn().mockRejectedValue(new Error("query failed")) });
+    expect(await isUserAdmin("507f1f77bcf86cd799439011")).toBeNull();
+  });
+
+  it("returns null when userId is malformed (ObjectId parse error)", async () => {
+    const { ObjectId } = jest.requireMock("mongodb");
+    (ObjectId as jest.Mock).mockImplementationOnce(() => {
+      throw Object.assign(new Error("bad objectid"), { name: "BSONError" });
+    });
+    mockCollection({ findOne: jest.fn() });
+    expect(await isUserAdmin("not-valid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts duplicated `isUserAdmin` from two route files into `lib/permissions.ts`
- Changes return type `boolean` → `boolean | null` — DB errors now surface as 500 instead of silent 403
- Adds `null` check before existing `!admin` → 403 check at all 4 call sites
- Adds integration test with real MongoDB via testcontainer

## Changes

- `lib/permissions.ts` — NEW: exports `isUserAdmin(userId: string): Promise<boolean | null>`
- `app/api/monsters/global/route.ts` — removes local fn, imports from lib/permissions, handles null
- `app/api/monsters/global/[id]/route.ts` — same
- `tests/integration/permissions.test.ts` — NEW: covers admin/non-admin/unknown/malformed cases

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit` — 708/708 pass
- [x] `npm run test:integration` — 57/57 pass
- [x] `npm run build` — succeeds
- [x] No local `isUserAdmin` definitions remain in `app/`

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)