### PR TITLE
extract-dnd-beyond-defenses: extract defenses normalizers

### DIFF
--- a/lib/dndBeyondCharacterImport.ts
+++ b/lib/dndBeyondCharacterImport.ts
@@ -27,6 +27,7 @@ import {
   normalizeMaxHp,
 } from "./import/dndBeyond-ability-scores";
 import { normalizeClasses, normalizeRace } from "./import/dndBeyond-classes";
+import { normalizeImmunities, normalizeByModifierType, normalizeLanguages } from "./import/dndBeyond-defenses";
 import { PASSIVE_SENSE_SKILLS, SKILL_ABILITY_MAP } from "./characterReference";
 import { filterToDamageTypes } from "./constants";
 
@@ -365,17 +366,6 @@ function buildNormalizedCharacter(
   };
 }
 
-function normalizeLanguages(modifiers: DndBeyondModifier[]): string[] {
-  return dedupeStrings(
-    modifiers
-      .filter((modifier) => modifier.type === "language")
-      .map(
-        (modifier) =>
-          modifier.friendlySubtypeName || titleize(modifier.subType || ""),
-      ),
-  );
-}
-
 function normalizeAlignment(
   alignmentId: number | null | undefined,
 ): DnDAlignment | undefined {
@@ -537,55 +527,6 @@ function normalizeSenses(
   );
 
   return senses;
-}
-
-function normalizeByModifierType(
-  modifiers: DndBeyondModifier[],
-  type: string,
-): string[] {
-  return dedupeStrings(
-    modifiers
-      .filter((modifier) => modifier.type === type)
-      .map(
-        (modifier) =>
-          modifier.friendlySubtypeName || titleize(modifier.subType || ""),
-      ),
-  );
-}
-
-function normalizeImmunities(modifiers: DndBeyondModifier[]): {
-  damageImmunities: string[];
-  conditionImmunities: string[];
-} {
-  const classified = modifiers
-    .filter((modifier) => modifier.type === "immunity")
-    .reduce(
-      (result, modifier) => {
-        const label =
-          modifier.friendlySubtypeName || titleize(modifier.subType || "");
-
-        if (!label) {
-          return result;
-        }
-
-        if (isDamageTypeModifier(modifier)) {
-          result.damageImmunities.push(label);
-        } else {
-          result.conditionImmunities.push(label);
-        }
-
-        return result;
-      },
-      {
-        damageImmunities: [] as string[],
-        conditionImmunities: [] as string[],
-      },
-    );
-
-  return {
-    damageImmunities: dedupeStrings(classified.damageImmunities),
-    conditionImmunities: dedupeStrings(classified.conditionImmunities),
-  };
 }
 
 function normalizeAbilities(

--- a/lib/import/dndBeyond-defenses.ts
+++ b/lib/import/dndBeyond-defenses.ts
@@ -56,12 +56,5 @@ export function normalizeByModifierType(
 }
 
 export function normalizeLanguages(modifiers: DndBeyondModifier[]): string[] {
-  return dedupeStrings(
-    modifiers
-      .filter((modifier) => modifier.type === "language")
-      .map(
-        (modifier) =>
-          modifier.friendlySubtypeName || titleize(modifier.subType || ""),
-      ),
-  );
+  return normalizeByModifierType(modifiers, "language");
 }

--- a/lib/import/dndBeyond-defenses.ts
+++ b/lib/import/dndBeyond-defenses.ts
@@ -1,0 +1,67 @@
+import { dedupeStrings, titleize, isDamageTypeModifier } from "./utils";
+
+interface DndBeyondModifier {
+  type?: "bonus" | "set" | "set-base" | "proficiency" | "expertise" | "language" | "resistance" | "immunity" | "vulnerability" | null;
+  subType?: string | null;
+  friendlySubtypeName?: string | null;
+}
+
+export function normalizeImmunities(modifiers: DndBeyondModifier[]): {
+  damageImmunities: string[];
+  conditionImmunities: string[];
+} {
+  const classified = modifiers
+    .filter((modifier) => modifier.type === "immunity")
+    .reduce(
+      (result, modifier) => {
+        const label =
+          modifier.friendlySubtypeName || titleize(modifier.subType || "");
+
+        if (!label) {
+          return result;
+        }
+
+        if (isDamageTypeModifier(modifier)) {
+          result.damageImmunities.push(label);
+        } else {
+          result.conditionImmunities.push(label);
+        }
+
+        return result;
+      },
+      {
+        damageImmunities: [] as string[],
+        conditionImmunities: [] as string[],
+      },
+    );
+
+  return {
+    damageImmunities: dedupeStrings(classified.damageImmunities),
+    conditionImmunities: dedupeStrings(classified.conditionImmunities),
+  };
+}
+
+export function normalizeByModifierType(
+  modifiers: DndBeyondModifier[],
+  type: string,
+): string[] {
+  return dedupeStrings(
+    modifiers
+      .filter((modifier) => modifier.type === type)
+      .map(
+        (modifier) =>
+          modifier.friendlySubtypeName || titleize(modifier.subType || ""),
+      ),
+  );
+}
+
+export function normalizeLanguages(modifiers: DndBeyondModifier[]): string[] {
+  return dedupeStrings(
+    modifiers
+      .filter((modifier) => modifier.type === "language")
+      .map(
+        (modifier) =>
+          modifier.friendlySubtypeName || titleize(modifier.subType || ""),
+      ),
+  );
+}

--- a/openspec/changes/extract-dnd-beyond-defenses/.openspec.yaml
+++ b/openspec/changes/extract-dnd-beyond-defenses/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-04

--- a/openspec/changes/extract-dnd-beyond-defenses/tasks.md
+++ b/openspec/changes/extract-dnd-beyond-defenses/tasks.md
@@ -1,0 +1,70 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b extract-dnd-beyond-defenses` then immediately `git push -u origin extract-dnd-beyond-defenses`
+
+## Execution
+
+- [x] **Create `lib/import/dndBeyond-defenses.ts`** with:
+  - Local `interface DndBeyondModifier` (fields: `type`, `subType`, `friendlySubtypeName`) — unexported
+  - `import { dedupeStrings, titleize, isDamageTypeModifier } from "./utils"`
+  - Export `normalizeLanguages`, `normalizeByModifierType`, `normalizeImmunities` — copied verbatim from `lib/dndBeyondCharacterImport.ts`
+- [x] **Update `lib/dndBeyondCharacterImport.ts`**:
+  - Add `import { normalizeImmunities, normalizeByModifierType, normalizeLanguages } from "./import/dndBeyond-defenses"`
+  - Remove the three local function definitions (`normalizeLanguages` at line ~368, `normalizeByModifierType` at line ~542, `normalizeImmunities` at line ~556)
+- [x] Verify no `from "../dndBeyondCharacterImport"` import exists in the new file
+- [x] Review for duplication and unnecessary complexity
+
+## Validation
+
+- [x] `npx tsc --noEmit` — passes with no errors
+- [x] `npm test` — all tests pass
+- [x] `npm run build` — build succeeds
+- [x] `npm run lint` (or equivalent) — no lint errors
+- [x] Confirm `lib/import/dndBeyond-defenses.ts` has no import from `../dndBeyondCharacterImport`
+- [x] All completed tasks marked as complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- **Type check** — `npx tsc --noEmit`; must pass
+
+If **ANY** of the above fail, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review from `skills/openspec-apply-change/SKILL.md` before committing
+- [ ] Commit all changes to `extract-dnd-beyond-defenses` branch and push to remote
+- [ ] Open PR from `extract-dnd-beyond-defenses` to `main`
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] Enable auto-merge: `gh pr merge --auto --merge`
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, follow all steps in [Remote push validation] then push; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously; when any CI check fails, diagnose and fix, commit fixes, follow all steps in [Remote push validation] then push; wait 180 seconds then repeat until all checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): agentic reviewer (auto)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No doc updates needed — purely structural refactor
+- [ ] Archive the change: move `openspec/changes/extract-dnd-beyond-defenses/` to `openspec/changes/archive/YYYY-MM-DD-extract-dnd-beyond-defenses/` — stage both the new location and deletion of the old in a single commit
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-extract-dnd-beyond-defenses/` exists and `openspec/changes/extract-dnd-beyond-defenses/` is gone
+- [ ] Commit and push the archive to main in one commit
+- [ ] Prune merged local feature branch: `git fetch --prune` and `git branch -d extract-dnd-beyond-defenses`


### PR DESCRIPTION
## Summary
- Extract `normalizeImmunities`, `normalizeByModifierType`, and `normalizeLanguages` from `lib/dndBeyondCharacterImport.ts` into `lib/import/dndBeyond-defenses.ts`
- Use a local `DndBeyondModifier` interface to avoid circular dependencies
- All tests pass, build succeeds, lint clean

## Change Type
Structural refactor (no behavior change)