### PR TITLE
refactor: centralize D&D Beyond mock server and unify importMonsterSingle dedupe check (closes #165)

### DIFF
--- a/lib/import/dedupeEngine.ts
+++ b/lib/import/dedupeEngine.ts
@@ -62,19 +62,15 @@ async function importSingle<T extends MonsterTemplate | SpellTemplate>(
 async function importMonsterSingle(
   raw: Open5ECreature
 ): Promise<{ inserted: boolean; skipped: boolean; error: boolean }> {
+  const { should } = await shouldImport("monsters", raw.name, "open5e");
+  if (!should) {
+    return { inserted: false, skipped: true, error: false };
+  }
+
   const { monster, valid, errors } = transformMonster(raw);
   if (!valid) {
     console.warn("Invalid monster skipped:", errors);
     return { inserted: false, skipped: false, error: true };
-  }
-
-  const existing = await storage.findMonsterByNameAndSource(
-    monster.name,
-    monster.source || ""
-  );
-
-  if (existing) {
-    return { inserted: false, skipped: true, error: false };
   }
 
   await storage.saveMonsterTemplate(monster);

--- a/lib/import/dedupeEngine.ts
+++ b/lib/import/dedupeEngine.ts
@@ -62,9 +62,11 @@ async function importSingle<T extends MonsterTemplate | SpellTemplate>(
 async function importMonsterSingle(
   raw: Open5ECreature
 ): Promise<{ inserted: boolean; skipped: boolean; error: boolean }> {
-  const { should } = await shouldImport("monsters", raw.name, "open5e");
-  if (!should) {
-    return { inserted: false, skipped: true, error: false };
+  if (raw.name) {
+    const { should } = await shouldImport("monsters", raw.name, "open5e");
+    if (!should) {
+      return { inserted: false, skipped: true, error: false };
+    }
   }
 
   const { monster, valid, errors } = transformMonster(raw);

--- a/openspec/changes/refactor-import-tests-165/tasks.md
+++ b/openspec/changes/refactor-import-tests-165/tasks.md
@@ -1,0 +1,88 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b refactor/import-tests-165` then immediately `git push -u origin refactor/import-tests-165`
+
+## Execution
+
+### Phase 1: Refactor dedupeEngine
+
+- [x] **1.1 — Update dedupeEngine tests first (TDD):** In `tests/unit/import/dedupeEngine.test.ts`, update/add assertions for `importMonsterSingle`:
+  - Assert `shouldImport` is called before `transformMonster` for duplicate case
+  - Assert `transformMonster` is NOT called when duplicate detected
+  - Assert invalid+duplicate monster returns `skipped: true` (not `error: true`)
+- [x] **1.2 — Refactor `importMonsterSingle`** in `lib/import/dedupeEngine.ts`:
+  - Replace inline `storage.findMonsterByNameAndSource` call with `shouldImport("monsters", raw.name, raw.source ?? "")`
+  - Move existence check before `transformMonster` call
+  - Return `{ inserted: false, skipped: true, error: false }` when `!should`
+- [x] **1.3 — Verify dedupeEngine integration tests** in `tests/integration/import/dedupeEngine.integration.test.ts` still pass; update if any assertions relied on old order
+
+### Phase 2: Extract D&D Beyond mock server
+
+- [x] **2.1 — Create `tests/mocks/dndBeyond/server.ts`:**
+  - Export `createDndBeyondMockServer()` factory
+  - Returns `{ setup(): Promise<void>, teardown(): Promise<void> }`
+  - `setup()` starts a `createServer` on a random port, sets `process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL`
+  - `teardown()` closes the server
+  - Handler logic extracted verbatim from `characterImport.integration.test.ts` lines 48–65
+- [x] **2.2 — Update `tests/integration/import/characterImport.integration.test.ts`:**
+  - Remove inline `createServer` block and related `let mockService`/`let mockServicePort` variables
+  - Import and use `createDndBeyondMockServer`
+  - Wire `setup()`/`teardown()` into existing `beforeAll`/`afterAll` hooks
+- [x] **2.3 — Verify integration test still passes** with new helper wiring
+
+## Validation
+
+- [x] Run unit tests: `npm test -- --testPathPattern="dedupeEngine"`
+- [x] Run integration tests: `npm run test:integration -- --testPathPattern="import"`
+- [x] Run full unit suite: `npm test`
+- [x] Run type check: `npm run type-check` (or `npx tsc --noEmit`)
+- [x] Run build: `npm run build`
+- [x] Confirm no new entries in `package.json`
+- [x] All tasks above marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review from `skills/openspec-apply-change/SKILL.md` before committing
+- [ ] Commit all changes to `refactor/import-tests-165` and push to remote
+- [ ] Open PR from `refactor/import-tests-165` to `main` — title: `refactor: centralize D&D Beyond mock server and unify importMonsterSingle dedupe check (closes #165)`
+- [ ] Wait 120 seconds for agentic reviewers to post comments
+- [ ] **Monitor PR comments** — address each, commit fixes, follow Remote push validation, push; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — diagnose and fix any failure, commit, follow Remote push validation, push; repeat until all checks pass
+- [ ] Wait for PR to merge — **never force-merge**; if human force-merges, continue to Post-Merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): automated PR review (agentic)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No documentation updates needed (test-only change)
+- [ ] Sync approved spec deltas into `openspec/specs/` (dedupe-engine and mock-server specs)
+- [ ] Archive the change: move `openspec/changes/refactor-import-tests-165/` to `openspec/changes/archive/2026-05-19-refactor-import-tests-165/` **in a single commit** (stage both copy and deletion together)
+- [ ] Confirm `openspec/changes/archive/2026-05-19-refactor-import-tests-165/` exists and `openspec/changes/refactor-import-tests-165/` is gone
+- [ ] Commit and push archive to `main`
+- [ ] Prune: `git fetch --prune` and `git branch -d refactor/import-tests-165`

--- a/openspec/changes/refactor-import-tests-165/tasks.md
+++ b/openspec/changes/refactor-import-tests-165/tasks.md
@@ -14,7 +14,7 @@
   - Assert `transformMonster` is NOT called when duplicate detected
   - Assert invalid+duplicate monster returns `skipped: true` (not `error: true`)
 - [x] **1.2 — Refactor `importMonsterSingle`** in `lib/import/dedupeEngine.ts`:
-  - Replace inline `storage.findMonsterByNameAndSource` call with `shouldImport("monsters", raw.name, raw.source ?? "")`
+  - Replace inline `storage.findMonsterByNameAndSource` call with `shouldImport("monsters", raw.name, "open5e")` (Open5ECreature has no source field; "open5e" matches what transformMonster hardcodes)
   - Move existence check before `transformMonster` call
   - Return `{ inserted: false, skipped: true, error: false }` when `!should`
 - [x] **1.3 — Verify dedupeEngine integration tests** in `tests/integration/import/dedupeEngine.integration.test.ts` still pass; update if any assertions relied on old order
@@ -35,10 +35,10 @@
 
 ## Validation
 
-- [x] Run unit tests: `npm test -- --testPathPattern="dedupeEngine"`
+- [x] Run unit tests: `npm run test:unit -- --testPathPattern="dedupeEngine"`
 - [x] Run integration tests: `npm run test:integration -- --testPathPattern="import"`
-- [x] Run full unit suite: `npm test`
-- [x] Run type check: `npm run type-check` (or `npx tsc --noEmit`)
+- [x] Run full unit suite: `npm run test:unit`
+- [x] Run type check: `npx tsc --noEmit`
 - [x] Run build: `npm run build`
 - [x] Confirm no new entries in `package.json`
 - [x] All tasks above marked complete
@@ -54,9 +54,9 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Run the required pre-PR self-review from `skills/openspec-apply-change/SKILL.md` before committing
-- [ ] Commit all changes to `refactor/import-tests-165` and push to remote
-- [ ] Open PR from `refactor/import-tests-165` to `main` — title: `refactor: centralize D&D Beyond mock server and unify importMonsterSingle dedupe check (closes #165)`
+- [x] Run the required pre-PR self-review from `skills/openspec-apply-change/SKILL.md` before committing
+- [x] Commit all changes to `refactor/import-tests-165` and push to remote
+- [x] Open PR from `refactor/import-tests-165` to `main` — title: `refactor: centralize D&D Beyond mock server and unify importMonsterSingle dedupe check (closes #165)`
 - [ ] Wait 120 seconds for agentic reviewers to post comments
 - [ ] **Monitor PR comments** — address each, commit fixes, follow Remote push validation, push; repeat until no unresolved comments remain
 - [ ] Enable auto-merge once no blocking review comments remain

--- a/tests/integration/import/characterImport.integration.test.ts
+++ b/tests/integration/import/characterImport.integration.test.ts
@@ -6,93 +6,33 @@ import {
   expect,
   test,
 } from "@jest/globals";
-import { createServer, Server } from "http";
 import fetch from "node-fetch";
 import {
   startTestServer,
   registerAndGetCookie,
   TestServer,
 } from "../helpers/server";
-import { sampleDndBeyondCharacterResponse } from "@/tests/fixtures/dndBeyondCharacter";
 import {
   DND_BEYOND_CHARACTER_NAME,
   DND_BEYOND_CHARACTER_URL,
 } from "@/tests/helpers/dndBeyondImport";
-
-function listen(server: Server): Promise<number> {
-  return new Promise((resolve) => {
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("Failed to bind mock character service");
-      }
-      resolve(address.port);
-    });
-  });
-}
+import { createDndBeyondMockServer } from "@/tests/mocks/dndBeyond/server";
 
 describe("Character import API integration", () => {
   let server: TestServer;
   let baseUrl: string;
   let cookie: string;
-  let mockService: Server;
-  let mockServicePort: number;
-  let originalCharacterServiceBaseUrl: string | undefined;
-  let originalAllowInsecureCharacterServiceBaseUrl: string | undefined;
+  const mockServer = createDndBeyondMockServer();
 
   beforeAll(async () => {
-    originalCharacterServiceBaseUrl =
-      process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-    originalAllowInsecureCharacterServiceBaseUrl =
-      process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-    mockService = createServer((request, response) => {
-      if (request.url?.startsWith("/character/v5/character/91913267")) {
-        response.writeHead(200, { "Content-Type": "application/json" });
-        response.end(JSON.stringify(sampleDndBeyondCharacterResponse));
-        return;
-      }
-
-      if (request.url?.startsWith("/character/v5/character/500")) {
-        response.writeHead(500, { "Content-Type": "application/json" });
-        response.end(JSON.stringify({ error: "Upstream failed" }));
-        return;
-      }
-
-      response.writeHead(404, { "Content-Type": "application/json" });
-      response.end(JSON.stringify({ error: "Not found" }));
-    });
-
-    mockServicePort = await listen(mockService);
-    process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL = `http://127.0.0.1:${mockServicePort}/character/v5`;
-    process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL = "true";
-
+    await mockServer.setup();
     server = await startTestServer();
     baseUrl = server.baseUrl;
   }, 120000);
 
   afterAll(async () => {
-    if (typeof originalCharacterServiceBaseUrl === "string") {
-      process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL =
-        originalCharacterServiceBaseUrl;
-    } else {
-      delete process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-    }
-    if (typeof originalAllowInsecureCharacterServiceBaseUrl === "string") {
-      process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL =
-        originalAllowInsecureCharacterServiceBaseUrl;
-    } else {
-      delete process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
-    }
     await server.cleanup();
-    await new Promise<void>((resolve, reject) => {
-      mockService.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve();
-      });
-    });
+    await mockServer.teardown();
   }, 30000);
 
   beforeEach(async () => {

--- a/tests/mocks/dndBeyond/server.ts
+++ b/tests/mocks/dndBeyond/server.ts
@@ -1,0 +1,79 @@
+import { createServer, Server } from "http";
+import { sampleDndBeyondCharacterResponse } from "@/tests/fixtures/dndBeyondCharacter";
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to bind mock character service");
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+export function createDndBeyondMockServer(): {
+  setup(): Promise<void>;
+  teardown(): Promise<void>;
+} {
+  let server: Server | null = null;
+  let originalCharacterServiceBaseUrl: string | undefined;
+  let originalAllowInsecureCharacterServiceBaseUrl: string | undefined;
+
+  return {
+    async setup() {
+      originalCharacterServiceBaseUrl = process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
+      originalAllowInsecureCharacterServiceBaseUrl =
+        process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
+
+      server = createServer((request, response) => {
+        if (request.url?.startsWith("/character/v5/character/91913267")) {
+          response.writeHead(200, { "Content-Type": "application/json" });
+          response.end(JSON.stringify(sampleDndBeyondCharacterResponse));
+          return;
+        }
+
+        if (request.url?.startsWith("/character/v5/character/500")) {
+          response.writeHead(500, { "Content-Type": "application/json" });
+          response.end(JSON.stringify({ error: "Upstream failed" }));
+          return;
+        }
+
+        response.writeHead(404, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "Not found" }));
+      });
+
+      const port = await listen(server);
+      process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL = `http://127.0.0.1:${port}/character/v5`;
+      process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL = "true";
+    },
+
+    async teardown() {
+      if (typeof originalCharacterServiceBaseUrl === "string") {
+        process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL = originalCharacterServiceBaseUrl;
+      } else {
+        delete process.env.DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
+      }
+      if (typeof originalAllowInsecureCharacterServiceBaseUrl === "string") {
+        process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL =
+          originalAllowInsecureCharacterServiceBaseUrl;
+      } else {
+        delete process.env.ALLOW_INSECURE_DND_BEYOND_CHARACTER_SERVICE_BASE_URL;
+      }
+
+      if (server) {
+        await new Promise<void>((resolve, reject) => {
+          server!.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+        server = null;
+      }
+    },
+  };
+}

--- a/tests/mocks/dndBeyond/server.ts
+++ b/tests/mocks/dndBeyond/server.ts
@@ -2,11 +2,13 @@ import { createServer, Server } from "http";
 import { sampleDndBeyondCharacterResponse } from "@/tests/fixtures/dndBeyondCharacter";
 
 function listen(server: Server): Promise<number> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
       const address = server.address();
       if (!address || typeof address === "string") {
-        throw new Error("Failed to bind mock character service");
+        reject(new Error("Failed to bind mock character service"));
+        return;
       }
       resolve(address.port);
     });

--- a/tests/unit/import/dedupeEngine.test.ts
+++ b/tests/unit/import/dedupeEngine.test.ts
@@ -5,6 +5,7 @@ import {
   importSpellsFromOpen5E,
 } from "@/lib/import/dedupeEngine";
 import { storage } from "@/lib/storage";
+import { transformMonster } from "@/lib/import/transformMonster";
 import {
   createMockClient,
   createTestCreature,
@@ -12,12 +13,25 @@ import {
 } from "@/tests/helpers/importTestHelpers";
 
 jest.mock("@/lib/storage");
+jest.mock("@/lib/import/transformMonster");
 
 const mockedStorage = jest.mocked(storage);
+const mockedTransformMonster = jest.mocked(transformMonster);
 
 describe("dedupeEngine", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedTransformMonster.mockImplementation((raw) => {
+      const name = (raw as { name?: string }).name ?? "";
+      if (!name) {
+        return { monster: {} as any, valid: false, errors: ["Missing required field: name"] };
+      }
+      return {
+        monster: { name, source: "open5e" } as any,
+        valid: true,
+        errors: [],
+      };
+    });
   });
 
   describe("shouldImport", () => {
@@ -89,6 +103,36 @@ describe("dedupeEngine", () => {
       expect(result.skipped).toBe(1);
       expect(result.errors).toBe(0);
       expect(mockedStorage.saveMonsterTemplate).not.toHaveBeenCalled();
+    });
+
+    it("does not call transformMonster when duplicate is detected", async () => {
+      mockedStorage.findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" } as any);
+
+      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
+      const client = createMockClient([creature], []);
+
+      await importMonstersFromOpen5E(client);
+
+      expect(mockedTransformMonster).not.toHaveBeenCalled();
+    });
+
+    it("returns skipped (not error) for invalid+duplicate monster", async () => {
+      mockedStorage.findMonsterByNameAndSource.mockResolvedValue({ id: "existing-id" } as any);
+      mockedTransformMonster.mockReturnValue({
+        monster: {} as any,
+        valid: false,
+        errors: ["Missing required field: name"],
+      });
+
+      const creature = createTestCreature({ key: "goblin", name: "Goblin" });
+      const client = createMockClient([creature], []);
+
+      const result = await importMonstersFromOpen5E(client);
+
+      expect(result.inserted).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toBe(0);
+      expect(mockedTransformMonster).not.toHaveBeenCalled();
     });
 
     it("counts error when monster transform is invalid", async () => {


### PR DESCRIPTION
## Summary

Two focused refactors to clean up the import test architecture:

1. **`importMonsterSingle` uses `shouldImport` for existence check** — replaces the direct `storage.findMonsterByNameAndSource` call with `shouldImport("monsters", raw.name, "open5e")`, consistent with the spell import path. The check now happens *before* `transformMonster`, so duplicate monsters skip transformation entirely.

2. **D&D Beyond HTTP mock server extracted** — the inline `createServer` block from `characterImport.integration.test.ts` is now a reusable `createDndBeyondMockServer()` factory at `tests/mocks/dndBeyond/server.ts`. Enforces the `tests/helpers/` (data factories) vs `tests/mocks/` (real HTTP servers) split.

## Changes

- `lib/import/dedupeEngine.ts` — `importMonsterSingle` calls `shouldImport` first, then transforms
- `tests/unit/import/dedupeEngine.test.ts` — added mock for `transformMonster`; 2 new tests (duplicate skips transform, invalid+duplicate returns skipped not error)
- `tests/mocks/dndBeyond/server.ts` — new file with `createDndBeyondMockServer()` setup/teardown factory
- `tests/integration/import/characterImport.integration.test.ts` — uses new helper; inline server removed

## Behavior notes

- Invalid monsters that are also duplicates now return `skipped` instead of `error`. This is acceptable — the duplicate check is deterministic and the error result had no meaningful consumer.
- No user-visible behavior changes. No new package dependencies.

## Validation

- ✅ Unit tests: 979 passed
- ✅ Integration tests (import): 12 passed  
- ✅ Type check: clean
- ✅ Build: no errors
- ✅ `package.json` unchanged