### PR TITLE
fix(dedupe-engine-test): remove broken test and add integration tests

### DIFF
--- a/openspec/changes/fix-dedupe-engine-test/.openspec.yaml
+++ b/openspec/changes/fix-dedupe-engine-test/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-02

--- a/openspec/changes/fix-dedupe-engine-test/README.md
+++ b/openspec/changes/fix-dedupe-engine-test/README.md
@@ -1,0 +1,3 @@
+# fix-dedupe-engine-test
+
+Fix dedupeEngine unit test and migrate to integration layer

--- a/openspec/changes/fix-dedupe-engine-test/design.md
+++ b/openspec/changes/fix-dedupe-engine-test/design.md
@@ -1,0 +1,158 @@
+## Context
+
+- **Relevant architecture**:
+  - Import pipeline: Open5E API client → dedupeEngine → MongoDB storage
+  - dedupeEngine.ts exports `importMonstersFromOpen5E` and `importSpellsFromOpen5E`
+  - Unit tests at `tests/unit/import/dedupeEngine.test.ts`
+  - Integration tests at `tests/integration/helpers/server.ts` (MongoDB testcontainer)
+
+- **Dependencies**:
+  - `@testcontainers/mongodb` for MongoDB testcontainer
+  - `open5e.mockHelpers.ts` for Open5E API mocking
+  - `storage` module from `@/lib/storage`
+
+- **Interfaces/contracts touched**:
+  - `IOpen5EClient` (getAllMonsters, getAllSpells)
+  - `storage.findMonsterByNameAndSource`, `storage.saveMonsterTemplate`
+  - `storage.spellExistsByNameAndSource`, `storage.saveSpellTemplate`
+
+## Goals / Non-Goals
+
+### Goals
+
+- Fix the broken test (mock/assertion mismatch) so CI passes
+- Correctly layer tests: unit tests for logic, integration tests for persistence
+- Ensure all tests pass with correct assertions
+
+### Non-Goals
+
+- Refactoring `importMonsterSingle` to use `shouldImport` (deferred to #165)
+- Centralizing mock helpers (deferred to #165)
+- Modifying production code behavior
+
+## Decisions
+
+### Decision 1: Fix broken unit test by removing it
+
+- **Chosen**: Remove the test at lines 80-91 from `tests/unit/import/dedupeEngine.test.ts`
+- **Alternatives considered**:
+  - Fix the assertions to match the mock: rejected because the test name says "skips monster when transform is invalid" but passes a valid creature with an "exists" mock—this test conflates two scenarios
+  - Fix the mock to match the assertions: rejected because a test named "when transform is invalid" should not use an "exists" mock
+- **Rationale**: The test is fundamentally confused (name, mock, assertions don't align). The scenarios it attempts to test are covered correctly by other tests:
+  - "skips when exists" is covered by lines 93-105
+  - "inserts when not exists" is covered by lines 65-78
+- **Trade-offs**: Removing a test might reduce coverage, but the scenarios it was attempting to test are already covered
+
+### Decision 2: Move persistence behavior tests to integration layer
+
+- **Chosen**: Create `tests/integration/import/dedupeEngine.integration.test.ts`
+- **Alternatives considered**:
+  - Keep all tests as unit tests with better mocks: rejected because mocked storage can't verify actual skip/insert behavior
+  - Test via HTTP API route: rejected because characterImport uses this pattern but dedupeEngine is a library function, not an API route
+- **Rationale**: Integration tests with real MongoDB verify:
+  - A monster is actually inserted and can be retrieved
+  - A monster is actually skipped and not duplicated
+- **Trade-offs**: Integration tests are slower but necessary for persistence verification
+
+### Decision 3: Use direct function call pattern (not HTTP)
+
+- **Chosen**: Import and call `importMonstersFromOpen5E` directly in integration tests
+- **Alternatives considered**:
+  - Spin up full Next.js server and test via HTTP: rejected as unnecessary overhead
+  - Use `setupTestServer()` helper that spins up MongoDB + Next.js: rejected as overkill for library testing
+- **Rationale**: dedupeEngine is a library function. Integration tests should:
+  - Use MongoDB testcontainer directly (not full Next.js stack)
+  - Call library functions directly to test behavior
+  - Only mock the Open5E API client
+- **Trade-offs**: Deviates from `characterImport.integration.test.ts` pattern which uses HTTP, but that pattern is appropriate for API route testing
+
+### Decision 4: Keep "error on invalid transform" at unit level
+
+- **Chosen**: Keep the test "counts error when monster transform is invalid" (lines 107-118) in unit tests
+- **Alternatives considered**: Move to integration with valid+invalid data
+- **Rationale**: Invalid transforms are rejected before reaching persistence. Testing at unit level:
+  - Is faster (no MongoDB needed)
+  - Clearly verifies transform validation logic
+  - Doesn't require persistence setup for error case
+- **Trade-offs**: If transform logic changes to allow partial persistence, this test would need to move
+
+## Proposal to Design Mapping
+
+| Proposal Element | Design Decision | Validation |
+|-----------------|-----------------|------------|
+| Fix broken test | Remove confusing test, rely on existing correct tests | Tests pass |
+| Move skip/insert to integration | Create integration test with real MongoDB | Integration tests verify actual persistence |
+| Keep error-on-invalid as unit test | Keep lines 107-118 in unit test | Unit tests verify transform validation |
+| Ensure unit tests stay isolated | Keep shouldImport tests at unit level | Unit tests run fast without MongoDB |
+
+## Functional Requirements Mapping
+
+- **Requirement**: Skip duplicates when importing monsters with same name+source
+  - **Design element**: Integration test "skips when exists"
+  - **Acceptance criteria**: `result.skipped === 1, result.inserted === 0`
+  - **Testability notes**: Must use real MongoDB to verify no duplicate created
+
+- **Requirement**: Insert new monsters when not duplicate
+  - **Design element**: Integration test "inserts when new"
+  - **Acceptance criteria**: `result.inserted === 1` and monster retrievable from MongoDB
+  - **Testability notes**: Query MongoDB after import to verify persistence
+
+- **Requirement**: Count error when transform is invalid
+  - **Design element**: Unit test with empty name creature
+  - **Acceptance criteria**: `result.errors === 1, result.inserted === 0`
+  - **Testability notes**: Unit test with mocked storage sufficient
+
+- **Requirement**: Process multiple monsters in one call
+  - **Design element**: Unit test "processes multiple monsters"
+  - **Acceptance criteria**: `result.inserted === 2`
+  - **Testability notes**: Unit test appropriate (no persistence verification needed)
+
+## Non-Functional Requirements Mapping
+
+- **Requirement category**: performance
+  - **Requirement**: Unit tests run fast (<100ms each)
+  - **Design element**: Keep logic/transform tests at unit level, no MongoDB
+  - **Acceptance criteria**: Unit test suite completes in <5s
+  - **Testability notes**: CI pipeline measures and enforces
+
+- **Requirement category**: reliability
+  - **Requirement**: Deduplication works correctly under all scenarios
+  - **Design element**: Integration tests verify actual MongoDB behavior
+  - **Acceptance criteria**: No duplicates created on re-import
+  - **Testability notes**: Integration tests cover this
+
+## Risks / Trade-offs
+
+- **Risk**: Test removal might leave coverage gap
+  - **Impact**: Low—the removed test's scenarios are covered by existing tests
+  - **Mitigation**: Verify coverage with `jest --coverage` before/after
+
+- **Risk**: Integration tests increase CI time
+  - **Impact**: Medium—integration tests are slower than unit tests
+  - **Mitigation**: Only move persistence-critical tests to integration; keep transform validation at unit
+
+- **Risk**: Integration test pattern differs from characterImport.integration.test.ts
+  - **Impact**: Low—inconsistency in test patterns could confuse future developers
+  - **Mitigation**: Document that library functions use direct-call integration pattern, API routes use HTTP integration pattern
+
+## Rollback / Mitigation
+
+- **Rollback trigger**: CI fails after merge, or coverage decreases by >5%
+- **Rollback steps**:
+  1. Revert changes to `tests/unit/import/dedupeEngine.test.ts`
+  2. Delete `tests/integration/import/dedupeEngine.integration.test.ts`
+- **Data migration considerations**: No data migration needed—test file changes only
+- **Verification after rollback**: Run `npm test` to verify all tests pass
+
+## Operational Blocking Policy
+
+- **If CI checks fail**: Block merge until tests pass. Do not skip or bypass.
+- **If security checks fail**: Not applicable—test-only changes
+- **If required reviews are blocked/stale**: Escalate to team lead after 48 hours of inactivity
+- **Escalation path**: Author → Reviewer → Team Lead
+
+## Open Questions
+
+- **Question**: Should `shouldImport` function tests move to integration?
+  - **Answer**: No, they test orchestration logic with mocked storage. Acceptable at unit level.
+  - **Status**: Resolved

--- a/openspec/changes/fix-dedupe-engine-test/proposal.md
+++ b/openspec/changes/fix-dedupe-engine-test/proposal.md
@@ -1,0 +1,89 @@
+## GitHub Issues
+
+- #164
+
+## Why
+
+- **Problem statement**: The `importMonstersFromOpen5E` unit test at `tests/unit/import/dedupeEngine.test.ts` (lines 80-91) is failing. The mock tells storage to return an existing monster (`findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" })`), but the assertions expect an insert (`inserted: 1`). This is a logical contradiction—the test cannot pass as written.
+
+- **Why now**: This test was introduced in PR #163 (extract-dnd-ability-scores-foundation) which is currently blocked by this failing test. The bug was caught before merge.
+
+- **Business/user impact**: No direct user impact, but failing CI blocks a feature PR.
+
+## Problem Space
+
+- **Current behavior**:
+  - `dedupeEngine.test.ts` contains unit tests that mock both the Open5E API client and the storage layer
+  - Tests for "skips when exists" and "inserts when new" exercise the full import pipeline with both dependencies mocked
+  - The test at line 80-91 has a mock/assertion mismatch and will never pass
+
+- **Desired behavior**:
+  - Unit tests should test isolated logic (transform validation, orchestration without external dependencies)
+  - Integration tests should test behavior that requires real persistence (skip-on-duplicate, insert-on-new)
+  - All tests should pass with correct assertions
+
+- **Constraints**:
+  - Integration tests use MongoDB testcontainers via `tests/integration/helpers/server.ts`
+  - The Open5E API client must be mocked in both unit and integration tests (external dependency)
+
+- **Assumptions**:
+  - Tests that verify persistence behavior (skip vs insert) belong in the integration layer
+  - Tests that verify transform validation errors belong in the unit layer (invalid transforms never reach persistence)
+
+- **Edge cases considered**:
+  - Multiple monsters in one import call: covered by existing test "processes multiple monsters"
+  - Spell imports use a different code path (`importSpellsFromOpen5E` uses `shouldImport`; `importMonstersFromOpen5E` uses inline duplicate check): handled consistently with deferral to #165
+
+## Scope
+
+### In Scope
+
+- Fix the broken test at `tests/unit/import/dedupeEngine.test.ts` lines 80-91 (assertion mismatch)
+- Create `tests/integration/import/dedupeEngine.integration.test.ts` with real MongoDB
+- Move "skips when exists" and "inserts when new" tests to integration layer
+- Keep "error when transform is invalid" as a unit test (never reaches persistence)
+- Ensure unit test directory only contains true unit tests (isolated, fast)
+
+### Out of Scope
+
+- Refactoring `importMonsterSingle` to use `shouldImport` (DRY violation with spells path): deferred to #165
+- Centralizing mock helpers to `tests/mocks/`: deferred to #165
+- Changes to production code (`lib/import/dedupeEngine.ts`)
+
+## What Changes
+
+1. **Fix `tests/unit/import/dedupeEngine.test.ts`**:
+   - Remove the broken test (lines 80-91) - its intent is tested correctly in "skips monster when it already exists" (lines 93-105)
+   - Keep unit tests for `shouldImport` (lines 23-62) - these test orchestration logic with mocked storage but are acceptable as-is since they test logic, not persistence
+   - Keep unit tests for transform validation errors - these appropriately stay unit-level
+
+2. **Create `tests/integration/import/dedupeEngine.integration.test.ts`**:
+   - Test import pipeline with mocked Open5E client (via `open5e.mockHelpers.ts`)
+   - Use real MongoDB via testcontainer (via `tests/integration/helpers/server.ts`)
+   - Test "inserts when new" - verify monster is actually persisted and retrievable
+   - Test "skips when exists" - verify monster is not duplicated on re-import
+   - Test "error when transform invalid" - verify invalid transforms are counted as errors
+
+## Risks
+
+- **Risk**: Integration tests are slower than unit tests
+  - **Impact**: CI pipeline may take longer
+  - **Mitigation**: Integration tests run in parallel with unit tests; only test persistence-relevant behavior at integration layer
+
+## Open Questions
+
+- **Question**: Should the `shouldImport` function tests remain in unit or move to integration?
+  - **Needed from**: Team consensus
+  - **Blocker for apply**: No - these tests mock storage but test logic; acceptable to leave as unit tests
+
+## Non-Goals
+
+- Fixing the DRY violation where `importMonsterSingle` duplicates `shouldImport` logic (issue #165)
+- Centralizing Open5E mock helpers to `tests/mocks/open5e/` (issue #165)
+- Any changes to production code behavior
+- Modifying the spell import path (`importSpellsFromOpen5E`)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/fix-dedupe-engine-test/specs/dedupe-engine-tests/spec.md
+++ b/openspec/changes/fix-dedupe-engine-test/specs/dedupe-engine-tests/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED DedupEngine Test Layering
+
+The dedupeEngine import tests SHALL be organized by layer to ensure fast, reliable, and accurate testing.
+
+#### Scenario: Transform validation at unit level
+
+- **Given** a creature with an invalid transform (e.g., empty name)
+- **When** `importMonstersFromOpen5E` is called
+- **Then** the result SHALL have `errors: 1`
+- **And** the result SHALL have `inserted: 0`
+- **And** no monster SHALL be saved to storage
+
+#### Scenario: Insert when not duplicate (integration)
+
+- **Given** no monster named "Goblin" with source "open5e" exists in MongoDB
+- **When** `importMonstersFromOpen5E` is called with a valid Goblin creature
+- **Then** the result SHALL have `inserted: 1`
+- **AND** the monster SHALL be retrievable from MongoDB by name and source
+
+#### Scenario: Skip when duplicate exists (integration)
+
+- **Given** a monster "Goblin" with source "open5e" already exists in MongoDB
+- **When** `importMonstersFromOpen5E` is called with a Goblin creature of the same name and source
+- **Then** the result SHALL have `skipped: 1`
+- **AND** `inserted: 0`
+- **AND** only one monster "Goblin" with source "open5e" SHALL exist in MongoDB
+
+#### Scenario: Multiple monsters processed (unit)
+
+- **Given** a mock client returning multiple valid creatures
+- **When** `importMonstersFromOpen5E` is called
+- **Then** each valid, non-duplicate creature SHALL be inserted
+- **AND** the result SHALL reflect the correct count of insertions
+
+### Requirement: ADDED Broken Test Removal
+
+The test file `tests/unit/import/dedupeEngine.test.ts` SHALL NOT contain tests with mock/assertion mismatches.
+
+#### Scenario: No contradictory mocks
+
+- **Given** a test that mocks `findMonsterByNameAndSource` to return an existing monster
+- **When** the test asserts the result
+- **Then** the assertions SHALL be consistent with an existing monster (skipped, not inserted)
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Deduplication Engine
+
+The system SHALL prevent duplicate entries when syncing from open5e. This requirement is unchanged from the original specification at `openspec/specs/dedupe-logic/spec.md`. This change does not modify the requirement itself, only ensures correct test coverage for it.
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Conflicting Test Scenario
+
+The test scenario "skips monster when transform is invalid (not when it exists)" at `tests/unit/import/dedupeEngine.test.ts` lines 80-91 SHALL be removed.
+
+Reason for removal: The test had a mock/assertion mismatch making it impossible to pass. The scenarios it attempted to test are already covered by other tests.
+
+## Traceability
+
+- Proposal element: Fix broken test
+  - Requirement: Broken Test Removal
+  - Design decision: Remove conflicting test
+- Proposal element: Move persistence tests to integration
+  - Requirement: DedupEngine Test Layering
+  - Design decision: Create integration test with real MongoDB
+- Proposal element: Keep error-on-invalid as unit test
+  - Requirement: DedupEngine Test Layering - Transform validation at unit level
+  - Design decision: Keep lines 107-118 in unit tests
+- Design decision: Use direct function call in integration tests
+  - Requirement: DedupEngine Test Layering - Skip when duplicate exists (integration)
+  - Design decision: Integration test pattern for library functions
+- Requirement (original): Deduplication Engine
+  - Traceability: Tests validate this requirement at appropriate layers
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Unit test execution time
+
+- **Given** running the unit test suite for dedupeEngine
+- **When** tests execute
+- **Then** unit tests SHALL complete in under 5 seconds total
+- **AND** no unit test SHALL require MongoDB or external services
+
+### Requirement: Reliability
+
+#### Scenario: Test determinism
+
+- **Given** running dedupeEngine tests multiple times
+- **When** tests execute
+- **Then** results SHALL be consistent across runs
+- **AND** no tests SHALL have race conditions or timing dependencies

--- a/openspec/changes/fix-dedupe-engine-test/tasks.md
+++ b/openspec/changes/fix-dedupe-engine-test/tasks.md
@@ -26,8 +26,8 @@
 - [x] **2.2** Create `tests/integration/import/dedupeEngine.integration.test.ts`
 - [x] **2.3** Set up MongoDB testcontainer connection using pattern from `tests/integration/helpers/server.ts` (simplified for direct function calls)
 - [x] **2.4** Import `importMonstersFromOpen5E` from `@/lib/import/dedupeEngine`
-- [x] **2.5** Import `createMockClient`, `createTestCreature` from `tests/unit/import/open5e.mockHelpers`
-- [x] **2.6** Import `storage` from `@/lib/storage`
+- [x] **2.5** Import `createMockClient`, `createTestCreature` from `tests/integration/import/testHelpers` (new file created for integration helpers)
+- [x] **2.6** Use dynamic imports of `@/lib/db` for direct MongoDB access (not `storage` module)
 
 ### Task 3: Write integration test for "inserts when not duplicate"
 

--- a/openspec/changes/fix-dedupe-engine-test/tasks.md
+++ b/openspec/changes/fix-dedupe-engine-test/tasks.md
@@ -1,0 +1,122 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b fix-dedupe-engine-test` then immediately `git push -u origin fix-dedupe-engine-test`
+
+## Execution
+
+### Task 1: Remove broken test from unit tests
+
+- [x] **1.1** Open `tests/unit/import/dedupeEngine.test.ts`
+- [x] **1.2** Remove the test at lines 80-91 ("skips monster when transform is invalid (not when it exists)")
+- [x] **1.3** Verify the file still contains:
+  - Tests for `shouldImport` (lines 23-62)
+  - Tests for "inserts monster when not duplicate and valid" (lines 65-78)
+  - Tests for "skips monster when it already exists" (lines 93-105)
+  - Tests for "counts error when monster transform is invalid" (lines 107-118)
+  - Tests for "processes multiple monsters" (lines 120-160)
+  - Spell import tests (lines 163-218)
+- [x] **1.4** Run `npm test -- tests/unit/import/dedupeEngine.test.ts --passWithNoTests` to verify tests still exist
+
+### Task 2: Create integration test file
+
+- [x] **2.1** Create directory `tests/integration/import/`
+- [x] **2.2** Create `tests/integration/import/dedupeEngine.integration.test.ts`
+- [x] **2.3** Set up MongoDB testcontainer connection using pattern from `tests/integration/helpers/server.ts` (simplified for direct function calls)
+- [x] **2.4** Import `importMonstersFromOpen5E` from `@/lib/import/dedupeEngine`
+- [x] **2.5** Import `createMockClient`, `createTestCreature` from `tests/unit/import/open5e.mockHelpers`
+- [x] **2.6** Import `storage` from `@/lib/storage`
+
+### Task 3: Write integration test for "inserts when not duplicate"
+
+- [x] **3.1** Create test "inserts monster when not duplicate and valid"
+  - Use `createTestCreature` to make a valid Goblin
+  - Use `createMockClient` with the creature
+  - Call `importMonstersFromOpen5E(client)`
+  - Assert `result.inserted === 1`
+  - Assert `result.skipped === 0`
+  - Query MongoDB directly to verify monster exists
+- [x] **3.2** Run the test and verify it passes
+
+### Task 4: Write integration test for "skips when exists"
+
+- [x] **4.1** Create test "skips monster when it already exists"
+  - First, import a Goblin (inserted)
+  - Then, import the same Goblin again (skipped)
+  - Assert first call: `result.inserted === 1, result.skipped === 0`
+  - Assert second call: `result.inserted === 0, result.skipped === 1`
+  - Query MongoDB to verify only one Goblin exists
+- [x] **4.2** Run the test and verify it passes
+
+### Task 5: Write integration test for "errors when transform invalid"
+
+- [x] **5.1** Create test "counts error when monster transform is invalid"
+  - Create a creature with empty name (invalid)
+  - Use `createMockClient` with the invalid creature
+  - Call `importMonstersFromOpen5E(client)`
+  - Assert `result.errors === 1`
+  - Assert `result.inserted === 0`
+  - Assert `result.skipped === 0`
+- [x] **5.2** Run the test and verify it passes
+
+### Task 6: Clean up and verify
+
+- [x] **6.1** Run all unit tests: `npm test -- tests/unit/`
+- [x] **6.2** Run all integration tests: `npm test -- tests/integration/`
+- [x] **6.3** Verify no duplicate test coverage between unit and integration
+
+## Validation
+
+- [x] **Unit tests pass:** `npm test -- tests/unit/import/dedupeEngine.test.ts`
+- [x] **Integration tests pass:** `npm test -- tests/integration/import/dedupeEngine.integration.test.ts`
+- [x] **Type checks pass:** `npm run typecheck` (or `npm run tsc -- --noEmit`)
+- [x] **Build succeeds:** `npm run build` (if applicable)
+- [x] **No lint errors:** `npm run lint` (if applicable)
+- [x] All completed tasks marked as complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test -- tests/unit/import/dedupeEngine.test.ts` — all tests must pass
+- **Integration tests** — `npm test -- tests/integration/import/dedupeEngine.integration.test.ts` — all tests must pass
+- **Type checks** — `npm run typecheck` — no errors
+- **Build** — `npm run build` — build must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review from `skills/openspec-apply-change/SKILL.md` before committing
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `fix-dedupe-engine-test` to `main`
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously; when any CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
+
+Ownership metadata:
+
+- Implementer: AI agent
+- Reviewer(s): Human reviewer
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (no spec changes for this fix-only change)
+- [ ] Archive the change: move `openspec/changes/fix-dedupe-engine-test/` to `openspec/changes/archive/2026-05-02-fix-dedupe-engine-test/` and stage both the new location and the deletion of the old location in a single commit — do not commit the copy and delete separately
+- [ ] Confirm `openspec/changes/archive/2026-05-02-fix-dedupe-engine-test/` exists and `openspec/changes/fix-dedupe-engine-test/` is gone
+- [ ] Commit and push the archive to the default branch in one commit
+- [ ] Prune merged local feature branches: `git fetch --prune` and `git branch -d fix-dedupe-engine-test`
+
+Required cleanup after archive: `git fetch --prune` and `git branch -d fix-dedupe-engine-test`

--- a/openspec/changes/fix-dedupe-engine-test/tests.md
+++ b/openspec/changes/fix-dedupe-engine-test/tests.md
@@ -93,11 +93,11 @@ For each task in `tasks.md`:
 
 ```bash
 # Unit tests only
-npm test -- tests/unit/import/dedupeEngine.test.ts
+npm run test:unit -- --testPathPattern='tests/unit/import/dedupeEngine.test.ts'
 
 # Integration tests only
-npm test -- tests/integration/import/dedupeEngine.integration.test.ts
+npm run test:integration -- --testPathPattern='tests/integration/import/dedupeEngine.integration.test.ts'
 
 # Both
-npm test -- tests/unit/import/dedupeEngine.test.ts tests/integration/import/dedupeEngine.integration.test.ts
+npm run test:unit -- --testPathPattern='tests/unit/import/dedupeEngine.test.ts' && npm run test:integration -- --testPathPattern='tests/integration/import/dedupeEngine.integration.test.ts'
 ```

--- a/openspec/changes/fix-dedupe-engine-test/tests.md
+++ b/openspec/changes/fix-dedupe-engine-test/tests.md
@@ -1,0 +1,103 @@
+---
+name: tests
+description: Tests for the fix-dedupe-engine-test change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `fix-dedupe-engine-test` change. Tests are organized by layer (unit vs integration) and follow TDD workflow.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test**: Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2. **Write code to pass the test**: Write the simplest possible code to make the test pass.
+3. **Refactor**: Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### Unit Tests (tests/unit/import/dedupeEngine.test.ts)
+
+- [ ] **Test 1.1 (Task 1.3):** Verify tests for `shouldImport` function still exist
+  - Returns should=false for spells that exist by name and source
+  - Returns should=true for spells that do not exist
+  - Returns should=true and no existingId for new monsters
+  - Returns should=false and existingId for existing monsters
+
+- [ ] **Test 1.2 (Task 1.3):** Verify "inserts monster when not duplicate and valid" test exists
+  - Mock: `findMonsterByNameAndSource` returns null
+  - Assert: `result.inserted === 1, result.skipped === 0, result.errors === 0`
+  - Maps to spec: "Transform validation at unit level" scenario
+
+- [ ] **Test 1.3 (Task 1.3):** Verify "skips monster when it already exists" test exists
+  - Mock: `findMonsterByNameAndSource` returns `{ id: "existing-id" }`
+  - Assert: `result.inserted === 0, result.skipped === 1, result.errors === 0`
+  - Maps to spec: REMOVED requirement (but test remains as unit-level verification with mocks)
+
+- [ ] **Test 1.4 (Task 1.3):** Verify "counts error when monster transform is invalid" test exists
+  - Mock: `findMonsterByNameAndSource` returns null
+  - Input: creature with empty name
+  - Assert: `result.errors === 1, result.inserted === 0, result.skipped === 0`
+  - Maps to spec: "Transform validation at unit level" scenario
+
+- [ ] **Test 1.5 (Task 1.3):** Verify "processes multiple monsters" test exists
+  - Mock: `findMonsterByNameAndSource` returns null, multiple creatures passed
+  - Assert: `result.inserted === 2`
+  - Maps to spec: "Multiple monsters processed (unit)" scenario
+
+- [ ] **Test 1.6 (Task 1.2):** Verify broken test is removed
+  - Search file for "skips monster when transform is invalid (not when it exists)"
+  - Should NOT exist in file
+  - Maps to spec: "REMOVED Requirements - Conflicting Test Scenario"
+
+### Integration Tests (tests/integration/import/dedupeEngine.integration.test.ts)
+
+- [ ] **Test 2.1 (Task 3.1):** "inserts monster when not duplicate and valid"
+  - Given: No Goblin with source "open5e" exists in MongoDB
+  - When: `importMonstersFromOpen5E` is called with valid Goblin
+  - Then: `result.inserted === 1`
+  - And: Monster is retrievable from MongoDB by name and source
+  - Maps to spec: "Insert when not duplicate (integration)" scenario
+
+- [ ] **Test 4.1 (Task 4.1):** "skips monster when it already exists"
+  - Given: Goblin with source "open5e" already exists in MongoDB (from Test 2.1)
+  - When: `importMonstersFromOpen5E` is called with same Goblin
+  - Then: `result.skipped === 1, result.inserted === 0`
+  - And: Only one Goblin with source "open5e" exists in MongoDB
+  - Maps to spec: "Skip when duplicate exists (integration)" scenario
+
+- [ ] **Test 5.1 (Task 5.1):** "counts error when monster transform is invalid"
+  - Given: No monsters exist
+  - When: `importMonstersFromOpen5E` is called with creature having empty name
+  - Then: `result.errors === 1, result.inserted === 0, result.skipped === 0`
+  - And: No monster is saved to MongoDB
+  - Maps to spec: "Transform validation at unit level" scenario (tested at integration level for consistency)
+
+## Test Mapping Summary
+
+| Task | Spec Scenario | Test File | Layer |
+|------|--------------|-----------|-------|
+| 1.2 | Insert when not duplicate | dedupeEngine.test.ts | Unit |
+| 1.3 | Skip when exists (with mock) | dedupeEngine.test.ts | Unit |
+| 1.4 | Transform validation | dedupeEngine.test.ts | Unit |
+| 1.5 | Multiple monsters | dedupeEngine.test.ts | Unit |
+| 1.6 | Conflicting test removed | dedupeEngine.test.ts | Unit |
+| 3.1 | Insert when not duplicate | dedupeEngine.integration.test.ts | Integration |
+| 4.1 | Skip when exists | dedupeEngine.integration.test.ts | Integration |
+| 5.1 | Error when invalid | dedupeEngine.integration.test.ts | Integration |
+
+## Running Tests
+
+```bash
+# Unit tests only
+npm test -- tests/unit/import/dedupeEngine.test.ts
+
+# Integration tests only
+npm test -- tests/integration/import/dedupeEngine.integration.test.ts
+
+# Both
+npm test -- tests/unit/import/dedupeEngine.test.ts tests/integration/import/dedupeEngine.integration.test.ts
+```

--- a/tests/integration/import/dedupeEngine.integration.test.ts
+++ b/tests/integration/import/dedupeEngine.integration.test.ts
@@ -1,0 +1,79 @@
+import { MongoDBContainer, StartedMongoDBContainer } from "@testcontainers/mongodb";
+import { importMonstersFromOpen5E } from "@/lib/import/dedupeEngine";
+import { createMockClient, createTestCreature } from "./testHelpers";
+
+describe("dedupeEngine integration", () => {
+  let mongoContainer: StartedMongoDBContainer;
+  let mongoUri: string;
+
+  beforeAll(async () => {
+    mongoContainer = await new MongoDBContainer("mongo:8").withExposedPorts(27017).start();
+    mongoUri = `mongodb://localhost:${mongoContainer.getMappedPort(27017)}/?directConnection=true`;
+    process.env.MONGODB_URI = mongoUri;
+    process.env.MONGODB_DB = "session-combat-test";
+  }, 120000);
+
+  afterAll(async () => {
+    await mongoContainer.stop();
+  }, 30000);
+
+  beforeEach(async () => {
+    const { getDatabase } = await import("@/lib/db");
+    const db = await getDatabase();
+    await db.collection("monsterTemplates").deleteMany({});
+    await db.collection("spellTemplates").deleteMany({});
+  });
+
+  describe("importMonstersFromOpen5E", () => {
+    it("inserts monster when not duplicate and valid", async () => {
+      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
+      const client = createMockClient([creature], []);
+
+      const result = await importMonstersFromOpen5E(client);
+
+      expect(result.inserted).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toBe(0);
+
+      const { getDatabase } = await import("@/lib/db");
+      const db = await getDatabase();
+      const found = await db.collection("monsterTemplates").findOne({ name: "Goblin", source: "open5e" });
+      expect(found).not.toBeNull();
+      expect(found?.name).toBe("Goblin");
+    });
+
+    it("skips monster when it already exists", async () => {
+      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
+
+      const result1 = await importMonstersFromOpen5E(createMockClient([creature], []));
+      expect(result1.inserted).toBe(1);
+      expect(result1.skipped).toBe(0);
+
+      const result2 = await importMonstersFromOpen5E(createMockClient([creature], []));
+      expect(result2.inserted).toBe(0);
+      expect(result2.skipped).toBe(1);
+      expect(result2.errors).toBe(0);
+
+      const { getDatabase } = await import("@/lib/db");
+      const db = await getDatabase();
+      const count = await db.collection("monsterTemplates").countDocuments({ name: "Goblin", source: "open5e" });
+      expect(count).toBe(1);
+    });
+
+    it("counts error when monster transform is invalid", async () => {
+      const invalidCreature = createTestCreature({ name: "" });
+      const client = createMockClient([invalidCreature], []);
+
+      const result = await importMonstersFromOpen5E(client);
+
+      expect(result.inserted).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toBe(1);
+
+      const { getDatabase } = await import("@/lib/db");
+      const db = await getDatabase();
+      const count = await db.collection("monsterTemplates").countDocuments({});
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/tests/integration/import/dedupeEngine.integration.test.ts
+++ b/tests/integration/import/dedupeEngine.integration.test.ts
@@ -1,19 +1,24 @@
 import { MongoDBContainer, StartedMongoDBContainer } from "@testcontainers/mongodb";
-import { importMonstersFromOpen5E } from "@/lib/import/dedupeEngine";
 import { createMockClient, createTestCreature } from "./testHelpers";
 
 describe("dedupeEngine integration", () => {
   let mongoContainer: StartedMongoDBContainer;
   let mongoUri: string;
+  let importMonstersFromOpen5E: (client: unknown) => Promise<{ inserted: number; skipped: number; errors: number }>;
 
   beforeAll(async () => {
+    jest.resetModules();
     mongoContainer = await new MongoDBContainer("mongo:8").withExposedPorts(27017).start();
     mongoUri = `mongodb://localhost:${mongoContainer.getMappedPort(27017)}/?directConnection=true`;
     process.env.MONGODB_URI = mongoUri;
     process.env.MONGODB_DB = "session-combat-test";
+    const mod = await import("@/lib/import/dedupeEngine");
+    importMonstersFromOpen5E = mod.importMonstersFromOpen5E;
   }, 120000);
 
   afterAll(async () => {
+    const { closeDatabase } = await import("@/lib/db");
+    await closeDatabase();
     await mongoContainer.stop();
   }, 30000);
 

--- a/tests/integration/import/testHelpers.ts
+++ b/tests/integration/import/testHelpers.ts
@@ -1,0 +1,45 @@
+import { IOpen5EClient, Open5ECreature, Open5ESpell } from "@/lib/import/open5eAdapter";
+
+export function createMockClient(creatures: Open5ECreature[], spells: Open5ESpell[]) {
+  const monsterGenerator = (async function* () {
+    for (const creature of creatures) {
+      yield creature;
+    }
+  })();
+
+  const spellGenerator = (async function* () {
+    for (const spell of spells) {
+      yield spell;
+    }
+  })();
+
+  return {
+    getAllMonsters: () => monsterGenerator,
+    getAllSpells: () => spellGenerator,
+  } as unknown as IOpen5EClient;
+}
+
+export function createTestCreature(overrides: Partial<Open5ECreature> = {}): Open5ECreature {
+  return {
+    key: "test-creature",
+    name: "Test Creature",
+    size: { Name: "Medium", key: "medium" },
+    type: { Name: "Beast", key: "beast" },
+    alignment: "neutral",
+    speed: { walk: 30 },
+    ability_scores: {
+      strength: 10,
+      dexterity: 10,
+      constitution: 10,
+      intelligence: 10,
+      wisdom: 10,
+      charisma: 10,
+    },
+    hit_points: 10,
+    armor_class: 10,
+    challenge_rating: 1,
+    actions: [],
+    traits: [],
+    ...overrides,
+  };
+}

--- a/tests/integration/import/testHelpers.ts
+++ b/tests/integration/import/testHelpers.ts
@@ -1,21 +1,17 @@
 import { IOpen5EClient, Open5ECreature, Open5ESpell } from "@/lib/import/open5eAdapter";
 
 export function createMockClient(creatures: Open5ECreature[], spells: Open5ESpell[]) {
-  const monsterGenerator = (async function* () {
-    for (const creature of creatures) {
-      yield creature;
-    }
-  })();
-
-  const spellGenerator = (async function* () {
-    for (const spell of spells) {
-      yield spell;
-    }
-  })();
-
   return {
-    getAllMonsters: () => monsterGenerator,
-    getAllSpells: () => spellGenerator,
+    getAllMonsters: () => (async function* () {
+      for (const creature of creatures) {
+        yield creature;
+      }
+    })(),
+    getAllSpells: () => (async function* () {
+      for (const spell of spells) {
+        yield spell;
+      }
+    })(),
   } as unknown as IOpen5EClient;
 }
 

--- a/tests/unit/import/dedupeEngine.test.ts
+++ b/tests/unit/import/dedupeEngine.test.ts
@@ -77,19 +77,6 @@ describe("dedupeEngine", () => {
       expect(mockedStorage.saveMonsterTemplate).toHaveBeenCalledTimes(1);
     });
 
-    it("skips monster when transform is invalid (not when it exists)", async () => {
-      mockedStorage.findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" } as any);
-
-      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
-      const client = createMockClient([creature], []);
-
-      const result = await importMonstersFromOpen5E(client);
-
-      expect(result.inserted).toBe(1);
-      expect(result.skipped).toBe(0);
-      expect(mockedStorage.saveMonsterTemplate).toHaveBeenCalledTimes(1);
-    });
-
     it("skips monster when it already exists", async () => {
       mockedStorage.findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" } as any);
 


### PR DESCRIPTION
## Summary
- Remove conflicting test from `dedupeEngine.unit.test.ts` (lines 80-91) that had mock/assertion mismatch
- Create integration tests for dedupeEngine with MongoDB testcontainer
- Tests cover: insert-on-new, skip-on-duplicate, error-on-invalid-transform

## Testing
- Unit tests: 881 passing
- Integration tests: 64 passing
- Build: passing
- Lint: passing