### PR TITLE
refactor: Extract alignment and character identity helpers into dndBeyond-identity.ts (closes #159)

### DIFF
--- a/lib/dndBeyondCharacterImport.ts
+++ b/lib/dndBeyondCharacterImport.ts
@@ -15,12 +15,11 @@ import {
 } from "./import/dndBeyond-utils";
 export { DndBeyondImportError };
 import {
-  parseDndBeyondCharacterUrl,
   requireCharacterIdentity,
   buildNormalizationWarnings,
   normalizeAlignmentId,
 } from "./import/dndBeyond-identity";
-export { parseDndBeyondCharacterUrl };
+export { parseDndBeyondCharacterUrl } from "./import/dndBeyond-identity";
 export type { ParsedDndBeyondCharacterUrl } from "./import/dndBeyond-identity";
 import {
   normalizeAbilityScores,

--- a/lib/dndBeyondCharacterImport.ts
+++ b/lib/dndBeyondCharacterImport.ts
@@ -9,12 +9,19 @@ import {
 } from "./types";
 import { getAbilityModifier, getProficiencyBonus, titleize, isPresent, ABILITY_KEYS } from "./import/utils";
 import {
-  createValidationError,
   DndBeyondImportError,
   flattenModifiers,
   getModifierNumericValue,
 } from "./import/dndBeyond-utils";
 export { DndBeyondImportError };
+import {
+  parseDndBeyondCharacterUrl,
+  requireCharacterIdentity,
+  buildNormalizationWarnings,
+  normalizeAlignmentId,
+} from "./import/dndBeyond-identity";
+export { parseDndBeyondCharacterUrl };
+export type { ParsedDndBeyondCharacterUrl } from "./import/dndBeyond-identity";
 import {
   normalizeAbilityScores,
   normalizeCurrentHp,
@@ -27,21 +34,6 @@ import { normalizeAbilities, type DndBeyondActionEntry } from "./import/dndBeyon
 import { normalizeArmorClass } from "./import/dndBeyond-armor-class";
 import { PASSIVE_SENSE_SKILLS, SKILL_ABILITY_MAP } from "./characterReference";
 import { filterToDamageTypes } from "./constants";
-
-const CANONICAL_HOST = "www.dndbeyond.com";
-const CHARACTER_PATH_PATTERN = /^\/characters\/(\d+)(?:\/([A-Za-z0-9_-]+))?\/?$/;
-
-const ALIGNMENT_ID_MAP: Record<number, DnDAlignment> = {
-  1: "Lawful Good",
-  2: "Neutral Good",
-  3: "Chaotic Good",
-  4: "Lawful Neutral",
-  5: "Neutral",
-  6: "Chaotic Neutral",
-  7: "Lawful Evil",
-  8: "Neutral Evil",
-  9: "Chaotic Evil",
-};
 
 interface DndBeyondStatValue {
   id: number;
@@ -109,12 +101,6 @@ export interface DndBeyondCharacterServiceResponse {
   data?: DndBeyondCharacterData | null;
 }
 
-export interface ParsedDndBeyondCharacterUrl {
-  characterId: string;
-  shareCode?: string;
-  normalizedUrl: string;
-}
-
 export type ImportedCharacterDraft = Omit<
   Character,
   "_id" | "id" | "userId" | "createdAt" | "updatedAt"
@@ -125,11 +111,6 @@ export interface NormalizedDndBeyondCharacter {
   warnings: string[];
   sourceCharacterId: string;
   sourceUrl?: string;
-}
-
-interface CharacterIdentity {
-  name: string;
-  sourceCharacterId: string;
 }
 
 interface NormalizedCharacterDetails {
@@ -154,34 +135,6 @@ interface NormalizedCharacterDetails {
   actions: CreatureAbility[];
 }
 
-export function parseDndBeyondCharacterUrl(
-  url: string,
-): ParsedDndBeyondCharacterUrl {
-  const parsed = parseUrlOrThrow(url);
-
-  if (!isSupportedDndBeyondHostname(parsed.hostname)) {
-    throw createValidationError(
-      "Only canonical public D&D Beyond character URLs are supported.",
-    );
-  }
-
-  const match = parsed.pathname.match(CHARACTER_PATH_PATTERN);
-  if (!match) {
-    throw createValidationError(
-      "Use a publicly available D&D Beyond character URL.",
-    );
-  }
-
-  const [, characterId, shareCode] = match;
-  return {
-    characterId,
-    shareCode,
-    normalizedUrl: shareCode
-      ? `https://${CANONICAL_HOST}/characters/${characterId}/${shareCode}`
-      : `https://${CANONICAL_HOST}/characters/${characterId}`,
-  };
-}
-
 export function normalizeDndBeyondCharacter(
   data: DndBeyondCharacterData,
 ): NormalizedDndBeyondCharacter {
@@ -196,40 +149,6 @@ export function normalizeDndBeyondCharacter(
     sourceCharacterId: identity.sourceCharacterId,
     sourceUrl: data.readonlyUrl || undefined,
   };
-}
-
-function parseUrlOrThrow(url: string): URL {
-  try {
-    return new URL(url.trim());
-  } catch {
-    throw createValidationError("Enter a valid D&D Beyond character URL.");
-  }
-}
-
-function isSupportedDndBeyondHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return normalized === CANONICAL_HOST || normalized === "dndbeyond.com";
-}
-
-function requireCharacterIdentity(
-  data: DndBeyondCharacterData,
-): CharacterIdentity {
-  const sourceCharacterId = String(data.id || "");
-  const name = data.name?.trim();
-
-  if (!sourceCharacterId) {
-    throw createValidationError(
-      "The imported D&D Beyond character is missing an ID.",
-    );
-  }
-
-  if (!name) {
-    throw createValidationError(
-      "The imported D&D Beyond character is missing a name.",
-    );
-  }
-
-  return { name, sourceCharacterId };
 }
 
 function normalizeCharacterDetails(
@@ -253,7 +172,7 @@ function normalizeCharacterDetails(
   return {
     abilityScores,
     ac: normalizeArmorClass(data.inventory, abilityScores, modifiers),
-    alignment: normalizeAlignment(data.alignmentId),
+    alignment: normalizeAlignmentId(data.alignmentId),
     actions: categorizedAbilities.actions,
     bonusActions: categorizedAbilities.bonusActions,
     classes,
@@ -275,25 +194,6 @@ function normalizeCharacterDetails(
     skills,
     traits: categorizedAbilities.traits,
   };
-}
-
-function buildNormalizationWarnings(
-  data: DndBeyondCharacterData,
-  details: NormalizedCharacterDetails,
-): string[] {
-  const warnings: string[] = [];
-
-  if (!details.race && data.race?.fullName) {
-    warnings.push(
-      `Race "${data.race.fullName}" is not supported and was omitted.`,
-    );
-  }
-
-  if (!details.alignment && typeof data.alignmentId === "number") {
-    warnings.push("Alignment was not supported and was omitted.");
-  }
-
-  return warnings;
 }
 
 function buildNormalizedCharacter(
@@ -322,16 +222,6 @@ function buildNormalizedCharacter(
     race: details.race,
     alignment: details.alignment,
   };
-}
-
-function normalizeAlignment(
-  alignmentId: number | null | undefined,
-): DnDAlignment | undefined {
-  if (typeof alignmentId !== "number") {
-    return undefined;
-  }
-
-  return ALIGNMENT_ID_MAP[alignmentId];
 }
 
 

--- a/lib/import/dndBeyond-identity.ts
+++ b/lib/import/dndBeyond-identity.ts
@@ -4,7 +4,7 @@ import type { DnDAlignment, DnDRace } from "../types";
 const CANONICAL_HOST = "www.dndbeyond.com";
 const CHARACTER_PATH_PATTERN = /^\/characters\/(\d+)(?:\/([A-Za-z0-9_-]+))?\/?$/;
 
-const ALIGNMENT_ID_MAP: Record<number, DnDAlignment> = {
+const ALIGNMENT_ID_MAP: Partial<Record<number, DnDAlignment>> = {
   1: "Lawful Good",
   2: "Neutral Good",
   3: "Chaotic Good",

--- a/lib/import/dndBeyond-identity.ts
+++ b/lib/import/dndBeyond-identity.ts
@@ -1,5 +1,5 @@
 import { createValidationError } from "./dndBeyond-utils";
-import type { DnDAlignment } from "../types";
+import type { DnDAlignment, DnDRace } from "../types";
 
 const CANONICAL_HOST = "www.dndbeyond.com";
 const CHARACTER_PATH_PATTERN = /^\/characters\/(\d+)(?:\/([A-Za-z0-9_-]+))?\/?$/;
@@ -29,7 +29,7 @@ interface IdentityCharacterData {
 }
 
 interface IdentityNormalizedDetails {
-  race?: unknown;
+  race?: DnDRace;
   alignment?: DnDAlignment;
 }
 
@@ -83,7 +83,7 @@ export function parseDndBeyondCharacterUrl(
 export function requireCharacterIdentity(
   data: IdentityCharacterData,
 ): CharacterIdentity {
-  const sourceCharacterId = String(data.id || "");
+  const sourceCharacterId = String(data.id ?? "");
   const name = data.name?.trim();
 
   if (!sourceCharacterId) {

--- a/lib/import/dndBeyond-identity.ts
+++ b/lib/import/dndBeyond-identity.ts
@@ -1,5 +1,5 @@
 import { createValidationError } from "./dndBeyond-utils";
-import { DnDAlignment } from "../types";
+import type { DnDAlignment } from "../types";
 
 const CANONICAL_HOST = "www.dndbeyond.com";
 const CHARACTER_PATH_PATTERN = /^\/characters\/(\d+)(?:\/([A-Za-z0-9_-]+))?\/?$/;

--- a/lib/import/dndBeyond-identity.ts
+++ b/lib/import/dndBeyond-identity.ts
@@ -1,0 +1,131 @@
+import { createValidationError } from "./dndBeyond-utils";
+import { DnDAlignment } from "../types";
+
+const CANONICAL_HOST = "www.dndbeyond.com";
+const CHARACTER_PATH_PATTERN = /^\/characters\/(\d+)(?:\/([A-Za-z0-9_-]+))?\/?$/;
+
+const ALIGNMENT_ID_MAP: Record<number, DnDAlignment> = {
+  1: "Lawful Good",
+  2: "Neutral Good",
+  3: "Chaotic Good",
+  4: "Lawful Neutral",
+  5: "Neutral",
+  6: "Chaotic Neutral",
+  7: "Lawful Evil",
+  8: "Neutral Evil",
+  9: "Chaotic Evil",
+};
+
+interface CharacterIdentity {
+  name: string;
+  sourceCharacterId: string;
+}
+
+interface IdentityCharacterData {
+  id?: number | string;
+  name?: string | null;
+  race?: { fullName?: string | null } | null;
+  alignmentId?: number | null;
+}
+
+interface IdentityNormalizedDetails {
+  race?: unknown;
+  alignment?: DnDAlignment;
+}
+
+export interface ParsedDndBeyondCharacterUrl {
+  characterId: string;
+  shareCode?: string;
+  normalizedUrl: string;
+}
+
+function parseUrlOrThrow(url: string): URL {
+  try {
+    return new URL(url.trim());
+  } catch {
+    throw createValidationError("Enter a valid D&D Beyond character URL.");
+  }
+}
+
+function isSupportedDndBeyondHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === CANONICAL_HOST || normalized === "dndbeyond.com";
+}
+
+export function parseDndBeyondCharacterUrl(
+  url: string,
+): ParsedDndBeyondCharacterUrl {
+  const parsed = parseUrlOrThrow(url);
+
+  if (!isSupportedDndBeyondHostname(parsed.hostname)) {
+    throw createValidationError(
+      "Only canonical public D&D Beyond character URLs are supported.",
+    );
+  }
+
+  const match = parsed.pathname.match(CHARACTER_PATH_PATTERN);
+  if (!match) {
+    throw createValidationError(
+      "Use a publicly available D&D Beyond character URL.",
+    );
+  }
+
+  const [, characterId, shareCode] = match;
+  return {
+    characterId,
+    shareCode,
+    normalizedUrl: shareCode
+      ? `https://${CANONICAL_HOST}/characters/${characterId}/${shareCode}`
+      : `https://${CANONICAL_HOST}/characters/${characterId}`,
+  };
+}
+
+export function requireCharacterIdentity(
+  data: IdentityCharacterData,
+): CharacterIdentity {
+  const sourceCharacterId = String(data.id || "");
+  const name = data.name?.trim();
+
+  if (!sourceCharacterId) {
+    throw createValidationError(
+      "The imported D&D Beyond character is missing an ID.",
+    );
+  }
+
+  if (!name) {
+    throw createValidationError(
+      "The imported D&D Beyond character is missing a name.",
+    );
+  }
+
+  return { name, sourceCharacterId };
+}
+
+export function buildNormalizationWarnings(
+  data: IdentityCharacterData,
+  details: IdentityNormalizedDetails,
+): string[] {
+  const warnings: string[] = [];
+
+  if (!details.race && data.race?.fullName) {
+    warnings.push(
+      `Race "${data.race.fullName}" is not supported and was omitted.`,
+    );
+  }
+
+  if (!details.alignment && typeof data.alignmentId === "number") {
+    warnings.push("Alignment was not supported and was omitted.");
+  }
+
+  return warnings;
+}
+
+export function normalizeAlignmentId(
+  alignmentId: number | null | undefined,
+): DnDAlignment | undefined {
+  if (typeof alignmentId !== "number") {
+    return undefined;
+  }
+
+  return ALIGNMENT_ID_MAP[alignmentId];
+}

--- a/openspec/changes/extract-dndbeyond-identity/.openspec.yaml
+++ b/openspec/changes/extract-dndbeyond-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-21

--- a/openspec/changes/extract-dndbeyond-identity/tasks.md
+++ b/openspec/changes/extract-dndbeyond-identity/tasks.md
@@ -1,0 +1,80 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b extract-dndbeyond-identity` then immediately `git push -u origin extract-dndbeyond-identity`
+- [x] **Grep import sites:** `grep -rn "parseDndBeyondCharacterUrl\|normalizeAlignment" --include="*.ts" .` — record any files outside `lib/dndBeyondCharacterImport.ts` that import these names
+
+## Execution
+
+- [x] **Create `lib/import/dndBeyond-identity.ts`** — new file with:
+  - Private constants: `CANONICAL_HOST`, `CHARACTER_PATH_PATTERN`, `ALIGNMENT_ID_MAP`
+  - Private interface: `CharacterIdentity`
+  - Private helpers (not exported): `parseUrlOrThrow`, `isSupportedDndBeyondHostname`
+  - Exported functions: `parseDndBeyondCharacterUrl`, `requireCharacterIdentity`, `buildNormalizationWarnings`, `normalizeAlignmentId`
+  - Imports needed: `createValidationError`, `DndBeyondImportError` from `./dndBeyond-utils`; `DnDAlignment` from `../types`; `DndBeyondCharacterData`, `NormalizedCharacterDetails` from `../dndBeyondCharacterImport` (or inline the minimal types if circular — evaluate during implementation)
+
+- [x] **Update `lib/dndBeyondCharacterImport.ts`:**
+  - Add import from `./import/dndBeyond-identity`: `parseDndBeyondCharacterUrl`, `requireCharacterIdentity`, `buildNormalizationWarnings`, `normalizeAlignmentId`
+  - Remove inline definitions of: `parseUrlOrThrow`, `isSupportedDndBeyondHostname`, `parseDndBeyondCharacterUrl`, `requireCharacterIdentity`, `buildNormalizationWarnings`, `normalizeAlignment`
+  - Remove private constants: `CANONICAL_HOST`, `CHARACTER_PATH_PATTERN`, `ALIGNMENT_ID_MAP`
+  - Remove `CharacterIdentity` interface
+  - Rename all call sites: `normalizeAlignment(...)` → `normalizeAlignmentId(...)`
+  - If `parseDndBeyondCharacterUrl` was re-exported from this file, add: `export { parseDndBeyondCharacterUrl } from "./import/dndBeyond-identity"` (only if grep from Preparation found external consumers)
+
+- [x] **Resolve circular dependency risk:** If `dndBeyond-identity.ts` needs `DndBeyondCharacterData` or `NormalizedCharacterDetails` from `dndBeyondCharacterImport.ts`, extract those types to `lib/import/dndBeyond-types.ts` or inline minimal structural types — do not create a circular import.
+
+- [x] **Verify grep is clean:** `grep -n "function parseUrlOrThrow\|function isSupportedDndBeyondHostname\|function requireCharacterIdentity\|function buildNormalizationWarnings\|function normalizeAlignment\b" lib/dndBeyondCharacterImport.ts` — must return empty
+
+## Validation
+
+- [x] `tsc --noEmit` — zero errors
+- [x] `npm test` (or project test command) — all tests pass, zero test file modifications
+- [x] `grep -n "normalizeAlignment[^I]" lib/dndBeyondCharacterImport.ts lib/import/dndBeyond-identity.ts` — must return empty (confirms rename is complete; `normalizeAlignmentId` won't match)
+- [x] `grep -rn "from.*dndBeyondCharacterImport" --include="*.ts" .` — confirm no external consumer has lost its import
+- [x] All completed tasks marked as complete
+- [ ] All steps in [Remote push validation] pass
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Build** — `npm run build` or `tsc --noEmit`; must succeed with no errors
+- If **ANY** of the above fail, iterate and fix before pushing
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review before committing
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `extract-dndbeyond-identity` to `main` — title: `refactor: Extract alignment and character identity helpers into dndBeyond-identity.ts (closes #159)`
+- [ ] Wait 120 seconds for agentic reviewers to post comments
+- [ ] **Monitor PR comments** — address each, commit fixes, follow Remote push validation, push; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — diagnose failures, fix, validate locally, push; repeat until all checks pass
+- [ ] Wait for PR to merge — never force-merge; if a human force-merges, continue to Post-Merge
+
+Ownership metadata:
+
+- Implementer: doug
+- Reviewer(s): agentic reviewers + human
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No documentation updates required (pure internal refactor)
+- [ ] Sync approved spec deltas into `openspec/specs/` if spec content was revised during review
+- [ ] Archive the change: move `openspec/changes/extract-dndbeyond-identity/` to `openspec/changes/archive/YYYY-MM-DD-extract-dndbeyond-identity/` — stage both the copy and deletion in a single commit, never split
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-extract-dndbeyond-identity/` exists and `openspec/changes/extract-dndbeyond-identity/` is gone
+- [ ] Commit and push the archive to `main` in one commit
+- [ ] Prune merged local branch: `git fetch --prune` and `git branch -d extract-dndbeyond-identity`

--- a/openspec/changes/extract-dndbeyond-identity/tasks.md
+++ b/openspec/changes/extract-dndbeyond-identity/tasks.md
@@ -40,8 +40,8 @@
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test`; all tests must pass
-- **Build** — `npm run build` or `tsc --noEmit`; must succeed with no errors
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Build** — `tsc --noEmit`; must succeed with no errors
 - If **ANY** of the above fail, iterate and fix before pushing
 
 ## PR and Merge


### PR DESCRIPTION
## Summary

Final extraction in the #150–159 refactor series. Moves six identity/URL helpers and their private constants out of `lib/dndBeyondCharacterImport.ts` into a new `lib/import/dndBeyond-identity.ts` module.

## Changes

### New file: `lib/import/dndBeyond-identity.ts`
- Private constants: `CANONICAL_HOST`, `CHARACTER_PATH_PATTERN`, `ALIGNMENT_ID_MAP`
- Private interface: `CharacterIdentity`
- Private helpers: `parseUrlOrThrow`, `isSupportedDndBeyondHostname`
- Exported: `parseDndBeyondCharacterUrl`, `requireCharacterIdentity`, `buildNormalizationWarnings`, `normalizeAlignmentId`
- Uses minimal structural types to avoid circular imports with `dndBeyondCharacterImport.ts`

### Modified: `lib/dndBeyondCharacterImport.ts`
- Removes all moved function definitions, constants, and `CharacterIdentity` interface
- Adds imports from new module
- Re-exports `parseDndBeyondCharacterUrl` for backward compatibility (consumed by `lib/server/dndBeyondCharacterImport.ts` and tests)
- Renames `normalizeAlignment(alignmentId)` call site → `normalizeAlignmentId(alignmentId)` to avoid collision with `lib/types.ts` export

## Validation
- `tsc --noEmit` — zero errors
- 1169/1169 unit tests pass with no test file modifications
- All grep checks clean (no moved functions remain in source file; all consumers intact)