### PR TITLE
feat: Concentration Tracking (OpenSpec Proposal)

### DIFF
--- a/openspec/changes/concentration-tracking/.openspec.yaml
+++ b/openspec/changes/concentration-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-04-30

--- a/openspec/changes/concentration-tracking/design.md
+++ b/openspec/changes/concentration-tracking/design.md
@@ -1,0 +1,155 @@
+## Context
+
+- Relevant architecture: Combat tracker UI (`app/combat/page.tsx`), `CombatantCard` component, `CombatantState` type
+- Dependencies: Issue #146 (spell collection) — will provide dropdown data, but free-text fallback always works
+- Interfaces/contracts touched: `CombatantState` interface (`lib/types.ts`), `adjustHp()` function behavior, turn advance logic
+
+## Goals / Non-Goals
+
+### Goals
+
+- Track which combatant is concentrating and on what spell
+- Show DC reminder when damage is dealt to a concentrator
+- Auto-clear concentration when combatant reaches 0 HP
+- Provide manual end button with confirmation toast
+- Keep UI non-blocking — no dialogs that halt combat flow
+
+### Non-Goals
+
+- Automating the CON save roll itself
+- Combat-level toggle (UI only appears when combatant has concentration set)
+- Spell validation or list management (deferred to #146)
+- HP history integration
+
+## Decisions
+
+### Decision 1: Data Model
+
+- Chosen: Add `concentrationSpell?: string` to `CombatantState`
+- Alternatives considered: Separate `ConcentrationState` object, concentration as special condition type
+- Rationale: Simplest possible addition. Single optional string field. No new types, no new collections. Logic lives in UI layer.
+- Trade-offs: No built-in validation of spell names, but free-text fallback ensures always works before #146 ships
+
+### Decision 2: DC Calculation
+
+- Chosen: `dc = max(10, Math.floor(damageDealt / 2))`
+- Alternatives considered: Custom formula per-spell (out of scope), always DC 10
+- Rationale: Matches D&D 5e PHB rule exactly. "Half damage taken, rounded down, minimum 10"
+- Trade-offs: None — this is the defined rule
+
+### Decision 3: DC Badge Trigger & Clear
+
+- Chosen: Badge appears immediately after damage to concentrator. Clears on turn advance (`nextTurn()`)
+- Alternatives considered: Badge persists until manually dismissed
+- Rationale: Badge is a momentary reminder. Once DM asks for the save roll, DC is no longer relevant. Turn advance is the natural "acknowledge and move on" gesture
+- Trade-offs: If multiple damage events happen same turn, badge updates to latest DC — correct per rules
+
+### Decision 4: Auto-Clear Trigger
+
+- Chosen: `hp === 0` triggers auto-clear (not `hp <= 0`)
+- Alternatives considered: `hp <= 0` (would trigger on temp HP cushion)
+- Rationale: D&D rule uses actual HP, not temp HP. Someone with 5 temp HP who takes 10 damage has 0 HP but is not unconscious — concentration should persist
+- Trade-offs: Slightly more complex condition (`hp === 0` not `hp <= 0`)
+
+### Decision 5: Toast Notifications
+
+- Chosen: Non-blocking toasts for both manual end and auto-clear on 0 HP
+- Alternatives considered: No notification, alert() dialog
+- Rationale: Toasts are visible but don't halt combat. DM sees the message and it fades — sufficient for awareness without disruption
+- Trade-offs: DM might miss a toast if they look away — but this is acceptable for non-critical info
+
+### Decision 6: Concentration Field in Detail Popup
+
+- Chosen: Always visible free-text input, dropdown for spell selection when focus (future: from #146)
+- Alternatives considered: Only visible on click, separate "Concentration" panel
+- Rationale: Discoverability — if DM is looking at the detail popup, they should immediately see if/where to set concentration. Simple and clear
+- Trade-offs: More fields in popup, but concentration is a single field and doesn't add much complexity
+
+## Proposal to Design Mapping
+
+| Proposal Element | Design Decision | Validation Approach |
+|-----------------|------------------|---------------------|
+| Add `concentrationSpell` field | Decision 1 | Type exists, field optional, persists to API |
+| Concentration indicator in row | CombatantCard renders 🔮 + spell name + [End] | Visual inspection |
+| End Concentration button | onClick clears field, shows toast | Unit test |
+| DC badge on damage | `adjustHp` detects concentrator, calculates DC, stores in local state | Unit test |
+| Auto-clear on 0 HP | `adjustHp` checks `hp === 0` after damage, clears if concentrating | Unit test |
+| DC badge clears on turn advance | `nextTurn` resets DC badge state | E2E test |
+| Concentration field in detail popup | Present in detail popup, saves to `concentrationSpell` | UI test |
+
+## Functional Requirements Mapping
+
+- Requirement: Combatant marked as concentrating shows 🔮 indicator
+  - Design element: `CombatantCard` checks `concentrationSpell` and renders indicator
+  - Acceptance criteria reference: (from #93 AC)
+  - Testability notes: Render with/without field, verify indicator shows/hides
+
+- Requirement: DC badge appears when damage dealt to concentrator
+  - Design element: `adjustHp` calculates and displays DC
+  - Acceptance criteria reference: AC: "auto-calculate and display CON save DC"
+  - Testability notes: Mock damage to concentrator, verify badge appears with correct DC
+
+- Requirement: End button clears concentration with toast
+  - Design element: `endConcentration` handler + toast system
+  - Acceptance criteria reference: AC: '"End concentration" button to manually clear'
+  - Testability notes: Click button, verify field cleared, toast shown
+
+- Requirement: Concentration auto-clears at 0 HP
+  - Design element: `adjustHp` checks `hp === 0` post-damage
+  - Acceptance criteria reference: AC: "Concentration clears automatically if knocked unconscious"
+  - Testability notes: Set hp to 0 via damage, verify concentration cleared, toast shown
+
+- Requirement: DC badge clears on turn advance
+  - Design element: `nextTurn` resets per-turn DC badge state
+  - Acceptance criteria reference: Implicit from non-blocking UX
+  - Testability notes: Advance turn, verify badge no longer visible
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: operability
+  - Requirement: Non-blocking UI — no alert() or confirm()
+  - Design element: Toast system, DC badge only appears in-row
+  - Acceptance criteria reference: "The DC prompt should be non-blocking"
+  - Testability notes: Damage flow produces no blocking dialogs
+
+- Requirement category: performance
+  - Requirement: DC calculation is O(1), no recomputation
+  - Design element: Simple formula, local state
+  - Acceptance criteria reference: N/A (implicit)
+  - Testability notes: Measure render time with many combatants
+
+## Risks / Trade-offs
+
+- Risk: DC badge clutters UI when many combatants concentrating
+  - Impact: Visual noise during combat
+  - Mitigation: Badge is single line, clears on turn advance, only appears after damage
+  - Trade-off accepted: Benefit outweighs noise for typical combat size
+
+- Risk: Spell name is free-form with no validation
+  - Impact: Misspelled names could cause confusion
+  - Mitigation: #146 will add spell list dropdown; free-text always works
+  - Trade-off accepted: Field is optional, DM responsible for accuracy
+
+- Risk: Temp HP edge case (`hp === 0` but not unconscious)
+  - Impact: Concentration might persist when player expects it to drop
+  - Mitigation: Rule is clear (actual HP, not temp), documented in proposal
+  - Trade-off accepted: Correct behavior per D&D rules
+
+## Rollback / Mitigation
+
+- Rollback trigger: If deployment causes unexpected behavior (e.g., DC calculation wrong)
+- Rollback steps: Revert `concentrationSpell` field from `CombatantState`, remove UI elements from `CombatantCard`
+- Data migration considerations: Existing `concentrationSpell` values become orphaned — acceptable since feature is new
+- Verification after rollback: Load existing combat, combatants with/without field render correctly
+
+## Operational Blocking Policy
+
+- If CI checks fail: Block merge. Fix test/code until CI passes.
+- If security checks fail: Block merge. Address any security concerns before proceeding.
+- If required reviews are blocked/stale: Ping PR reviewer. After 48h without response, proceed with merge if other checks pass.
+- Escalation path: Tag repo maintainer for review.
+
+## Open Questions
+
+- Question: Should toast auto-dismiss or require manual dismiss?
+  - Answer: Auto-dismiss after 3 seconds (matches existing toast pattern in codebase)

--- a/openspec/changes/concentration-tracking/proposal.md
+++ b/openspec/changes/concentration-tracking/proposal.md
@@ -1,0 +1,69 @@
+## GitHub Issues
+
+- #93
+
+## Why
+
+- Problem statement: D&D 5e spells that require concentration need to be tracked during combat. When a concentrating creature takes damage, they must make a Constitution saving throw (DC 10 or half damage taken, whichever is higher) or lose the spell. Currently, there's no mechanism to track this.
+- Why now: DM manually tracks concentration using paper notes or external tools. This is error-prone during intense combat.
+- Business/user impact: Reduces cognitive load for DMs, prevents forgotten concentration checks, provides auto-calculated DC reminders.
+
+## Problem Space
+
+- Current behavior: No concentration tracking exists. DMs must remember which combatants are concentrating, manually track when damage occurs, and calculate the DC themselves.
+- Desired behavior: Combatants can be marked as concentrating on a named spell. When damage is dealt to a concentrator, the DC is automatically calculated and displayed. Concentration clears on 0 HP or manually via button.
+- Constraints: DC calculation must follow D&D 5e rules (DC = max(10, floor(damage/2))). The DM still asks the player to roll the actual save — this is a reminder/calculator only, not a roller.
+- Assumptions: Spell names will be stored as free-form text. Spell validation is out of scope (DM can enter any text). Spell list population will be addressed by issue #146.
+- Edge cases considered: Combatant at 0 HP with temp HP still standing — only true 0 HP (not temp HP cushion) triggers auto-clear. Multiple damage sources same turn — DC badge updates per-instance. Non-blocking UX — no alert() or confirm() dialogs that halt flow.
+
+## Scope
+
+### In Scope
+
+- Add `concentrationSpell?: string` field to `CombatantState`
+- Concentration indicator in combatant row (icon + spell name)
+- End Concentration button with toast notification
+- DC badge on damage to concentrator (non-blocking reminder)
+- Auto-clear concentration when HP reaches 0 (with toast)
+- DC badge clears when turn advances
+- Concentration field in combatant detail popup
+
+### Out of Scope
+
+- Actual CON save roll (DM handles this outside app)
+- Concentration tracking toggle at combat level (always available if combatant has spell)
+- Spell validation or spell list management (deferred to #146)
+- HP history integration (concentration saves are separate from HP changes)
+
+## What Changes
+
+- `lib/types.ts`: Add `concentrationSpell?: string` to `CombatantState`
+- `app/combat/page.tsx`: Add concentration UI to `CombatantCard`, DC badge logic in `adjustHp()`, turn advance clears DC badge
+- Toast notifications for manual end and auto-clear on 0 HP
+
+## Risks
+
+- Risk: DC badge appears on every damage event, could clutter UI if many combatants are concentrating
+  - Impact: Visual noise during combat
+  - Mitigation: Badge is compact (single line) and clears automatically on turn advance
+- Risk: Spell name is free-form text with no validation
+  - Impact: DM could misspell spell names, making concentration unclear
+  - Mitigation: Future spell list from #146 will provide autocomplete; free-text still works as fallback
+
+## Open Questions
+
+- Question: Should the concentration field in detail popup be visible always, or only when clicked/focused?
+  - Needed from: Decision (leaning toward always visible for discoverability)
+  - Blocker for apply: no
+
+## Non-Goals
+
+- Automating the actual CON save roll
+- Combat-level concentration tracking toggle
+- Spell validation or spell list management (handled in #146)
+- Tracking concentration in HP history
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/concentration-tracking/specs/concentration-tracking.md
+++ b/openspec/changes/concentration-tracking/specs/concentration-tracking.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Combatant Concentration State
+
+The system SHALL allow a combatant to be marked as concentrating on a named spell.
+
+#### Scenario: Set concentration on a combatant
+
+- **Given** A combatant in an active combat
+- **When** The DM opens the combatant detail popup and enters a spell name in the Concentration field
+- **Then** The combatant row displays a concentration indicator with the spell name and an [End] button
+
+#### Scenario: End concentration manually
+
+- **Given** A combatant with an active concentration spell
+- **When** The DM clicks the [End] button on the combatant row
+- **Then** The concentration spell is cleared, the indicator is removed, and a toast appears: "[Name] ended concentration on [Spell]"
+
+### Requirement: ADDED Concentration DC Reminder
+
+The system SHALL display a DC badge when damage is dealt to a concentrating combatant.
+
+#### Scenario: DC badge appears on damage
+
+- **Given** A combatant concentrating on "Hold Person" with 45 HP
+- **When** 24 damage is dealt to the combatant
+- **Then** A DC badge appears showing "DC 12 (took 24 dmg)" where DC = max(10, floor(24/2)) = 12
+
+#### Scenario: DC badge updates on subsequent damage
+
+- **Given** A combatant concentrating with an existing DC badge showing DC 10 (took 20 dmg)
+- **When** An additional 8 damage is dealt to the combatant
+- **Then** The DC badge updates to show "DC 14 (took 28 dmg)"
+
+#### Scenario: DC badge clears on turn advance
+
+- **Given** A combatant concentrating with a visible DC badge
+- **When** The turn advances (nextTurn is called)
+- **Then** The DC badge is no longer visible
+
+### Requirement: ADDED Concentration Auto-Clear on Unconsciousness
+
+The system SHALL automatically clear concentration when a combatant reaches 0 HP.
+
+#### Scenario: Concentration clears at 0 HP
+
+- **Given** A combatant concentrating on "Hold Person" with 5 HP
+- **When** 10 damage is dealt (reducing HP to 0)
+- **Then** The concentration spell is cleared, and a toast appears: "[Name] lost concentration on Hold Person"
+
+#### Scenario: Concentration persists when temp HP absorbs damage
+
+- **Given** A combatant concentrating on "Hold Person" with 30 HP and 5 temp HP
+- **When** 10 damage is dealt (temp HP absorbs 5, actual HP drops to 25)
+- **Then** The concentration persists (HP is not 0, temp HP cushion applies)
+
+### Requirement: ADDED Concentration Field in Detail Popup
+
+The system SHALL display a concentration field in the combatant detail popup at all times.
+
+#### Scenario: Detail popup shows concentration field
+
+- **Given** Any combatant
+- **When** The DM clicks the detail toggle on the combatant row
+- **Then** The detail popup includes a "Concentration" field (free-text input)
+
+## MODIFIED Requirements
+
+None — this is a new feature with no existing requirements being modified.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+| Proposal Element | Requirement |
+|-----------------|-------------|
+| Add `concentrationSpell?: string` to CombatantState | ADDED Combatant Concentration State |
+| Concentration indicator in combatant row | ADDED Combatant Concentration State |
+| End Concentration button with toast | ADDED Combatant Concentration State |
+| DC badge on damage to concentrator | ADDED Concentration DC Reminder |
+| Auto-clear concentration on 0 HP | ADDED Concentration Auto-Clear on Unconsciousness |
+| Concentration field in detail popup | ADDED Concentration Field in Detail Popup |
+
+| Design Decision | Requirement |
+|-----------------|-------------|
+| Decision 1: Data Model | ADDED Combatant Concentration State |
+| Decision 2: DC Calculation | ADDED Concentration DC Reminder |
+| Decision 3: DC Badge Trigger & Clear | ADDED Concentration DC Reminder |
+| Decision 4: Auto-Clear Trigger | ADDED Concentration Auto-Clear on Unconsciousness |
+| Decision 5: Toast Notifications | ADDED Combatant Concentration State, Concentration Auto-Clear |
+| Decision 6: Concentration Field | ADDED Concentration Field in Detail Popup |
+
+| Requirement | Task(s) |
+|-------------|---------|
+| ADDED Combatant Concentration State | Add concentrationSpell field, add indicator in CombatantCard, add End button handler |
+| ADDED Concentration DC Reminder | Add DC badge state, calculate on damage, clear on turn advance |
+| ADDED Concentration Auto-Clear on Unconsciousness | Add hp === 0 check in adjustHp, clear concentration, show toast |
+| ADDED Concentration Field in Detail Popup | Add field to detail popup, wire to updateCombatant |
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: Non-blocking UX
+
+- **Given** A combatant concentrating, 20 damage dealt
+- **When** the DC badge appears
+- **Then** No dialog, alert, or confirmation blocks the UI; the DM can continue combat immediately
+
+#### Scenario: Toast visibility
+
+- **Given** Concentration ends (manual or auto-clear)
+- **When** Toast appears
+- **Then** Toast is visible for 3 seconds then auto-dismisses; user can continue without action

--- a/openspec/changes/concentration-tracking/tasks.md
+++ b/openspec/changes/concentration-tracking/tasks.md
@@ -1,0 +1,110 @@
+# Tasks
+
+## Preparation
+
+- [ ] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [ ] **Step 2 — Create and publish working branch:** `git checkout -b feature/concentration-tracking` then immediately `git push -u origin feature/concentration-tracking`
+
+## Execution
+
+### 1. Add concentration field to CombatantState type
+
+- [ ] Add `concentrationSpell?: string` to `CombatantState` interface in `lib/types.ts`
+- [ ] Update any type references if needed
+
+### 2. Add concentration state management in CombatantCard
+
+- [ ] Add `concentrationDc` state (displays DC badge) to `CombatantCard`
+- [ ] Wire `concentrationSpell` into the combatant row display
+- [ ] Add "End Concentration" button next to concentration indicator
+- [ ] Handle [End] click: clear `concentrationSpell`, show toast
+
+### 3. Add DC badge display logic
+
+- [ ] In `CombatantCard.adjustHp()`, after damage is calculated:
+  - Check if `combatant.concentrationSpell` is set
+  - Calculate DC: `dc = Math.max(10, Math.floor(rawDamage / 2))`
+  - Set `concentrationDc` state with `{ dc, damage: rawDamage }`
+- [ ] Render DC badge in combatant row when `concentrationDc` is set: `⚠️ DC {dc} (took {damage} dmg)`
+
+### 4. Add auto-clear on 0 HP logic
+
+- [ ] In `adjustHp()`, after damage application:
+  - If result HP === 0 and `combatant.concentrationSpell` is set
+  - Clear `concentrationSpell`
+  - Show toast: "[Name] lost concentration on [Spell]"
+  - Clear `concentrationDc` badge
+
+### 5. Clear DC badge on turn advance
+
+- [ ] In `nextTurn()` function in `CombatantContent`:
+  - Reset `concentrationDc` state for all combatants (or track per-combatant)
+  - Consider: store `concentrationDc` per-combatant in a Map or pass through `updateCombatant`
+
+### 6. Add concentration field to detail popup
+
+- [ ] In the detail popup JSX (inside `CombatantCard`):
+  - Add "Concentration" label and text input field
+  - Field always visible (not conditional on focus)
+  - On change: call `onUpdate({ concentrationSpell: value })`
+
+### 7. Add toast notification support
+
+- [ ] Verify existing toast state mechanism in `CombatantContent`
+- [ ] If not present, add toast state: `{ message: string, type: 'success' | 'error' }`
+- [ ] End concentration toast: `"[Name] ended concentration on [Spell]"`
+- [ ] Auto-clear toast: `"[Name] lost concentration on [Spell]"`
+
+## Validation
+
+- [ ] Run unit tests: `npm test -- --testPathPattern="combat"` — all pass
+- [ ] Run type checks: `npm run typecheck` — no errors
+- [ ] Run build: `npm run build` — succeeds
+- [ ] Manual verification: Open combat, set concentration on a combatant, deal damage, verify DC badge appears, advance turn, verify badge clears
+
+All completed tasks marked as complete.
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — run `npm test -- --testPathPattern="combat"`; all must pass
+- **Type checks** — run `npm run typecheck`; no errors
+- **Build** — run `npm run build`; must succeed with no errors
+
+If **ANY** of the above fail, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review from `skills/openspec-apply-change/SKILL.md` before committing
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `feature/concentration-tracking` to `main`
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, validate locally, push, wait 180 seconds, repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously; when any CI check fails, diagnose and fix, commit, validate locally, push, wait 180 seconds, repeat until all checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+
+Ownership metadata:
+
+- Implementer: AI agent (human review before merge)
+- Reviewer(s): Human reviewer required
+- Required approvals: 1 (human approval)
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change
+- [ ] Sync approved spec deltas into `openspec/specs/`
+- [ ] Archive the change: move `openspec/changes/concentration-tracking/` to `openspec/changes/archive/YYYY-MM-DD-concentration-tracking/` and stage both the new location and the deletion of the old location in a single commit
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-concentration-tracking/` exists and `openspec/changes/concentration-tracking/` is gone
+- [ ] Commit and push the archive to main in one commit
+- [ ] Prune merged local feature branches: `git fetch --prune` and `git branch -d feature/concentration-tracking`

--- a/openspec/changes/concentration-tracking/tests.md
+++ b/openspec/changes/concentration-tracking/tests.md
@@ -1,0 +1,115 @@
+---
+name: tests
+description: Tests for the concentration-tracking change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `concentration-tracking` change. All work should follow a strict TDD (Test-Driven Development) process: write failing tests first, then implement against them, then refactor.
+
+Testing framework: Jest + React Testing Library (matching existing project patterns)
+
+## Test Cases
+
+### Task 1: Add concentration field to CombatantState type
+
+- [ ] `concentrationSpell` field is optional on `CombatantState`
+- [ ] TypeScript compilation succeeds with new field
+- [ ] Field persists through combat state save/load cycle
+
+### Task 2: Add concentration state management in CombatantCard
+
+- [ ] **Given** a combatant with `concentrationSpell: "Hold Person"`
+- [ ] **When** the `CombatantCard` renders
+- [ ] **Then** a concentration indicator (🔮 icon) and "Hold Person" text appear in the row
+
+- [ ] **Given** a combatant with `concentrationSpell` set
+- [ ] **When** the [End] button is clicked
+- [ ] **Then** `concentrationSpell` is cleared and a toast appears
+
+### Task 3: Add DC badge display logic
+
+- [ ] **Given** a combatant concentrating on "Hold Person" with 45 HP
+- [ ] **When** 24 damage is dealt
+- [ ] **Then** DC badge shows "⚠️ DC 12 (took 24 dmg)" where dc = max(10, floor(24/2)) = 12
+
+- [ ] **Given** a combatant with existing DC badge showing DC 10 (took 20 dmg)
+- [ ] **When** an additional 8 damage is dealt
+- [ ] **Then** DC badge updates to "DC 14 (took 28 dmg)"
+
+- [ ] **Given** a combatant not concentrating
+- [ ] **When** 20 damage is dealt
+- [ ] **Then** No DC badge appears
+
+### Task 4: Add auto-clear on 0 HP logic
+
+- [ ] **Given** a combatant concentrating on "Hold Person" with 5 HP
+- [ ] **When** 10 damage is dealt (reducing HP to 0)
+- [ ] **Then** `concentrationSpell` is cleared, and a toast appears: "[Name] lost concentration on Hold Person"
+
+- [ ] **Given** a combatant concentrating on "Hold Person" with 30 HP and 5 temp HP
+- [ ] **When** 10 damage is dealt (temp HP absorbs 5, actual HP drops to 25, not 0)
+- [ ] **Then** Concentration persists (HP is not 0)
+
+### Task 5: Clear DC badge on turn advance
+
+- [ ] **Given** a combatant with visible DC badge
+- [ ] **When** `nextTurn()` is called
+- [ ] **Then** DC badge is no longer visible
+
+### Task 6: Add concentration field to detail popup
+
+- [ ] **Given** any combatant
+- [ ] **When** the detail popup is opened
+- [ ] **Then** a "Concentration" text input field is visible
+
+- [ ] **Given** a combatant with `concentrationSpell: "Hold Person"`
+- [ ] **When** the detail popup is opened
+- [ ] **Then** the concentration field shows "Hold Person"
+
+- [ ] **Given** a combatant with empty concentration field in detail popup
+- [ ] **When** user types "Hold Person" and blurs
+- [ ] **Then** `concentrationSpell` is set to "Hold Person" and row shows indicator
+
+### Task 7: Toast notifications
+
+- [ ] **Given** [End] button clicked on concentrating combatant
+- [ ] **When** handler executes
+- [ ] **Then** toast shows "[Name] ended concentration on [Spell]" and auto-dismisses after 3 seconds
+
+- [ ] **Given** combatant at 0 HP with active concentration
+- [ ] **When** damage causes HP to reach 0
+- [ ] **Then** toast shows "[Name] lost concentration on [Spell]" and auto-dismisses after 3 seconds
+
+## Traceability
+
+| Test Case | Task | Spec Scenario |
+|-----------|------|---------------|
+| concentration indicator in row | Task 2 | ADDED Combatant Concentration State - scenario 1 |
+| End button clears and toasts | Task 2 | ADDED Combatant Concentration State - scenario 2 |
+| DC badge appears on damage | Task 3 | ADDED Concentration DC Reminder - scenario 1 |
+| DC badge updates on subsequent damage | Task 3 | ADDED Concentration DC Reminder - scenario 2 |
+| No badge for non-concentrator | Task 3 | Implicit (no spec scenario but required) |
+| Auto-clear at 0 HP with toast | Task 4 | ADDED Concentration Auto-Clear - scenario 1 |
+| Concentration persists with temp HP | Task 4 | ADDED Concentration Auto-Clear - scenario 2 |
+| DC badge clears on turn advance | Task 5 | ADDED Concentration DC Reminder - scenario 3 |
+| Detail popup has concentration field | Task 6 | ADDED Concentration Field in Detail Popup - scenario 1 |
+| Detail popup pre-fills with spell | Task 6 | ADDED Concentration Field in Detail Popup - scenario 2 |
+| Detail popup can set new spell | Task 6 | ADDED Concentration Field in Detail Popup - scenario 3 |
+| Manual end toast | Task 7 | Derived from ADDED Combatant Concentration State |
+| Auto-clear toast | Task 7 | Derived from ADDED Concentration Auto-Clear |
+
+## Testing Strategy
+
+1. **Unit tests** for pure functions (DC calculation, auto-clear logic)
+2. **Component tests** for `CombatantCard` rendering (with/without concentration)
+3. **Integration tests** for turn advance clearing DC badge
+
+## Edge Cases to Test
+
+- Damage exactly equals temp HP + HP (e.g., 5 temp, 5 HP, 10 damage → HP=0, not temp HP)
+- Multiple damage events same turn
+- Setting same spell name (no-op)
+- Empty string concentration (should clear indicator)


### PR DESCRIPTION
## Summary

Implement D&D 5e concentration tracking for combat (issue #93):

- Mark combatants as concentrating on a named spell
- Auto-calculate and display CON save DC when damage dealt to concentrator
- Auto-clear concentration when HP reaches 0
- Manual "End Concentration" button with toast notification
- DC badge clears on turn advance

## Blockers

- **#146**: Spell Collection with Admin Import — will provide searchable dropdown for spell selection (free-text fallback works before #146 ships)

## Artifacts

| Artifact | Description |
|----------|-------------|
| `proposal.md` | Why, problem space, scope, risks, open questions |
| `design.md` | Technical design decisions, DC calculation, UI behavior |
| `specs/concentration-tracking.md` | Behavior-driven acceptance criteria (Given/When/Then) |
| `tasks.md` | Implementation checklist |
| `tests.md` | TDD test cases |

## Notes

This PR is for the **proposal only** — implementation will follow after human review and approval.

Ready for implementation once approved. Run `/opsx:apply concentration-tracking` to begin.