### PR TITLE
fix(dedupe-engine-test): remove broken test and add integration tests

### DIFF
--- a/tests/integration/import/dedupeEngine.integration.test.ts
+++ b/tests/integration/import/dedupeEngine.integration.test.ts
@@ -1,0 +1,84 @@
+import { MongoDBContainer, StartedMongoDBContainer } from "@testcontainers/mongodb";
+import { createMockClient, createTestCreature } from "./testHelpers";
+
+describe("dedupeEngine integration", () => {
+  let mongoContainer: StartedMongoDBContainer;
+  let mongoUri: string;
+  let importMonstersFromOpen5E: (client: unknown) => Promise<{ inserted: number; skipped: number; errors: number }>;
+
+  beforeAll(async () => {
+    jest.resetModules();
+    mongoContainer = await new MongoDBContainer("mongo:8").withExposedPorts(27017).start();
+    mongoUri = `mongodb://localhost:${mongoContainer.getMappedPort(27017)}/?directConnection=true`;
+    process.env.MONGODB_URI = mongoUri;
+    process.env.MONGODB_DB = "session-combat-test";
+    const mod = await import("@/lib/import/dedupeEngine");
+    importMonstersFromOpen5E = mod.importMonstersFromOpen5E;
+  }, 120000);
+
+  afterAll(async () => {
+    const { closeDatabase } = await import("@/lib/db");
+    await closeDatabase();
+    await mongoContainer.stop();
+  }, 30000);
+
+  beforeEach(async () => {
+    const { getDatabase } = await import("@/lib/db");
+    const db = await getDatabase();
+    await db.collection("monsterTemplates").deleteMany({});
+    await db.collection("spellTemplates").deleteMany({});
+  });
+
+  describe("importMonstersFromOpen5E", () => {
+    it("inserts monster when not duplicate and valid", async () => {
+      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
+      const client = createMockClient([creature], []);
+
+      const result = await importMonstersFromOpen5E(client);
+
+      expect(result.inserted).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toBe(0);
+
+      const { getDatabase } = await import("@/lib/db");
+      const db = await getDatabase();
+      const found = await db.collection("monsterTemplates").findOne({ name: "Goblin", source: "open5e" });
+      expect(found).not.toBeNull();
+      expect(found?.name).toBe("Goblin");
+    });
+
+    it("skips monster when it already exists", async () => {
+      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
+
+      const result1 = await importMonstersFromOpen5E(createMockClient([creature], []));
+      expect(result1.inserted).toBe(1);
+      expect(result1.skipped).toBe(0);
+
+      const result2 = await importMonstersFromOpen5E(createMockClient([creature], []));
+      expect(result2.inserted).toBe(0);
+      expect(result2.skipped).toBe(1);
+      expect(result2.errors).toBe(0);
+
+      const { getDatabase } = await import("@/lib/db");
+      const db = await getDatabase();
+      const count = await db.collection("monsterTemplates").countDocuments({ name: "Goblin", source: "open5e" });
+      expect(count).toBe(1);
+    });
+
+    it("counts error when monster transform is invalid", async () => {
+      const invalidCreature = createTestCreature({ name: "" });
+      const client = createMockClient([invalidCreature], []);
+
+      const result = await importMonstersFromOpen5E(client);
+
+      expect(result.inserted).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toBe(1);
+
+      const { getDatabase } = await import("@/lib/db");
+      const db = await getDatabase();
+      const count = await db.collection("monsterTemplates").countDocuments({});
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/tests/integration/import/testHelpers.ts
+++ b/tests/integration/import/testHelpers.ts
@@ -1,0 +1,41 @@
+import { IOpen5EClient, Open5ECreature, Open5ESpell } from "@/lib/import/open5eAdapter";
+
+export function createMockClient(creatures: Open5ECreature[], spells: Open5ESpell[]) {
+  return {
+    getAllMonsters: () => (async function* () {
+      for (const creature of creatures) {
+        yield creature;
+      }
+    })(),
+    getAllSpells: () => (async function* () {
+      for (const spell of spells) {
+        yield spell;
+      }
+    })(),
+  } as unknown as IOpen5EClient;
+}
+
+export function createTestCreature(overrides: Partial<Open5ECreature> = {}): Open5ECreature {
+  return {
+    key: "test-creature",
+    name: "Test Creature",
+    size: { Name: "Medium", key: "medium" },
+    type: { Name: "Beast", key: "beast" },
+    alignment: "neutral",
+    speed: { walk: 30 },
+    ability_scores: {
+      strength: 10,
+      dexterity: 10,
+      constitution: 10,
+      intelligence: 10,
+      wisdom: 10,
+      charisma: 10,
+    },
+    hit_points: 10,
+    armor_class: 10,
+    challenge_rating: 1,
+    actions: [],
+    traits: [],
+    ...overrides,
+  };
+}

--- a/tests/unit/import/dedupeEngine.test.ts
+++ b/tests/unit/import/dedupeEngine.test.ts
@@ -77,19 +77,6 @@ describe("dedupeEngine", () => {
       expect(mockedStorage.saveMonsterTemplate).toHaveBeenCalledTimes(1);
     });
 
-    it("skips monster when transform is invalid (not when it exists)", async () => {
-      mockedStorage.findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" } as any);
-
-      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
-      const client = createMockClient([creature], []);
-
-      const result = await importMonstersFromOpen5E(client);
-
-      expect(result.inserted).toBe(1);
-      expect(result.skipped).toBe(0);
-      expect(mockedStorage.saveMonsterTemplate).toHaveBeenCalledTimes(1);
-    });
-
     it("skips monster when it already exists", async () => {
       mockedStorage.findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" } as any);
 


### PR DESCRIPTION
## Summary
- Remove conflicting test from `dedupeEngine.unit.test.ts` (lines 80-91) that had mock/assertion mismatch
- Create integration tests for dedupeEngine with MongoDB testcontainer
- Tests cover: insert-on-new, skip-on-duplicate, error-on-invalid-transform

## Changes Address Review Feedback
- **Fresh generators per call**: `createMockClient` now returns a new generator each time (matching `IOpen5EClient` interface)
- **Proper env var timing**: Uses `jest.resetModules()` and dynamic import before importing dedupeEngine
- **Cleanup**: Calls `closeDatabase()` before stopping the MongoDB container

## Testing
- Unit tests: 881 passing
- Integration tests: 64 passing  
- Build: passing
- Lint: passing