### PR TITLE
test: campaign global route unit tests — fix diff coverage

### DIFF
--- a/tests/e2e/combat.spec.ts
+++ b/tests/e2e/combat.spec.ts
@@ -112,7 +112,7 @@ test.describe("Combat flows", () => {
 
     await page.goto("/characters");
     await expect(
-      page.getByRole("heading", { name: "Characters" }),
+      page.getByRole("heading", { name: "Characters", exact: true }),
     ).toBeVisible();
 
     await page

--- a/tests/unit/api/campaigns/global.id.copy.route.test.ts
+++ b/tests/unit/api/campaigns/global.id.copy.route.test.ts
@@ -1,0 +1,142 @@
+import { POST } from "@/app/api/campaigns/global/[id]/copy/route";
+import { requireAuth } from "@/lib/middleware";
+import { storage } from "@/lib/storage";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  mockUnauthorized,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () => ({ requireAuth: jest.fn() }));
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    loadGlobalCampaignTemplateById: jest.fn(),
+    saveCampaign: jest.fn(),
+  },
+}));
+
+let uuidCounter = 0;
+jest.mock("crypto", () => ({
+  randomUUID: jest.fn(() => `uuid-${++uuidCounter}`),
+}));
+
+const mockedRequireAuth = jest.mocked(requireAuth);
+const mockedStorage = jest.mocked(storage);
+
+const TEMPLATE_ID = "tpl-1";
+const BASE_URL = `http://localhost/api/campaigns/global/${TEMPLATE_ID}/copy`;
+const PARAMS = Promise.resolve({ id: TEMPLATE_ID });
+
+const MOCK_TEMPLATE = {
+  id: TEMPLATE_ID,
+  userId: "GLOBAL",
+  isGlobal: true,
+  name: "Lost Mine of Phandelver",
+  moduleName: "LMoP",
+  chapters: [
+    { id: "orig-ch-1", title: "Chapter 1", order: 0 },
+    { id: "orig-ch-2", title: "Chapter 2", order: 1 },
+  ],
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  uuidCounter = 0;
+  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+  mockedStorage.saveCampaign.mockResolvedValue(undefined as any);
+});
+
+describe("POST /api/campaigns/global/[id]/copy — auth", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthorized(mockedRequireAuth as jest.Mock);
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/campaigns/global/[id]/copy — not found", () => {
+  it("returns 404 when template does not exist", async () => {
+    mockedStorage.loadGlobalCampaignTemplateById.mockResolvedValue(null as any);
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/not found/i);
+  });
+});
+
+describe("POST /api/campaigns/global/[id]/copy — success", () => {
+  beforeEach(() => {
+    mockedStorage.loadGlobalCampaignTemplateById.mockResolvedValue(MOCK_TEMPLATE as any);
+  });
+
+  it("returns 201 with the new campaign", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect(res.status).toBe(201);
+  });
+
+  it("assigns the authenticated user's userId", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect((await res.json()).userId).toBe(MOCK_AUTH.userId);
+  });
+
+  it("copies name and moduleName from template", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    const data = await res.json();
+    expect(data.name).toBe("Lost Mine of Phandelver");
+    expect(data.moduleName).toBe("LMoP");
+  });
+
+  it("gives chapters new UUIDs — not the originals", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    const data = await res.json();
+    expect(data.chapters).toHaveLength(2);
+    const ids = data.chapters.map((ch: { id: string }) => ch.id);
+    expect(ids).not.toContain("orig-ch-1");
+    expect(ids).not.toContain("orig-ch-2");
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("sets currentChapterId to the first copied chapter", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    const data = await res.json();
+    expect(data.currentChapterId).toBe(data.chapters[0].id);
+  });
+
+  it("sets templateId to the source template id", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect((await res.json()).templateId).toBe(TEMPLATE_ID);
+  });
+
+  it("creates campaign as inactive", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect((await res.json()).active).toBe(false);
+  });
+
+  it("handles empty chapters — currentChapterId is absent", async () => {
+    mockedStorage.loadGlobalCampaignTemplateById.mockResolvedValue({
+      ...MOCK_TEMPLATE,
+      chapters: [],
+    } as any);
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.chapters).toEqual([]);
+    expect(data.currentChapterId).toBeUndefined();
+  });
+});
+
+describe("POST /api/campaigns/global/[id]/copy — error handling", () => {
+  it("returns 500 when loadGlobalCampaignTemplateById throws", async () => {
+    mockedStorage.loadGlobalCampaignTemplateById.mockRejectedValue(new Error("DB error"));
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when saveCampaign throws", async () => {
+    mockedStorage.loadGlobalCampaignTemplateById.mockResolvedValue(MOCK_TEMPLATE as any);
+    mockedStorage.saveCampaign.mockRejectedValue(new Error("write failed"));
+    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/api/campaigns/global.id.route.test.ts
+++ b/tests/unit/api/campaigns/global.id.route.test.ts
@@ -1,0 +1,58 @@
+import { DELETE } from "@/app/api/campaigns/global/[id]/route";
+import { requireAdmin } from "@/lib/api-helpers";
+import { storage } from "@/lib/storage";
+import {
+  makeRouteRequest,
+  mockAdminDenied,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/api-helpers", () => ({ requireAdmin: jest.fn() }));
+jest.mock("@/lib/storage", () => ({
+  storage: { deleteCampaignTemplate: jest.fn() },
+}));
+
+const mockedRequireAdmin = jest.mocked(requireAdmin);
+const mockedStorage = jest.mocked(storage);
+
+const TEMPLATE_ID = "tpl-1";
+const BASE_URL = `http://localhost/api/campaigns/global/${TEMPLATE_ID}`;
+const PARAMS = Promise.resolve({ id: TEMPLATE_ID });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedRequireAdmin.mockResolvedValue(null);
+});
+
+describe("DELETE /api/campaigns/global/[id]", () => {
+  it("returns 200 when template is deleted", async () => {
+    mockedStorage.deleteCampaignTemplate.mockResolvedValue(true as any);
+    const res = await DELETE(makeRouteRequest(BASE_URL, "DELETE"), { params: PARAMS });
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it("returns 404 when template does not exist", async () => {
+    mockedStorage.deleteCampaignTemplate.mockResolvedValue(false as any);
+    const res = await DELETE(makeRouteRequest(BASE_URL, "DELETE"), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/not found/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAdminDenied(mockedRequireAdmin as jest.Mock, 401);
+    const res = await DELETE(makeRouteRequest(BASE_URL, "DELETE"), { params: PARAMS });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAdminDenied(mockedRequireAdmin as jest.Mock, 403);
+    const res = await DELETE(makeRouteRequest(BASE_URL, "DELETE"), { params: PARAMS });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 500 when storage throws", async () => {
+    mockedStorage.deleteCampaignTemplate.mockRejectedValue(new Error("DB error"));
+    const res = await DELETE(makeRouteRequest(BASE_URL, "DELETE"), { params: PARAMS });
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/api/campaigns/global.route.test.ts
+++ b/tests/unit/api/campaigns/global.route.test.ts
@@ -1,0 +1,183 @@
+import { GET, POST, PUT } from "@/app/api/campaigns/global/route";
+import { requireAdmin } from "@/lib/api-helpers";
+import { storage } from "@/lib/storage";
+import {
+  makeRouteRequest,
+  mockAdminDenied,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/api-helpers", () => ({ requireAdmin: jest.fn() }));
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    loadGlobalCampaignTemplates: jest.fn(),
+    saveCampaignTemplate: jest.fn(),
+  },
+}));
+jest.mock("crypto", () => ({ randomUUID: jest.fn(() => "test-uuid") }));
+
+const mockedRequireAdmin = jest.mocked(requireAdmin);
+const mockedStorage = jest.mocked(storage);
+
+const BASE_URL = "http://localhost/api/campaigns/global";
+
+const MOCK_TEMPLATE = {
+  id: "tpl-1",
+  userId: "GLOBAL",
+  isGlobal: true,
+  name: "Lost Mine of Phandelver",
+  moduleName: "LMoP",
+  chapters: [],
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedRequireAdmin.mockResolvedValue(null);
+});
+
+// ─── GET /api/campaigns/global ────────────────────────────────────────────────
+
+describe("GET /api/campaigns/global", () => {
+  it("returns 200 with templates array", async () => {
+    mockedStorage.loadGlobalCampaignTemplates.mockResolvedValue([MOCK_TEMPLATE] as any);
+    const res = await GET(makeRouteRequest(BASE_URL, "GET"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].name).toBe("Lost Mine of Phandelver");
+  });
+
+  it("returns empty array when no templates exist", async () => {
+    mockedStorage.loadGlobalCampaignTemplates.mockResolvedValue([]);
+    const res = await GET(makeRouteRequest(BASE_URL, "GET"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("returns 500 when storage throws", async () => {
+    mockedStorage.loadGlobalCampaignTemplates.mockRejectedValue(new Error("DB error"));
+    const res = await GET(makeRouteRequest(BASE_URL, "GET"));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/failed/i);
+  });
+});
+
+// ─── POST /api/campaigns/global — auth ────────────────────────────────────────
+
+describe("POST /api/campaigns/global — auth", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAdminDenied(mockedRequireAdmin as jest.Mock, 401);
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { name: "Test" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAdminDenied(mockedRequireAdmin as jest.Mock, 403);
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { name: "Test" }));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── POST /api/campaigns/global — validation ──────────────────────────────────
+
+describe("POST /api/campaigns/global — validation", () => {
+  it("returns 400 when name is missing", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { moduleName: "LMoP" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/name/i);
+  });
+
+  it("returns 400 when name is blank string", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { name: "   " }));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── POST /api/campaigns/global — success ─────────────────────────────────────
+
+describe("POST /api/campaigns/global — success", () => {
+  beforeEach(() => {
+    mockedStorage.saveCampaignTemplate.mockResolvedValue(undefined as any);
+  });
+
+  it("returns 201 with created template", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", {
+      name: "Lost Mine",
+      moduleName: "LMoP",
+      description: "A starter adventure",
+      chapters: [{ id: "ch-1", title: "Chapter 1", order: 0 }],
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.name).toBe("Lost Mine");
+    expect(data.moduleName).toBe("LMoP");
+    expect(data.description).toBe("A starter adventure");
+    expect(data.isGlobal).toBe(true);
+    expect(data.chapters).toHaveLength(1);
+  });
+
+  it("defaults moduleName to empty string when omitted", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { name: "No Module" }));
+    expect(res.status).toBe(201);
+    expect((await res.json()).moduleName).toBe("");
+  });
+
+  it("passes through chapter optional fields (description, levelRange, location)", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", {
+      name: "Test",
+      chapters: [{
+        id: "ch-1", title: "Chapter 1", order: 0,
+        description: "Intro", levelRange: "1-4", location: "Phandalin",
+      }],
+    }));
+    const ch = (await res.json()).chapters[0];
+    expect(ch.description).toBe("Intro");
+    expect(ch.levelRange).toBe("1-4");
+    expect(ch.location).toBe("Phandalin");
+  });
+
+  it("strips invalid chapters and keeps valid ones", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", {
+      name: "Test Template",
+      chapters: [
+        { id: "ch-1", title: "Valid", order: 0 },
+        { id: "", title: "Empty id", order: 1 },
+        { id: "ch-3", title: "", order: 2 },
+        { title: "Missing id", order: 3 },
+        { id: "ch-5", title: "Missing order" },
+      ],
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.chapters).toHaveLength(1);
+    expect(data.chapters[0].id).toBe("ch-1");
+  });
+
+  it("defaults chapters to empty array when omitted", async () => {
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { name: "No Chapters" }));
+    expect(res.status).toBe(201);
+    expect((await res.json()).chapters).toEqual([]);
+  });
+
+  it("returns 500 when saveCampaignTemplate throws", async () => {
+    mockedStorage.saveCampaignTemplate.mockRejectedValue(new Error("write failed"));
+    const res = await POST(makeRouteRequest(BASE_URL, "POST", { name: "Test" }));
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── PUT /api/campaigns/global ────────────────────────────────────────────────
+
+describe("PUT /api/campaigns/global", () => {
+  it("returns 501 for admin", async () => {
+    const res = await PUT(makeRouteRequest(BASE_URL, "PUT", {}));
+    expect(res.status).toBe(501);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAdminDenied(mockedRequireAdmin as jest.Mock, 403);
+    const res = await PUT(makeRouteRequest(BASE_URL, "PUT", {}));
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/api/campaigns/global.route.test.ts
+++ b/tests/unit/api/campaigns/global.route.test.ts
@@ -127,8 +127,12 @@ describe("POST /api/campaigns/global — success", () => {
     const res = await POST(makeRouteRequest(BASE_URL, "POST", {
       name: "Test",
       chapters: [{
-        id: "ch-1", title: "Chapter 1", order: 0,
-        description: "Intro", levelRange: "1-4", location: "Phandalin",
+        id: "ch-1",
+        title: "Chapter 1",
+        order: 0,
+        description: "Intro",
+        levelRange: "1-4",
+        location: "Phandalin",
       }],
     }));
     const ch = (await res.json()).chapters[0];

--- a/tests/unit/helpers/route.test.helpers.ts
+++ b/tests/unit/helpers/route.test.helpers.ts
@@ -20,6 +20,14 @@ export function mockUnauthorized(mockedFn: jest.Mock): void {
   );
 }
 
+/** Configure a mocked requireAdmin (async) to return a 401 or 403 response */
+export function mockAdminDenied(mockedFn: jest.Mock, status: 401 | 403): void {
+  const message = status === 401 ? "Unauthorized" : "Only administrators can perform this action";
+  mockedFn.mockResolvedValue(
+    NextResponse.json({ error: message }, { status })
+  );
+}
+
 /**
  * Configure a mocked getDatabase to return a collection with the given methods.
  * Used by route handlers that access MongoDB directly.


### PR DESCRIPTION
## Summary

Adds unit test coverage for the three new campaign global API routes introduced in #201, which were merged without adequate diff coverage.

## What Changed

- `tests/unit/api/campaigns/global.route.test.ts` — GET, POST (auth, validation, success, chapter filtering, optional fields), PUT
- `tests/unit/api/campaigns/global.id.route.test.ts` — DELETE (200, 404, 401, 403, 500)
- `tests/unit/api/campaigns/global.id.copy.route.test.ts` — POST (401, 404, success: userId/name/chapters/new UUIDs/currentChapterId/templateId/inactive, empty chapters, 500)
- `tests/unit/helpers/route.test.helpers.ts` — added `mockAdminDenied()` helper for async requireAdmin mocks (avoids duplicating the inline NextResponse construction pattern)

## Coverage

All three route directories now at 100% statement/branch/function/line coverage.

Fixes diff coverage gate from #201.