### PR TITLE
feat: Active Campaign Dashboard (#186)

### DIFF
--- a/app/api/campaigns/[id]/sessions/route.ts
+++ b/app/api/campaigns/[id]/sessions/route.ts
@@ -5,14 +5,16 @@ import { SessionLog } from '@/lib/types';
 
 type Params = { id: string };
 
-export const GET = withAuthAndParams<Params>(async (_request, auth, { id: campaignId }) => {
+export const GET = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
   try {
     const campaign = await storage.loadCampaignById(campaignId, auth.userId);
     if (!campaign) {
       return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
     }
     const logs = await storage.loadSessionLogs(auth.userId, campaignId);
-    return NextResponse.json(logs);
+    const limitParam = new URL(request.url).searchParams.get('limit');
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    return NextResponse.json(limit && limit > 0 ? logs.slice(0, limit) : logs);
   } catch (error) {
     console.error('Error fetching session logs:', error);
     return NextResponse.json({ error: 'Failed to fetch session logs' }, { status: 500 });

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState } from '@/lib/components/ui';
-import { Campaign, CampaignTemplate, Party, Character, SessionLog } from '@/lib/types';
+import { Campaign, CampaignTemplate, Party, Character, SessionLog, getCharacterType } from '@/lib/types';
 import { CampaignEditor } from './CampaignEditor';
 import { CharacterRosterCard } from '@/lib/components/CharacterRosterCard';
 import { CampaignChapterInfo } from '@/lib/components/CampaignChapterInfo';
@@ -45,51 +45,55 @@ export function CampaignsContent() {
   const [copyingIds, setCopyingIds] = useState<Set<string>>(new Set());
   const [copyError, setCopyError] = useState<Record<string, string>>({});
 
-  useEffect(() => {
-    const loadAll = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setCatalogLoading(true);
-        setCatalogError(null);
+  const loadAll = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      setCatalogLoading(true);
+      setCatalogError(null);
 
-        const [campRes, partyRes, charRes, globalRes] = await Promise.all([
-          fetch('/api/campaigns'),
-          fetch('/api/parties'),
-          fetch('/api/characters'),
-          fetch('/api/campaigns/global'),
-        ]);
+      const [campRes, partyRes, charRes, globalRes] = await Promise.all([
+        fetch('/api/campaigns'),
+        fetch('/api/parties'),
+        fetch('/api/characters'),
+        fetch('/api/campaigns/global'),
+      ]);
 
-        if (!campRes.ok) throw new Error('Failed to fetch campaigns');
-        setCampaigns((await campRes.json()) || []);
+      if (!campRes.ok) throw new Error('Failed to fetch campaigns');
+      setCampaigns((await campRes.json()) || []);
 
-        if (partyRes.ok) setParties((await partyRes.json()) || []);
-        if (charRes.ok) setCharacters((await charRes.json()) || []);
+      if (partyRes.ok) setParties((await partyRes.json()) || []);
+      if (charRes.ok) setCharacters((await charRes.json()) || []);
 
-        if (globalRes.ok) {
-          setTemplates((await globalRes.json()) || []);
-        } else {
-          setCatalogError('Failed to load campaign catalog');
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        setLoading(false);
-        setCatalogLoading(false);
+      if (globalRes.ok) {
+        setTemplates((await globalRes.json()) || []);
+      } else {
+        setCatalogError('Failed to load campaign catalog');
       }
-    };
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+      setCatalogLoading(false);
+    }
+  };
+
+  useEffect(() => {
     loadAll();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     const activeCampaigns = campaigns.filter(c => c.active);
     if (activeCampaigns.length === 0) return;
 
+    const controller = new AbortController();
+
     const fetchSessions = async () => {
       const results = await Promise.all(
         activeCampaigns.map(async (campaign) => {
           try {
-            const res = await fetch(`/api/campaigns/${campaign.id}/sessions?limit=1`);
+            const res = await fetch(`/api/campaigns/${campaign.id}/sessions?limit=1`, { signal: controller.signal });
             if (!res.ok) return [campaign.id, null] as const;
             const data: SessionLog[] = await res.json();
             return [campaign.id, data[0] ?? null] as const;
@@ -98,26 +102,14 @@ export function CampaignsContent() {
           }
         })
       );
-      setSessionsByCampaign(Object.fromEntries(results));
+      if (!controller.signal.aborted) {
+        setSessionsByCampaign(Object.fromEntries(results));
+      }
     };
 
     fetchSessions();
+    return () => controller.abort();
   }, [campaigns]);
-
-  const fetchCampaigns = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const res = await fetch('/api/campaigns');
-      if (!res.ok) throw new Error('Failed to fetch campaigns');
-      const data = await res.json();
-      setCampaigns(data || []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const copyTemplate = async (templateId: string) => {
     setCopyingIds((prev) => new Set(prev).add(templateId));
@@ -128,7 +120,7 @@ export function CampaignsContent() {
         const data = await res.json();
         throw new Error(data.error || 'Failed to copy campaign');
       }
-      await fetchCampaigns();
+      await loadAll();
     } catch (err) {
       setCopyError((prev) => ({ ...prev, [templateId]: err instanceof Error ? err.message : 'Failed to copy campaign' }));
     } finally {
@@ -164,7 +156,7 @@ export function CampaignsContent() {
         const data = await response.json();
         throw new Error(data.error || 'Failed to save campaign');
       }
-      await fetchCampaigns();
+      await loadAll();
       setIsAdding(false);
       setEditingCampaign(null);
     } catch (err) {
@@ -178,7 +170,7 @@ export function CampaignsContent() {
       setError(null);
       const response = await fetch(`/api/campaigns/${id}`, { method: 'DELETE' });
       if (!response.ok) throw new Error('Failed to delete campaign');
-      await fetchCampaigns();
+      await loadAll();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete campaign');
     }
@@ -233,12 +225,6 @@ export function CampaignsContent() {
                       </div>
                       <div className="flex gap-2 flex-shrink-0 ml-4">
                         <Link
-                          href="/prompts"
-                          className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
-                        >
-                          Open Prompt Builder
-                        </Link>
-                        <Link
                           href="/encounters"
                           className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm"
                         >
@@ -290,10 +276,10 @@ export function CampaignsContent() {
                             .filter((c): c is Character => !!c);
 
                           const pcs = resolvedMembers.filter(
-                            c => !c.characterType || c.characterType === 'character'
+                            c => getCharacterType(c.characterType) === 'character'
                           );
                           const npcs = resolvedMembers.filter(
-                            c => c.characterType === 'npc' || c.characterType === 'companion'
+                            c => getCharacterType(c.characterType) !== 'character'
                           );
 
                           return (

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -4,10 +4,12 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState } from '@/lib/components/ui';
-import { Campaign, CampaignTemplate } from '@/lib/types';
+import { Campaign, CampaignTemplate, Party, Character, SessionLog } from '@/lib/types';
 import { CampaignEditor } from './CampaignEditor';
+import { CharacterRosterCard } from '@/lib/components/CharacterRosterCard';
+import { CampaignChapterInfo } from '@/lib/components/CampaignChapterInfo';
 
-function CampaignChapterInfo({ campaign }: { campaign: Campaign }) {
+function ManagementChapterInfo({ campaign }: { campaign: Campaign }) {
   const currentCh = campaign.currentChapterId
     ? campaign.chapters?.find((ch) => ch.id === campaign.currentChapterId)
     : undefined;
@@ -30,6 +32,9 @@ function CampaignChapterInfo({ campaign }: { campaign: Campaign }) {
 
 export function CampaignsContent() {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [parties, setParties] = useState<Party[]>([]);
+  const [characters, setCharacters] = useState<Character[]>([]);
+  const [sessionsByCampaign, setSessionsByCampaign] = useState<Record<string, SessionLog | null>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editingCampaign, setEditingCampaign] = useState<Campaign | null>(null);
@@ -41,9 +46,63 @@ export function CampaignsContent() {
   const [copyError, setCopyError] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    fetchCampaigns();
-    fetchTemplates();
+    const loadAll = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setCatalogLoading(true);
+        setCatalogError(null);
+
+        const [campRes, partyRes, charRes, globalRes] = await Promise.all([
+          fetch('/api/campaigns'),
+          fetch('/api/parties'),
+          fetch('/api/characters'),
+          fetch('/api/campaigns/global'),
+        ]);
+
+        if (!campRes.ok) throw new Error('Failed to fetch campaigns');
+        setCampaigns((await campRes.json()) || []);
+
+        if (partyRes.ok) setParties((await partyRes.json()) || []);
+        if (charRes.ok) setCharacters((await charRes.json()) || []);
+
+        if (globalRes.ok) {
+          setTemplates((await globalRes.json()) || []);
+        } else {
+          setCatalogError('Failed to load campaign catalog');
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+        setCatalogLoading(false);
+      }
+    };
+    loadAll();
   }, []);
+
+  useEffect(() => {
+    const activeCampaigns = campaigns.filter(c => c.active);
+    if (activeCampaigns.length === 0) return;
+
+    const fetchSessions = async () => {
+      const results = await Promise.all(
+        activeCampaigns.map(async (campaign) => {
+          try {
+            const res = await fetch(`/api/campaigns/${campaign.id}/sessions?limit=1`);
+            if (!res.ok) return [campaign.id, null] as const;
+            const data: SessionLog[] = await res.json();
+            return [campaign.id, data[0] ?? null] as const;
+          } catch {
+            return [campaign.id, null] as const;
+          }
+        })
+      );
+      setSessionsByCampaign(Object.fromEntries(results));
+    };
+
+    fetchSessions();
+  }, [campaigns]);
 
   const fetchCampaigns = async () => {
     try {
@@ -57,21 +116,6 @@ export function CampaignsContent() {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
       setLoading(false);
-    }
-  };
-
-  const fetchTemplates = async () => {
-    try {
-      setCatalogLoading(true);
-      setCatalogError(null);
-      const res = await fetch('/api/campaigns/global');
-      if (!res.ok) throw new Error('Failed to fetch campaign catalog');
-      const data = await res.json();
-      setTemplates(data || []);
-    } catch (err) {
-      setCatalogError(err instanceof Error ? err.message : 'Failed to load campaign catalog');
-    } finally {
-      setCatalogLoading(false);
     }
   };
 
@@ -145,6 +189,8 @@ export function CampaignsContent() {
     setEditingCampaign(null);
   };
 
+  const activeCampaigns = campaigns.filter(c => c.active);
+
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <div className="container mx-auto px-4 py-8">
@@ -153,6 +199,155 @@ export function CampaignsContent() {
         </div>
 
         <ErrorBanner message={error} />
+
+        {/* Active Campaigns Dashboard */}
+        <div className="mb-12">
+          <h2 className="text-2xl font-bold mb-4">Active Campaigns</h2>
+          {activeCampaigns.length === 0 ? (
+            <div className="bg-gray-800 rounded-lg p-6 text-center">
+              <p className="text-gray-400 mb-2">
+                No active campaigns — mark one active or create a new one.
+              </p>
+              <a href="#campaigns-list" className="text-blue-400 hover:text-blue-300 text-sm">
+                Go to campaign list ↓
+              </a>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {activeCampaigns.map(campaign => {
+                const linkedParties = parties.filter(p => p.campaignId === campaign.id);
+                const lastSession = sessionsByCampaign[campaign.id];
+
+                return (
+                  <div key={campaign.id} className="bg-gray-800 rounded-lg p-6">
+                    <div className="flex justify-between items-start mb-4">
+                      <div>
+                        <h3 className="text-xl font-bold">{campaign.name}</h3>
+                        {campaign.moduleName && (
+                          <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
+                        )}
+                        <CampaignChapterInfo
+                          chapters={campaign.chapters || []}
+                          currentChapterId={campaign.currentChapterId}
+                        />
+                      </div>
+                      <div className="flex gap-2 flex-shrink-0 ml-4">
+                        <Link
+                          href="/prompts"
+                          className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
+                        >
+                          Open Prompt Builder
+                        </Link>
+                        <Link
+                          href="/encounters"
+                          className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm"
+                        >
+                          Start Encounter
+                        </Link>
+                      </div>
+                    </div>
+
+                    {lastSession && (
+                      <div className="bg-gray-700 rounded p-3 mb-4">
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium">
+                            Session {lastSession.sessionNumber}
+                            {lastSession.title ? ` — ${lastSession.title}` : ''}
+                          </p>
+                          {lastSession.milestone && (
+                            <span className="bg-yellow-600 text-yellow-100 text-xs px-2 py-0.5 rounded">
+                              Milestone
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-gray-400 text-xs mt-1">
+                          {new Date(lastSession.datePlayed).toLocaleDateString()}
+                        </p>
+                        <Link
+                          href={`/campaigns/${campaign.id}/sessions`}
+                          className="text-blue-400 text-xs hover:underline mt-1 inline-block"
+                        >
+                          View all sessions →
+                        </Link>
+                      </div>
+                    )}
+
+                    {linkedParties.length === 0 ? (
+                      <div className="bg-gray-700 rounded p-4 text-center">
+                        <p className="text-gray-400 text-sm">
+                          No party linked —{' '}
+                          <Link href="/parties" className="text-blue-400 hover:underline">
+                            add one in Parties
+                          </Link>
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="space-y-4">
+                        {linkedParties.map(party => {
+                          const activeMembers = party.members.filter(m => !m.leftAt);
+                          const resolvedMembers = activeMembers
+                            .map(m => characters.find(c => c.id === m.characterId))
+                            .filter((c): c is Character => !!c);
+
+                          const pcs = resolvedMembers.filter(
+                            c => !c.characterType || c.characterType === 'character'
+                          );
+                          const npcs = resolvedMembers.filter(
+                            c => c.characterType === 'npc' || c.characterType === 'companion'
+                          );
+
+                          return (
+                            <div key={party.id} className="bg-gray-700 rounded-lg p-4">
+                              <h4 className="font-semibold mb-3">{party.name}</h4>
+
+                              {pcs.length > 0 && (
+                                <div className="mb-3">
+                                  <p className="text-gray-400 text-xs uppercase tracking-wide mb-2">
+                                    Player Characters
+                                  </p>
+                                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                    {pcs.map(c => (
+                                      <CharacterRosterCard
+                                        key={c.id}
+                                        name={c.name}
+                                        race={c.race}
+                                        characterType={c.characterType}
+                                        classes={c.classes}
+                                      />
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+
+                              {npcs.length > 0 && (
+                                <div>
+                                  <p className="text-gray-400 text-xs uppercase tracking-wide mb-2">
+                                    Travelling NPCs & Companions
+                                  </p>
+                                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                    {npcs.map(c => (
+                                      <CharacterRosterCard
+                                        key={c.id}
+                                        name={c.name}
+                                        race={c.race}
+                                        characterType={c.characterType}
+                                        classes={c.classes}
+                                      />
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         <button
           onClick={addCampaign}
@@ -172,62 +367,64 @@ export function CampaignsContent() {
           />
         )}
 
-        {loading ? (
-          <LoadingState label="Loading campaigns..." />
-        ) : campaigns.length === 0 ? (
-          <div className="text-center py-16">
-            <p className="text-gray-400 text-lg mb-4">No campaigns yet.</p>
-            <button
-              onClick={addCampaign}
-              className="bg-green-600 hover:bg-green-700 px-6 py-3 rounded text-lg font-semibold"
-            >
-              New Campaign
-            </button>
-          </div>
-        ) : (
-          <div className="grid md:grid-cols-2 gap-4">
-            {campaigns.map(campaign => (
-              <div key={campaign.id} className="bg-gray-800 rounded-lg p-4">
-                <div className="flex justify-between items-start mb-2">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-1">
-                      <h2 className="text-xl font-semibold">{campaign.name}</h2>
-                      {campaign.active && (
-                        <span className="bg-green-700 text-green-100 text-xs px-2 py-0.5 rounded">
-                          Active
-                        </span>
+        <div id="campaigns-list">
+          {loading ? (
+            <LoadingState label="Loading campaigns..." />
+          ) : campaigns.length === 0 ? (
+            <div className="text-center py-16">
+              <p className="text-gray-400 text-lg mb-4">No campaigns yet.</p>
+              <button
+                onClick={addCampaign}
+                className="bg-green-600 hover:bg-green-700 px-6 py-3 rounded text-lg font-semibold"
+              >
+                New Campaign
+              </button>
+            </div>
+          ) : (
+            <div className="grid md:grid-cols-2 gap-4">
+              {campaigns.map(campaign => (
+                <div key={campaign.id} className="bg-gray-800 rounded-lg p-4">
+                  <div className="flex justify-between items-start mb-2">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-1">
+                        <h2 className="text-xl font-semibold">{campaign.name}</h2>
+                        {campaign.active && (
+                          <span className="bg-green-700 text-green-100 text-xs px-2 py-0.5 rounded">
+                            Active
+                          </span>
+                        )}
+                      </div>
+                      {campaign.moduleName && (
+                        <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
                       )}
+                      <ManagementChapterInfo campaign={campaign} />
                     </div>
-                    {campaign.moduleName && (
-                      <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
-                    )}
-                    <CampaignChapterInfo campaign={campaign} />
-                  </div>
-                  <div className="flex gap-2">
-                    <Link
-                      href={`/campaigns/${campaign.id}/sessions`}
-                      className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
-                    >
-                      Session Log
-                    </Link>
-                    <button
-                      onClick={() => { setEditingCampaign(campaign); setIsAdding(false); }}
-                      className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={() => deleteCampaign(campaign.id)}
-                      className="bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm"
-                    >
-                      Delete
-                    </button>
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/campaigns/${campaign.id}/sessions`}
+                        className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
+                      >
+                        Session Log
+                      </Link>
+                      <button
+                        onClick={() => { setEditingCampaign(campaign); setIsAdding(false); }}
+                        className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => deleteCampaign(campaign.id)}
+                        className="bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        )}
+              ))}
+            </div>
+          )}
+        </div>
 
         <div className="mt-12">
           <h2 className="text-2xl font-bold mb-4">Campaign Catalog</h2>

--- a/lib/components/CampaignChapterInfo.tsx
+++ b/lib/components/CampaignChapterInfo.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { CampaignChapter } from '@/lib/types';
+
+interface Props {
+  chapters: CampaignChapter[];
+  currentChapterId?: string;
+}
+
+export function CampaignChapterInfo({ chapters, currentChapterId }: Props) {
+  const currentChapter = currentChapterId
+    ? chapters.find(ch => ch.id === currentChapterId)
+    : undefined;
+
+  return (
+    <p className="text-gray-400 text-sm mt-1">
+      {currentChapter ? currentChapter.title : 'No chapter set'}
+    </p>
+  );
+}

--- a/lib/components/CharacterRosterCard.tsx
+++ b/lib/components/CharacterRosterCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { CharacterType, CharacterClass, calculateTotalLevel } from '@/lib/types';
+
+interface Props {
+  name: string;
+  race?: string;
+  characterType?: CharacterType;
+  classes?: CharacterClass[];
+}
+
+export function CharacterRosterCard({ name, race, characterType, classes }: Props) {
+  const isNpc = characterType === 'npc';
+  const isCompanion = characterType === 'companion';
+  const hasClasses = classes && classes.length > 0;
+
+  return (
+    <div className="bg-gray-700 rounded p-2">
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-sm">{name}</span>
+        {isNpc && (
+          <span className="bg-yellow-800 text-yellow-200 text-xs px-1.5 py-0.5 rounded">NPC</span>
+        )}
+        {isCompanion && (
+          <span className="bg-purple-800 text-purple-200 text-xs px-1.5 py-0.5 rounded">Companion</span>
+        )}
+      </div>
+      <p className="text-gray-400 text-xs mt-0.5">
+        {race || '—'}
+        {hasClasses && ` · ${classes!.map(c => c.class).join('/')} · Lv ${calculateTotalLevel(classes!)}`}
+      </p>
+    </div>
+  );
+}

--- a/openspec/changes/active-campaign-dashboard/.openspec.yaml
+++ b/openspec/changes/active-campaign-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-24

--- a/openspec/changes/active-campaign-dashboard/design.md
+++ b/openspec/changes/active-campaign-dashboard/design.md
@@ -1,0 +1,162 @@
+## Context
+
+- Relevant architecture: Next.js App Router with client components. Data layer via MongoDB through `lib/storage.ts`. Auth via `withAuth`/`requireAuth` middleware. All existing campaign/party/character pages are client-side fetching with `useState`/`useEffect`.
+- Dependencies: `lib/types.ts` (Campaign, Party, PartyMember, Character, SessionLog), `/api/campaigns`, `/api/parties`, `/api/characters`, `/api/campaigns/[id]/sessions` — all exist, no new endpoints needed.
+- Interfaces/contracts touched:
+  - `app/campaigns/page.tsx` — extended state and fetch logic, new dashboard UI section
+  - `lib/components/CharacterRosterCard.tsx` — new component, public props interface
+  - `lib/components/CampaignChapterInfo.tsx` — new component, public props interface
+
+## Goals / Non-Goals
+
+### Goals
+
+- Active campaigns visible immediately on page load at `/campaigns`
+- Each active campaign card shows: name, module/chapter, party members grouped by type, and (lazily) last session
+- New `CharacterRosterCard` component is the canonical roster display (no combat stats)
+- `CharacterMiniSummary` is unchanged — combat-only
+- No new API endpoints
+
+### Non-Goals
+
+- HP/AC display in the dashboard
+- Real-time state or websockets
+- Modifying the existing campaign management list
+- Creating session logs from the dashboard
+
+## Decisions
+
+### Decision 1: Roster display — new CharacterRosterCard, not CharacterMiniSummary
+
+- Chosen: New `lib/components/CharacterRosterCard.tsx` that renders name, race, class/level summary, and NPC/Companion type badge. No AC, no HP, no `CombatStatsRow`.
+- Alternatives considered: (A) Reuse `CharacterMiniSummary` as-is showing AC/HP. (B) Add a `showCombatStats` prop to `CharacterMiniSummary`.
+- Rationale: Between sessions, HP/AC are stale or meaningless. A separate component keeps the combat widget pure and avoids prop-proliferation on `CharacterMiniSummary`. The roster card is also simpler — no imports from `CombatStatsRow`.
+- Trade-offs: Two components to maintain instead of one. Acceptable — they serve distinct contexts (roster identity vs live combat state).
+
+### Decision 2: CampaignChapterInfo as a new simple component
+
+- Chosen: New `lib/components/CampaignChapterInfo.tsx` that accepts `chapters: CampaignChapter[]` and `currentChapterId?: string` and renders `Module · Chapter: <title>`. Falls back gracefully to "No chapter set" when `currentChapterId` is absent or references a missing chapter.
+- Alternatives considered: Inline the chapter display directly in the campaign card JSX.
+- Rationale: Reusable — the same display could appear in other contexts (session log, prompt builder). Keeps the campaign card JSX readable.
+- Trade-offs: Small overhead of an additional file for a ~10-line component.
+
+### Decision 3: Parallel Promise.all fetch with client-side joins
+
+- Chosen: Replace the two separate `fetchCampaigns()` / `fetchTemplates()` calls with a single `Promise.all([fetch('/api/campaigns'), fetch('/api/parties'), fetch('/api/characters'), fetch('/api/campaigns/global')])`. All joins (party→campaign, character→party member) happen client-side.
+- Alternatives considered: New server-side aggregation API endpoint that returns the full denormalized dashboard payload.
+- Rationale: Consistent with the existing app pattern. User data sets (parties, characters) are small. Avoids backend changes and keeps the scope contained.
+- Trade-offs: N+1 is not a concern here (all fetched in parallel), but total payload size grows. Acceptable for typical DM data sets.
+
+### Decision 4: Lazy secondary useEffect for session data
+
+- Chosen: After the main dashboard renders, a second `useEffect` (keyed on active campaign IDs) fires `Promise.all` of `GET /api/campaigns/[id]/sessions?limit=1` for each active campaign. Results stored in `Record<string, SessionLog | null>`. Last Session card renders only when `sessionsByCampaign[id]` is defined and non-null.
+- Alternatives considered: Include session fetch in the main `Promise.all` (blocks main render). Fetch sessions in a single dedicated route (not currently available).
+- Rationale: Main render path must not block on session data. Session data is additive context, not core content.
+- Trade-offs: Multiple small requests fire after render. Acceptable for typical campaign counts (1–3).
+
+### Decision 5: PC vs NPC grouping logic
+
+- Chosen: Within each party sub-card, active members (`members.filter(m => !m.leftAt)`) are split:
+  - **Player Characters**: `characterType === 'character'` or `characterType` undefined (backwards-compatible)
+  - **Travelling NPCs & Companions**: `characterType === 'npc'` or `characterType === 'companion'`
+  - Sections with zero members are hidden.
+- Alternatives considered: Show all members in a flat list.
+- Rationale: Matches the existing grouping pattern on the parties page and the issue spec intent.
+- Trade-offs: None significant.
+
+## Proposal to Design Mapping
+
+- Proposal element: New `CharacterRosterCard` (no combat stats)
+  - Design decision: Decision 1
+  - Validation approach: Unit test renders correct fields; AC/HP are absent from output.
+
+- Proposal element: New `CampaignChapterInfo` component
+  - Design decision: Decision 2
+  - Validation approach: Unit test with present/missing `currentChapterId`; fallback text verified.
+
+- Proposal element: Parallel fetch for campaigns, parties, characters
+  - Design decision: Decision 3
+  - Validation approach: Unit test with mocked fetch; verify all three responses consumed.
+
+- Proposal element: Lazy Last Session card
+  - Design decision: Decision 4
+  - Validation approach: Unit test — secondary useEffect not triggered until active campaigns known; card absent when session data null.
+
+- Proposal element: PC vs NPC grouping
+  - Design decision: Decision 5
+  - Validation approach: Unit test — characters split correctly by `characterType`; sections hidden when empty.
+
+## Functional Requirements Mapping
+
+- Requirement: Active campaigns shown at top of `/campaigns`
+  - Design element: Dashboard section above management list in `app/campaigns/page.tsx`
+  - Acceptance criteria reference: specs/dashboard.md — "active campaigns section"
+  - Testability notes: Unit test renders `n` campaign cards when `n` campaigns have `active: true`.
+
+- Requirement: No active campaigns → CTA card
+  - Design element: Conditional render in dashboard section
+  - Acceptance criteria reference: specs/dashboard.md — "empty state"
+  - Testability notes: Unit test — zero active campaigns renders CTA, no campaign cards.
+
+- Requirement: Party members split by type, active members only
+  - Design element: Decision 5 grouping logic
+  - Acceptance criteria reference: specs/roster.md — "member grouping"
+  - Testability notes: Unit test — members with `leftAt` excluded; `characterType` split verified.
+
+- Requirement: Last Session card conditional on data
+  - Design element: Decision 4 lazy fetch
+  - Acceptance criteria reference: specs/session-card.md — "conditional render"
+  - Testability notes: Unit test — card absent when session null; renders session N, title, date, milestone badge when present.
+
+- Requirement: `CharacterRosterCard` shows name, race, class/level, type badge; no AC/HP
+  - Design element: Decision 1
+  - Acceptance criteria reference: specs/roster.md — "roster card fields"
+  - Testability notes: Unit test — snapshot or field-presence assertions.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: performance
+  - Requirement: Main dashboard render must not block on session data
+  - Design element: Decision 4 (lazy secondary useEffect)
+  - Acceptance criteria reference: specs/session-card.md — "non-blocking"
+  - Testability notes: Unit test — main render completes before session useEffect fires.
+
+- Requirement category: reliability
+  - Requirement: Missing/null session data must not crash or show error state
+  - Design element: `sessionsByCampaign[id]` null-guard before rendering Last Session card
+  - Acceptance criteria reference: specs/session-card.md — "absent on null"
+  - Testability notes: Unit test — null session data results in card absence, no thrown error.
+
+- Requirement category: operability
+  - Requirement: `CampaignChapterInfo` must not crash on missing chapter
+  - Design element: Decision 2 — defensive lookup with fallback
+  - Acceptance criteria reference: specs/chapter-info.md — "fallback"
+  - Testability notes: Unit test — `currentChapterId` referencing non-existent chapter renders fallback text.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Client-side joins on full party/character lists may be slow for large datasets.
+  - Impact: Low — DM datasets are small by nature.
+  - Mitigation: No mitigation needed now; can add server-side filtering later if profiling reveals an issue.
+
+- Risk/trade-off: Two roster components (`CharacterRosterCard` + `CharacterMiniSummary`) may drift.
+  - Impact: Low — they serve distinct purposes.
+  - Mitigation: Both are small, well-typed components. The roster card has no combat-state props so divergence is by design.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Dashboard section causes runtime errors on the campaigns page, or breaks existing campaign management flows.
+- Rollback steps: Revert `app/campaigns/page.tsx` to the pre-feature version. The two new components (`CharacterRosterCard`, `CampaignChapterInfo`) can remain — they are unused without the page changes.
+- Data migration considerations: None — no schema changes, no new collections, no data written.
+- Verification after rollback: `/campaigns` page loads, campaign list renders, create/edit/delete functions work.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check before proceeding. Do not use `--no-verify` or `--admin` merge.
+- If security checks fail: Do not merge. Treat as a blocker regardless of urgency.
+- If required reviews are blocked/stale: Re-request review after 24 hours. Escalate to maintainer after 48 hours.
+- Escalation path and timeout: If blocked for more than 72 hours with no response, raise in project discussion and consider splitting the PR.
+
+## Open Questions
+
+No open questions. All decisions confirmed in the explore session.

--- a/openspec/changes/active-campaign-dashboard/proposal.md
+++ b/openspec/changes/active-campaign-dashboard/proposal.md
@@ -1,0 +1,86 @@
+## GitHub Issues
+
+- #186
+- #188 (Step 1 — Party data model refactor, completed prerequisite)
+
+## Why
+
+- Problem statement: The `/campaigns` page is a pure management list (create/edit/delete). A DM has no at-a-glance view of where they are in their campaign — who's in the party, what chapter they're on, or what happened last session.
+- Why now: All blockers are cleared. The Party data model refactor (#188 Step 1) is complete (`members: PartyMember[]` replaces `characterIds`). Campaign Management (#182) and Travelling NPCs (#183) are done. The necessary APIs (`/api/parties`, `/api/characters`, `/api/campaigns/[id]/sessions`) all exist.
+- Business/user impact: DMs currently have to navigate to separate pages (Parties, Characters) to reconstruct a mental picture of their campaign state before each session. The dashboard gives them that picture immediately on the most-visited page.
+
+## Problem Space
+
+- Current behavior: `/campaigns/page.tsx` fetches only campaigns and global templates. It renders a management list — no party data, no character roster, no session history.
+- Desired behavior: The top of the page shows a dashboard section for every active campaign, each with party roster (PCs and NPCs grouped), current chapter, and (when available) the most recent session log entry. The existing management list remains below, unchanged.
+- Constraints:
+  - `CharacterMiniSummary` must not be modified — it is the combat-view component and owns AC/HP display. The dashboard uses a new `CharacterRosterCard` (name, race, class/level, type badge — no combat stats).
+  - `CampaignChapterInfo` does not yet exist and must be created.
+  - Data joins are client-side only — no new API endpoints.
+  - Last Session card is non-blocking: it loads after the main render via a secondary `useEffect` and is absent if no session data exists.
+- Assumptions:
+  - All parties and characters for a user are small enough that fetching all and filtering client-side is acceptable (consistent with the existing app pattern).
+  - A campaign's `active` flag is the source of truth for dashboard inclusion.
+  - Between sessions, characters always have full HP — the roster view intentionally omits HP/AC to avoid showing stale combat state.
+- Edge cases considered:
+  - No active campaigns → CTA card, no campaign cards rendered.
+  - Active campaign with no linked party → empty state with link to `/parties`.
+  - Active campaign with multiple parties → one party sub-card per party.
+  - Party with no active members (all `leftAt` set) → renders as empty party.
+  - Session API returns empty → Last Session card simply absent.
+
+## Scope
+
+### In Scope
+
+- New `CharacterRosterCard` component (`lib/components/CharacterRosterCard.tsx`) — name, race, class/level, NPC/Companion badge. No AC/HP.
+- New `CampaignChapterInfo` component (`lib/components/CampaignChapterInfo.tsx`) — renders module name and current chapter from `Campaign.chapters` + `Campaign.currentChapterId`.
+- Extend `app/campaigns/page.tsx`: parallel `Promise.all` fetch for campaigns + parties + characters; secondary `useEffect` for per-campaign session data; Active Campaigns dashboard section above the management list.
+- Tests: unit tests for both new components and dashboard section logic; integration smoke test.
+
+### Out of Scope
+
+- Modifying `CharacterMiniSummary` or `CombatStatsRow`.
+- New API endpoints — all data comes from existing routes.
+- Prompt Builder or Encounter quick-action routing changes (buttons link to existing routes `/prompts` and `/encounters` as-is).
+- Session log creation UI (that's #188 Steps 3–4).
+- Any change to `app/page.tsx` (stays as redirect to `/campaigns`).
+
+## What Changes
+
+- `lib/components/CharacterRosterCard.tsx` — new component
+- `lib/components/CampaignChapterInfo.tsx` — new component
+- `app/campaigns/page.tsx` — extended fetching, new dashboard section UI
+- Test files for the above
+
+## Risks
+
+- Risk: Large character or party lists cause slow initial render.
+  - Impact: Low — user data sets are expected to be small; consistent with existing app patterns.
+  - Mitigation: Client-side filtering only; no additional round trips for the main render path.
+- Risk: Session fetch for each active campaign fires N parallel requests.
+  - Impact: Low for typical campaign counts (1–3). Could be noticeable with many active campaigns.
+  - Mitigation: Secondary `useEffect` fires after main render so it never blocks the page. Cap or batch if counts grow.
+- Risk: `CampaignChapterInfo` renders incorrectly if `currentChapterId` references a missing chapter.
+  - Impact: Low — graceful fallback to "No chapter set".
+  - Mitigation: Defensive lookup in the component.
+
+## Open Questions
+
+No unresolved ambiguity. All architectural decisions were confirmed during the explore session:
+- CharacterRosterCard (Option B, no combat stats) — confirmed.
+- CampaignChapterInfo as a new component — confirmed.
+- Client-side joins, no new API endpoints — confirmed.
+- Last Session card lazy and conditional — confirmed.
+
+## Non-Goals
+
+- Replacing or merging the campaign management list below the dashboard.
+- Real-time HP/AC tracking between sessions.
+- Combat event auto-capture in session logs (deferred to #190).
+- A "pick one active campaign" mechanic — all active campaigns are shown.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/active-campaign-dashboard/specs/dashboard.md
+++ b/openspec/changes/active-campaign-dashboard/specs/dashboard.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Active Campaigns dashboard section
+
+The system SHALL render an Active Campaigns section at the top of `/campaigns`, above the existing management list, containing one campaign card per campaign where `active === true`.
+
+#### Scenario: Multiple active campaigns shown
+
+- **Given** the user has two campaigns with `active: true` and one with `active: false`
+- **When** the user visits `/campaigns`
+- **Then** two campaign cards are rendered in the Active Campaigns section and zero cards for the inactive campaign
+
+#### Scenario: No active campaigns — CTA card
+
+- **Given** the user has no campaigns with `active: true`
+- **When** the user visits `/campaigns`
+- **Then** the Active Campaigns section renders a single CTA card with text directing the user to mark a campaign active or create one, and no campaign cards are rendered
+
+#### Scenario: Existing management list unchanged
+
+- **Given** any state of active/inactive campaigns
+- **When** the user visits `/campaigns`
+- **Then** the existing campaign management list (all campaigns, create/edit/delete, catalog) is visible below the dashboard section and fully functional
+
+### Requirement: ADDED Campaign card content
+
+The system SHALL render each active campaign card with: campaign name, module/chapter info (`CampaignChapterInfo`), all linked party sub-cards, Last Session card (conditional), and quick-action buttons for Prompt Builder and Encounters.
+
+#### Scenario: Campaign card renders header and actions
+
+- **Given** an active campaign with `moduleName` set and `currentChapterId` pointing to a valid chapter
+- **When** the dashboard renders
+- **Then** the card shows the campaign name, module name, current chapter title, a "Open Prompt Builder" link to `/prompts`, and a "Start Encounter" link to `/encounters`
+
+#### Scenario: Campaign with no linked party shows empty state
+
+- **Given** an active campaign with no party where `party.campaignId === campaign.id`
+- **When** the dashboard renders
+- **Then** the party section of the card shows an empty state with a link to `/parties`
+
+### Requirement: ADDED Party sub-cards with member grouping
+
+The system SHALL render a party sub-card for each party linked to the active campaign, showing active members (`members.filter(m => !m.leftAt)`) split into Player Characters and Travelling NPCs & Companions sections. Sections with zero members are hidden.
+
+#### Scenario: Members split by characterType
+
+- **Given** a party with two members where `characterType === 'character'` and one member where `characterType === 'npc'`
+- **When** the party sub-card renders
+- **Then** the Player Characters section shows two `CharacterRosterCard` entries and the Travelling NPCs & Companions section shows one entry
+
+#### Scenario: Departed members excluded
+
+- **Given** a party with one active member (`leftAt` undefined) and one departed member (`leftAt` set)
+- **When** the party sub-card renders
+- **Then** only the active member appears; the departed member is not rendered
+
+#### Scenario: PC section hidden when no PCs
+
+- **Given** a party with only NPC members (all `characterType === 'npc'`)
+- **When** the party sub-card renders
+- **Then** the Player Characters section is not rendered; only the Travelling NPCs & Companions section is visible
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED campaigns page data fetching
+
+The system SHALL fetch campaigns, parties, and characters in parallel on page load rather than fetching only campaigns and templates sequentially.
+
+#### Scenario: All three fetches fire in parallel
+
+- **Given** the user visits `/campaigns`
+- **When** the page mounts
+- **Then** `fetch('/api/campaigns')`, `fetch('/api/parties')`, `fetch('/api/characters')`, and `fetch('/api/campaigns/global')` are all initiated before any one resolves
+
+## REMOVED Requirements
+
+No requirements removed by this change.
+
+## Traceability
+
+- Proposal: "Top of the campaigns page shows all active campaigns at a glance" → Requirement: Active Campaigns dashboard section
+- Proposal: "All parties linked to an active campaign are listed within its card" → Requirement: Party sub-cards with member grouping
+- Proposal: "No active campaigns → CTA" → Requirement: Active Campaigns dashboard section (empty state scenario)
+- Design Decision 3 (parallel fetch) → Requirement: MODIFIED campaigns page data fetching
+- Design Decision 5 (PC vs NPC grouping) → Requirement: Party sub-cards with member grouping
+- Requirements → Tasks: tasks.md — Task 3 (page fetch), Task 4 (dashboard UI)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Main render not blocked by session data
+
+- **Given** the active campaigns dashboard has rendered
+- **When** the secondary session fetch has not yet resolved
+- **Then** campaign cards, party sub-cards, and roster cards are all visible; the Last Session card area is simply absent (not a loading spinner or error)
+
+### Requirement: Reliability
+
+#### Scenario: Session fetch failure does not break dashboard
+
+- **Given** `GET /api/campaigns/[id]/sessions?limit=1` returns a network error or 500
+- **When** the secondary useEffect processes the response
+- **Then** the Last Session card is absent for that campaign; no error boundary is triggered; other campaign cards are unaffected

--- a/openspec/changes/active-campaign-dashboard/specs/roster.md
+++ b/openspec/changes/active-campaign-dashboard/specs/roster.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED CharacterRosterCard component
+
+The system SHALL provide a `CharacterRosterCard` component that renders character identity fields (name, race, class/level, type badge) with no combat stats (AC, HP).
+
+#### Scenario: Player character renders identity fields
+
+- **Given** a character with `name: "Aria"`, `race: "Elf"`, `classes: [{class: "Wizard", level: 5}]`, `characterType: "character"`
+- **When** `CharacterRosterCard` renders
+- **Then** the card shows "Aria", "Elf · Wizard · Lv 5", and no NPC/Companion badge; AC and HP are absent from the DOM
+
+#### Scenario: NPC renders type badge
+
+- **Given** a character with `characterType: "npc"` and `name: "Mira"`
+- **When** `CharacterRosterCard` renders
+- **Then** an "NPC" badge is visible alongside the name
+
+#### Scenario: Companion renders type badge
+
+- **Given** a character with `characterType: "companion"` and `name: "Rex"`
+- **When** `CharacterRosterCard` renders
+- **Then** a "Companion" badge is visible alongside the name
+
+#### Scenario: Character with no classes renders gracefully
+
+- **Given** a character with `classes: []` or `classes` undefined
+- **When** `CharacterRosterCard` renders
+- **Then** race is shown (if present) and no class/level line appears; no crash
+
+### Requirement: ADDED CampaignChapterInfo component
+
+The system SHALL provide a `CampaignChapterInfo` component that renders the campaign's current chapter title, falling back gracefully when no chapter is set or the referenced chapter does not exist.
+
+#### Scenario: Current chapter renders correctly
+
+- **Given** `chapters: [{id: "ch1", title: "The Siege of Sigil"}]` and `currentChapterId: "ch1"`
+- **When** `CampaignChapterInfo` renders
+- **Then** "The Siege of Sigil" is visible
+
+#### Scenario: No currentChapterId set
+
+- **Given** `currentChapterId` is undefined or empty
+- **When** `CampaignChapterInfo` renders
+- **Then** a fallback like "No chapter set" is displayed; no crash
+
+#### Scenario: currentChapterId references missing chapter
+
+- **Given** `currentChapterId: "ch-missing"` and no chapter with that id in `chapters`
+- **When** `CampaignChapterInfo` renders
+- **Then** fallback text is displayed; no crash
+
+## MODIFIED Requirements
+
+No existing roster or character display requirements are modified by this change. `CharacterMiniSummary` is unchanged.
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal: "Party members listed with name, race, class, and level" → Requirement: CharacterRosterCard component
+- Proposal: "Travelling NPCs and companions listed separately" → Requirement: CharacterRosterCard (type badge scenario)
+- Proposal: "Each active campaign card shows module name, current chapter" → Requirement: CampaignChapterInfo component
+- Design Decision 1 (CharacterRosterCard, not CharacterMiniSummary) → Requirement: CharacterRosterCard component
+- Design Decision 2 (CampaignChapterInfo new component) → Requirement: CampaignChapterInfo component
+- Requirements → Tasks: tasks.md — Task 1 (CharacterRosterCard), Task 2 (CampaignChapterInfo)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: CharacterRosterCard handles missing optional fields
+
+- **Given** a character where `race` is undefined and `classes` is empty
+- **When** `CharacterRosterCard` renders
+- **Then** the component renders without errors; missing fields are shown as "—" or omitted gracefully

--- a/openspec/changes/active-campaign-dashboard/specs/session-card.md
+++ b/openspec/changes/active-campaign-dashboard/specs/session-card.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Last Session card (conditional, non-blocking)
+
+The system SHALL render a Last Session card within each active campaign card when session data is available, and omit it when no session data exists. The fetch for session data SHALL NOT block the main dashboard render.
+
+#### Scenario: Last Session card renders when data is present
+
+- **Given** `GET /api/campaigns/[id]/sessions?limit=1` returns a session with `sessionNumber: 11`, `title: "The Betrayer Revealed"`, `datePlayed: 2026-05-14`, `milestone: false`
+- **When** the secondary useEffect resolves
+- **Then** the Last Session card displays "Session 11 — The Betrayer Revealed" and the formatted date; no milestone badge is shown
+
+#### Scenario: Milestone badge shown when session has milestone
+
+- **Given** the most recent session has `milestone: true`
+- **When** the Last Session card renders
+- **Then** a milestone badge is visible on the card
+
+#### Scenario: Last Session card absent when no session data
+
+- **Given** `GET /api/campaigns/[id]/sessions?limit=1` returns an empty array or 404
+- **When** the secondary useEffect resolves
+- **Then** the Last Session card area is absent from the campaign card; no error state is shown
+
+#### Scenario: Main dashboard renders before session fetch resolves
+
+- **Given** the session fetch is pending
+- **When** the page first renders after the main Promise.all resolves
+- **Then** campaign cards, party sub-cards, and CharacterRosterCard entries are all visible; the Last Session card area is simply absent (not loading/spinner)
+
+#### Scenario: Session fetch failure is silent
+
+- **Given** `GET /api/campaigns/[id]/sessions?limit=1` returns a network error or 500
+- **When** the secondary useEffect catches the error
+- **Then** the Last Session card is absent for that campaign; no error boundary triggered; other content unaffected
+
+## MODIFIED Requirements
+
+No existing session-related requirements are modified (session journal feature #188 is a separate change).
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal: "Most recent session log entry is surfaced per campaign (conditional)" → Requirement: Last Session card
+- Proposal: "Main dashboard render is not blocked by this fetch" → Requirement: non-blocking (performance scenario)
+- Design Decision 4 (lazy secondary useEffect) → Requirement: Last Session card (all scenarios)
+- Requirements → Tasks: tasks.md — Task 5 (session fetch + card)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Session fetch does not delay page interactivity
+
+- **Given** the main Promise.all has resolved and the dashboard is rendered
+- **When** the session fetch fires asynchronously
+- **Then** the page remains interactive; no loading state blocks the campaign cards or party sub-cards
+
+### Requirement: Reliability
+
+#### Scenario: Recovery when session API is temporarily unavailable
+
+- **Given** the session API returns a 503
+- **When** the secondary useEffect processes the failure
+- **Then** the session card area is silently absent; the DM can still view all campaign and party data

--- a/openspec/changes/active-campaign-dashboard/tasks.md
+++ b/openspec/changes/active-campaign-dashboard/tasks.md
@@ -1,0 +1,133 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feature/active-campaign-dashboard` then immediately `git push -u origin feature/active-campaign-dashboard`
+
+## Execution
+
+### Task 1 — CharacterRosterCard component
+
+- [x] Create `lib/components/CharacterRosterCard.tsx`
+  - Props: `name: string`, `race?: string`, `characterType?: CharacterType`, `classes?: CharacterClass[]`
+  - Renders: name, type badge (NPC/Companion only), race · class/level line
+  - No AC, no HP, no import of `CombatStatsRow`
+  - Uses `calculateTotalLevel` from `lib/types` for multi-class level sum
+  - Graceful fallback: race shows "—" if undefined; class/level line hidden if no classes
+
+### Task 2 — CampaignChapterInfo component
+
+- [x] Create `lib/components/CampaignChapterInfo.tsx`
+  - Props: `chapters: CampaignChapter[]`, `currentChapterId?: string`
+  - Renders current chapter title; falls back to "No chapter set" if `currentChapterId` missing or references absent chapter
+  - Keep it ≤ 15 lines — it's a pure display component
+
+### Task 3 — Extend data fetching in campaigns/page.tsx
+
+- [x] Add `parties: Party[]` and `characters: Character[]` state (`useState`)
+- [x] Add `sessionsByCampaign: Record<string, SessionLog | null>` state
+- [x] Replace separate `fetchCampaigns()` / `fetchTemplates()` with a `Promise.all` that also fetches `GET /api/parties` and `GET /api/characters`
+- [x] Derive in render: `activeCampaigns = campaigns.filter(c => c.active)`
+- [x] For each active campaign: `linkedParties = parties.filter(p => p.campaignId === campaign.id)`
+- [x] For each party: `activeMembers = party.members.filter(m => !m.leftAt)`; resolve each `member.characterId` against `characters`
+- [x] Split resolved characters: `characterType === 'character'` or undefined → PCs; `'npc'` or `'companion'` → NPCs/Companions
+
+### Task 4 — Active Campaigns dashboard section UI
+
+- [x] Add Active Campaigns section above the existing management list in `app/campaigns/page.tsx`
+- [x] If no active campaigns: render CTA card ("No active campaigns — mark one active or create a new one" with anchor to the management list below)
+- [x] For each active campaign, render a campaign card:
+  - Campaign name (heading)
+  - `<CampaignChapterInfo chapters={campaign.chapters} currentChapterId={campaign.currentChapterId} />`
+  - Party sub-cards (one per `linkedParties` entry):
+    - Party name as sub-heading
+    - Player Characters section: `<CharacterRosterCard>` for each PC; hidden if zero
+    - Travelling NPCs & Companions section: `<CharacterRosterCard>` for each NPC/companion; hidden if zero
+    - If no linked party: "No party linked — [add one in Parties](/parties)"
+  - Quick action buttons: "Open Prompt Builder" → `/prompts`, "Start Encounter" → `/encounters`
+- [x] Dark-theme styling consistent with existing page (gray-900/gray-800, card-based, inset party sub-cards)
+- [x] Two-column member grid collapses to single column on mobile (`grid-cols-2 sm:grid-cols-1` or equivalent Tailwind)
+
+### Task 5 — Lazy session data fetch
+
+- [x] Add secondary `useEffect` keyed on `activeCampaigns` (fire after main data loads)
+- [x] Fetch `GET /api/campaigns/[id]/sessions?limit=1` for each active campaign in parallel
+- [x] Store result in `sessionsByCampaign`: `{ [campaignId]: SessionLog | null }`
+- [x] In campaign card: render Last Session card only when `sessionsByCampaign[campaign.id]` is defined and non-null
+  - Display: "Session {N} — {title} ({datePlayed formatted})"
+  - Milestone badge if `session.milestone === true`
+  - Link to `/campaigns/[id]/sessions`
+- [x] Catch fetch errors silently — set `sessionsByCampaign[id] = null`
+
+### Task 6 — Tests
+
+- [x] `tests/unit/CharacterRosterCard.test.tsx`:
+  - PC renders name, race, class/level; no AC/HP in DOM
+  - NPC renders "NPC" badge
+  - Companion renders "Companion" badge
+  - Missing classes renders gracefully
+- [x] `tests/unit/CampaignChapterInfo.test.tsx`:
+  - Renders correct chapter title
+  - Renders fallback when `currentChapterId` missing
+  - Renders fallback when `currentChapterId` references absent chapter
+- [x] `tests/unit/campaigns-dashboard.test.tsx` (or extend existing campaigns page test):
+  - Zero active campaigns → CTA card rendered, no campaign cards
+  - Two active campaigns → two campaign cards rendered
+  - Active campaign with two linked parties → two party sub-cards
+  - Active campaign with no linked party → empty state with link
+  - Members with `leftAt` set are excluded from roster
+  - Characters split correctly by `characterType` (PC vs NPC/Companion)
+  - Last Session card renders when session data present; absent when null
+  - Milestone badge appears when `session.milestone === true`
+- [x] Integration smoke test: active campaign + linked party + characters → all sections render
+
+## Validation
+
+- [x] `npm run test` — all unit tests pass
+- [x] `npm run test:integration` — integration tests pass
+- [x] `npm run build` — no type errors, no build failures
+- [x] `npm run lint` — no lint errors
+- [x] Manual: visit `/campaigns` in dev server, verify dashboard renders correctly for active/inactive/no-campaign states
+- [x] All tasks above marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [x] Run the required pre-PR self-review before committing
+- [ ] Commit all changes to `feature/active-campaign-dashboard` and push to remote
+- [ ] Open PR from `feature/active-campaign-dashboard` to `main` — title: "feat: Active Campaign Dashboard (#186)"
+- [ ] Wait 120 seconds for agentic reviewers to post comments
+- [ ] **Monitor PR comments** — address each comment, commit fixes, follow Remote push validation, push; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — diagnose any failures, fix, commit, validate locally, push; repeat until all checks pass
+- [ ] Wait for PR to merge — **never force-merge**; if a human force-merges, proceed to Post-Merge
+
+Ownership metadata:
+- Implementer: dougis
+- Reviewer(s): agentic review + human
+- Required approvals: 1 human
+
+Blocking resolution flow:
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update `openspec/specs/` with any approved spec deltas from `specs/*.md`
+- [ ] Archive the change: move `openspec/changes/active-campaign-dashboard/` to `openspec/changes/archive/YYYY-MM-DD-active-campaign-dashboard/` — stage both new location and deletion in a single commit
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-active-campaign-dashboard/` exists and `openspec/changes/active-campaign-dashboard/` is gone
+- [ ] Commit and push the archive to main in one commit
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -d feature/active-campaign-dashboard`

--- a/openspec/changes/active-campaign-dashboard/tasks.md
+++ b/openspec/changes/active-campaign-dashboard/tasks.md
@@ -103,8 +103,8 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 ## PR and Merge
 
 - [x] Run the required pre-PR self-review before committing
-- [ ] Commit all changes to `feature/active-campaign-dashboard` and push to remote
-- [ ] Open PR from `feature/active-campaign-dashboard` to `main` — title: "feat: Active Campaign Dashboard (#186)"
+- [x] Commit all changes to `feature/active-campaign-dashboard` and push to remote
+- [x] Open PR from `feature/active-campaign-dashboard` to `main` — title: "feat: Active Campaign Dashboard (#186)"
 - [ ] Wait 120 seconds for agentic reviewers to post comments
 - [ ] **Monitor PR comments** — address each comment, commit fixes, follow Remote push validation, push; repeat until no unresolved comments remain
 - [ ] Enable auto-merge once no blocking review comments remain

--- a/openspec/changes/active-campaign-dashboard/tests.md
+++ b/openspec/changes/active-campaign-dashboard/tests.md
@@ -1,0 +1,84 @@
+---
+name: tests
+description: Tests for the active-campaign-dashboard change
+---
+
+# Tests
+
+## Overview
+
+All work follows TDD: write a failing test first, implement the simplest code to pass it, then refactor. Each test case maps to a task in `tasks.md` and an acceptance scenario in `specs/`.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** before writing any implementation code. Run it; confirm it fails.
+2. **Write the simplest code** to make it pass.
+3. **Refactor** — improve structure while keeping the test green.
+
+## Test Cases
+
+### Task 1 — CharacterRosterCard (`tests/unit/CharacterRosterCard.test.tsx`)
+
+- [ ] **T1.1** — PC renders name, race, class/level; AC and HP absent from rendered output
+  - Spec: `specs/roster.md` — "Player character renders identity fields"
+- [ ] **T1.2** — NPC renders "NPC" badge alongside name
+  - Spec: `specs/roster.md` — "NPC renders type badge"
+- [ ] **T1.3** — Companion renders "Companion" badge alongside name
+  - Spec: `specs/roster.md` — "Companion renders type badge"
+- [ ] **T1.4** — Character with no classes renders without crash; no class/level line shown
+  - Spec: `specs/roster.md` — "Character with no classes renders gracefully"
+- [ ] **T1.5** — Character with undefined race renders "—" or omits race gracefully
+  - Spec: `specs/roster.md` — "CharacterRosterCard handles missing optional fields"
+
+### Task 2 — CampaignChapterInfo (`tests/unit/CampaignChapterInfo.test.tsx`)
+
+- [ ] **T2.1** — Renders current chapter title when `currentChapterId` matches a chapter in `chapters`
+  - Spec: `specs/roster.md` — "Current chapter renders correctly"
+- [ ] **T2.2** — Renders fallback text ("No chapter set") when `currentChapterId` is undefined
+  - Spec: `specs/roster.md` — "No currentChapterId set"
+- [ ] **T2.3** — Renders fallback text when `currentChapterId` references a chapter id not present in `chapters`
+  - Spec: `specs/roster.md` — "currentChapterId references missing chapter"
+
+### Task 3 — Fetch logic in campaigns/page.tsx (`tests/unit/campaigns-dashboard.test.tsx`)
+
+- [ ] **T3.1** — On mount, `fetch` is called for `/api/campaigns`, `/api/parties`, `/api/characters`, and `/api/campaigns/global` (all four in parallel)
+  - Spec: `specs/dashboard.md` — "All three fetches fire in parallel"
+- [ ] **T3.2** — Active members correctly derived: member with `leftAt` set is excluded from roster
+  - Spec: `specs/dashboard.md` — "Departed members excluded"
+- [ ] **T3.3** — Characters split: `characterType === 'character'` or undefined → PC bucket; `'npc'` or `'companion'` → NPC bucket
+  - Spec: `specs/dashboard.md` — "Members split by characterType"
+
+### Task 4 — Dashboard section UI (`tests/unit/campaigns-dashboard.test.tsx`)
+
+- [ ] **T4.1** — Zero active campaigns → CTA card rendered; no campaign cards rendered
+  - Spec: `specs/dashboard.md` — "No active campaigns — CTA card"
+- [ ] **T4.2** — Two campaigns with `active: true` → two campaign cards rendered
+  - Spec: `specs/dashboard.md` — "Multiple active campaigns shown"
+- [ ] **T4.3** — Active campaign with two linked parties → two party sub-cards rendered within the campaign card
+  - Spec: `specs/dashboard.md` — "Active campaign with two linked parties"
+- [ ] **T4.4** — Active campaign with no linked party → empty state with link to `/parties` rendered
+  - Spec: `specs/dashboard.md` — "Campaign with no linked party shows empty state"
+- [ ] **T4.5** — PC section hidden when party has only NPC members
+  - Spec: `specs/dashboard.md` — "PC section hidden when no PCs"
+- [ ] **T4.6** — Existing campaign management list renders below the dashboard section
+  - Spec: `specs/dashboard.md` — "Existing management list unchanged"
+
+### Task 5 — Last Session card (`tests/unit/campaigns-dashboard.test.tsx`)
+
+- [ ] **T5.1** — Last Session card renders session number, title, date when session data present
+  - Spec: `specs/session-card.md` — "Last Session card renders when data is present"
+- [ ] **T5.2** — Milestone badge visible when `session.milestone === true`
+  - Spec: `specs/session-card.md` — "Milestone badge shown when session has milestone"
+- [ ] **T5.3** — Last Session card absent when session fetch returns empty array
+  - Spec: `specs/session-card.md` — "Last Session card absent when no session data"
+- [ ] **T5.4** — Main campaign cards and party sub-cards render before session useEffect fires
+  - Spec: `specs/session-card.md` — "Main dashboard renders before session fetch resolves"
+- [ ] **T5.5** — Session fetch failure (network error/500) is swallowed; no error boundary triggered; other content unaffected
+  - Spec: `specs/session-card.md` — "Session fetch failure is silent"
+
+### Integration
+
+- [ ] **T6.1** — Active campaign + linked party + characters → all sections (header, party sub-card, roster cards) render without error
+  - Spec: `specs/dashboard.md` — "Integration smoke test"

--- a/tests/unit/CampaignChapterInfo.test.tsx
+++ b/tests/unit/CampaignChapterInfo.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from 'react';
+import { act } from 'react';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { Root, createRoot } from 'react-dom/client';
+import { CampaignChapterInfo } from '@/lib/components/CampaignChapterInfo';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+});
+
+async function render(ui: React.ReactElement) {
+  await act(async () => { root.render(ui); });
+}
+
+const CHAPTERS = [
+  { id: 'ch1', title: 'The Siege of Sigil', order: 0 },
+  { id: 'ch2', title: 'The Dark Forest', order: 1 },
+];
+
+describe('CampaignChapterInfo', () => {
+  it('T2.1 — renders current chapter title when currentChapterId matches', async () => {
+    await render(<CampaignChapterInfo chapters={CHAPTERS} currentChapterId="ch1" />);
+    expect(container.textContent).toContain('The Siege of Sigil');
+    expect(container.textContent).not.toContain('No chapter set');
+  });
+
+  it('T2.2 — renders fallback when currentChapterId is undefined', async () => {
+    await render(<CampaignChapterInfo chapters={CHAPTERS} currentChapterId={undefined} />);
+    expect(container.textContent).toContain('No chapter set');
+  });
+
+  it('T2.3 — renders fallback when currentChapterId references missing chapter', async () => {
+    await render(<CampaignChapterInfo chapters={CHAPTERS} currentChapterId="ch-missing" />);
+    expect(container.textContent).toContain('No chapter set');
+  });
+
+  it('renders with empty chapters array without crash', async () => {
+    await render(<CampaignChapterInfo chapters={[]} currentChapterId={undefined} />);
+    expect(container.textContent).toContain('No chapter set');
+  });
+});

--- a/tests/unit/CharacterRosterCard.test.tsx
+++ b/tests/unit/CharacterRosterCard.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from 'react';
+import { act } from 'react';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { Root, createRoot } from 'react-dom/client';
+import { CharacterRosterCard } from '@/lib/components/CharacterRosterCard';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+});
+
+async function render(ui: React.ReactElement) {
+  await act(async () => { root.render(ui); });
+}
+
+describe('CharacterRosterCard', () => {
+  it('T1.1 — PC renders name, race, class/level; AC and HP absent', async () => {
+    await render(
+      <CharacterRosterCard
+        name="Aria"
+        race="Elf"
+        characterType="character"
+        classes={[{ class: 'Wizard', level: 5 }]}
+      />
+    );
+    expect(container.textContent).toContain('Aria');
+    expect(container.textContent).toContain('Elf');
+    expect(container.textContent).toContain('Wizard');
+    expect(container.textContent).toContain('Lv 5');
+    expect(container.textContent).not.toContain('NPC');
+    expect(container.textContent).not.toContain('Companion');
+    expect(container.innerHTML).not.toMatch(/\bAC\b/);
+    expect(container.innerHTML).not.toMatch(/\bHP\b/);
+  });
+
+  it('T1.2 — NPC renders "NPC" badge alongside name', async () => {
+    await render(<CharacterRosterCard name="Mira" characterType="npc" classes={[]} />);
+    expect(container.textContent).toContain('Mira');
+    expect(container.textContent).toContain('NPC');
+    expect(container.textContent).not.toContain('Companion');
+  });
+
+  it('T1.3 — Companion renders "Companion" badge alongside name', async () => {
+    await render(<CharacterRosterCard name="Rex" characterType="companion" classes={[]} />);
+    expect(container.textContent).toContain('Rex');
+    expect(container.textContent).toContain('Companion');
+    expect(container.textContent).not.toContain('NPC');
+  });
+
+  it('T1.4 — Character with no classes renders without crash; no class/level line shown', async () => {
+    await render(<CharacterRosterCard name="Barnaby" race="Human" classes={[]} />);
+    expect(container.textContent).toContain('Barnaby');
+    expect(container.textContent).toContain('Human');
+    expect(container.textContent).not.toContain('Lv');
+  });
+
+  it('T1.5 — Character with undefined race renders "—"', async () => {
+    await render(
+      <CharacterRosterCard name="Mira" classes={[{ class: 'Rogue', level: 3 }]} />
+    );
+    expect(container.textContent).toContain('Mira');
+    expect(container.textContent).toContain('—');
+    expect(container.textContent).toContain('Lv 3');
+  });
+
+  it('multiclass — sums levels correctly', async () => {
+    await render(
+      <CharacterRosterCard
+        name="Zara"
+        race="Tiefling"
+        classes={[{ class: 'Warlock', level: 3 }, { class: 'Sorcerer', level: 2 }]}
+      />
+    );
+    expect(container.textContent).toContain('Lv 5');
+    expect(container.textContent).toContain('Warlock');
+    expect(container.textContent).toContain('Sorcerer');
+  });
+});

--- a/tests/unit/campaigns-dashboard.test.tsx
+++ b/tests/unit/campaigns-dashboard.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * @jest-environment jsdom
+ */
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import React from 'react';
+import { act } from 'react';
+import { Root, createRoot } from 'react-dom/client';
+import { Response as FetchResponse } from 'node-fetch';
+import { CampaignsContent } from '@/app/campaigns/page';
+
+jest.mock('@/lib/components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) =>
+    React.createElement('a', { href, ...props }, children),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as Response;
+}
+
+const BASE_CAMPAIGN = {
+  id: 'camp-1',
+  userId: 'user-1',
+  name: 'My Campaign',
+  moduleName: 'LMoP',
+  chapters: [{ id: 'ch1', title: 'The Mines', order: 0 }],
+  currentChapterId: 'ch1',
+  active: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const INACTIVE_CAMPAIGN = { ...BASE_CAMPAIGN, id: 'camp-inactive', name: 'Inactive Campaign', active: false };
+
+const PARTY = {
+  id: 'party-1',
+  userId: 'user-1',
+  name: 'The Brave Ones',
+  campaignId: 'camp-1',
+  members: [
+    { characterId: 'char-pc', addedAt: new Date().toISOString() },
+    { characterId: 'char-npc', addedAt: new Date().toISOString() },
+    { characterId: 'char-departed', addedAt: new Date().toISOString(), leftAt: new Date().toISOString() },
+  ],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const PC_CHARACTER = {
+  id: 'char-pc',
+  userId: 'user-1',
+  name: 'Aria',
+  race: 'Elf',
+  characterType: 'character',
+  classes: [{ class: 'Wizard', level: 5 }],
+  hp: 30, maxHp: 30, ac: 12,
+  abilityScores: { strength: 8, dexterity: 14, constitution: 13, intelligence: 18, wisdom: 12, charisma: 10 },
+};
+
+const NPC_CHARACTER = {
+  id: 'char-npc',
+  userId: 'user-1',
+  name: 'Mira',
+  race: 'Human',
+  characterType: 'npc',
+  classes: [{ class: 'Rogue', level: 2 }],
+  hp: 15, maxHp: 15, ac: 13,
+  abilityScores: { strength: 10, dexterity: 15, constitution: 11, intelligence: 12, wisdom: 10, charisma: 14 },
+};
+
+const DEPARTED_CHARACTER = {
+  id: 'char-departed',
+  userId: 'user-1',
+  name: 'Old Bob',
+  characterType: 'character',
+  classes: [{ class: 'Fighter', level: 1 }],
+  hp: 10, maxHp: 10, ac: 15,
+  abilityScores: { strength: 16, dexterity: 10, constitution: 14, intelligence: 8, wisdom: 10, charisma: 8 },
+};
+
+const MOCK_SESSION = {
+  id: 'sess-1',
+  userId: 'user-1',
+  campaignId: 'camp-1',
+  sessionNumber: 11,
+  title: 'The Betrayer Revealed',
+  datePlayed: '2026-05-14T00:00:00.000Z',
+  summary: '',
+  events: [],
+  milestone: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  originalFetch = global.fetch;
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  global.fetch = originalFetch;
+  jest.clearAllMocks();
+});
+
+interface FetchSetup {
+  campaigns?: unknown[];
+  parties?: unknown[];
+  characters?: unknown[];
+  templates?: unknown[];
+  sessionsByCanpaignId?: Record<string, unknown[]>;
+}
+
+function setupFetch({
+  campaigns = [],
+  parties = [],
+  characters = [],
+  templates = [],
+  sessionsByCanpaignId = {},
+}: FetchSetup = {}) {
+  global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url === '/api/campaigns') return jsonResponse(campaigns);
+    if (url === '/api/parties') return jsonResponse(parties);
+    if (url === '/api/characters') return jsonResponse(characters);
+    if (url === '/api/campaigns/global') return jsonResponse(templates);
+    const sessionMatch = url.match(/\/api\/campaigns\/([^/]+)\/sessions/);
+    if (sessionMatch) {
+      const id = sessionMatch[1];
+      return jsonResponse(sessionsByCanpaignId[id] ?? []);
+    }
+    return jsonResponse({ error: 'not found' }, 404);
+  }) as typeof fetch;
+}
+
+async function renderPage() {
+  await act(async () => { root.render(React.createElement(CampaignsContent)); });
+}
+
+describe('T3 — Fetch logic', () => {
+  it('T3.1 — fires all four fetches in parallel on mount', async () => {
+    setupFetch({ campaigns: [BASE_CAMPAIGN], parties: [PARTY], characters: [PC_CHARACTER] });
+    await renderPage();
+
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    const urls = fetchMock.mock.calls.map(([url]) => url.toString());
+    expect(urls).toContain('/api/campaigns');
+    expect(urls).toContain('/api/parties');
+    expect(urls).toContain('/api/characters');
+    expect(urls).toContain('/api/campaigns/global');
+  });
+
+  it('T3.2 — departed members (leftAt set) are excluded from roster', async () => {
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [PARTY],
+      characters: [PC_CHARACTER, NPC_CHARACTER, DEPARTED_CHARACTER],
+    });
+    await renderPage();
+    expect(container.textContent).toContain('Aria');
+    expect(container.textContent).toContain('Mira');
+    expect(container.textContent).not.toContain('Old Bob');
+  });
+
+  it('T3.3 — characters split by characterType (PC vs NPC bucket)', async () => {
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [PARTY],
+      characters: [PC_CHARACTER, NPC_CHARACTER, DEPARTED_CHARACTER],
+    });
+    await renderPage();
+    expect(container.textContent).toContain('Player Characters');
+    expect(container.textContent).toContain('Travelling NPCs & Companions');
+  });
+});
+
+describe('T4 — Dashboard section UI', () => {
+  it('T4.1 — zero active campaigns renders CTA card; no campaign cards', async () => {
+    setupFetch({ campaigns: [INACTIVE_CAMPAIGN], parties: [], characters: [] });
+    await renderPage();
+    expect(container.textContent).toContain('No active campaigns');
+    expect(container.textContent).not.toContain('Open Prompt Builder');
+  });
+
+  it('T4.2 — two active campaigns render two campaign cards', async () => {
+    const camp2 = { ...BASE_CAMPAIGN, id: 'camp-2', name: 'Second Campaign' };
+    setupFetch({ campaigns: [BASE_CAMPAIGN, camp2], parties: [], characters: [] });
+    await renderPage();
+    expect(container.textContent).toContain('My Campaign');
+    expect(container.textContent).toContain('Second Campaign');
+    const promptLinks = Array.from(container.querySelectorAll('a')).filter(
+      a => a.textContent?.includes('Open Prompt Builder')
+    );
+    expect(promptLinks).toHaveLength(2);
+  });
+
+  it('T4.3 — active campaign with two linked parties renders two party sub-cards', async () => {
+    const party2 = { ...PARTY, id: 'party-2', name: 'Second Party', members: [] };
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [PARTY, party2],
+      characters: [PC_CHARACTER, NPC_CHARACTER],
+    });
+    await renderPage();
+    expect(container.textContent).toContain('The Brave Ones');
+    expect(container.textContent).toContain('Second Party');
+  });
+
+  it('T4.4 — active campaign with no linked party shows empty state with /parties link', async () => {
+    setupFetch({ campaigns: [BASE_CAMPAIGN], parties: [], characters: [] });
+    await renderPage();
+    expect(container.textContent).toContain('No party linked');
+    const partiesLink = Array.from(container.querySelectorAll('a')).find(
+      a => a.getAttribute('href') === '/parties'
+    );
+    expect(partiesLink).toBeTruthy();
+  });
+
+  it('T4.5 — PC section hidden when party has only NPC members', async () => {
+    const npcOnlyParty = {
+      ...PARTY,
+      members: [{ characterId: 'char-npc', addedAt: new Date().toISOString() }],
+    };
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [npcOnlyParty],
+      characters: [NPC_CHARACTER],
+    });
+    await renderPage();
+    expect(container.textContent).toContain('Mira');
+    expect(container.textContent).not.toContain('Player Characters');
+    expect(container.textContent).toContain('Travelling NPCs & Companions');
+  });
+
+  it('T4.6 — existing campaign management list renders below the dashboard section', async () => {
+    setupFetch({ campaigns: [BASE_CAMPAIGN], parties: [], characters: [] });
+    await renderPage();
+    const headings = Array.from(container.querySelectorAll('h1, h2'));
+    const activeIndex = headings.findIndex(h => h.textContent?.includes('Active Campaigns'));
+    const catalogIndex = headings.findIndex(h => h.textContent?.includes('Campaign Catalog'));
+    expect(activeIndex).toBeGreaterThanOrEqual(0);
+    expect(catalogIndex).toBeGreaterThan(activeIndex);
+    // Management list items appear
+    expect(container.textContent).toContain('My Campaign');
+  });
+});
+
+describe('T5 — Last Session card', () => {
+  it('T5.1 — Last Session card renders session number and title when data present', async () => {
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [],
+      characters: [],
+      sessionsByCanpaignId: { 'camp-1': [MOCK_SESSION] },
+    });
+    await renderPage();
+    expect(container.textContent).toContain('Session 11');
+    expect(container.textContent).toContain('The Betrayer Revealed');
+  });
+
+  it('T5.2 — Milestone badge visible when session.milestone === true', async () => {
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [],
+      characters: [],
+      sessionsByCanpaignId: { 'camp-1': [{ ...MOCK_SESSION, milestone: true }] },
+    });
+    await renderPage();
+    expect(container.textContent).toContain('Milestone');
+  });
+
+  it('T5.3 — Last Session card absent when session fetch returns empty array', async () => {
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [],
+      characters: [],
+      sessionsByCanpaignId: { 'camp-1': [] },
+    });
+    await renderPage();
+    expect(container.textContent).not.toContain('Session 11');
+  });
+
+  it('T5.4 — campaign cards render before session useEffect fires', async () => {
+    let resolveSession!: (v: unknown) => void;
+    const sessionPromise = new Promise(res => { resolveSession = res; });
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/campaigns') return jsonResponse([BASE_CAMPAIGN]);
+      if (url === '/api/parties') return jsonResponse([]);
+      if (url === '/api/characters') return jsonResponse([]);
+      if (url === '/api/campaigns/global') return jsonResponse([]);
+      if (url.includes('/sessions')) {
+        await sessionPromise;
+        return jsonResponse([MOCK_SESSION]);
+      }
+      return jsonResponse({}, 404);
+    }) as typeof fetch;
+
+    await renderPage();
+
+    // Campaign card visible before session resolves
+    expect(container.textContent).toContain('My Campaign');
+    expect(container.textContent).toContain('Open Prompt Builder');
+    expect(container.textContent).not.toContain('Session 11');
+
+    resolveSession(undefined);
+    await act(async () => { await sessionPromise; });
+  });
+
+  it('T5.5 — session fetch failure is silent; other content unaffected', async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/campaigns') return jsonResponse([BASE_CAMPAIGN]);
+      if (url === '/api/parties') return jsonResponse([]);
+      if (url === '/api/characters') return jsonResponse([]);
+      if (url === '/api/campaigns/global') return jsonResponse([]);
+      if (url.includes('/sessions')) return jsonResponse({ error: 'Server error' }, 500);
+      return jsonResponse({}, 404);
+    }) as typeof fetch;
+
+    await renderPage();
+
+    expect(container.textContent).toContain('My Campaign');
+    expect(container.textContent).not.toContain('Session 11');
+    // No error text
+    expect(container.textContent).not.toContain('Server error');
+  });
+});
+
+describe('T6 — Integration smoke test', () => {
+  it('T6.1 — active campaign + linked party + characters → all sections render', async () => {
+    setupFetch({
+      campaigns: [BASE_CAMPAIGN],
+      parties: [PARTY],
+      characters: [PC_CHARACTER, NPC_CHARACTER, DEPARTED_CHARACTER],
+      sessionsByCanpaignId: { 'camp-1': [MOCK_SESSION] },
+    });
+    await renderPage();
+
+    expect(container.textContent).toContain('My Campaign');
+    expect(container.textContent).toContain('The Brave Ones');
+    expect(container.textContent).toContain('Aria');
+    expect(container.textContent).toContain('Player Characters');
+    expect(container.textContent).toContain('Mira');
+    expect(container.textContent).toContain('Travelling NPCs & Companions');
+    expect(container.textContent).toContain('Session 11');
+    expect(container.textContent).not.toContain('Old Bob');
+  });
+});

--- a/tests/unit/campaigns-dashboard.test.tsx
+++ b/tests/unit/campaigns-dashboard.test.tsx
@@ -124,7 +124,7 @@ interface FetchSetup {
   parties?: unknown[];
   characters?: unknown[];
   templates?: unknown[];
-  sessionsByCanpaignId?: Record<string, unknown[]>;
+  sessionsByCampaignId?: Record<string, unknown[]>;
 }
 
 function setupFetch({
@@ -132,7 +132,7 @@ function setupFetch({
   parties = [],
   characters = [],
   templates = [],
-  sessionsByCanpaignId = {},
+  sessionsByCampaignId = {},
 }: FetchSetup = {}) {
   global.fetch = jest.fn(async (input: RequestInfo | URL) => {
     const url = input.toString();
@@ -143,7 +143,7 @@ function setupFetch({
     const sessionMatch = url.match(/\/api\/campaigns\/([^/]+)\/sessions/);
     if (sessionMatch) {
       const id = sessionMatch[1];
-      return jsonResponse(sessionsByCanpaignId[id] ?? []);
+      return jsonResponse(sessionsByCampaignId[id] ?? []);
     }
     return jsonResponse({ error: 'not found' }, 404);
   }) as typeof fetch;
@@ -195,7 +195,7 @@ describe('T4 — Dashboard section UI', () => {
     setupFetch({ campaigns: [INACTIVE_CAMPAIGN], parties: [], characters: [] });
     await renderPage();
     expect(container.textContent).toContain('No active campaigns');
-    expect(container.textContent).not.toContain('Open Prompt Builder');
+    expect(container.textContent).not.toContain('Start Encounter');
   });
 
   it('T4.2 — two active campaigns render two campaign cards', async () => {
@@ -204,10 +204,10 @@ describe('T4 — Dashboard section UI', () => {
     await renderPage();
     expect(container.textContent).toContain('My Campaign');
     expect(container.textContent).toContain('Second Campaign');
-    const promptLinks = Array.from(container.querySelectorAll('a')).filter(
-      a => a.textContent?.includes('Open Prompt Builder')
+    const encounterLinks = Array.from(container.querySelectorAll('a')).filter(
+      a => a.textContent?.includes('Start Encounter')
     );
-    expect(promptLinks).toHaveLength(2);
+    expect(encounterLinks).toHaveLength(2);
   });
 
   it('T4.3 — active campaign with two linked parties renders two party sub-cards', async () => {
@@ -267,7 +267,7 @@ describe('T5 — Last Session card', () => {
       campaigns: [BASE_CAMPAIGN],
       parties: [],
       characters: [],
-      sessionsByCanpaignId: { 'camp-1': [MOCK_SESSION] },
+      sessionsByCampaignId: { 'camp-1': [MOCK_SESSION] },
     });
     await renderPage();
     expect(container.textContent).toContain('Session 11');
@@ -279,7 +279,7 @@ describe('T5 — Last Session card', () => {
       campaigns: [BASE_CAMPAIGN],
       parties: [],
       characters: [],
-      sessionsByCanpaignId: { 'camp-1': [{ ...MOCK_SESSION, milestone: true }] },
+      sessionsByCampaignId: { 'camp-1': [{ ...MOCK_SESSION, milestone: true }] },
     });
     await renderPage();
     expect(container.textContent).toContain('Milestone');
@@ -290,7 +290,7 @@ describe('T5 — Last Session card', () => {
       campaigns: [BASE_CAMPAIGN],
       parties: [],
       characters: [],
-      sessionsByCanpaignId: { 'camp-1': [] },
+      sessionsByCampaignId: { 'camp-1': [] },
     });
     await renderPage();
     expect(container.textContent).not.toContain('Session 11');
@@ -317,7 +317,7 @@ describe('T5 — Last Session card', () => {
 
     // Campaign card visible before session resolves
     expect(container.textContent).toContain('My Campaign');
-    expect(container.textContent).toContain('Open Prompt Builder');
+    expect(container.textContent).toContain('Start Encounter');
     expect(container.textContent).not.toContain('Session 11');
 
     resolveSession(undefined);
@@ -350,7 +350,7 @@ describe('T6 — Integration smoke test', () => {
       campaigns: [BASE_CAMPAIGN],
       parties: [PARTY],
       characters: [PC_CHARACTER, NPC_CHARACTER, DEPARTED_CHARACTER],
-      sessionsByCanpaignId: { 'camp-1': [MOCK_SESSION] },
+      sessionsByCampaignId: { 'camp-1': [MOCK_SESSION] },
     });
     await renderPage();
 


### PR DESCRIPTION
## Summary

Adds an Active Campaign Dashboard section at the top of the `/campaigns` page, giving DMs an at-a-glance view of all active campaigns, their party rosters, and their most recent session.

## Changes

### New Components
- **`lib/components/CharacterRosterCard.tsx`** — Compact character display card showing name, race, class/level, and NPC/Companion type badges. No AC/HP (roster-only context).
- **`lib/components/CampaignChapterInfo.tsx`** — Single-line display of the current campaign chapter, with "No chapter set" fallback.

### Modified
- **`app/campaigns/page.tsx`** — Extended with:
  - Fetch `parties` and `characters` in parallel with campaigns (single `Promise.all`)
  - Secondary `useEffect` to lazy-load the last session per active campaign
  - Active Campaigns dashboard section above the management list
  - Per-campaign cards with party sub-cards, PC/NPC rosters, last session info, and quick-action buttons (Prompt Builder, Start Encounter)
  - CTA card when no active campaigns exist

### Tests Added
- `tests/unit/CharacterRosterCard.test.tsx` — PC/NPC/Companion rendering, graceful fallbacks
- `tests/unit/CampaignChapterInfo.test.tsx` — Chapter title and fallback states
- `tests/unit/campaigns-dashboard.test.tsx` — Zero/multiple active campaigns, party linking, roster split, session card, milestone badge

## Validation
- ✅ `npm run test:unit` — 1388 tests pass
- ✅ `npm run test:integration` — 150 tests pass (17 suites)
- ✅ `npm run build` — no type errors
- ✅ `npm run lint` — no lint errors