### PR TITLE
feat: Prompt Builder as campaign child route + shared context helper (fixes #212)

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-05-24T18:43:39.667Z
-> Files: 721 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-05-24T20:53:48.133Z
+> Files: 739 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../.claude/plans/
 
@@ -762,6 +762,10 @@
 
 - `route.ts` — Next.js API route: POST (~554 tok)
 
+## app/api/auth/logout/
+
+- `route.ts` — Next.js API route: POST (~144 tok)
+
 ## app/api/auth/me/
 
 - `route.ts` — Next.js API route (~186 tok)
@@ -865,7 +869,7 @@
 
 ## app/campaigns/[id]/prompts/
 
-- `page.tsx` — PromptBuilderContent — renders form (~2060 tok)
+- `page.tsx` — PromptBuilderContent — renders form (~2109 tok)
 
 ## app/campaigns/[id]/sessions/
 
@@ -923,7 +927,7 @@
 
 ## lib/prompts/
 
-- `templates.ts` — Exports PromptField, PromptTemplate, buildSystemPrompt, npcTemplate + 5 more (~1689 tok)
+- `templates.ts` — Exports PromptField, PromptTemplate, buildSystemPrompt, npcTemplate + 5 more (~1690 tok)
 
 ## lib/scripts/
 
@@ -931,7 +935,7 @@
 
 ## lib/utils/
 
-- `campaignContext.ts` — Exports fetchCampaignContext (~365 tok)
+- `campaignContext.ts` — Exports fetchCampaignContext (~384 tok)
 - `partySelection.ts` — Returns the Character objects that belong to the given party. (~604 tok)
 - `sessionEvents.ts` — Computes auto-populated NPC events from party membership changes in a time window. (~502 tok)
 
@@ -1093,13 +1097,6 @@
 
 - `spec.md` — ADDED Requirements (~1032 tok)
 
-## openspec/changes/session-invalidation-foundation/
-
-- `.openspec.yaml` (~15 tok)
-- `design.md` — Context (~622 tok)
-- `proposal.md` — GitHub Issues (~713 tok)
-- `tasks.md` — Tasks (~566 tok)
-- `tests.md` — Tests (~1417 tok)
 ## openspec/changes/prompt-builder-campaign-child/
 
 - `design.md` — Context (~3145 tok)
@@ -1122,6 +1119,14 @@
 ## openspec/changes/prompt-builder-campaign-child/specs/session-logs-refactor/
 
 - `spec.md` — ADDED Requirements (~774 tok)
+
+## openspec/changes/session-invalidation-foundation/
+
+- `.openspec.yaml` (~15 tok)
+- `design.md` — Context (~622 tok)
+- `proposal.md` — GitHub Issues (~713 tok)
+- `tasks.md` — Tasks (~566 tok)
+- `tests.md` — Tests (~1417 tok)
 
 ## openspec/changes/travelling-npcs-character-type/
 
@@ -1160,7 +1165,7 @@
 
 ## tests/integration/prompts/
 
-- `promptBuilder.test.tsx` — FULL_PROMPT (~3258 tok)
+- `promptBuilder.test.tsx` — FULL_PROMPT (~3126 tok)
 
 ## tests/integration/sessions/
 

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -861,7 +861,11 @@
 ## app/campaigns/
 
 - `CampaignEditor.tsx` — CampaignEditor (~756 tok)
-- `page.tsx` — CampaignChapterInfo (~2900 tok)
+- `page.tsx` — ManagementChapterInfo (~5405 tok)
+
+## app/campaigns/[id]/prompts/
+
+- `page.tsx` — PromptBuilderContent — renders form (~2060 tok)
 
 ## app/campaigns/[id]/sessions/
 
@@ -905,6 +909,7 @@
 ## lib/hooks/
 
 - `useAuth.ts` — Exports AuthUser, useAuth (~1197 tok)
+- `useCampaignContext.ts` — Exports useCampaignContext (~336 tok)
 
 ## lib/import/
 
@@ -916,12 +921,17 @@
 - `dndBeyond-utils.ts` — Exports DndBeyondImportError, createValidationError, ABILITY_ID_MAP, indexStatValues + 6 more (~1014 tok)
 - `utils.ts` — Exports ModifierLike, getAbilityModifier, getProficiencyBonus, dedupeStrings + 9 more (~676 tok)
 
+## lib/prompts/
+
+- `templates.ts` — Exports PromptField, PromptTemplate, buildSystemPrompt, npcTemplate + 5 more (~1689 tok)
+
 ## lib/scripts/
 
 - `seedCampaignTemplates.ts` — one-time ingestion: seeds 50 global campaign templates with chapters and level ranges (~2800 tok)
 
 ## lib/utils/
 
+- `campaignContext.ts` — Exports fetchCampaignContext (~365 tok)
 - `partySelection.ts` — Returns the Character objects that belong to the given party. (~604 tok)
 - `sessionEvents.ts` — Computes auto-populated NPC events from party membership changes in a time window. (~502 tok)
 
@@ -1090,6 +1100,28 @@
 - `proposal.md` — GitHub Issues (~713 tok)
 - `tasks.md` — Tasks (~566 tok)
 - `tests.md` — Tests (~1417 tok)
+## openspec/changes/prompt-builder-campaign-child/
+
+- `design.md` — Context (~3145 tok)
+- `proposal.md` — GitHub Issues (~1582 tok)
+- `tasks.md` — Tasks (~2250 tok)
+- `tests.md` — Tests (~1662 tok)
+
+## openspec/changes/prompt-builder-campaign-child/specs/campaign-context/
+
+- `spec.md` — ADDED Requirements (~1278 tok)
+
+## openspec/changes/prompt-builder-campaign-child/specs/prompt-builder-ui/
+
+- `spec.md` — ADDED Requirements (~1390 tok)
+
+## openspec/changes/prompt-builder-campaign-child/specs/prompt-templates/
+
+- `spec.md` — ADDED Requirements (~1139 tok)
+
+## openspec/changes/prompt-builder-campaign-child/specs/session-logs-refactor/
+
+- `spec.md` — ADDED Requirements (~774 tok)
 
 ## openspec/changes/travelling-npcs-character-type/
 
@@ -1125,6 +1157,14 @@
 ## tests/integration/offline/
 
 - `logout-clears-storage.test.ts` — replaceMock: Harness, Harness, Harness (~1556 tok)
+
+## tests/integration/prompts/
+
+- `promptBuilder.test.tsx` — FULL_PROMPT (~3258 tok)
+
+## tests/integration/sessions/
+
+- `sessionLogs.test.tsx` — MOCK_LOG (~1958 tok)
 
 ## tests/unit/
 
@@ -1166,12 +1206,16 @@
 - `CampaignsPage.test.tsx` — jsonResponse (~2672 tok)
 - `NavBar.test.tsx` — mockedUseAuth (~922 tok)
 - `PartiesPage.test.tsx` — PC (~2381 tok)
-- `SessionsPage.test.tsx` — MOCK_LOG (~1323 tok)
+- `SessionsPage.test.tsx` — MOCK_LOG (~1414 tok)
 - `ui.test.tsx` — render — renders form (~2132 tok)
 
 ## tests/unit/helpers/
 
 - `route.test.helpers.ts` — Shared auth payload used across route unit tests (~2070 tok)
+
+## tests/unit/hooks/
+
+- `useCampaignContext.test.ts` — makeContext: renderHook, Probe (~998 tok)
 
 ## tests/unit/import/
 
@@ -1193,6 +1237,10 @@
 - `permissions.test.ts` — ObjectId: mockCollection (~1104 tok)
 - `useAuth.test.ts` — Mock next/navigation (~1552 tok)
 
+## tests/unit/prompts/
+
+- `templates.test.ts` — Declares makeContext (~2538 tok)
+
 ## tests/unit/storage/
 
 - `campaigns.test.ts` — mockedGetDatabase: makeMockCollection (~2885 tok)
@@ -1201,5 +1249,6 @@
 
 ## tests/unit/utils/
 
+- `campaignContext.test.ts` — makeCampaign: makeFetch (~1992 tok)
 - `partySelection.test.ts` — Declares makeCharacter (~702 tok)
 - `sessionEvents.test.ts` — Declares T0 (~783 tok)

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -7,7 +7,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/dndBeyondCharacterImport.ts",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 8→6 lines (2 removed)",
+      "fix": "Rewrote 8\u21926 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -23,7 +23,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/dndBeyondCharacterImport.ts",
       "root_cause": "17 lines replaced/restructured",
-      "fix": "Rewrote 24→4 lines (17 removed)",
+      "fix": "Rewrote 24\u21924 lines (17 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -39,7 +39,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/import/armor-class.ts",
       "root_cause": "3 lines replaced/restructured",
-      "fix": "Rewrote 7→12 lines (3 removed)",
+      "fix": "Rewrote 7\u219212 lines (3 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -87,7 +87,7 @@
       "error_message": "Significant refactor of ",
       "file": "openspec/changes/extract-armor-class-normalization/design.md",
       "root_cause": "3 lines replaced/restructured",
-      "fix": "Rewrote 9→12 lines (3 removed)",
+      "fix": "Rewrote 9\u219212 lines (3 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -119,7 +119,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/storage.ts",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 21→81 lines (2 removed)",
+      "fix": "Rewrote 21\u219281 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -151,7 +151,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/parties/page.tsx",
       "root_cause": "3 lines replaced/restructured",
-      "fix": "Rewrote 5→3 lines (3 removed) | Also: <div className=\"bg-gray-800 rounded-lg p-6 mb-6 bo; <h2 className=\"text-2xl font-bold mb-4\">{isNew ? '",
+      "fix": "Rewrote 5\u21923 lines (3 removed) | Also: <div className=\"bg-gray-800 rounded-lg p-6 mb-6 bo; <h2 className=\"text-2xl font-bold mb-4\">{isNew ? '",
       "tags": [
         "auto-detected",
         "refactor",
@@ -167,7 +167,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/api/campaigns/[id]/route.ts",
       "root_cause": "5 lines replaced/restructured",
-      "fix": "Rewrote 12→18 lines (5 removed) | Also: name: name !== undefined ? name.trim() : existingP; description: description !== undefined ? descripti",
+      "fix": "Rewrote 12\u219218 lines (5 removed) | Also: name: name !== undefined ? name.trim() : existingP; description: description !== undefined ? descripti",
       "tags": [
         "auto-detected",
         "refactor",
@@ -183,7 +183,7 @@
       "error_message": "Wrong reference: campaignId should be typeof",
       "file": "app/api/parties/route.ts",
       "root_cause": "Used \"campaignId\" instead of \"typeof\"",
-      "fix": "Changed campaignId → typeof",
+      "fix": "Changed campaignId \u2192 typeof",
       "tags": [
         "auto-detected",
         "wrong-reference",
@@ -214,8 +214,8 @@
       "timestamp": "2026-05-19T16:21:40.022Z",
       "error_message": "CSS fix: Campaign",
       "file": "app/parties/page.tsx",
-      "root_cause": "Campaign: {party.campaignId ? (campaigns.find(c => c.id === party.campaignId)?.name ?? 'No Campaign') : 'No Campaign' → {party.campaignId ? (campaignMap.get(party.campaignId) ?? 'No Campaign') : 'No Campaign'",
-      "fix": "Changed Campaign: {party.campaignId ? (campaigns.find(c => c.id === party.campaignId)?.name ?? 'No Campaign') : 'No Campaign' → {party.campaignId ? (campaignMap.get(party.campaignId) ?? 'No Campaign') : 'No Campaign'",
+      "root_cause": "Campaign: {party.campaignId ? (campaigns.find(c => c.id === party.campaignId)?.name ?? 'No Campaign') : 'No Campaign' \u2192 {party.campaignId ? (campaignMap.get(party.campaignId) ?? 'No Campaign') : 'No Campaign'",
+      "fix": "Changed Campaign: {party.campaignId ? (campaigns.find(c => c.id === party.campaignId)?.name ?? 'No Campaign') : 'No Campaign' \u2192 {party.campaignId ? (campaignMap.get(party.campaignId) ?? 'No Campaign') : 'No Campaign'",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -231,7 +231,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/campaigns/page.tsx",
       "root_cause": "11 lines replaced/restructured",
-      "fix": "Rewrote 14→3 lines (11 removed)",
+      "fix": "Rewrote 14\u21923 lines (11 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -311,7 +311,7 @@
       "error_message": "Wrong reference: FormField should be TextInputField",
       "file": "app/campaigns/page.tsx",
       "root_cause": "Used \"FormField\" instead of \"TextInputField\"",
-      "fix": "Changed FormField → TextInputField",
+      "fix": "Changed FormField \u2192 TextInputField",
       "tags": [
         "auto-detected",
         "wrong-reference",
@@ -342,8 +342,8 @@
       "timestamp": "2026-05-19T20:26:05.534Z",
       "error_message": "CSS fix: campaignId",
       "file": "app/parties/page.tsx",
-      "root_cause": "campaignId: campaignId || undefined, → campaignId || null,",
-      "fix": "Changed campaignId: campaignId || undefined, → campaignId || null,",
+      "root_cause": "campaignId: campaignId || undefined, \u2192 campaignId || null,",
+      "fix": "Changed campaignId: campaignId || undefined, \u2192 campaignId || null,",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -358,7 +358,7 @@
       "timestamp": "2026-05-19T20:26:49.442Z",
       "error_message": "Missing await",
       "file": "tests/e2e/auth.spec.ts",
-      "root_cause": "Async call without await — returned Promise instead of value",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
       "fix": "Added await to async call",
       "tags": [
         "auto-detected",
@@ -406,7 +406,7 @@
       "timestamp": "2026-05-20T23:03:15.379Z",
       "error_message": "Missing await",
       "file": "tests/unit/lib/middleware.test.ts",
-      "root_cause": "Async call without await — returned Promise instead of value",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
       "fix": "Added await to async call",
       "tags": [
         "auto-detected",
@@ -454,8 +454,8 @@
       "timestamp": "2026-05-21T02:11:40.578Z",
       "error_message": "CSS fix: campaign",
       "file": "tests/unit/components/CampaignEditor.test.tsx",
-      "root_cause": "campaign: { ...BASE_CAMPAIGN, name: '' → BASE_CAMPAIGN, onSave: jest.fn(), onCancel: jest.fn(), isNew: false",
-      "fix": "Changed campaign: { ...BASE_CAMPAIGN, name: '' → BASE_CAMPAIGN, onSave: jest.fn(), onCancel: jest.fn(), isNew: false",
+      "root_cause": "campaign: { ...BASE_CAMPAIGN, name: '' \u2192 BASE_CAMPAIGN, onSave: jest.fn(), onCancel: jest.fn(), isNew: false",
+      "fix": "Changed campaign: { ...BASE_CAMPAIGN, name: '' \u2192 BASE_CAMPAIGN, onSave: jest.fn(), onCancel: jest.fn(), isNew: false",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -471,7 +471,7 @@
       "error_message": "Significant refactor of ",
       "file": "tests/unit/components/CampaignEditor.test.tsx",
       "root_cause": "4 lines replaced/restructured",
-      "fix": "Rewrote 6→3 lines (4 removed)",
+      "fix": "Rewrote 6\u21923 lines (4 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -486,8 +486,8 @@
       "timestamp": "2026-05-21T02:13:34.283Z",
       "error_message": "CSS fix: isAuthenticated",
       "file": "tests/unit/components/NavBar.test.tsx",
-      "root_cause": "isAuthenticated: false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, checkAuth: jest.fn() as any → false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, error: null",
-      "fix": "Changed isAuthenticated: false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, checkAuth: jest.fn() as any → false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, error: null",
+      "root_cause": "isAuthenticated: false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, checkAuth: jest.fn() as any \u2192 false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, error: null",
+      "fix": "Changed isAuthenticated: false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, checkAuth: jest.fn() as any \u2192 false, loading: false, logout: jest.fn() as any, user: null, login: jest.fn() as any, register: jest.fn() as any, error: null",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -535,7 +535,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/hooks/useAuth.ts",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 4→5 lines (2 removed)",
+      "fix": "Rewrote 4\u21925 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -551,7 +551,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/register/page.tsx",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 5→5 lines (2 removed)",
+      "fix": "Rewrote 5\u21925 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -583,7 +583,7 @@
       "error_message": "Significant refactor of ",
       "file": "tests/unit/lib/clientStorage.test.ts",
       "root_cause": "12 lines replaced/restructured",
-      "fix": "Rewrote 50→38 lines (12 removed)",
+      "fix": "Rewrote 50\u219238 lines (12 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -614,7 +614,7 @@
       "timestamp": "2026-05-21T23:28:11.935Z",
       "error_message": "Missing await",
       "file": "tests/unit/api/characters/route.test.ts",
-      "root_cause": "Async call without await — returned Promise instead of value",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
       "fix": "Added await to async call",
       "tags": [
         "auto-detected",
@@ -630,7 +630,7 @@
       "timestamp": "2026-05-21T23:28:22.522Z",
       "error_message": "Missing await",
       "file": "tests/unit/api/characters/[id].route.test.ts",
-      "root_cause": "Async call without await — returned Promise instead of value",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
       "fix": "Added await to async call",
       "tags": [
         "auto-detected",
@@ -711,7 +711,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/parties/page.tsx",
       "root_cause": "8 lines replaced/restructured",
-      "fix": "Rewrote 9→4 lines (8 removed)",
+      "fix": "Rewrote 9\u21924 lines (8 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -742,7 +742,7 @@
       "timestamp": "2026-05-22T01:36:41.619Z",
       "error_message": "Missing await",
       "file": "tests/unit/api/characters/[id].route.test.ts",
-      "root_cause": "Async call without await — returned Promise instead of value",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
       "fix": "Added await to async call",
       "tags": [
         "auto-detected",
@@ -775,7 +775,7 @@
       "error_message": "Wrong reference: null should be undefined",
       "file": "tests/unit/characterTypeUI.test.tsx",
       "root_cause": "Used \"null\" instead of \"undefined\"",
-      "fix": "Changed null → undefined",
+      "fix": "Changed null \u2192 undefined",
       "tags": [
         "auto-detected",
         "wrong-reference",
@@ -791,7 +791,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/types.ts",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 12→35 lines (2 removed)",
+      "fix": "Rewrote 12\u219235 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -807,7 +807,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/api/campaigns/[id]/route.ts",
       "root_cause": "3 lines replaced/restructured",
-      "fix": "Rewrote 18→16 lines (3 removed)",
+      "fix": "Rewrote 18\u219216 lines (3 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -822,8 +822,8 @@
       "timestamp": "2026-05-22T14:57:30.451Z",
       "error_message": "CSS fix: name",
       "file": "app/campaigns/CampaignEditor.tsx",
-      "root_cause": "name: name.trim(), moduleName: moduleName.trim(), currentChapter: currentChapter.trim(), currentChapterOrder, active → name.trim(), moduleName: moduleName.trim(), active",
-      "fix": "Changed name: name.trim(), moduleName: moduleName.trim(), currentChapter: currentChapter.trim(), currentChapterOrder, active → name.trim(), moduleName: moduleName.trim(), active",
+      "root_cause": "name: name.trim(), moduleName: moduleName.trim(), currentChapter: currentChapter.trim(), currentChapterOrder, active \u2192 name.trim(), moduleName: moduleName.trim(), active",
+      "fix": "Changed name: name.trim(), moduleName: moduleName.trim(), currentChapter: currentChapter.trim(), currentChapterOrder, active \u2192 name.trim(), moduleName: moduleName.trim(), active",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -838,7 +838,7 @@
       "timestamp": "2026-05-22T14:58:02.785Z",
       "error_message": "Missing error handling in unknown",
       "file": "app/campaigns/page.tsx",
-      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
       "fix": "Added try/catch block",
       "tags": [
         "auto-detected",
@@ -854,7 +854,7 @@
       "timestamp": "2026-05-22T14:58:29.790Z",
       "error_message": "Missing error handling in loadGlobalCampaignTemplates",
       "file": "lib/storage.ts",
-      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
       "fix": "Added try/catch block",
       "tags": [
         "auto-detected",
@@ -887,7 +887,7 @@
       "error_message": "Significant refactor of ",
       "file": "tests/unit/api/campaigns/route.test.ts",
       "root_cause": "9 lines replaced/restructured",
-      "fix": "Rewrote 42→29 lines (9 removed)",
+      "fix": "Rewrote 42\u219229 lines (9 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -903,7 +903,7 @@
       "error_message": "Significant refactor of ",
       "file": "lib/storage.ts",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 45→60 lines (2 removed)",
+      "fix": "Rewrote 45\u219260 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -919,7 +919,7 @@
       "error_message": "Significant refactor of ",
       "file": "app/api/campaigns/global/[id]/copy/route.ts",
       "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 5→4 lines (2 removed)",
+      "fix": "Rewrote 5\u21924 lines (2 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -967,7 +967,7 @@
       "error_message": "Wrong operator: === should be >>",
       "file": "lib/components/CharacterMiniSummary.tsx",
       "root_cause": "Used \"===\" instead of \">>\"",
-      "fix": "Changed operator === → >>",
+      "fix": "Changed operator === \u2192 >>",
       "tags": [
         "auto-detected",
         "operator-fix",
@@ -1046,8 +1046,8 @@
       "timestamp": "2026-05-22T17:39:16.194Z",
       "error_message": "CSS fix: Members",
       "file": "app/parties/page.tsx",
-      "root_cause": "Members: {party.characterIds.length → {partyCharacters.length",
-      "fix": "Changed Members: {party.characterIds.length → {partyCharacters.length",
+      "root_cause": "Members: {party.characterIds.length \u2192 {partyCharacters.length",
+      "fix": "Changed Members: {party.characterIds.length \u2192 {partyCharacters.length",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -1062,8 +1062,8 @@
       "timestamp": "2026-05-22T17:55:17.365Z",
       "error_message": "CSS fix: Members",
       "file": "app/parties/page.tsx",
-      "root_cause": "Members: {partyCharacters.length → {party.characterIds.length",
-      "fix": "Changed Members: {partyCharacters.length → {party.characterIds.length",
+      "root_cause": "Members: {partyCharacters.length \u2192 {party.characterIds.length",
+      "fix": "Changed Members: {partyCharacters.length \u2192 {party.characterIds.length",
       "tags": [
         "auto-detected",
         "style-fix",
@@ -1075,42 +1075,58 @@
     },
     {
       "id": "bug-068",
-      "timestamp": "2026-05-23T01:03:48.908Z",
-      "error_message": "Significant refactor of ",
-      "file": "openspec/changes/add-password-reset-ability/design.md",
-      "root_cause": "3 lines replaced/restructured",
-      "fix": "Rewrote 4→4 lines (3 removed)",
+      "timestamp": "2026-05-22T23:37:04.883Z",
+      "error_message": "Missing guard clause",
+      "file": "tests/unit/import/dndBeyond-ability-scores.test.ts",
+      "root_cause": "No early return/throw for edge case: value == null",
+      "fix": "Added guard clause: if (value == null)",
       "tags": [
         "auto-detected",
-        "refactor",
-        "md"
+        "guard-clause",
+        "ts"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T01:03:48.908Z"
+      "last_seen": "2026-05-22T23:37:04.883Z"
     },
     {
       "id": "bug-069",
-      "timestamp": "2026-05-23T14:16:33.785Z",
-      "error_message": "Significant refactor of ",
-      "file": "openspec/changes/add-password-reset-ability/proposal.md",
-      "root_cause": "3 lines replaced/restructured",
-      "fix": "Rewrote 5→5 lines (3 removed)",
+      "timestamp": "2026-05-23T00:59:41.272Z",
+      "error_message": "Null/undefined access in ",
+      "file": "lib/storage.ts",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
       "tags": [
         "auto-detected",
-        "refactor",
-        "md"
+        "null-safety",
+        "ts"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T14:16:33.785Z"
+      "last_seen": "2026-05-23T00:59:41.272Z"
     },
     {
       "id": "bug-070",
-      "timestamp": "2026-05-23T14:22:59.278Z",
-      "error_message": "Missing error handling in function",
-      "file": "lib/middleware.ts",
-      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "timestamp": "2026-05-23T00:59:52.804Z",
+      "error_message": "Significant refactor of ",
+      "file": "lib/storage.ts",
+      "root_cause": "6 lines replaced/restructured",
+      "fix": "Rewrote 15\u219213 lines (6 removed) | Also: // Also remove character from all parties to ensur; .updateMany({ userId }, { $pull: { characterIds: i",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 2,
+      "last_seen": "2026-05-23T01:00:06.364Z"
+    },
+    {
+      "id": "bug-071",
+      "timestamp": "2026-05-23T01:00:16.523Z",
+      "error_message": "Missing error handling in loadSessionLogs",
+      "file": "lib/storage.ts",
+      "root_cause": "Code path had no error handling \u2014 exceptions would propagate uncaught",
       "fix": "Added try/catch block",
       "tags": [
         "auto-detected",
@@ -1119,79 +1135,111 @@
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T14:22:59.278Z"
-    },
-    {
-      "id": "bug-071",
-      "timestamp": "2026-05-23T14:23:16.340Z",
-      "error_message": "Type error",
-      "file": "app/api/auth/login/route.ts",
-      "root_cause": "Missing or incorrect type annotation",
-      "fix": "Added type assertion/annotation",
-      "tags": [
-        "auto-detected",
-        "type-fix",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-23T14:23:16.340Z"
+      "last_seen": "2026-05-23T01:00:16.523Z"
     },
     {
       "id": "bug-072",
-      "timestamp": "2026-05-23T14:26:16.981Z",
-      "error_message": "Wrong reference: requireAuth should be withAuth",
-      "file": "app/api/monsters/route.ts",
-      "root_cause": "Used \"requireAuth\" instead of \"withAuth\"",
-      "fix": "Changed requireAuth → withAuth",
+      "timestamp": "2026-05-23T01:00:37.916Z",
+      "error_message": "Significant refactor of ",
+      "file": "app/api/parties/route.ts",
+      "root_cause": "3 lines replaced/restructured",
+      "fix": "Rewrote 10\u219214 lines (3 removed) | Also: characterIds: Array.isArray(characterIds) ? charac; updatedAt: new Date(),",
       "tags": [
         "auto-detected",
-        "wrong-reference",
+        "refactor",
         "ts"
       ],
       "related_bugs": [],
       "occurrences": 2,
-      "last_seen": "2026-05-23T14:26:33.109Z"
+      "last_seen": "2026-05-23T01:00:53.383Z"
     },
     {
       "id": "bug-073",
-      "timestamp": "2026-05-23T14:30:18.701Z",
-      "error_message": "Type error",
-      "file": "tests/unit/lib/middleware.test.ts",
-      "root_cause": "Missing or incorrect type annotation",
-      "fix": "Added type assertion/annotation",
+      "timestamp": "2026-05-23T01:01:28.259Z",
+      "error_message": "CSS fix: Members",
+      "file": "app/parties/page.tsx",
+      "root_cause": "Members: {party.characterIds.length \u2192 {activeIds.length",
+      "fix": "Changed Members: {party.characterIds.length \u2192 {activeIds.length",
       "tags": [
         "auto-detected",
-        "type-fix",
-        "ts"
+        "style-fix",
+        "tsx"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T14:30:18.701Z"
+      "last_seen": "2026-05-23T01:01:28.259Z"
     },
     {
       "id": "bug-074",
-      "timestamp": "2026-05-23T14:30:21.546Z",
-      "error_message": "Incorrect value in code",
-      "file": "tests/unit/lib/middleware.test.ts",
-      "root_cause": "Had \"user-123\"",
-      "fix": "Changed to \"507f1f77bcf86cd799439011\"",
+      "timestamp": "2026-05-23T01:01:32.311Z",
+      "error_message": "Wrong reference: characterIds should be members",
+      "file": "app/parties/page.tsx",
+      "root_cause": "Used \"characterIds\" instead of \"members\"",
+      "fix": "Changed characterIds \u2192 members",
       "tags": [
         "auto-detected",
-        "wrong-value",
-        "ts"
+        "wrong-reference",
+        "tsx"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T14:30:21.546Z"
+      "last_seen": "2026-05-23T01:01:32.311Z"
     },
     {
       "id": "bug-075",
-      "timestamp": "2026-05-23T14:30:41.859Z",
+      "timestamp": "2026-05-23T01:07:03.356Z",
       "error_message": "Significant refactor of ",
-      "file": "tests/unit/lib/middleware.test.ts",
-      "root_cause": "2 lines replaced/restructured",
-      "fix": "Rewrote 52→108 lines (2 removed)",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "27 lines replaced/restructured",
+      "fix": "Rewrote 30\u21924 lines (27 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T01:07:03.356Z"
+    },
+    {
+      "id": "bug-076",
+      "timestamp": "2026-05-23T01:10:59.091Z",
+      "error_message": "CSS fix: id",
+      "file": "tests/unit/partyCharacterTypeUI.test.tsx",
+      "root_cause": "id: 'p1', name: 'Fellowship', characterIds: ['c1', 'c2', 'c3'], userId: 'u1', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() \u2192 'p1', name: 'Fellowship', members: [",
+      "fix": "Changed id: 'p1', name: 'Fellowship', characterIds: ['c1', 'c2', 'c3'], userId: 'u1', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() \u2192 'p1', name: 'Fellowship', members: [",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T01:10:59.091Z"
+    },
+    {
+      "id": "bug-077",
+      "timestamp": "2026-05-23T01:11:25.227Z",
+      "error_message": "CSS fix: id",
+      "file": "tests/unit/components/PartiesPage.test.tsx",
+      "root_cause": "id: 'p3', name: 'Empty Party', characterIds: [], \u2192 'p3', name: 'Empty Party', members: [],",
+      "fix": "Changed id: 'p3', name: 'Empty Party', characterIds: [], \u2192 'p3', name: 'Empty Party', members: [],",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 3,
+      "last_seen": "2026-05-23T01:11:38.122Z"
+    },
+    {
+      "id": "bug-078",
+      "timestamp": "2026-05-23T01:11:51.282Z",
+      "error_message": "Significant refactor of ",
+      "file": "tests/unit/storage/storage.test.ts",
+      "root_cause": "3 lines replaced/restructured",
+      "fix": "Rewrote 9\u219210 lines (3 removed)",
       "tags": [
         "auto-detected",
         "refactor",
@@ -1199,109 +1247,77 @@
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T14:30:41.859Z"
-    },
-    {
-      "id": "bug-076",
-      "timestamp": "2026-05-23T15:49:00.250Z",
-      "error_message": "Missing guard clause",
-      "file": "tests/unit/api/monsters/duplicate.test.ts",
-      "root_cause": "No early return/throw for edge case: auth && 'status' in auth",
-      "fix": "Added guard clause: if (auth && 'status' in auth)",
-      "tags": [
-        "auto-detected",
-        "guard-clause",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-23T15:49:00.250Z"
-    },
-    {
-      "id": "bug-077",
-      "timestamp": "2026-05-23T15:49:23.760Z",
-      "error_message": "Missing guard clause",
-      "file": "tests/unit/api/campaigns/route.test.ts",
-      "root_cause": "No early return/throw for edge case: auth && 'status' in auth",
-      "fix": "Added guard clause: if (auth && 'status' in auth)",
-      "tags": [
-        "auto-detected",
-        "guard-clause",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 2,
-      "last_seen": "2026-05-23T15:49:30.422Z"
-    },
-    {
-      "id": "bug-078",
-      "timestamp": "2026-05-23T15:49:39.381Z",
-      "error_message": "Missing guard clause",
-      "file": "tests/unit/import/characterImportRoute.test.ts",
-      "root_cause": "No early return/throw for edge case: auth && 'status' in auth",
-      "fix": "Added guard clause: if (auth && 'status' in auth)",
-      "tags": [
-        "auto-detected",
-        "guard-clause",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-23T15:49:39.381Z"
+      "last_seen": "2026-05-23T01:11:51.282Z"
     },
     {
       "id": "bug-079",
-      "timestamp": "2026-05-23T15:49:56.644Z",
-      "error_message": "Type error",
-      "file": "tests/unit/lib/api-helpers.test.ts",
-      "root_cause": "Missing or incorrect type annotation",
-      "fix": "Added type assertion/annotation",
+      "timestamp": "2026-05-23T01:12:08.797Z",
+      "error_message": "Wrong reference: characterIds should be members",
+      "file": "tests/unit/api/parties/route.test.ts",
+      "root_cause": "Used \"characterIds\" instead of \"members\"",
+      "fix": "Changed characterIds \u2192 members",
       "tags": [
         "auto-detected",
-        "type-fix",
+        "wrong-reference",
         "ts"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T15:49:56.644Z"
+      "last_seen": "2026-05-23T01:12:08.797Z"
     },
     {
       "id": "bug-080",
-      "timestamp": "2026-05-23T21:14:33.948Z",
+      "timestamp": "2026-05-23T01:13:39.489Z",
       "error_message": "Type error",
-      "file": "tests/unit/api/monsters/global.route.test.ts",
+      "file": "app/parties/page.tsx",
       "root_cause": "Missing or incorrect type annotation",
       "fix": "Added type assertion/annotation",
       "tags": [
         "auto-detected",
         "type-fix",
-        "ts"
+        "tsx"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T21:14:33.948Z"
+      "last_seen": "2026-05-23T01:13:39.489Z"
     },
     {
       "id": "bug-081",
-      "timestamp": "2026-05-23T21:34:18.721Z",
-      "error_message": "Null/undefined access in ",
-      "file": "app/api/auth/login/route.ts",
-      "root_cause": "Property access on potentially null/undefined value",
-      "fix": "Added null safety (optional chaining or null check)",
+      "timestamp": "2026-05-23T01:14:14.270Z",
+      "error_message": "CSS fix: name",
+      "file": "app/parties/page.tsx",
+      "root_cause": "name: name.trim(), \u2192 name.trim(), description: description.trim(), campaignId: campaignId",
+      "fix": "Changed name: name.trim(), \u2192 name.trim(), description: description.trim(), campaignId: campaignId",
       "tags": [
         "auto-detected",
-        "null-safety",
-        "ts"
+        "style-fix",
+        "tsx"
       ],
       "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-23T21:34:18.721Z"
+      "occurrences": 2,
+      "last_seen": "2026-05-23T01:16:17.430Z"
     },
     {
       "id": "bug-082",
-      "timestamp": "2026-05-23T21:39:59.898Z",
+      "timestamp": "2026-05-23T01:16:11.479Z",
+      "error_message": "Wrong reference: void should be characterIds",
+      "file": "app/parties/page.tsx",
+      "root_cause": "Used \"void\" instead of \"characterIds\"",
+      "fix": "Changed void \u2192 characterIds",
+      "tags": [
+        "auto-detected",
+        "wrong-reference",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T01:16:11.479Z"
+    },
+    {
+      "id": "bug-083",
+      "timestamp": "2026-05-23T15:49:32.102Z",
       "error_message": "Type error",
-      "file": "tests/unit/api/monsters/global.id.route.test.ts",
+      "file": "lib/storage.ts",
       "root_cause": "Missing or incorrect type annotation",
       "fix": "Added type assertion/annotation",
       "tags": [
@@ -1311,125 +1327,125 @@
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T21:39:59.898Z"
-    },
-    {
-      "id": "bug-083",
-      "timestamp": "2026-05-23T22:34:46.914Z",
-      "error_message": "Null/undefined access in ",
-      "file": "lib/middleware.ts",
-      "root_cause": "Property access on potentially null/undefined value",
-      "fix": "Added null safety (optional chaining or null check)",
-      "tags": [
-        "auto-detected",
-        "null-safety",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-23T22:34:46.914Z"
+      "last_seen": "2026-05-23T15:49:32.102Z"
     },
     {
       "id": "bug-084",
-      "timestamp": "2026-05-23T22:34:49.702Z",
-      "error_message": "Null/undefined access in ",
-      "file": "lib/api-helpers.ts",
-      "root_cause": "Property access on potentially null/undefined value",
-      "fix": "Added null safety (optional chaining or null check)",
+      "timestamp": "2026-05-23T15:49:44.211Z",
+      "error_message": "Wrong operator: ?? should be ===",
+      "file": "lib/utils/sessionEvents.ts",
+      "root_cause": "Used \"??\" instead of \"===\"",
+      "fix": "Changed operator ?? \u2192 ===",
       "tags": [
         "auto-detected",
-        "null-safety",
+        "operator-fix",
         "ts"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-23T22:34:49.702Z"
+      "last_seen": "2026-05-23T15:49:44.211Z"
     },
     {
       "id": "bug-085",
-      "timestamp": "2026-05-23T22:35:01.020Z",
+      "timestamp": "2026-05-23T15:49:54.162Z",
       "error_message": "Incorrect value in code",
-      "file": "openspec/changes/session-invalidation-foundation/tests.md",
-      "root_cause": "Had `npm run type-check`",
-      "fix": "Changed to `npm run typecheck`",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "Had 'Up'",
+      "fix": "Changed to 'undefined'",
+      "tags": [
+        "auto-detected",
+        "wrong-value",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T15:49:54.162Z"
+    },
+    {
+      "id": "bug-086",
+      "timestamp": "2026-05-23T15:50:12.931Z",
+      "error_message": "Incorrect value in code",
+      "file": "openspec/changes/campaign-session-journal/tasks.md",
+      "root_cause": "Had `npm test`",
+      "fix": "Changed to `npm run test:unit`",
       "tags": [
         "auto-detected",
         "wrong-value",
         "md"
       ],
       "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-23T22:35:01.020Z"
-    },
-    {
-      "id": "bug-086",
-      "timestamp": "2026-05-24T13:07:14.600Z",
-      "error_message": "Incorrect value in code",
-      "file": "lib/middleware.ts",
-      "root_cause": "Had 'number'",
-      "fix": "Changed to 'tokenVersion'",
-      "tags": [
-        "auto-detected",
-        "wrong-value",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 1,
-      "last_seen": "2026-05-24T13:07:14.600Z"
+      "occurrences": 2,
+      "last_seen": "2026-05-23T15:50:19.021Z"
     },
     {
       "id": "bug-087",
-      "timestamp": "2026-05-24T13:07:26.312Z",
-      "error_message": "Incorrect value in code",
-      "file": "lib/api-helpers.ts",
-      "root_cause": "Had 'number'",
-      "fix": "Changed to 'tokenVersion'",
+      "timestamp": "2026-05-23T16:35:04.038Z",
+      "error_message": "Null/undefined access in ",
+      "file": "tests/unit/components/CampaignsPage.test.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
       "tags": [
         "auto-detected",
-        "wrong-value",
-        "ts"
+        "null-safety",
+        "tsx"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-24T13:07:26.312Z"
+      "last_seen": "2026-05-23T16:35:04.038Z"
     },
     {
       "id": "bug-088",
-      "timestamp": "2026-05-24T13:08:01.966Z",
-      "error_message": "Type error",
-      "file": "tests/unit/lib/middleware.test.ts",
-      "root_cause": "Missing or incorrect type annotation",
-      "fix": "Added type assertion/annotation | Also: it(\"allows pre-rollout JWT with no tokenVersion field when D; const preRolloutPayload = { userId: MOCK_PAYLOAD.userId, ema",
+      "timestamp": "2026-05-23T16:43:16.214Z",
+      "error_message": "Significant refactor of ",
+      "file": "tests/unit/helpers/route.test.helpers.ts",
+      "root_cause": "3 lines replaced/restructured",
+      "fix": "Rewrote 12\u219227 lines (3 removed)",
       "tags": [
         "auto-detected",
-        "type-fix",
-        "ts"
-      ],
-      "related_bugs": [],
-      "occurrences": 2,
-      "last_seen": "2026-05-24T13:08:10.672Z"
-    },
-    {
-      "id": "bug-089",
-      "timestamp": "2026-05-24T13:08:22.641Z",
-      "error_message": "Type error",
-      "file": "tests/unit/lib/api-helpers.test.ts",
-      "root_cause": "Missing or incorrect type annotation",
-      "fix": "Added type assertion/annotation",
-      "tags": [
-        "auto-detected",
-        "type-fix",
+        "refactor",
         "ts"
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-24T13:08:22.641Z"
+      "last_seen": "2026-05-23T16:43:16.214Z"
+    },
+    {
+      "id": "bug-089",
+      "timestamp": "2026-05-23T16:44:14.579Z",
+      "error_message": "Wrong reference: MOCK_LOG should be MOCK_SESSION_LOG",
+      "file": "tests/unit/api/campaigns/sessions.route.test.ts",
+      "root_cause": "Used \"MOCK_LOG\" instead of \"MOCK_SESSION_LOG\"",
+      "fix": "Changed MOCK_LOG \u2192 MOCK_SESSION_LOG",
+      "tags": [
+        "auto-detected",
+        "wrong-reference",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T16:44:14.579Z"
     },
     {
       "id": "bug-090",
-      "timestamp": "2026-05-24T17:27:05.792Z",
+      "timestamp": "2026-05-23T16:44:37.783Z",
+      "error_message": "Wrong return value",
+      "file": "tests/integration/api/parties.test.ts",
+      "root_cause": "Was returning: { \"Content-Type\": \"application/json\", Cookie: auth",
+      "fix": "Now returns: fetch(`${baseUrl}/api/parties/${partyId}`, {",
+      "tags": [
+        "auto-detected",
+        "return-value",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T16:44:37.783Z"
+    },
+    {
+      "id": "bug-091",
+      "timestamp": "2026-05-23T21:28:55.429Z",
       "error_message": "Null/undefined access in ",
-      "file": "app/api/monsters/[id]/route.ts",
+      "file": "lib/storage.ts",
       "root_cause": "Property access on potentially null/undefined value",
       "fix": "Added null safety (optional chaining or null check)",
       "tags": [
@@ -1439,23 +1455,215 @@
       ],
       "related_bugs": [],
       "occurrences": 1,
-      "last_seen": "2026-05-24T17:27:05.792Z"
+      "last_seen": "2026-05-23T21:28:55.429Z"
     },
     {
-      "id": "bug-091",
-      "timestamp": "2026-05-24T17:27:11.568Z",
-      "error_message": "Missing guard clause",
-      "file": "app/api/monsters/[id]/route.ts",
-      "root_cause": "No early return/throw for edge case: template instanceof NextResponse",
-      "fix": "Added guard clause: if (template instanceof NextResponse)",
+      "id": "bug-092",
+      "timestamp": "2026-05-23T21:29:21.561Z",
+      "error_message": "Wrong return value",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "Was returning: new Date(d).toLocaleDateString('en-US', { year: 'n",
+      "fix": "Now returns: date.toLocaleDateString('en-US', { year: 'numeric'",
       "tags": [
         "auto-detected",
-        "guard-clause",
+        "return-value",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T21:29:21.561Z"
+    },
+    {
+      "id": "bug-093",
+      "timestamp": "2026-05-23T21:29:30.221Z",
+      "error_message": "Type error",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "Missing or incorrect type annotation",
+      "fix": "Added type assertion/annotation",
+      "tags": [
+        "auto-detected",
+        "type-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T21:29:30.221Z"
+    },
+    {
+      "id": "bug-094",
+      "timestamp": "2026-05-23T21:29:33.526Z",
+      "error_message": "Wrong reference: void should be Promise",
+      "file": "app/parties/page.tsx",
+      "root_cause": "Used \"void\" instead of \"Promise\"",
+      "fix": "Changed void \u2192 Promise",
+      "tags": [
+        "auto-detected",
+        "wrong-reference",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T21:29:33.526Z"
+    },
+    {
+      "id": "bug-095",
+      "timestamp": "2026-05-23T21:30:41.862Z",
+      "error_message": "Significant refactor of ",
+      "file": "tests/integration/api/sessions.test.ts",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 13\u219222 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
         "ts"
       ],
       "related_bugs": [],
-      "occurrences": 3,
-      "last_seen": "2026-05-24T17:27:19.800Z"
+      "occurrences": 1,
+      "last_seen": "2026-05-23T21:30:41.862Z"
+    },
+    {
+      "id": "bug-096",
+      "timestamp": "2026-05-23T21:30:59.651Z",
+      "error_message": "Missing await",
+      "file": "tests/unit/storage/storage.test.ts",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
+      "fix": "Added await to async call",
+      "tags": [
+        "auto-detected",
+        "async-fix",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-23T21:30:59.651Z"
+    },
+    {
+      "id": "bug-097",
+      "timestamp": "2026-05-24T18:38:16.693Z",
+      "error_message": "Null/undefined access in ",
+      "file": "tests/integration/prompts/promptBuilder.test.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
+      "tags": [
+        "auto-detected",
+        "null-safety",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:38:16.693Z"
+    },
+    {
+      "id": "bug-098",
+      "timestamp": "2026-05-24T18:39:42.239Z",
+      "error_message": "CSS fix: id",
+      "file": "tests/integration/prompts/promptBuilder.test.tsx",
+      "root_cause": "id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant' \u2192 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant', optional: true",
+      "fix": "Changed id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant' \u2192 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant', optional: true",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 2,
+      "last_seen": "2026-05-24T18:42:25.596Z"
+    },
+    {
+      "id": "bug-099",
+      "timestamp": "2026-05-24T18:41:11.809Z",
+      "error_message": "Wrong reference: party should be hasParty",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "Used \"party\" instead of \"hasParty\"",
+      "fix": "Changed party \u2192 hasParty",
+      "tags": [
+        "auto-detected",
+        "wrong-reference",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:41:11.809Z"
+    },
+    {
+      "id": "bug-100",
+      "timestamp": "2026-05-24T18:41:21.593Z",
+      "error_message": "Wrong operator: === should be ||",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "Used \"===\" instead of \"||\"",
+      "fix": "Changed operator === \u2192 ||",
+      "tags": [
+        "auto-detected",
+        "operator-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:41:21.594Z"
+    },
+    {
+      "id": "bug-101",
+      "timestamp": "2026-05-24T18:41:32.696Z",
+      "error_message": "Null/undefined access in ",
+      "file": "app/campaigns/[id]/sessions/page.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
+      "tags": [
+        "auto-detected",
+        "null-safety",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:41:32.696Z"
+    },
+    {
+      "id": "bug-102",
+      "timestamp": "2026-05-24T18:41:52.771Z",
+      "error_message": "CSS fix: logs",
+      "file": "tests/integration/sessions/sessionLogs.test.tsx",
+      "root_cause": "logs: object[], parties: object[]) { \u2192 object[], parties: typeof PARTY_ALICE_BOB[]) {",
+      "fix": "Changed logs: object[], parties: object[]) { \u2192 object[], parties: typeof PARTY_ALICE_BOB[]) {",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:41:52.771Z"
+    },
+    {
+      "id": "bug-103",
+      "timestamp": "2026-05-24T18:43:45.791Z",
+      "error_message": "Significant refactor of ",
+      "file": "tests/unit/components/SessionsPage.test.tsx",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 4\u21925 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:43:45.791Z"
+    },
+    {
+      "id": "bug-104",
+      "timestamp": "2026-05-24T18:45:04.716Z",
+      "error_message": "Missing await",
+      "file": "lib/hooks/useCampaignContext.ts",
+      "root_cause": "Async call without await \u2014 returned Promise instead of value",
+      "fix": "Added await to async call",
+      "tags": [
+        "auto-detected",
+        "async-fix",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T18:45:04.716Z"
     }
   ]
 }

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1664,6 +1664,54 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-05-24T18:45:04.716Z"
+    },
+    {
+      "id": "bug-105",
+      "timestamp": "2026-05-24T19:00:04.911Z",
+      "error_message": "Missing error handling in function",
+      "file": "app/campaigns/[id]/prompts/page.tsx",
+      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "fix": "Added try/catch block",
+      "tags": [
+        "auto-detected",
+        "error-handling",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T19:00:04.911Z"
+    },
+    {
+      "id": "bug-106",
+      "timestamp": "2026-05-24T19:00:20.059Z",
+      "error_message": "CSS fix: templates, build",
+      "file": "tests/integration/prompts/promptBuilder.test.tsx",
+      "root_cause": "templates: 5 tabs (real ids), but the first has no required fields for generate tests → NPC tab has optional-only fields (Generate works without filling them).; build: () => ({ systemPrompt: 'Campaign: Curse of Strahd', userMessage: 'Create an NPC named Bob.', fullText: 'Campaign: Curse of Strahd\\n\\nCreate an NPC named Bob.' → () => ({ systemPrompt: '', userMessage: '', fullText: ''",
+      "fix": "Changed templates: 5 tabs (real ids), but the first has no required fields for generate tests → NPC tab has optional-only fields (Generate works without filling them).; build: () => ({ systemPrompt: 'Campaign: Curse of Strahd', userMessage: 'Create an NPC named Bob.', fullText: 'Campaign: Curse of Strahd\\n\\nCreate an NPC named Bob.' → () => ({ systemPrompt: '', userMessage: '', fullText: ''",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T19:00:20.059Z"
+    },
+    {
+      "id": "bug-107",
+      "timestamp": "2026-05-24T19:00:32.049Z",
+      "error_message": "Null/undefined access in ",
+      "file": "tests/integration/prompts/promptBuilder.test.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
+      "tags": [
+        "auto-detected",
+        "null-safety",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-05-24T19:00:32.049Z"
     }
   ]
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -1086,3 +1086,19 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+| 11:55 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | 7→7 lines | ~87 |
+| 11:55 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | 4→4 lines | ~112 |
+| 11:55 | Session end: 2 writes across 1 files (tasks.md) | 3 reads | ~4045 tok |
+| 11:55 | Session end: 2 writes across 1 files (tasks.md) | 3 reads | ~4045 tok |
+| 11:59 | Edited app/campaigns/[id]/prompts/page.tsx | inline fix | ~15 |
+| 11:59 | Edited app/campaigns/[id]/prompts/page.tsx | added 1 condition(s) | ~89 |
+| 12:00 | Edited app/campaigns/[id]/prompts/page.tsx | added error handling | ~114 |
+| 12:00 | Edited tests/integration/prompts/promptBuilder.test.tsx | 10→11 lines | ~332 |
+| 12:00 | Edited tests/integration/prompts/promptBuilder.test.tsx | added nullish coalescing | ~304 |
+| 12:11 | Edited lib/prompts/templates.ts | inline fix | ~26 |
+| 12:11 | Edited lib/prompts/templates.ts | reduce() → calculateTotalLevel() | ~61 |
+| 12:11 | Edited lib/utils/campaignContext.ts | 2→4 lines | ~55 |
+| 12:11 | Edited app/campaigns/[id]/prompts/page.tsx | unavailable() → rejected() | ~120 |
+| 12:11 | Edited app/campaigns/[id]/prompts/page.tsx | CSS: rows, type | ~233 |
+| 13:53 | Edited app/api/auth/logout/route.ts | modified POST() | ~142 |
+| 13:53 | Edited app/api/auth/logout/route.ts | modified POST() | ~144 |

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -954,3 +954,135 @@
 | 11:42 | Edited openspec/changes/session-invalidation-foundation/tasks.md | 7→7 lines | ~110 |
 | 11:43 | Edited openspec/changes/session-invalidation-foundation/tasks.md | 5→5 lines | ~85 |
 | 11:44 | Session end: 19 writes across 7 files (middleware.ts, api-helpers.ts, middleware.test.ts, api-helpers.test.ts, duplicate.test.ts) | 20 reads | ~29675 tok |
+| 09:43 | Edited tests/unit/helpers/route.test.helpers.ts | expanded (+15 lines) | ~306 |
+| 09:43 | Edited tests/unit/helpers/route.test.helpers.ts | modified itReturns401WithParams() | ~468 |
+| 09:43 | Edited tests/unit/api/campaigns/sessions.id.route.test.ts | reduced (-10 lines) | ~1021 |
+| 09:44 | Edited tests/unit/api/campaigns/sessions.route.test.ts | 10→11 lines | ~100 |
+| 09:44 | Edited tests/unit/api/campaigns/sessions.route.test.ts | reduced (-11 lines) | ~25 |
+| 09:44 | Edited tests/unit/api/campaigns/sessions.route.test.ts | inline fix | ~5 |
+| 09:44 | Edited tests/unit/api/campaigns/sessions.route.test.ts | 8→8 lines | ~70 |
+| 09:44 | Edited tests/integration/helpers/server.ts | modified makeAuthedHeaders() | ~65 |
+| 09:44 | Edited tests/integration/api/parties.test.ts | 2→2 lines | ~40 |
+| 09:44 | Edited tests/integration/api/parties.test.ts | modified putParty() | ~161 |
+| 09:44 | Edited tests/integration/api/parties.test.ts | reduced (-12 lines) | ~553 |
+| 09:44 | Edited tests/integration/api/parties.test.ts | json() → getParty() | ~162 |
+| 09:45 | Edited tests/integration/api/sessions.test.ts | 2→2 lines | ~40 |
+| 09:45 | Edited tests/integration/api/sessions.test.ts | authed() → makeAuthedHeaders() | ~20 |
+| 10:43 | Refactor: generalize ContextHandler to generic, add MOCK_SESSION_LOG, makeAuthedHeaders; remove clones in sessions route tests and integration test helpers | route.test.helpers.ts, sessions.id.route.test.ts, sessions.route.test.ts, server.ts, parties.test.ts, sessions.test.ts | 22→15 clone reduction | ~2k |
+| 10:46 | Session end: 14 writes across 6 files (route.test.helpers.ts, sessions.id.route.test.ts, sessions.route.test.ts, server.ts, parties.test.ts) | 16 reads | ~25198 tok |
+| 14:17 | Session end: 14 writes across 6 files (route.test.helpers.ts, sessions.id.route.test.ts, sessions.route.test.ts, server.ts, parties.test.ts) | 16 reads | ~25198 tok |
+| 14:28 | Edited lib/utils/sessionEvents.ts | inline fix | ~18 |
+| 14:28 | Edited lib/storage.ts | added 1 condition(s) | ~110 |
+| 14:29 | Edited app/api/campaigns/[id]/sessions/route.ts | 4→4 lines | ~65 |
+| 14:29 | Edited app/api/campaigns/[id]/sessions/route.ts | 2→2 lines | ~46 |
+| 14:29 | Edited app/campaigns/[id]/sessions/page.tsx | CSS: T12, 00 | ~62 |
+| 14:29 | Edited app/campaigns/[id]/sessions/page.tsx | 5→5 lines | ~68 |
+| 14:29 | Edited app/campaigns/[id]/sessions/page.tsx | inline fix | ~31 |
+| 14:29 | Edited app/parties/page.tsx | inline fix | ~19 |
+| 14:30 | Edited tests/unit/components/SessionsPage.test.tsx | 5→5 lines | ~66 |
+| 14:30 | Edited tests/integration/api/sessions.test.ts | expanded (+9 lines) | ~224 |
+| 14:30 | Edited tests/unit/storage/storage.test.ts | expanded (+23 lines) | ~288 |
+| 14:31 | Edited tests/unit/api/campaigns/sessions.route.test.ts | expanded (+19 lines) | ~284 |
+
+## Session: 2026-05-23 14:39
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-23 15:34
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 15:37 | Edited openspec/changes/campaign-session-journal/tasks.md | inline fix | ~15 |
+| 15:37 | Edited openspec/changes/campaign-session-journal/tasks.md | 2→2 lines | ~46 |
+| 15:37 | Edited openspec/changes/campaign-session-journal/tasks.md | 8→8 lines | ~203 |
+| 15:37 | Edited openspec/changes/campaign-session-journal/tasks.md | 3→3 lines | ~39 |
+| 15:38 | Edited openspec/changes/campaign-session-journal/tasks.md | 6→6 lines | ~174 |
+| 10:28 | Session end: 29 writes across 12 files (page.tsx, storage.ts, tasks.md, api.integration.test.ts, sessionEvents.ts) | 21 reads | ~39382 tok |
+| 10:29 | Session end: 29 writes across 12 files (page.tsx, storage.ts, tasks.md, api.integration.test.ts, sessionEvents.ts) | 21 reads | ~39382 tok |
+
+## Session: 2026-05-24 10:36
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 11:16 | Created openspec/changes/prompt-builder-campaign-child/proposal.md | — | ~1687 |
+| 11:17 | Created openspec/changes/prompt-builder-campaign-child/design.md | — | ~3355 |
+| 11:18 | Created openspec/changes/prompt-builder-campaign-child/specs/campaign-context/spec.md | — | ~1363 |
+| 11:18 | Created openspec/changes/prompt-builder-campaign-child/specs/prompt-templates/spec.md | — | ~1215 |
+| 11:18 | Created openspec/changes/prompt-builder-campaign-child/specs/prompt-builder-ui/spec.md | — | ~1483 |
+| 11:19 | Created openspec/changes/prompt-builder-campaign-child/specs/session-logs-refactor/spec.md | — | ~826 |
+| 11:20 | Created openspec/changes/prompt-builder-campaign-child/tasks.md | — | ~2400 |
+| 11:20 | Created openspec/changes/prompt-builder-campaign-child/tests.md | — | ~1773 |
+| 11:20 | Session end: 8 writes across 5 files (proposal.md, design.md, spec.md, tasks.md, tests.md) | 3 reads | ~24633 tok |
+
+## Session: 2026-05-24 11:23
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-05-24 11:24
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 11:26 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~23 |
+| 11:26 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~50 |
+| 11:26 | Edited lib/types.ts | expanded (+14 lines) | ~136 |
+| 11:27 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~23 |
+| 11:27 | Created tests/unit/utils/campaignContext.test.ts | — | ~1992 |
+| 11:27 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~21 |
+| 11:27 | Created lib/utils/campaignContext.ts | — | ~365 |
+| 11:28 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~15 |
+| 11:28 | Created tests/unit/hooks/useCampaignContext.test.ts | — | ~1006 |
+| 11:28 | Created lib/hooks/useCampaignContext.ts | — | ~328 |
+| 11:28 | Created tests/unit/hooks/useCampaignContext.test.ts | — | ~1491 |
+| 11:29 | Created tests/unit/hooks/useCampaignContext.test.ts | — | ~992 |
+| 11:29 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~16 |
+| 11:30 | Created tests/unit/prompts/templates.test.ts | — | ~2559 |
+| 11:30 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~20 |
+| 11:30 | Created lib/prompts/templates.ts | — | ~1689 |
+| 11:30 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~14 |
+| 11:32 | Created tests/integration/prompts/promptBuilder.test.tsx | — | ~3306 |
+| 11:32 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~22 |
+| 11:35 | Created app/campaigns/[id]/prompts/page.tsx | — | ~2036 |
+| 11:36 | Edited app/campaigns/[id]/prompts/page.tsx | 27→31 lines | ~346 |
+| 11:36 | Edited tests/integration/prompts/promptBuilder.test.tsx | modified if() | ~336 |
+| 11:36 | Edited tests/integration/prompts/promptBuilder.test.tsx | modified if() | ~327 |
+| 11:36 | Edited tests/integration/prompts/promptBuilder.test.tsx | modified if() | ~202 |
+| 11:38 | Edited tests/integration/prompts/promptBuilder.test.tsx | added nullish coalescing | ~437 |
+| 11:39 | Created tests/integration/prompts/promptBuilder.test.tsx | — | ~3264 |
+| 11:39 | Edited tests/integration/prompts/promptBuilder.test.tsx | inline fix | ~92 |
+| 11:39 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~17 |
+| 11:40 | Edited app/campaigns/page.tsx | expanded (+6 lines) | ~190 |
+| 11:40 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~19 |
+| 11:40 | Created tests/integration/sessions/sessionLogs.test.tsx | — | ~1768 |
+| 11:40 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~20 |
+| 11:40 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~16 |
+| 11:40 | Edited app/campaigns/[id]/sessions/page.tsx | added 1 import(s) | ~149 |
+| 11:41 | Edited app/campaigns/[id]/sessions/page.tsx | CSS: allMembers, hasParty | ~387 |
+| 11:41 | Edited app/campaigns/[id]/sessions/page.tsx | 3→3 lines | ~40 |
+| 11:41 | Edited app/campaigns/[id]/sessions/page.tsx | CSS: loading, error | ~306 |
+| 11:41 | Edited app/campaigns/[id]/sessions/page.tsx | modified catch() | ~150 |
+| 11:41 | Edited app/campaigns/[id]/sessions/page.tsx | added optional chaining | ~138 |
+| 11:41 | Edited tests/integration/sessions/sessionLogs.test.tsx | CSS: useCampaignContext, useCampaignContext | ~166 |
+| 11:41 | Edited tests/integration/sessions/sessionLogs.test.tsx | modified makeContext() | ~166 |
+| 11:41 | Edited tests/integration/sessions/sessionLogs.test.tsx | modified renderSessions() | ~193 |
+| 11:42 | Edited tests/unit/prompts/templates.test.ts | 14→14 lines | ~176 |
+| 11:42 | Edited tests/integration/prompts/promptBuilder.test.tsx | inline fix | ~9 |
+| 11:42 | Edited tests/unit/hooks/useCampaignContext.test.ts | 4→2 lines | ~60 |
+| 11:42 | Edited tests/integration/sessions/sessionLogs.test.tsx | 8→8 lines | ~85 |
+| 11:43 | Edited openspec/changes/prompt-builder-campaign-child/tasks.md | inline fix | ~24 |
+| 11:43 | Edited tests/unit/components/SessionsPage.test.tsx | expanded (+9 lines) | ~84 |
+| 11:43 | Edited tests/unit/components/SessionsPage.test.tsx | 4→5 lines | ~62 |
+| 11:43 | Edited tests/unit/components/SessionsPage.test.tsx | CSS: context | ~124 |
+| 11:45 | Edited lib/hooks/useCampaignContext.ts | then() → load() | ~160 |
+| 11:45 | Edited tests/integration/prompts/promptBuilder.test.tsx | 2→1 lines | ~40 |
+| 11:45 | Edited tests/integration/sessions/sessionLogs.test.tsx | 9→7 lines | ~106 |
+| 11:45 | Edited tests/unit/hooks/useCampaignContext.test.ts | 2→1 lines | ~58 |
+| 11:46 | Edited lib/hooks/useCampaignContext.ts | modified catch() | ~160 |
+| 11:47 | Created lib/hooks/useCampaignContext.ts | — | ~336 |
+| 11:47 | Edited tests/integration/prompts/promptBuilder.test.tsx | 1→2 lines | ~41 |
+
+## Session: 2026-05-24 11:50
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-18T14:20:54.749Z",
   "lifetime": {
-    "total_tokens_estimated": 1132039,
-    "total_reads": 650,
-    "total_writes": 928,
-    "total_sessions": 45,
-    "anatomy_hits": 391,
-    "anatomy_misses": 252,
-    "repeated_reads_blocked": 294,
-    "estimated_savings_vs_bare_cli": 771311
+    "total_tokens_estimated": 1274189,
+    "total_reads": 712,
+    "total_writes": 1000,
+    "total_sessions": 51,
+    "anatomy_hits": 447,
+    "anatomy_misses": 258,
+    "repeated_reads_blocked": 326,
+    "estimated_savings_vs_bare_cli": 910505
   },
   "sessions": [
     {
@@ -9991,6 +9991,831 @@
         "writes_count": 19,
         "repeated_reads_blocked": 5,
         "anatomy_lookups": 13
+      }
+    },
+    {
+      "id": "session-2026-05-23-1815",
+      "started": "2026-05-23T01:15:48.053Z",
+      "ended": "2026-05-24T17:28:47.901Z",
+      "reads": [
+        {
+          "file": "/home/doug/dev2/session-combat/app/parties/page.tsx",
+          "tokens_estimated": 3852,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 7008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 2381,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/bknu7741e.output",
+          "tokens_estimated": 0,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/bkyxg8gg6.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/integration/api.integration.test.ts",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/b6o333mjc.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/utils/sessionEvents.ts",
+          "tokens_estimated": 375,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/parties/[id]/route.ts",
+          "tokens_estimated": 998,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 4153,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/route.ts",
+          "tokens_estimated": 680,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/[sessionId]/route.ts",
+          "tokens_estimated": 422,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/utils/sessionEvents.test.ts",
+          "tokens_estimated": 745,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/bmb6d8qgm.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 472,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/route.test.ts",
+          "tokens_estimated": 2600,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/helpers/route.test.helpers.ts",
+          "tokens_estimated": 2060,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/global.route.test.ts",
+          "tokens_estimated": 1870,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/global.id.route.test.ts",
+          "tokens_estimated": 631,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/middleware.ts",
+          "tokens_estimated": 695,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/CampaignsPage.test.tsx",
+          "tokens_estimated": 2226,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/doug/dev2/session-combat/app/parties/page.tsx",
+          "tokens_estimated": 17,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/parties/page.tsx",
+          "tokens_estimated": 117,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 37,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 56,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 10,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/integration/api.integration.test.ts",
+          "tokens_estimated": 73,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 16,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 163,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/utils/sessionEvents.ts",
+          "tokens_estimated": 485,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/parties/[id]/route.ts",
+          "tokens_estimated": 50,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 24,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 34,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 50,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/route.ts",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/[sessionId]/route.ts",
+          "tokens_estimated": 86,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 12,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 48,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/utils/sessionEvents.test.ts",
+          "tokens_estimated": 155,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/sessions.route.test.ts",
+          "tokens_estimated": 1524,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/sessions.id.route.test.ts",
+          "tokens_estimated": 1214,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 200,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 1515,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 47,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 207,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/SessionsPage.test.tsx",
+          "tokens_estimated": 1327,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/CampaignsPage.test.tsx",
+          "tokens_estimated": 290,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/SessionsPage.test.tsx",
+          "tokens_estimated": 288,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 31168,
+        "output_tokens_estimated": 8214,
+        "reads_count": 21,
+        "writes_count": 29,
+        "repeated_reads_blocked": 17,
+        "anatomy_lookups": 16
+      }
+    },
+    {
+      "id": "session-2026-05-23-1815",
+      "started": "2026-05-23T01:15:48.053Z",
+      "ended": "2026-05-24T17:29:32.650Z",
+      "reads": [
+        {
+          "file": "/home/doug/dev2/session-combat/app/parties/page.tsx",
+          "tokens_estimated": 3852,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 7008,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 2381,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/bknu7741e.output",
+          "tokens_estimated": 0,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/bkyxg8gg6.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/integration/api.integration.test.ts",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/b6o333mjc.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/utils/sessionEvents.ts",
+          "tokens_estimated": 375,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/parties/[id]/route.ts",
+          "tokens_estimated": 998,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 4153,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/route.ts",
+          "tokens_estimated": 680,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/[sessionId]/route.ts",
+          "tokens_estimated": 422,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/utils/sessionEvents.test.ts",
+          "tokens_estimated": 745,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/c2bf9084-19cf-47c8-93f8-7175c5b15abf/tasks/bmb6d8qgm.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 472,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/route.test.ts",
+          "tokens_estimated": 2600,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/helpers/route.test.helpers.ts",
+          "tokens_estimated": 2060,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/global.route.test.ts",
+          "tokens_estimated": 1870,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/global.id.route.test.ts",
+          "tokens_estimated": 631,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/middleware.ts",
+          "tokens_estimated": 695,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/CampaignsPage.test.tsx",
+          "tokens_estimated": 2226,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/doug/dev2/session-combat/app/parties/page.tsx",
+          "tokens_estimated": 17,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/parties/page.tsx",
+          "tokens_estimated": 117,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 37,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 56,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 10,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/integration/api.integration.test.ts",
+          "tokens_estimated": 73,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 16,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/storage.ts",
+          "tokens_estimated": 163,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/utils/sessionEvents.ts",
+          "tokens_estimated": 485,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/parties/[id]/route.ts",
+          "tokens_estimated": 50,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 24,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 34,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 50,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/route.ts",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/api/campaigns/[id]/sessions/[sessionId]/route.ts",
+          "tokens_estimated": 86,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 12,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/campaign-session-journal/tasks.md",
+          "tokens_estimated": 48,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/utils/sessionEvents.test.ts",
+          "tokens_estimated": 155,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/sessions.route.test.ts",
+          "tokens_estimated": 1524,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/api/campaigns/sessions.id.route.test.ts",
+          "tokens_estimated": 1214,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 200,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 1515,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 47,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/storage/sessionLog.test.ts",
+          "tokens_estimated": 207,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/SessionsPage.test.tsx",
+          "tokens_estimated": 1327,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/CampaignsPage.test.tsx",
+          "tokens_estimated": 290,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/tests/unit/components/SessionsPage.test.tsx",
+          "tokens_estimated": 288,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 31168,
+        "output_tokens_estimated": 8214,
+        "reads_count": 21,
+        "writes_count": 29,
+        "repeated_reads_blocked": 17,
+        "anatomy_lookups": 16
+      }
+    },
+    {
+      "id": "session-2026-05-24-1036",
+      "started": "2026-05-24T17:36:21.800Z",
+      "ended": "2026-05-24T17:39:28.293Z",
+      "reads": [
+        {
+          "file": "/home/doug/dev2/session-combat/lib/types.ts",
+          "tokens_estimated": 4854,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 4854,
+        "output_tokens_estimated": 0,
+        "reads_count": 1,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-05-24-1036",
+      "started": "2026-05-24T17:36:21.800Z",
+      "ended": "2026-05-24T17:56:43.110Z",
+      "reads": [
+        {
+          "file": "/home/doug/dev2/session-combat/lib/types.ts",
+          "tokens_estimated": 4854,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 4167,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 9021,
+        "output_tokens_estimated": 0,
+        "reads_count": 2,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 2
+      }
+    },
+    {
+      "id": "session-2026-05-24-1036",
+      "started": "2026-05-24T17:36:21.800Z",
+      "ended": "2026-05-24T18:02:11.984Z",
+      "reads": [
+        {
+          "file": "/home/doug/dev2/session-combat/lib/types.ts",
+          "tokens_estimated": 4854,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 4167,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/utils/sessionEvents.ts",
+          "tokens_estimated": 503,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 9524,
+        "output_tokens_estimated": 0,
+        "reads_count": 3,
+        "writes_count": 0,
+        "repeated_reads_blocked": 2,
+        "anatomy_lookups": 3
+      }
+    },
+    {
+      "id": "session-2026-05-24-1036",
+      "started": "2026-05-24T17:36:21.800Z",
+      "ended": "2026-05-24T18:20:52.437Z",
+      "reads": [
+        {
+          "file": "/home/doug/dev2/session-combat/lib/types.ts",
+          "tokens_estimated": 4854,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/app/campaigns/[id]/sessions/page.tsx",
+          "tokens_estimated": 4167,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/lib/utils/sessionEvents.ts",
+          "tokens_estimated": 503,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/proposal.md",
+          "tokens_estimated": 1808,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/design.md",
+          "tokens_estimated": 3595,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/specs/campaign-context/spec.md",
+          "tokens_estimated": 1460,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/specs/prompt-templates/spec.md",
+          "tokens_estimated": 1302,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/specs/prompt-builder-ui/spec.md",
+          "tokens_estimated": 1589,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/specs/session-logs-refactor/spec.md",
+          "tokens_estimated": 884,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 2572,
+          "action": "create"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tests.md",
+          "tokens_estimated": 1899,
+          "action": "create"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 9524,
+        "output_tokens_estimated": 15109,
+        "reads_count": 3,
+        "writes_count": 8,
+        "repeated_reads_blocked": 2,
+        "anatomy_lookups": 3
+      }
+    },
+    {
+      "id": "session-2026-05-24-1150",
+      "started": "2026-05-24T18:50:22.361Z",
+      "ended": "2026-05-24T18:55:12.862Z",
+      "reads": [
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/fe61e6db-fcf2-452a-8ce7-5db0f72f03dd/tasks/bqth1hcc5.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/proposal.md",
+          "tokens_estimated": 1582,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 2250,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 93,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 120,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 3832,
+        "output_tokens_estimated": 213,
+        "reads_count": 3,
+        "writes_count": 2,
+        "repeated_reads_blocked": 1,
+        "anatomy_lookups": 2
+      }
+    },
+    {
+      "id": "session-2026-05-24-1150",
+      "started": "2026-05-24T18:50:22.361Z",
+      "ended": "2026-05-24T18:55:33.283Z",
+      "reads": [
+        {
+          "file": "/tmp/claude-1000/-home-doug-dev2-session-combat/fe61e6db-fcf2-452a-8ce7-5db0f72f03dd/tasks/bqth1hcc5.output",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/proposal.md",
+          "tokens_estimated": 1582,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 2250,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 93,
+          "action": "edit"
+        },
+        {
+          "file": "/home/doug/dev2/session-combat/openspec/changes/prompt-builder-campaign-child/tasks.md",
+          "tokens_estimated": 120,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 3832,
+        "output_tokens_estimated": 213,
+        "reads_count": 3,
+        "writes_count": 2,
+        "repeated_reads_blocked": 1,
+        "anatomy_lookups": 2
       }
     }
   ],

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,16 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { clearAuthCookie, verifyAuth } from "@/lib/middleware";
+import { clearAuthCookie } from "@/lib/middleware";
 
-export async function POST(request: NextRequest) {
+export async function POST(_request: NextRequest) {
   try {
-    // Verify auth token exists and is valid
-    const auth = verifyAuth(request);
-
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Token is valid, clear it and return success
     const response = NextResponse.json(
       { message: "Logout successful" },
       { status: 200 },

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -63,7 +63,7 @@ function PromptOutput({ builtPrompt }: { builtPrompt: BuiltPrompt }) {
   }, []);
 
   async function handleCopy() {
-    if (!navigator.clipboard) return;
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
     try {
       await navigator.clipboard.writeText(builtPrompt.fullText);
       if (timerRef.current) clearTimeout(timerRef.current);

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -6,8 +6,86 @@ import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState, FormField, textInputClass } from '@/lib/components/ui';
 import { useCampaignContext } from '@/lib/hooks/useCampaignContext';
-import { TEMPLATES, PromptTemplate } from '@/lib/prompts/templates';
-import { BuiltPrompt } from '@/lib/types';
+import { TEMPLATES, PromptField, PromptTemplate } from '@/lib/prompts/templates';
+import type { BuiltPrompt, CampaignContext } from '@/lib/types';
+
+function TemplateField({ field, value, onChange }: {
+  field: PromptField;
+  value: string;
+  onChange: (key: string, value: string) => void;
+}) {
+  const Tag = field.multiline ? 'textarea' : 'input';
+  return (
+    <FormField label={field.label + (field.optional ? ' (optional)' : '')} htmlFor={field.key}>
+      <Tag
+        id={field.key}
+        value={value}
+        onChange={e => onChange(field.key, e.target.value)}
+        placeholder={field.placeholder}
+        className={textInputClass() + (field.multiline ? ' resize-y' : '')}
+        {...(Tag === 'textarea' ? { rows: 3 } : { type: 'text' })}
+      />
+    </FormField>
+  );
+}
+
+function TemplateForm({ template, fields, validationError, onFieldChange, onGenerate }: {
+  template: PromptTemplate;
+  fields: Record<string, string>;
+  validationError: string | null;
+  onFieldChange: (key: string, value: string) => void;
+  onGenerate: () => void;
+}) {
+  return (
+    <div className="bg-gray-800 rounded-lg p-6 mb-6">
+      <h2 className="text-xl font-semibold mb-4">{template.label}</h2>
+      <div className="space-y-4 mb-6">
+        {template.fields.map(field => (
+          <TemplateField key={field.key} field={field} value={fields[field.key] ?? ''} onChange={onFieldChange} />
+        ))}
+      </div>
+      {validationError && (
+        <p className="text-red-400 text-sm mb-4">{validationError}</p>
+      )}
+      <button onClick={onGenerate} className="bg-blue-600 hover:bg-blue-700 px-6 py-2 rounded font-medium">
+        Generate Prompt
+      </button>
+    </div>
+  );
+}
+
+function PromptOutput({ builtPrompt }: { builtPrompt: BuiltPrompt }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, []);
+
+  async function handleCopy() {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(builtPrompt.fullText);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write rejected (permissions / insecure context)
+    }
+  }
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-6">
+      <h2 className="text-lg font-semibold mb-3">Generated Prompt</h2>
+      <textarea readOnly value={builtPrompt.fullText} rows={12} className={textInputClass() + ' resize-y font-mono text-sm'} />
+      <div className="flex gap-3 mt-4">
+        <button onClick={handleCopy} className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-sm">
+          {copied ? 'Copied!' : 'Copy to Clipboard'}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 function PromptBuilderContent({ campaignId }: { campaignId: string }) {
   const { context, loading, error } = useCampaignContext(campaignId);
@@ -15,23 +93,14 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
   const [fields, setFields] = useState<Record<string, string>>({});
   const [builtPrompt, setBuiltPrompt] = useState<BuiltPrompt | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
-  const activeTemplate: PromptTemplate = TEMPLATES.find(t => t.id === activeTemplateId) ?? TEMPLATES[0];
-  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
-    };
-  }, []);
+  const activeTemplate = TEMPLATES.find(t => t.id === activeTemplateId) ?? TEMPLATES[0];
 
   function selectTemplate(template: PromptTemplate) {
     setActiveTemplateId(template.id);
     setFields({});
     setBuiltPrompt(null);
     setValidationError(null);
-    setCopied(false);
   }
 
   function handleFieldChange(key: string, value: string) {
@@ -40,34 +109,17 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
     setValidationError(null);
   }
 
-  function handleGenerate() {
-    if (!context) return;
-
-    const missingRequired = activeTemplate.fields
+  function handleGenerate(ctx: CampaignContext) {
+    const missing = activeTemplate.fields
       .filter(f => !f.optional && !fields[f.key]?.trim())
       .map(f => f.label);
-
-    if (missingRequired.length > 0) {
-      setValidationError(`Required fields missing: ${missingRequired.join(', ')}`);
+    if (missing.length > 0) {
+      setValidationError(`Required fields missing: ${missing.join(', ')}`);
       setBuiltPrompt(null);
       return;
     }
-
-    const prompt = activeTemplate.build(fields, context);
-    setBuiltPrompt(prompt);
+    setBuiltPrompt(activeTemplate.build(fields, ctx));
     setValidationError(null);
-  }
-
-  async function handleCopy() {
-    if (!builtPrompt || !navigator.clipboard) return;
-    try {
-      await navigator.clipboard.writeText(builtPrompt.fullText);
-      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
-      setCopied(true);
-      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // clipboard write rejected (permissions / insecure context)
-    }
   }
 
   if (loading) {
@@ -86,9 +138,7 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
         <div className="flex justify-between items-center mb-8">
           <div>
             <h1 className="text-3xl font-bold">Prompt Builder</h1>
-            {context && (
-              <p className="text-gray-400 mt-1">{context.campaign.name}</p>
-            )}
+            {context && <p className="text-gray-400 mt-1">{context.campaign.name}</p>}
           </div>
           <Link href="/campaigns" className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded text-sm">
             Back to Campaigns
@@ -105,78 +155,28 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
 
         {context && (
           <>
-            {/* Template selector tabs */}
             <div className="flex gap-2 mb-6 flex-wrap">
               {TEMPLATES.map(template => (
                 <button
                   key={template.id}
                   onClick={() => selectTemplate(template)}
-                  className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
-                    activeTemplateId === template.id
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
-                  }`}
+                  className={`px-4 py-2 rounded text-sm font-medium transition-colors ${activeTemplateId === template.id ? 'bg-blue-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'}`}
                 >
                   {template.label}
                 </button>
               ))}
             </div>
 
-            {/* Dynamic form */}
-            <div className="bg-gray-800 rounded-lg p-6 mb-6">
-              <h2 className="text-xl font-semibold mb-4">{activeTemplate.label}</h2>
-              <div className="space-y-4 mb-6">
-                {activeTemplate.fields.map(field => {
-                  const Tag = field.multiline ? 'textarea' : 'input';
-                  return (
-                    <FormField key={field.key} label={field.label + (field.optional ? ' (optional)' : '')} htmlFor={field.key}>
-                      <Tag
-                        id={field.key}
-                        value={fields[field.key] ?? ''}
-                        onChange={e => handleFieldChange(field.key, e.target.value)}
-                        placeholder={field.placeholder}
-                        className={textInputClass() + (field.multiline ? ' resize-y' : '')}
-                        {...(Tag === 'textarea' ? { rows: 3 } : { type: 'text' })}
-                      />
-                    </FormField>
-                  );
-                })}
-              </div>
+            <TemplateForm
+              template={activeTemplate}
+              fields={fields}
+              validationError={validationError}
+              onFieldChange={handleFieldChange}
+              onGenerate={() => handleGenerate(context)}
+            />
 
-              {validationError && (
-                <p className="text-red-400 text-sm mb-4">{validationError}</p>
-              )}
+            {builtPrompt && <PromptOutput builtPrompt={builtPrompt} />}
 
-              <button
-                onClick={handleGenerate}
-                className="bg-blue-600 hover:bg-blue-700 px-6 py-2 rounded font-medium"
-              >
-                Generate Prompt
-              </button>
-            </div>
-
-            {/* Generated prompt output */}
-            {builtPrompt && (
-              <div className="bg-gray-800 rounded-lg p-6">
-                <h2 className="text-lg font-semibold mb-3">Generated Prompt</h2>
-                <textarea
-                  readOnly
-                  value={builtPrompt.fullText}
-                  rows={12}
-                  className={textInputClass() + ' resize-y font-mono text-sm'}
-                />
-                <div className="flex gap-3 mt-4">
-                  <button
-                    onClick={handleCopy}
-                    className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-sm"
-                  >
-                    {copied ? 'Copied!' : 'Copy to Clipboard'}
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {/* Save to Library stub — always visible */}
             <div className="mt-4">
               <button
                 disabled

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
+import { ErrorBanner, LoadingState, FormField, textInputClass } from '@/lib/components/ui';
+import { useCampaignContext } from '@/lib/hooks/useCampaignContext';
+import { TEMPLATES, PromptTemplate } from '@/lib/prompts/templates';
+import { BuiltPrompt } from '@/lib/types';
+
+function PromptBuilderContent({ campaignId }: { campaignId: string }) {
+  const { context, loading, error } = useCampaignContext(campaignId);
+  const [activeTemplateId, setActiveTemplateId] = useState(TEMPLATES[0].id);
+  const [fields, setFields] = useState<Record<string, string>>({});
+  const [builtPrompt, setBuiltPrompt] = useState<BuiltPrompt | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const activeTemplate: PromptTemplate = TEMPLATES.find(t => t.id === activeTemplateId) ?? TEMPLATES[0];
+
+  function selectTemplate(template: PromptTemplate) {
+    setActiveTemplateId(template.id);
+    setFields({});
+    setBuiltPrompt(null);
+    setValidationError(null);
+    setCopied(false);
+  }
+
+  function handleFieldChange(key: string, value: string) {
+    setFields(prev => ({ ...prev, [key]: value }));
+    setBuiltPrompt(null);
+    setValidationError(null);
+  }
+
+  function handleGenerate() {
+    if (!context) return;
+
+    const missingRequired = activeTemplate.fields
+      .filter(f => !f.optional && !fields[f.key]?.trim())
+      .map(f => f.label);
+
+    if (missingRequired.length > 0) {
+      setValidationError(`Required fields missing: ${missingRequired.join(', ')}`);
+      setBuiltPrompt(null);
+      return;
+    }
+
+    const prompt = activeTemplate.build(fields, context);
+    setBuiltPrompt(prompt);
+    setValidationError(null);
+  }
+
+  async function handleCopy() {
+    if (!builtPrompt) return;
+    await navigator.clipboard.writeText(builtPrompt.fullText);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white">
+        <div className="container mx-auto px-4 py-8">
+          <LoadingState label="Loading campaign context..." />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <h1 className="text-3xl font-bold">Prompt Builder</h1>
+            {context && (
+              <p className="text-gray-400 mt-1">{context.campaign.name}</p>
+            )}
+          </div>
+          <Link href="/campaigns" className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded text-sm">
+            Back to Campaigns
+          </Link>
+        </div>
+
+        <ErrorBanner message={error} />
+
+        {context && context.parties.length === 0 && (
+          <div className="bg-yellow-900 border border-yellow-700 rounded p-4 mb-6 text-yellow-200 text-sm">
+            No party linked to this campaign. Prompts will be generated without party context.
+          </div>
+        )}
+
+        {context && (
+          <>
+            {/* Template selector tabs */}
+            <div className="flex gap-2 mb-6 flex-wrap">
+              {TEMPLATES.map(template => (
+                <button
+                  key={template.id}
+                  onClick={() => selectTemplate(template)}
+                  className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+                    activeTemplateId === template.id
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
+                  }`}
+                >
+                  {template.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Dynamic form */}
+            <div className="bg-gray-800 rounded-lg p-6 mb-6">
+              <h2 className="text-xl font-semibold mb-4">{activeTemplate.label}</h2>
+              <div className="space-y-4 mb-6">
+                {activeTemplate.fields.map(field => (
+                  <FormField key={field.key} label={field.label + (field.optional ? ' (optional)' : '')} htmlFor={field.key}>
+                    {field.multiline ? (
+                      <textarea
+                        id={field.key}
+                        value={fields[field.key] ?? ''}
+                        onChange={e => handleFieldChange(field.key, e.target.value)}
+                        placeholder={field.placeholder}
+                        rows={3}
+                        className={textInputClass() + ' resize-y'}
+                      />
+                    ) : (
+                      <input
+                        id={field.key}
+                        type="text"
+                        value={fields[field.key] ?? ''}
+                        onChange={e => handleFieldChange(field.key, e.target.value)}
+                        placeholder={field.placeholder}
+                        className={textInputClass()}
+                      />
+                    )}
+                  </FormField>
+                ))}
+              </div>
+
+              {validationError && (
+                <p className="text-red-400 text-sm mb-4">{validationError}</p>
+              )}
+
+              <button
+                onClick={handleGenerate}
+                className="bg-blue-600 hover:bg-blue-700 px-6 py-2 rounded font-medium"
+              >
+                Generate Prompt
+              </button>
+            </div>
+
+            {/* Generated prompt output */}
+            {builtPrompt && (
+              <div className="bg-gray-800 rounded-lg p-6">
+                <h2 className="text-lg font-semibold mb-3">Generated Prompt</h2>
+                <textarea
+                  readOnly
+                  value={builtPrompt.fullText}
+                  rows={12}
+                  className={textInputClass() + ' resize-y font-mono text-sm'}
+                />
+                <div className="flex gap-3 mt-4">
+                  <button
+                    onClick={handleCopy}
+                    className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-sm"
+                  >
+                    {copied ? 'Copied!' : 'Copy to Clipboard'}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Save to Library stub — always visible */}
+            <div className="mt-4">
+              <button
+                disabled
+                title="Available with Content Library (#185)"
+                className="bg-gray-600 text-gray-400 cursor-not-allowed px-4 py-2 rounded text-sm"
+              >
+                Save to Library
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function PromptBuilderPage() {
+  const params = useParams();
+  const campaignId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  return (
+    <ProtectedRoute>
+      <PromptBuilderContent campaignId={campaignId as string} />
+    </ProtectedRoute>
+  );
+}

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
@@ -18,6 +18,13 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
   const [copied, setCopied] = useState(false);
 
   const activeTemplate: PromptTemplate = TEMPLATES.find(t => t.id === activeTemplateId) ?? TEMPLATES[0];
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
 
   function selectTemplate(template: PromptTemplate) {
     setActiveTemplateId(template.id);
@@ -52,10 +59,15 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
   }
 
   async function handleCopy() {
-    if (!builtPrompt) return;
-    await navigator.clipboard.writeText(builtPrompt.fullText);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (!builtPrompt || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(builtPrompt.fullText);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      setCopied(true);
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write rejected (permissions / insecure context)
+    }
   }
 
   if (loading) {
@@ -114,29 +126,21 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
             <div className="bg-gray-800 rounded-lg p-6 mb-6">
               <h2 className="text-xl font-semibold mb-4">{activeTemplate.label}</h2>
               <div className="space-y-4 mb-6">
-                {activeTemplate.fields.map(field => (
-                  <FormField key={field.key} label={field.label + (field.optional ? ' (optional)' : '')} htmlFor={field.key}>
-                    {field.multiline ? (
-                      <textarea
+                {activeTemplate.fields.map(field => {
+                  const Tag = field.multiline ? 'textarea' : 'input';
+                  return (
+                    <FormField key={field.key} label={field.label + (field.optional ? ' (optional)' : '')} htmlFor={field.key}>
+                      <Tag
                         id={field.key}
                         value={fields[field.key] ?? ''}
                         onChange={e => handleFieldChange(field.key, e.target.value)}
                         placeholder={field.placeholder}
-                        rows={3}
-                        className={textInputClass() + ' resize-y'}
+                        className={textInputClass() + (field.multiline ? ' resize-y' : '')}
+                        {...(Tag === 'textarea' ? { rows: 3 } : { type: 'text' })}
                       />
-                    ) : (
-                      <input
-                        id={field.key}
-                        type="text"
-                        value={fields[field.key] ?? ''}
-                        onChange={e => handleFieldChange(field.key, e.target.value)}
-                        placeholder={field.placeholder}
-                        className={textInputClass()}
-                      />
-                    )}
-                  </FormField>
-                ))}
+                    </FormField>
+                  );
+                })}
               </div>
 
               {validationError && (

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -178,13 +178,14 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
             {builtPrompt && <PromptOutput builtPrompt={builtPrompt} />}
 
             <div className="mt-4">
-              <button
-                disabled
-                title="Available with Content Library (#185)"
-                className="bg-gray-600 text-gray-400 cursor-not-allowed px-4 py-2 rounded text-sm"
-              >
-                Save to Library
-              </button>
+              <span title="Available with Content Library (#185)">
+                <button
+                  disabled
+                  className="bg-gray-600 text-gray-400 cursor-not-allowed px-4 py-2 rounded text-sm"
+                >
+                  Save to Library
+                </button>
+              </span>
             </div>
           </>
         )}

--- a/app/campaigns/[id]/sessions/page.tsx
+++ b/app/campaigns/[id]/sessions/page.tsx
@@ -5,7 +5,8 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState, FormField, textInputClass } from '@/lib/components/ui';
-import { SessionLog, SessionEvent, Party } from '@/lib/types';
+import { SessionLog, SessionEvent, PartyMember } from '@/lib/types';
+import { useCampaignContext } from '@/lib/hooks/useCampaignContext';
 import { buildNpcEventsFromMemberChanges } from '@/lib/utils/sessionEvents';
 
 function formatDate(d: Date | string): string {
@@ -84,7 +85,8 @@ function SessionEntryCard({
 function SessionForm({
   campaignId,
   existing,
-  party,
+  allMembers,
+  hasParty,
   lastSessionDate,
   nextSessionNumber,
   onSave,
@@ -92,7 +94,8 @@ function SessionForm({
 }: {
   campaignId: string;
   existing?: SessionLog;
-  party: Party | null;
+  allMembers: PartyMember[];
+  hasParty: boolean;
   lastSessionDate: Date | null;
   nextSessionNumber: number;
   onSave: () => void;
@@ -112,9 +115,9 @@ function SessionForm({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (existing || !party) return;
-    setEvents(buildNpcEventsFromMemberChanges(party.members, lastSessionDate));
-  }, [party, lastSessionDate, existing]);
+    if (existing || !hasParty) return;
+    setEvents(buildNpcEventsFromMemberChanges(allMembers, lastSessionDate));
+  }, [allMembers, hasParty, lastSessionDate, existing]);
 
   const removeEvent = (index: number) => {
     setEvents(ev => ev.filter((_, i) => i !== index));
@@ -168,7 +171,7 @@ function SessionForm({
     <div className="bg-gray-800 rounded-lg p-4 mb-6">
       <h2 className="text-lg font-semibold mb-4">{existing ? 'Edit Session' : 'New Session'}</h2>
       <ErrorBanner message={error} />
-      {!party && !existing && (
+      {!hasParty && !existing && (
         <p className="text-yellow-400 text-sm mb-3">No linked party found for this campaign.</p>
       )}
 
@@ -308,54 +311,49 @@ function SessionForm({
 
 function SessionsContent({ campaignId }: { campaignId: string }) {
   const [logs, setLogs] = useState<SessionLog[]>([]);
-  const [party, setParty] = useState<Party | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [logsLoading, setLogsLoading] = useState(true);
+  const [logsError, setLogsError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingLog, setEditingLog] = useState<SessionLog | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const { context, loading: contextLoading, error: contextError } = useCampaignContext(campaignId);
+
+  const fetchLogs = useCallback(async () => {
     try {
-      setLoading(true);
-      setError(null);
-      const [logsRes, partiesRes] = await Promise.all([
-        fetch(`/api/campaigns/${campaignId}/sessions`),
-        fetch('/api/parties'),
-      ]);
-      if (!logsRes.ok) throw new Error('Failed to fetch session logs');
-      const logsData: SessionLog[] = await logsRes.json();
-      setLogs(logsData);
-      if (partiesRes.ok) {
-        const partiesData: Party[] = await partiesRes.json();
-        const linked = partiesData.find(p => p.campaignId === campaignId) ?? null;
-        setParty(linked);
-      }
+      setLogsLoading(true);
+      setLogsError(null);
+      const res = await fetch(`/api/campaigns/${campaignId}/sessions`);
+      if (!res.ok) throw new Error('Failed to fetch session logs');
+      setLogs(await res.json());
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setLogsError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
-      setLoading(false);
+      setLogsLoading(false);
     }
   }, [campaignId]);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    fetchLogs();
+  }, [fetchLogs]);
+
+  const loading = logsLoading || contextLoading;
+  const error = logsError ?? contextError;
 
   const handleDelete = async (id: string) => {
     if (!confirm('Delete this session log?')) return;
     try {
       const res = await fetch(`/api/campaigns/${campaignId}/sessions/${id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error('Failed to delete session log');
-      await fetchData();
+      await fetchLogs();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete');
+      setLogsError(err instanceof Error ? err.message : 'Failed to delete');
     }
   };
 
   const handleSaved = async () => {
     setShowForm(false);
     setEditingLog(null);
-    await fetchData();
+    await fetchLogs();
   };
 
   const lastSessionDate = logs.length > 0
@@ -391,7 +389,8 @@ function SessionsContent({ campaignId }: { campaignId: string }) {
           <SessionForm
             campaignId={campaignId}
             existing={editingLog ?? undefined}
-            party={party}
+            allMembers={context?.allMembers ?? []}
+            hasParty={(context?.parties.length ?? 0) > 0}
             lastSessionDate={lastSessionDate}
             nextSessionNumber={nextSessionNumber}
             onSave={handleSaved}

--- a/app/campaigns/[id]/sessions/page.tsx
+++ b/app/campaigns/[id]/sessions/page.tsx
@@ -10,7 +10,12 @@ import { useCampaignContext } from '@/lib/hooks/useCampaignContext';
 import { buildNpcEventsFromMemberChanges } from '@/lib/utils/sessionEvents';
 
 function formatDate(d: Date | string): string {
-  const date = typeof d === 'string' ? new Date(d + 'T12:00:00') : d;
+  const date = typeof d === 'string'
+    ? (d.includes('T') ? new Date(d) : new Date(d + 'T12:00:00'))
+    : d;
+  if (isNaN(date.getTime())) {
+    return typeof d === 'string' ? d : '';
+  }
   return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -225,6 +225,12 @@ export function CampaignsContent() {
                       </div>
                       <div className="flex gap-2 flex-shrink-0 ml-4">
                         <Link
+                          href={`/campaigns/${campaign.id}/prompts`}
+                          className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
+                        >
+                          Prompt Builder
+                        </Link>
+                        <Link
                           href="/encounters"
                           className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm"
                         >

--- a/lib/hooks/useCampaignContext.ts
+++ b/lib/hooks/useCampaignContext.ts
@@ -33,7 +33,6 @@ export function useCampaignContext(campaignId: string): {
 
   useEffect(() => {
     void load();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [load, tick]);
 
   return { context, loading, error, refresh };

--- a/lib/hooks/useCampaignContext.ts
+++ b/lib/hooks/useCampaignContext.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { CampaignContext } from '@/lib/types';
+import { fetchCampaignContext } from '@/lib/utils/campaignContext';
+
+export function useCampaignContext(campaignId: string): {
+  context: CampaignContext | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+} {
+  const [context, setContext] = useState<CampaignContext | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(() => setTick(t => t + 1), []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const ctx = await fetchCampaignContext(campaignId);
+      setContext(ctx);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load campaign context');
+      setContext(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [campaignId]);
+
+  useEffect(() => {
+    void load();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [load, tick]);
+
+  return { context, loading, error, refresh };
+}

--- a/lib/prompts/templates.ts
+++ b/lib/prompts/templates.ts
@@ -1,0 +1,125 @@
+import { BuiltPrompt, CampaignContext, Character } from '@/lib/types';
+
+export interface PromptField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  optional?: boolean;
+  multiline?: boolean;
+}
+
+export interface PromptTemplate {
+  id: string;
+  label: string;
+  fields: PromptField[];
+  build(fields: Record<string, string>, context: CampaignContext): BuiltPrompt;
+}
+
+function formatCharacter(c: Character): string {
+  const level = c.classes.reduce((sum, cl) => sum + cl.level, 0);
+  const classNames = c.classes.map(cl => cl.class).join('/');
+  return `${c.name} (Level ${level} ${classNames})`;
+}
+
+export function buildSystemPrompt(context: CampaignContext): string {
+  const { campaign, chapter, characters } = context;
+
+  const chapterLine = chapter ? `Current Chapter: ${chapter.title}` : '';
+  const partySection = characters.length > 0
+    ? `Party Members:\n${characters.map(c => `- ${formatCharacter(c)}`).join('\n')}`
+    : 'Party Members: None currently linked.';
+
+  return [
+    `You are a creative assistant helping a Dungeon Master run a D&D 5e campaign.`,
+    `Campaign: ${campaign.name} (${campaign.moduleName})`,
+    chapterLine,
+    partySection,
+  ].filter(Boolean).join('\n');
+}
+
+function makePrompt(systemPrompt: string, userMessage: string): BuiltPrompt {
+  return { systemPrompt, userMessage, fullText: `${systemPrompt}\n\n${userMessage}` };
+}
+
+export const npcTemplate: PromptTemplate = {
+  id: 'npc',
+  label: 'NPC',
+  fields: [
+    { key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant' },
+    { key: 'location', label: 'Location', placeholder: 'e.g. Barovia, the keep gates' },
+    { key: 'requirements', label: 'Special Requirements', placeholder: 'e.g. hostile, knows a secret', optional: true },
+  ],
+  build(fields, context) {
+    const req = fields.requirements ? `\nSpecial requirements: ${fields.requirements}` : '';
+    const userMessage = `Create an NPC with the role of ${fields.role || 'unnamed role'} located at ${fields.location || 'an unspecified location'}.${req}\n\nInclude: name, appearance, personality, a secret or motivation, and 2-3 conversation hooks.`;
+    return makePrompt(buildSystemPrompt(context), userMessage);
+  },
+};
+
+export const locationTemplate: PromptTemplate = {
+  id: 'location',
+  label: 'Location Description',
+  fields: [
+    { key: 'type', label: 'Location Type', placeholder: 'e.g. tavern, dungeon, forest clearing' },
+    { key: 'atmosphere', label: 'Atmosphere', placeholder: 'e.g. cozy, foreboding, bustling' },
+    { key: 'details', label: 'Additional Details', placeholder: 'e.g. recently ransacked, hidden cellar', optional: true },
+  ],
+  build(fields, context) {
+    const details = fields.details ? `\nAdditional details: ${fields.details}` : '';
+    const userMessage = `Describe a ${fields.type || 'location'} with a ${fields.atmosphere || 'neutral'} atmosphere.${details}\n\nInclude: sensory details (sight, sound, smell), notable features, and 2-3 interactive elements the party could investigate.`;
+    return makePrompt(buildSystemPrompt(context), userMessage);
+  },
+};
+
+export const shopTemplate: PromptTemplate = {
+  id: 'shop',
+  label: 'Shop / Establishment',
+  fields: [
+    { key: 'shopType', label: 'Shop Type', placeholder: 'e.g. blacksmith, apothecary, general store' },
+    { key: 'setting', label: 'Setting / District', placeholder: 'e.g. busy market, seedy docks, noble quarter' },
+    { key: 'inventory', label: 'Notable Inventory', placeholder: 'e.g. rare components, military surplus', optional: true },
+  ],
+  build(fields, context) {
+    const inv = fields.inventory ? `\nNotable inventory focus: ${fields.inventory}` : '';
+    const userMessage = `Create a ${fields.shopType || 'shop'} located in the ${fields.setting || 'town'}.${inv}\n\nInclude: proprietor name and personality, shop description, 3-5 items for sale with prices, and a rumour the proprietor knows.`;
+    return makePrompt(buildSystemPrompt(context), userMessage);
+  },
+};
+
+export const magicItemTemplate: PromptTemplate = {
+  id: 'magic-item',
+  label: 'Magic Item',
+  fields: [
+    { key: 'itemType', label: 'Item Type', placeholder: 'e.g. sword, ring, cloak, amulet' },
+    { key: 'rarity', label: 'Rarity', placeholder: 'e.g. common, uncommon, rare, very rare, legendary' },
+    { key: 'theme', label: 'Thematic Theme', placeholder: 'e.g. shadow, fire, nature, undeath', optional: true },
+  ],
+  build(fields, context) {
+    const theme = fields.theme ? ` with a ${fields.theme} theme` : '';
+    const userMessage = `Create a ${fields.rarity || 'uncommon'} magic ${fields.itemType || 'item'}${theme}.\n\nInclude: evocative name, physical description, magical properties (as D&D 5e stat block), lore or history, and any attunement requirements.`;
+    return makePrompt(buildSystemPrompt(context), userMessage);
+  },
+};
+
+export const roomTemplate: PromptTemplate = {
+  id: 'room',
+  label: 'Room Description',
+  fields: [
+    { key: 'roomName', label: 'Room Name', placeholder: 'e.g. Throne Room, Crypt, Library' },
+    { key: 'purpose', label: 'Purpose / Function', placeholder: 'e.g. seat of power, burial chamber, arcane study' },
+    { key: 'features', label: 'Special Features', placeholder: 'e.g. trapped floor, hidden door, magical lighting', optional: true },
+  ],
+  build(fields, context) {
+    const features = fields.features ? `\nSpecial features: ${fields.features}` : '';
+    const userMessage = `Describe a room called "${fields.roomName || 'the room'}" that serves as a ${fields.purpose || 'general purpose space'}.${features}\n\nInclude: read-aloud description (2-3 sentences), notable contents, any hazards or traps, and a secret element for observant players.`;
+    return makePrompt(buildSystemPrompt(context), userMessage);
+  },
+};
+
+export const TEMPLATES: PromptTemplate[] = [
+  npcTemplate,
+  locationTemplate,
+  shopTemplate,
+  magicItemTemplate,
+  roomTemplate,
+];

--- a/lib/prompts/templates.ts
+++ b/lib/prompts/templates.ts
@@ -1,4 +1,4 @@
-import { BuiltPrompt, CampaignContext, Character } from '@/lib/types';
+import { BuiltPrompt, CampaignContext, Character, calculateTotalLevel } from '@/lib/types';
 
 export interface PromptField {
   key: string;
@@ -16,7 +16,7 @@ export interface PromptTemplate {
 }
 
 function formatCharacter(c: Character): string {
-  const level = c.classes.reduce((sum, cl) => sum + cl.level, 0);
+  const level = calculateTotalLevel(c.classes);
   const classNames = c.classes.map(cl => cl.class).join('/');
   return `${c.name} (Level ${level} ${classNames})`;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -570,6 +570,20 @@ export interface Party {
   updatedAt: Date;
 }
 
+export interface CampaignContext {
+  campaign: Campaign;
+  chapter: CampaignChapter | null;
+  parties: Party[];
+  allMembers: PartyMember[];
+  characters: Character[];
+}
+
+export interface BuiltPrompt {
+  systemPrompt: string;
+  userMessage: string;
+  fullText: string;
+}
+
 export interface SessionEvent {
   type: 'npc_joined' | 'npc_left' | 'combat_completed' | 'custom';
   description: string;

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -22,7 +22,9 @@ export async function fetchCampaignContext(
 
   const parties = allParties.filter(p => p.campaignId === campaignId);
   const allMembers = parties.flatMap(p => p.members);
-  const memberIds = new Set(allMembers.map(m => m.characterId));
+  // Only active members (no leftAt) determine which characters appear in prompt context;
+  // allMembers retains the full history for session-event timeline diffing.
+  const memberIds = new Set(allMembers.filter(m => !m.leftAt).map(m => m.characterId));
 
   const chapter = campaign.currentChapterId
     ? (campaign.chapters.find(c => c.id === campaign.currentChapterId) ?? null)

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -1,4 +1,4 @@
-import { Campaign, Character, CampaignContext, Party } from '@/lib/types';
+import { Campaign, Character, CampaignContext, Party, PartyMember } from '@/lib/types';
 
 export async function fetchCampaignContext(
   campaignId: string,
@@ -21,7 +21,16 @@ export async function fetchCampaignContext(
   ]);
 
   const parties = allParties.filter(p => p.campaignId === campaignId);
-  const allMembers = parties.flatMap(p => p.members);
+  const allMembersRaw = parties.flatMap(p => p.members);
+  const seen = new Set<string>();
+  const allMembers: PartyMember[] = [];
+  for (const m of allMembersRaw) {
+    const key = `${m.characterId}_${new Date(m.addedAt).getTime()}_${m.leftAt ? new Date(m.leftAt).getTime() : 'active'}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      allMembers.push(m);
+    }
+  }
   // Only active members (no leftAt) determine which characters appear in prompt context;
   // allMembers retains the full history for session-event timeline diffing.
   const memberIds = new Set(allMembers.filter(m => !m.leftAt).map(m => m.characterId));

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -1,0 +1,36 @@
+import { Campaign, Character, CampaignContext, Party } from '@/lib/types';
+
+export async function fetchCampaignContext(
+  campaignId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CampaignContext> {
+  const [campaignRes, partiesRes, charactersRes] = await Promise.all([
+    fetchImpl(`/api/campaigns/${campaignId}`),
+    fetchImpl('/api/parties'),
+    fetchImpl('/api/characters'),
+  ]);
+
+  if (!campaignRes.ok) throw new Error('Failed to fetch campaign');
+  if (!partiesRes.ok) throw new Error('Failed to fetch parties');
+  if (!charactersRes.ok) throw new Error('Failed to fetch characters');
+
+  const [campaign, allParties, allCharacters]: [Campaign, Party[], Character[]] = await Promise.all([
+    campaignRes.json(),
+    partiesRes.json(),
+    charactersRes.json(),
+  ]);
+
+  const parties = allParties.filter(p => p.campaignId === campaignId);
+  const allMembers = parties.flatMap(p => p.members);
+  const memberIds = new Set(allMembers.map(m => m.characterId));
+
+  const chapter = campaign.currentChapterId
+    ? (campaign.chapters.find(c => c.id === campaign.currentChapterId) ?? null)
+    : null;
+
+  const characters = allCharacters.filter(
+    c => memberIds.has(c.id) && !c.deletedAt,
+  );
+
+  return { campaign, chapter, parties, allMembers, characters };
+}

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -21,9 +21,7 @@ export async function fetchCampaignContext(
   ]);
 
   const parties = allParties.filter(p => p.campaignId === campaignId);
-  const allMembers = Array.from(
-    new Map(parties.flatMap(p => p.members).map(m => [m.characterId, m])).values(),
-  );
+  const allMembers = parties.flatMap(p => p.members);
   const memberIds = new Set(allMembers.map(m => m.characterId));
 
   const chapter = campaign.currentChapterId

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -21,7 +21,9 @@ export async function fetchCampaignContext(
   ]);
 
   const parties = allParties.filter(p => p.campaignId === campaignId);
-  const allMembers = parties.flatMap(p => p.members);
+  const allMembers = Array.from(
+    new Map(parties.flatMap(p => p.members).map(m => [m.characterId, m])).values(),
+  );
   const memberIds = new Set(allMembers.map(m => m.characterId));
 
   const chapter = campaign.currentChapterId

--- a/openspec/changes/prompt-builder-campaign-child/.openspec.yaml
+++ b/openspec/changes/prompt-builder-campaign-child/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-24

--- a/openspec/changes/prompt-builder-campaign-child/design.md
+++ b/openspec/changes/prompt-builder-campaign-child/design.md
@@ -1,0 +1,197 @@
+## Context
+
+- **Relevant architecture:**
+  - Next.js App Router with `app/campaigns/[id]/` child routes (sessions pattern already established)
+  - MongoDB via raw `mongodb` Node.js driver — no Mongoose; data access in `lib/storage.ts`
+  - Auth via `requireAuth` middleware; all API routes follow `app/api/parties/route.ts` pattern
+  - `lib/types.ts` holds all shared interfaces (`Campaign`, `CampaignChapter`, `Party`, `PartyMember`, `Character`)
+  - Existing `/api/characters` and `/api/parties` endpoints return full arrays scoped to the authenticated user
+- **Dependencies:**
+  - Campaign Management (#182) — complete; `Campaign`, `CampaignChapter`, `Party` types and APIs exist
+  - `lib/utils/sessionEvents.ts` — `buildNpcEventsFromMemberChanges(members, windowStart)` consumed by session logs; must remain compatible after refactor
+- **Interfaces/contracts touched:**
+  - `app/campaigns/[id]/sessions/page.tsx` — internal fetch logic replaced with `useCampaignContext()`
+  - `lib/types.ts` — two new exported interfaces: `CampaignContext`, `BuiltPrompt`
+  - No API route changes required for v1
+
+## Goals / Non-Goals
+
+### Goals
+
+- Zero-configuration context loading: route param `campaignId` drives all data fetching
+- All parties linked to a campaign included (fixes #212)
+- Character names/classes/levels resolved for prompt injection
+- Template architecture supports future Claude API agentic path without rewrites
+- Session logs refactored to the same data path as the prompt builder
+
+### Non-Goals
+
+- Server-side prompt assembly or Claude API calls (v1)
+- Persistent prompt storage / Content Library (#185)
+- New API routes for prompt generation
+
+## Decisions
+
+### Decision 1: Shared data helper — pure async function + thin React hook
+
+- **Chosen:** `lib/utils/campaignContext.ts` exports `fetchCampaignContext(campaignId, fetchImpl?)` as a pure async function. `lib/hooks/useCampaignContext.ts` wraps it with `useState`/`useEffect`/`useCallback` and returns `{ context, loading, error, refresh }`.
+- **Alternatives considered:**
+  - Inline fetch logic in each page (current sessions approach) — rejected: duplicates code, propagates the #212 bug
+  - Server component with `async` page function — rejected: prompt builder needs client interactivity (form, clipboard); sessions page is already `'use client'`
+- **Rationale:** Separating the pure fetch from the React lifecycle makes the helper unit-testable without rendering. The hook is a thin adapter, not logic.
+- **Trade-offs:** Two files instead of one; hook is trivial boilerplate.
+
+### Decision 2: `fetchCampaignContext` fetches campaign, parties, and characters in parallel
+
+- **Chosen:** Single `Promise.all([fetch campaign, fetch parties, fetch characters])`. Resolves chapter from `campaign.chapters` in-memory. Filters parties by `campaignId`. Filters characters by merged member IDs.
+- **Alternatives considered:**
+  - Sequential fetches — rejected: unnecessary latency
+  - New `/api/campaigns/[id]/context` endpoint — rejected: over-engineering for v1; all data is already accessible client-side
+- **Rationale:** Three independent fetches; parallelism is free with `Promise.all`. Campaign detail (`/api/campaigns/[id]`) gives us the chapters array so chapter resolution is O(n) in-memory.
+- **Trade-offs:** Fetches all characters for the user then filters — acceptable given typical character counts (<50).
+
+### Decision 3: `CampaignContext` interface in `lib/types.ts`
+
+- **Chosen:**
+  ```typescript
+  export interface CampaignContext {
+    campaign: Campaign;
+    chapter: CampaignChapter | null;
+    parties: Party[];
+    allMembers: PartyMember[];   // merged across all parties
+    characters: Character[];      // resolved, excludes soft-deleted
+  }
+  ```
+- **Alternatives considered:** Local interface in `campaignContext.ts` — rejected: both sessions and prompts pages need to type against it.
+- **Rationale:** `lib/types.ts` is the single source of truth for shared types in this project.
+- **Trade-offs:** Adds one interface to an already large types file.
+
+### Decision 4: Template return type `BuiltPrompt` with `systemPrompt` / `userMessage` / `fullText`
+
+- **Chosen:**
+  ```typescript
+  export interface BuiltPrompt {
+    systemPrompt: string;  // campaign + party context
+    userMessage: string;   // template-specific request
+    fullText: string;      // concat for v1 copy-paste
+  }
+  ```
+  Each template's `build(fields, context)` returns `BuiltPrompt`. v1 displays `fullText` in a read-only textarea. A future agentic route receives `{ systemPrompt, userMessage }` as-is.
+- **Alternatives considered:**
+  - `build()` returns a plain string — rejected: collapses the context/request boundary, forces template rewrites when adding agentic support
+  - Separate `buildSystemPrompt()` utility + `build()` per template — rejected: duplication; callers must remember to call both
+- **Rationale:** `fullText` keeps v1 simple. The structured pair is ready for the Claude Messages API (`system` param + first `user` message) with zero changes.
+- **Trade-offs:** Slightly more template boilerplate; worth it for the agentic upgrade path.
+
+### Decision 5: Route at `app/campaigns/[id]/prompts/page.tsx`
+
+- **Chosen:** Child route of the campaign, identical in structure to `app/campaigns/[id]/sessions/page.tsx`.
+- **Alternatives considered:** Top-level `app/prompts/page.tsx` with campaign selector dropdown — rejected: forces the user to re-select context they already have; was the original issue design.
+- **Rationale:** Context is injected by the URL. Nav link sits alongside "Sessions" in the campaign detail view. Zero disambiguation needed.
+- **Trade-offs:** Prompt builder is only reachable from within a campaign — acceptable since all prompts are campaign-contextual.
+
+### Decision 6: Five templates in `lib/prompts/templates.ts`, ported from dm-dashboard reference
+
+- **Chosen:** NPC, Location Description, Shop/Establishment, Magic Item, Room Description. Each exported as a `PromptTemplate` object. Shared `buildSystemPrompt(context: CampaignContext): string` utility in same file.
+- **Rationale:** Direct TypeScript port of the dm-dashboard JS implementation. `buildSystemPrompt` is extracted so the system context boilerplate isn't duplicated across all five `build()` functions.
+- **Trade-offs:** Adding a sixth template in future requires a new `PromptTemplate` object only — no structural changes.
+
+### Decision 7: Session logs refactor is a distinct task, guarded by regression tests
+
+- **Chosen:** Write regression tests for session logs behaviour first, then replace the manual fetch+find with `useCampaignContext()`. Implemented as a separate task that can be reverted without touching the prompt builder.
+- **Rationale:** Session logs is a live feature. Independent task = independent revert if something goes wrong.
+- **Trade-offs:** Slight additional scope in this change; the alternative (a separate PR) was rejected because the shared helper would otherwise be unused at merge time.
+
+## Proposal to Design Mapping
+
+- Proposal element: shared helper fixing #212 (multi-party)
+  - Design decision: Decision 1 (`fetchCampaignContext`), Decision 2 (parallel fetch + `filter`)
+  - Validation approach: unit test — mock fetch returns 3 parties for same campaignId, assert all 3 in `context.parties` and all members merged in `context.allMembers`
+
+- Proposal element: agentic-ready template architecture
+  - Design decision: Decision 4 (`BuiltPrompt` interface)
+  - Validation approach: unit tests assert each template's `build()` returns non-empty `systemPrompt`, `userMessage`, and `fullText`; `fullText === systemPrompt + '\n\n' + userMessage`
+
+- Proposal element: route as campaign child
+  - Design decision: Decision 5 (route location)
+  - Validation approach: integration test — navigate to `/campaigns/[id]/prompts`, assert page renders with campaign name in heading
+
+- Proposal element: character resolution
+  - Design decision: Decision 2 (parallel fetch, filter by member IDs)
+  - Validation approach: unit test — mock characters endpoint, assert only members present in parties appear in `context.characters`
+
+- Proposal element: session logs refactor
+  - Design decision: Decision 7 (distinct guarded task)
+  - Validation approach: existing + new regression tests pass before and after refactor
+
+## Functional Requirements Mapping
+
+- **Requirement:** All parties linked to a campaign are included; members merged
+  - Design element: `fetchCampaignContext` — `filter()` + member array concat
+  - Acceptance criteria reference: specs/campaign-context/spec.md
+  - Testability notes: unit test with mocked fetch; 2-3 parties with overlapping/non-overlapping members
+
+- **Requirement:** Current chapter resolved from `currentChapterId`
+  - Design element: `fetchCampaignContext` — `campaign.chapters.find(c => c.id === campaign.currentChapterId)`
+  - Acceptance criteria reference: specs/campaign-context/spec.md
+  - Testability notes: unit test — campaign with known `currentChapterId`, assert `context.chapter.title` matches
+
+- **Requirement:** Each template assembles a complete prompt from `CampaignContext` + form fields
+  - Design element: `lib/prompts/templates.ts` — `build(fields, context): BuiltPrompt`
+  - Acceptance criteria reference: specs/prompt-templates/spec.md
+  - Testability notes: unit test each template with fixed context and fields; assert key strings present in output
+
+- **Requirement:** DM can copy generated prompt in one click
+  - Design element: `app/campaigns/[id]/prompts/page.tsx` — "Copy" button calls `navigator.clipboard.writeText(builtPrompt.fullText)`
+  - Acceptance criteria reference: specs/prompt-builder-ui/spec.md
+  - Testability notes: mock `navigator.clipboard`; assert `writeText` called with correct string
+
+- **Requirement:** Session logs uses merged member list (fixes #212)
+  - Design element: Decision 7 — session logs refactor task
+  - Acceptance criteria reference: specs/session-logs-refactor/spec.md
+  - Testability notes: integration test — campaign with 2 parties, assert NPC events suggested from both parties' members
+
+## Non-Functional Requirements Mapping
+
+- **Requirement category:** Performance
+  - Requirement: Context load does not serialize fetches
+  - Design element: `Promise.all` in `fetchCampaignContext`
+  - Testability notes: assert fetch mock called concurrently (same tick), not sequentially
+
+- **Requirement category:** Reliability
+  - Requirement: Graceful degradation when no parties or no current chapter
+  - Design element: `context.parties` may be `[]`; `context.chapter` may be `null`; templates handle both
+  - Testability notes: unit test each template with `null` chapter and empty `parties`/`characters`
+
+- **Requirement category:** Operability
+  - Requirement: Session logs regression-free after refactor
+  - Design element: Decision 7 regression tests written before refactor
+  - Testability notes: all existing session logs integration tests pass before and after
+
+## Risks / Trade-offs
+
+- **Risk/trade-off:** Session logs refactor introduces regression
+  - Impact: Medium — logs is a used feature
+  - Mitigation: Write regression tests first (separate task); refactor task can be reverted independently
+
+- **Risk/trade-off:** `buildNpcEventsFromMemberChanges` called with merged members changes auto-event suggestions
+  - Impact: Low — more complete suggestions is the desired behaviour
+  - Mitigation: Existing unit tests for `buildNpcEventsFromMemberChanges` remain; verify output is a superset, not different
+
+## Rollback / Mitigation
+
+- **Rollback trigger:** Session logs regression detected after sessions refactor task merges.
+- **Rollback steps:** Revert the sessions refactor task commit only (prompt builder commits are unaffected). The shared helper remains; sessions reverts to its own fetch logic temporarily.
+- **Data migration considerations:** None — no schema changes.
+- **Verification after rollback:** Session logs integration tests green; `useCampaignContext` still used by prompt builder.
+
+## Operational Blocking Policy
+
+- **If CI checks fail:** Do not merge. Fix the failing check. Do not use `--admin` bypass or `--no-verify`.
+- **If security checks fail:** Do not merge. Address Codacy findings before requesting re-review.
+- **If required reviews are blocked/stale:** Ping reviewer after 24 hours. Escalate to repo owner after 48 hours.
+- **Escalation path and timeout:** If blocked beyond 48 hours, open a discussion issue describing the block.
+
+## Open Questions
+
+No open questions. All ambiguities resolved during exploration phase (see proposal.md).

--- a/openspec/changes/prompt-builder-campaign-child/proposal.md
+++ b/openspec/changes/prompt-builder-campaign-child/proposal.md
@@ -1,0 +1,105 @@
+## GitHub Issues
+
+- #184
+- #212
+
+## Why
+
+- **Problem statement:** DMs using session-combat must manually re-type campaign name, module, chapter, and party composition every time they want AI assistance for generating NPCs, locations, shops, magic items, or room descriptions. There is no way to assemble context-rich prompts from the live session data that already exists in the app.
+- **Why now:** Campaign Management (#182) is complete, giving us the data model (`Campaign`, `CampaignChapter`, `Party`, `Character`) needed to drive contextual prompts. Issue #184 is open and prioritised. A related data bug (#212) in session logs was discovered during exploration — this change fixes it cleanly via a shared helper rather than a one-off patch.
+- **Business/user impact:** DMs save significant prep time. The app becomes a starting point for AI-assisted content creation rather than just a combat tracker. The agentic-ready architecture (structured `{ systemPrompt, userMessage, fullText }` output) future-proofs the feature for direct Claude API integration without requiring template rewrites.
+
+## Problem Space
+
+- **Current behavior:**
+  - No prompt builder exists.
+  - Session logs page fetches parties with `Array.find()`, silently dropping all but the first party linked to a campaign (#212).
+  - Party member IDs are never resolved to character names — NPC auto-events show raw `characterId` strings.
+- **Desired behavior:**
+  - DMs navigate to a campaign and click a "Prompt Builder" link (alongside the existing "Sessions" link).
+  - The page loads all parties linked to that campaign, resolves member IDs to full `Character` objects, and resolves `currentChapterId` to a `CampaignChapter`.
+  - DM picks a template, fills a short form, clicks Generate — a complete prompt appears ready to copy.
+  - Session logs page uses the same shared data helper, fixing the multi-party bug.
+- **Constraints:**
+  - No new backend required for prompt generation in v1 — all assembly is client-side.
+  - Must not break existing session logs functionality.
+  - Template architecture must support a future `/api/prompts/generate` agentic route without requiring template rewrites.
+- **Assumptions:**
+  - A campaign may have zero, one, or many linked parties. All are included.
+  - Character data is fetched via the existing `/api/characters` endpoint and filtered client-side.
+  - "Save to Library" (#185) is out of scope; the button can exist as a disabled stub.
+- **Edge cases considered:**
+  - Campaign with no linked parties: show informational message, templates still usable with empty party roster.
+  - Campaign with no current chapter set: chapter field in prompt omitted gracefully.
+  - Character deleted (soft-delete): excluded from member resolution.
+  - Multiple parties linked to same campaign: all members merged for prompt context.
+
+## Scope
+
+### In Scope
+
+- `lib/utils/campaignContext.ts` — `fetchCampaignContext(campaignId)` async helper
+- `lib/hooks/useCampaignContext.ts` — React hook wrapping the helper
+- `lib/prompts/templates.ts` — 5 templates (NPC, Location, Shop, Magic Item, Room) returning `BuiltPrompt`
+- `app/campaigns/[id]/prompts/page.tsx` — Prompt Builder UI as a child route
+- Nav link to Prompt Builder added to campaign detail view alongside Sessions
+- Refactor `app/campaigns/[id]/sessions/page.tsx` to use `useCampaignContext()`, fixing #212
+- Unit tests for all `build()` functions in `templates.ts`
+- Unit tests for `fetchCampaignContext` (mock fetch)
+- Integration test: render prompt builder, select each template, fill form, assert generated prompt contains campaign name and party members
+- Integration test: session logs page uses merged member list from all linked parties
+
+### Out of Scope
+
+- Saving prompts to a Content Library (#185)
+- `/api/prompts/generate` agentic route (future)
+- Direct Claude API calls from the UI
+- Prompt history or versioning
+- Any changes to the Campaign, Party, or Character data models
+
+## What Changes
+
+- New file: `lib/utils/campaignContext.ts`
+- New file: `lib/hooks/useCampaignContext.ts`
+- New file: `lib/prompts/templates.ts`
+- New file: `app/campaigns/[id]/prompts/page.tsx`
+- Modified: `app/campaigns/[id]/sessions/page.tsx` — replace manual fetch+find with `useCampaignContext()`
+- Modified: `app/campaigns/page.tsx` — add Prompt Builder nav link in campaign detail view
+- New test files for templates, campaignContext, and the prompt builder page
+
+## Risks
+
+- **Risk:** Refactoring session logs to use `useCampaignContext()` breaks existing session log behavior.
+  - **Impact:** High — session logs is a used feature.
+  - **Mitigation:** Write regression tests for session logs before refactoring; refactor as a distinct task that can be reverted independently.
+
+- **Risk:** Character fetch adds a second round-trip on the prompt builder page, increasing load time.
+  - **Impact:** Low — characters list is small for typical DM usage.
+  - **Mitigation:** Fetch characters and parties in parallel via `Promise.all`.
+
+- **Risk:** Template `systemPrompt` / `userMessage` split doesn't map cleanly to the Claude API message format when agentic support is added later.
+  - **Impact:** Medium — templates may need minor adjustments.
+  - **Mitigation:** The `BuiltPrompt` interface is defined in `lib/prompts/templates.ts` and can be evolved without changing callers if we keep `fullText` stable.
+
+## Open Questions
+
+No unresolved ambiguity remains. The following were resolved during exploration:
+
+- **Route location**: confirmed as `app/campaigns/[id]/prompts/page.tsx` (child of campaign, mirrors sessions).
+- **Multi-party handling**: confirmed — include all parties, merge members.
+- **Template return type**: confirmed — `{ systemPrompt, userMessage, fullText }` for agentic readiness.
+- **Save to Library button**: confirmed out of scope for this change; stub/disabled is acceptable.
+- **Character resolution**: confirmed — fetch all characters, filter to member IDs client-side.
+
+## Non-Goals
+
+- Agentic prompt execution (calling Claude from the app)
+- Content Library storage (#185)
+- Prompt editing or versioning
+- Mobile-specific layout optimisations
+- Sharing prompts between users
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/prompt-builder-campaign-child/specs/campaign-context/spec.md
+++ b/openspec/changes/prompt-builder-campaign-child/specs/campaign-context/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `fetchCampaignContext` returns all parties and merged members
+
+The system SHALL fetch all parties whose `campaignId` matches the given campaign ID, merge their `members` arrays, and return them in the `CampaignContext`.
+
+#### Scenario: Single party linked to campaign
+
+- **Given** one `Party` exists with `campaignId === "camp-1"`
+- **When** `fetchCampaignContext("camp-1")` is called
+- **Then** `context.parties` has length 1 and `context.allMembers` equals that party's `members` array
+
+#### Scenario: Multiple parties linked to same campaign
+
+- **Given** three `Party` records all have `campaignId === "camp-1"`, with 2, 3, and 4 members respectively
+- **When** `fetchCampaignContext("camp-1")` is called
+- **Then** `context.parties` has length 3 and `context.allMembers` has length 9 (all members merged)
+
+#### Scenario: No parties linked to campaign
+
+- **Given** no `Party` records have `campaignId === "camp-1"`
+- **When** `fetchCampaignContext("camp-1")` is called
+- **Then** `context.parties` is `[]` and `context.allMembers` is `[]`
+
+### Requirement: ADDED `fetchCampaignContext` resolves current chapter
+
+The system SHALL resolve `campaign.currentChapterId` to the matching `CampaignChapter` object from `campaign.chapters`.
+
+#### Scenario: Campaign has a current chapter set
+
+- **Given** a `Campaign` with `chapters: [{ id: "ch-2", title: "The Sunken Temple", ... }]` and `currentChapterId: "ch-2"`
+- **When** `fetchCampaignContext` resolves the campaign
+- **Then** `context.chapter.title === "The Sunken Temple"`
+
+#### Scenario: Campaign has no current chapter set
+
+- **Given** a `Campaign` with `currentChapterId: undefined`
+- **When** `fetchCampaignContext` resolves the campaign
+- **Then** `context.chapter === null`
+
+### Requirement: ADDED `fetchCampaignContext` resolves character objects for party members
+
+The system SHALL resolve each `PartyMember.characterId` in `allMembers` to a full `Character` object, excluding soft-deleted characters.
+
+#### Scenario: All members have active characters
+
+- **Given** `allMembers` contains two `PartyMember` records with `characterId` values "c-1" and "c-2"
+- **And** both characters exist and have `deletedAt === undefined`
+- **When** `fetchCampaignContext` resolves
+- **Then** `context.characters` contains exactly those two `Character` objects
+
+#### Scenario: A party member's character is soft-deleted
+
+- **Given** a `PartyMember` with `characterId: "c-3"` and the corresponding `Character` has `deletedAt` set
+- **When** `fetchCampaignContext` resolves
+- **Then** `context.characters` does not include the soft-deleted character
+
+### Requirement: ADDED fetches execute in parallel
+
+The system SHALL issue the campaign, parties, and characters fetch requests concurrently, not sequentially.
+
+#### Scenario: Parallel execution
+
+- **Given** mocked fetch functions for campaign, parties, and characters
+- **When** `fetchCampaignContext` is called
+- **Then** all three fetch calls are initiated before any awaited result is consumed (verified via `Promise.all` ordering in test)
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `CampaignContext` and `BuiltPrompt` interfaces exported from `lib/types.ts`
+
+The system SHALL export `CampaignContext` and `BuiltPrompt` from `lib/types.ts` as the canonical type definitions.
+
+#### Scenario: Interfaces importable by consumers
+
+- **Given** `lib/types.ts` defines and exports `CampaignContext` and `BuiltPrompt`
+- **When** `app/campaigns/[id]/prompts/page.tsx` and `app/campaigns/[id]/sessions/page.tsx` import them
+- **Then** TypeScript compilation succeeds with no type errors
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: shared helper fixing #212 → Requirement: ADDED `fetchCampaignContext` returns all parties and merged members
+- Proposal element: character resolution → Requirement: ADDED `fetchCampaignContext` resolves character objects
+- Design decision: Decision 1 (pure function + hook) → Requirement: interfaces exported from `lib/types.ts`
+- Design decision: Decision 2 (parallel fetch) → Requirement: ADDED fetches execute in parallel
+- Design decision: Decision 3 (`CampaignContext` interface) → Requirement: MODIFIED interfaces in `lib/types.ts`
+- Requirements → Tasks: Task group A in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Parallel fetch completes within acceptable latency
+
+- **Given** a campaign with 2 linked parties and 10 characters
+- **When** `useCampaignContext(campaignId)` mounts
+- **Then** `loading` transitions to `false` after a single `Promise.all` resolution (no serial awaits between fetches)
+
+### Requirement: Reliability
+
+#### Scenario: Fetch failure surfaces as error state
+
+- **Given** the `/api/parties` fetch returns a non-OK response
+- **When** `useCampaignContext(campaignId)` is mounted
+- **Then** `error` is set to a non-null string and `context` remains `null`; no unhandled promise rejection occurs

--- a/openspec/changes/prompt-builder-campaign-child/specs/prompt-builder-ui/spec.md
+++ b/openspec/changes/prompt-builder-campaign-child/specs/prompt-builder-ui/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Prompt Builder accessible at `/campaigns/[id]/prompts`
+
+The system SHALL render the Prompt Builder page when navigating to `/campaigns/[id]/prompts`, using the `campaignId` route param as the sole source of context.
+
+#### Scenario: Page renders with campaign context loaded
+
+- **Given** a campaign with id "camp-1", a linked party, and resolved characters
+- **When** the user navigates to `/campaigns/camp-1/prompts`
+- **Then** the page displays the campaign name in the heading
+- **And** the template selector is visible
+
+#### Scenario: Page accessible via nav link from campaign detail view
+
+- **Given** the user is on the campaigns page viewing campaign "camp-1"
+- **When** they click the "Prompt Builder" link
+- **Then** they are navigated to `/campaigns/camp-1/prompts`
+
+### Requirement: ADDED Template selector shows five tabs
+
+The system SHALL display a tab/button for each template: NPC, Location, Shop, Magic Item, Room.
+
+#### Scenario: First template selected by default
+
+- **Given** the Prompt Builder page has loaded
+- **When** no user interaction has occurred
+- **Then** the NPC template tab is active and its fields are rendered
+
+#### Scenario: Selecting a different template renders its fields
+
+- **Given** the Prompt Builder page is loaded with the NPC tab active
+- **When** the user clicks the "Room Description" tab
+- **Then** the Room Description template's fields are rendered and NPC fields are no longer visible
+
+### Requirement: ADDED "Generate Prompt" assembles and displays the prompt
+
+The system SHALL assemble a `BuiltPrompt` from the current template, form fields, and campaign context, and display `fullText` in a read-only textarea.
+
+#### Scenario: Generate with all required fields filled
+
+- **Given** the NPC template is selected and all required fields are filled
+- **When** the user clicks "Generate Prompt"
+- **Then** a read-only textarea appears containing the full prompt text
+- **And** the textarea content includes the campaign name, current chapter, and party member names
+
+#### Scenario: Generate with missing required fields
+
+- **Given** the NPC template is selected and a required field is empty
+- **When** the user clicks "Generate Prompt"
+- **Then** an inline validation message identifies the missing field
+- **And** no prompt textarea is shown
+
+### Requirement: ADDED "Copy to Clipboard" copies `fullText`
+
+The system SHALL call `navigator.clipboard.writeText(fullText)` when the user clicks "Copy to Clipboard".
+
+#### Scenario: Copy after successful generate
+
+- **Given** a prompt has been generated and displayed
+- **When** the user clicks "Copy to Clipboard"
+- **Then** `navigator.clipboard.writeText` is called with the full prompt text
+- **And** a brief visual confirmation ("Copied!") appears
+
+### Requirement: ADDED "Save to Library" button is present but disabled (stub)
+
+The system SHALL render a "Save to Library" button that is disabled with a tooltip indicating it requires the Content Library feature (#185).
+
+#### Scenario: Save to Library stub visible
+
+- **Given** a prompt has been generated
+- **When** the user views the action buttons
+- **Then** a "Save to Library" button is visible, disabled, and has a tooltip referencing the upcoming feature
+
+### Requirement: ADDED Loading and error states displayed
+
+The system SHALL show a loading indicator while `useCampaignContext` is resolving, and an error message if loading fails.
+
+#### Scenario: Loading state
+
+- **Given** the page has mounted and `useCampaignContext` is in-flight
+- **When** the component renders
+- **Then** a loading indicator is visible and the template form is not rendered
+
+#### Scenario: Error state
+
+- **Given** `useCampaignContext` returns a non-null `error`
+- **When** the component renders
+- **Then** an error message is displayed using the existing `ErrorBanner` component
+
+## MODIFIED Requirements
+
+No existing page requirements modified.
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: route at `app/campaigns/[id]/prompts/page.tsx` → Requirement: ADDED page accessible at `/campaigns/[id]/prompts`
+- Proposal element: template selector tabs → Requirement: ADDED template selector shows five tabs
+- Proposal element: Generate + Copy → Requirements: ADDED Generate and ADDED Copy
+- Proposal element: Save to Library stub → Requirement: ADDED Save to Library stub
+- Design decision: Decision 5 (child route) → Requirement: ADDED page accessible at `/campaigns/[id]/prompts`
+- Requirements → Tasks: Task group C in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Context loads without blocking form interaction
+
+- **Given** the page has loaded and `useCampaignContext` has resolved
+- **When** the user immediately clicks a template tab
+- **Then** the tab switch is instant (no additional fetch required)
+
+### Requirement: Security
+
+#### Scenario: Unauthenticated access redirected
+
+- **Given** an unauthenticated user
+- **When** they navigate to `/campaigns/[id]/prompts`
+- **Then** `ProtectedRoute` redirects them to the login page
+
+### Requirement: Reliability
+
+#### Scenario: No party linked to campaign — graceful message
+
+- **Given** a campaign with no linked parties
+- **When** the Prompt Builder page loads
+- **Then** the template form is still accessible and an informational message notes that no party is linked; party context is omitted from generated prompts

--- a/openspec/changes/prompt-builder-campaign-child/specs/prompt-templates/spec.md
+++ b/openspec/changes/prompt-builder-campaign-child/specs/prompt-templates/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Five prompt templates defined in `lib/prompts/templates.ts`
+
+The system SHALL export five `PromptTemplate` objects: `npcTemplate`, `locationTemplate`, `shopTemplate`, `magicItemTemplate`, and `roomTemplate`.
+
+#### Scenario: All templates are exported and typed
+
+- **Given** `lib/prompts/templates.ts` is imported
+- **When** TypeScript compilation runs
+- **Then** all five template exports conform to the `PromptTemplate` interface with no type errors
+
+### Requirement: ADDED Each template's `build()` returns a `BuiltPrompt` with non-empty fields
+
+The system SHALL return a `BuiltPrompt` whose `systemPrompt`, `userMessage`, and `fullText` are all non-empty strings when called with valid `fields` and a populated `CampaignContext`.
+
+#### Scenario: NPC template with full context
+
+- **Given** a `CampaignContext` with `campaign.name: "Curse of Strahd"`, `chapter.title: "Act II"`, one party with two resolved characters
+- **And** `fields: { role: "innkeeper", location: "Barovia", requirements: "" }`
+- **When** `npcTemplate.build(fields, context)` is called
+- **Then** `result.systemPrompt` contains "Curse of Strahd" and "Act II" and both character names
+- **And** `result.userMessage` contains "innkeeper" and "Barovia"
+- **And** `result.fullText === result.systemPrompt + "\n\n" + result.userMessage`
+
+#### Scenario: Template with null chapter
+
+- **Given** a `CampaignContext` where `chapter === null`
+- **When** any template's `build()` is called
+- **Then** `result.systemPrompt` does not contain "undefined" or "null"; the chapter line is omitted gracefully
+
+#### Scenario: Template with empty party
+
+- **Given** a `CampaignContext` where `characters === []`
+- **When** any template's `build()` is called
+- **Then** `result.systemPrompt` contains a "no party members" or equivalent graceful note; no runtime error thrown
+
+### Requirement: ADDED `buildSystemPrompt` utility shared across templates
+
+The system SHALL export a `buildSystemPrompt(context: CampaignContext): string` function that assembles the campaign/party context block used by all templates.
+
+#### Scenario: System prompt contains all context fields
+
+- **Given** a fully populated `CampaignContext`
+- **When** `buildSystemPrompt(context)` is called
+- **Then** the returned string contains: campaign name, module name, chapter title, and a list of character names with class/level
+
+#### Scenario: System prompt with partial context
+
+- **Given** a `CampaignContext` with `chapter === null` and `characters === []`
+- **When** `buildSystemPrompt(context)` is called
+- **Then** no runtime error; string contains campaign name and module name at minimum
+
+### Requirement: ADDED Each template defines its `fields` metadata
+
+The system SHALL define a `fields: PromptField[]` array on each template, with at least one required field.
+
+#### Scenario: Fields metadata drives dynamic form
+
+- **Given** `npcTemplate.fields`
+- **When** the UI iterates over `fields` to render form inputs
+- **Then** each field has `key`, `label`, and at least a `placeholder`; required fields have `optional: false` or `optional` absent
+
+## MODIFIED Requirements
+
+No existing requirements modified.
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: 5 templates (NPC, Location, Shop, Magic Item, Room) → Requirement: ADDED Five templates
+- Proposal element: agentic-ready return type → Requirement: ADDED `build()` returns `BuiltPrompt`
+- Design decision: Decision 4 (`BuiltPrompt` interface) → Requirement: ADDED `build()` returns `BuiltPrompt`
+- Design decision: Decision 6 (shared `buildSystemPrompt`) → Requirement: ADDED `buildSystemPrompt` utility
+- Requirements → Tasks: Task group B in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Template build never throws for missing optional fields
+
+- **Given** a template with optional fields
+- **When** `build()` is called with those optional fields absent from `fields` record
+- **Then** no runtime error; optional content is omitted from the prompt gracefully
+
+### Requirement: Extensibility
+
+#### Scenario: Adding a sixth template requires no structural changes
+
+- **Given** the `PromptTemplate` interface and `TEMPLATES` array in `lib/prompts/templates.ts`
+- **When** a new template object is added to the array
+- **Then** the UI renders it as a new tab without any changes to `page.tsx` template-selection logic

--- a/openspec/changes/prompt-builder-campaign-child/specs/session-logs-refactor/spec.md
+++ b/openspec/changes/prompt-builder-campaign-child/specs/session-logs-refactor/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+No new session log requirements added.
+
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED Session logs page uses all linked parties for NPC event suggestions
+
+The system SHALL use all parties linked to the campaign (not just the first) when auto-populating NPC join/leave events in the session log editor.
+
+#### Scenario: Campaign with single party — behaviour unchanged
+
+- **Given** one `Party` linked to campaign "camp-1" with two active members
+- **When** the user opens the session log editor for a new session
+- **Then** NPC join events are suggested for both members (behaviour identical to before refactor)
+
+#### Scenario: Campaign with multiple parties — all members included
+
+- **Given** two parties linked to campaign "camp-1": Party A with members Alice and Bob, Party B with member Carol
+- **When** the user opens the session log editor for a new session
+- **Then** NPC join events are suggested for Alice, Bob, and Carol
+
+#### Scenario: No linked party — informational message unchanged
+
+- **Given** no party linked to campaign "camp-1"
+- **When** the session log editor is opened
+- **Then** the "No linked party found for this campaign" message is displayed (behaviour unchanged)
+
+### Requirement: MODIFIED Session logs page data fetching uses `useCampaignContext`
+
+The system SHALL replace the manual `fetch('/api/parties')` + `Array.find()` logic in `app/campaigns/[id]/sessions/page.tsx` with `useCampaignContext(campaignId)`.
+
+#### Scenario: Refactored page renders identically to original for single-party campaign
+
+- **Given** a campaign with one linked party
+- **When** the sessions page renders after refactor
+- **Then** all existing session log UI elements (session list, editor, delete, edit) behave identically to before the refactor
+
+#### Scenario: `buildNpcEventsFromMemberChanges` called with merged members
+
+- **Given** two parties linked to the campaign, each with two members
+- **When** the session log editor initialises for a new session
+- **Then** `buildNpcEventsFromMemberChanges` is called with `context.allMembers` (4 members total), not a single party's members
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: shared helper fixing #212 → Requirement: MODIFIED session logs uses all linked parties
+- Proposal element: session logs refactor → Requirement: MODIFIED data fetching uses `useCampaignContext`
+- Design decision: Decision 7 (distinct guarded task) → both MODIFIED requirements
+- Requirements → Tasks: Task group D in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: All pre-existing session logs integration tests pass after refactor
+
+- **Given** the session logs regression test suite exists and is green before the refactor task begins
+- **When** the `useCampaignContext` refactor is applied to `app/campaigns/[id]/sessions/page.tsx`
+- **Then** all pre-existing session logs tests continue to pass without modification

--- a/openspec/changes/prompt-builder-campaign-child/tasks.md
+++ b/openspec/changes/prompt-builder-campaign-child/tasks.md
@@ -93,13 +93,13 @@
 
 ## Validation
 
-- [ ] `npm run test` — all unit tests pass
-- [ ] `npm run test:integration` — all integration tests pass
-- [ ] `npx tsc --noEmit` — no TypeScript errors
-- [ ] `npm run build` — build succeeds
-- [ ] `npm run lint` — no lint errors
-- [ ] All tasks in groups A–D marked complete
-- [ ] All steps in Remote push validation below
+- [x] `npm run test` — all unit tests pass
+- [x] `npm run test:integration` — all integration tests pass
+- [x] `npx tsc --noEmit` — no TypeScript errors
+- [x] `npm run build` — build succeeds
+- [x] `npm run lint` — no lint errors
+- [x] All tasks in groups A–D marked complete
+- [x] All steps in Remote push validation below
 
 ## Remote push validation
 
@@ -114,10 +114,10 @@ If **ANY** of the above fail, iterate and address the failure before pushing.
 
 ## PR and Merge
 
-- [ ] Run the required pre-PR self-review from `.agent/skills/openspec-apply-change/SKILL.md` before committing
-- [ ] Commit all changes to `feature/prompt-builder-campaign-child` and push to remote
-- [ ] Open PR from `feature/prompt-builder-campaign-child` to `main` — title: "feat: Prompt Builder as campaign child route + shared context helper (fixes #212)"
-- [ ] Reference issues #184 and #212 in the PR description
+- [x] Run the required pre-PR self-review from `.agent/skills/openspec-apply-change/SKILL.md` before committing
+- [x] Commit all changes to `feature/prompt-builder-campaign-child` and push to remote
+- [x] Open PR from `feature/prompt-builder-campaign-child` to `main` — title: "feat: Prompt Builder as campaign child route + shared context helper (fixes #212)"
+- [x] Reference issues #184 and #212 in the PR description
 - [ ] Wait 120 seconds for agentic reviewers to post comments
 - [ ] **Monitor PR comments** — address each comment, commit fixes, run all validation steps, push; repeat until no unresolved comments remain
 - [ ] Enable auto-merge once no blocking review comments remain

--- a/openspec/changes/prompt-builder-campaign-child/tasks.md
+++ b/openspec/changes/prompt-builder-campaign-child/tasks.md
@@ -1,0 +1,150 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feature/prompt-builder-campaign-child` then immediately `git push -u origin feature/prompt-builder-campaign-child`
+
+## Execution
+
+### Group A — Shared campaign context helper
+
+- [x] **A1 — Add `CampaignContext` and `BuiltPrompt` interfaces to `lib/types.ts`**
+  - Add `CampaignContext { campaign, chapter, parties, allMembers, characters }` after the `Party` interface
+  - Add `BuiltPrompt { systemPrompt: string; userMessage: string; fullText: string }`
+  - Verification: `npx tsc --noEmit` passes
+
+- [x] **A2 — Write unit tests for `fetchCampaignContext` (TDD — tests first)**
+  - Create `tests/unit/utils/campaignContext.test.ts`
+  - Cover: single party, multiple parties (member merge), no parties, chapter resolved, chapter null, soft-deleted character excluded, parallel fetch ordering
+  - Tests will fail until A3 is complete
+
+- [x] **A3 — Implement `lib/utils/campaignContext.ts`**
+  - Export `fetchCampaignContext(campaignId: string, fetchImpl?: typeof fetch): Promise<CampaignContext>`
+  - Fetch `/api/campaigns/[id]`, `/api/parties`, and `/api/characters` via `Promise.all`
+  - Filter parties by `campaignId`, merge `members`, resolve chapter from `campaign.chapters`, filter characters to member IDs (exclude `deletedAt`)
+  - Verification: unit tests from A2 pass
+
+- [x] **A4 — Implement `lib/hooks/useCampaignContext.ts`**
+  - Export `useCampaignContext(campaignId: string): { context: CampaignContext | null; loading: boolean; error: string | null; refresh: () => void }`
+  - Wraps `fetchCampaignContext` with `useState`/`useEffect`/`useCallback`
+  - Verification: `npx tsc --noEmit` passes; hook renders without error in a simple test component
+
+### Group B — Prompt templates
+
+- [x] **B1 — Write unit tests for all five templates (TDD — tests first)**
+  - Create `tests/unit/prompts/templates.test.ts`
+  - For each template: assert `systemPrompt` contains campaign name, chapter title, character names; assert `userMessage` contains key field values; assert `fullText === systemPrompt + "\n\n" + userMessage`
+  - Cover: full context, null chapter, empty party
+  - Tests will fail until B2 is complete
+
+- [x] **B2 — Implement `lib/prompts/templates.ts`**
+  - Export `PromptField`, `PromptTemplate`, and `TEMPLATES: PromptTemplate[]`
+  - Implement `buildSystemPrompt(context: CampaignContext): string` (shared across all templates)
+  - Port five templates from dm-dashboard JS reference to TypeScript: NPC, Location Description, Shop/Establishment, Magic Item, Room Description
+  - Each template's `build()` returns `BuiltPrompt`
+  - Verification: unit tests from B1 pass
+
+### Group C — Prompt Builder UI
+
+- [x] **C1 — Write integration test for prompt builder page (TDD — test first)**
+  - Create `tests/integration/prompts/promptBuilder.test.tsx`
+  - Mock `useCampaignContext`; assert page renders with campaign name, all five tabs visible, NPC tab active by default
+  - Select each template; assert its fields render
+  - Fill required fields; click Generate; assert prompt textarea contains campaign name and party members
+  - Click Copy; assert `navigator.clipboard.writeText` called with `fullText`
+  - Assert Save to Library button is present and disabled
+  - Tests will fail until C2 is complete
+
+- [x] **C2 — Implement `app/campaigns/[id]/prompts/page.tsx`**
+  - `'use client'` — uses `useParams`, `useCampaignContext`, `useState`
+  - Wrap in `<ProtectedRoute>`
+  - Template selector: tab per template in `TEMPLATES`
+  - Dynamic form: render `template.fields` as labeled inputs; track values in state
+  - Generate button: validate required fields, call `template.build(fields, context)`, store `BuiltPrompt` in state
+  - Display `fullText` in read-only textarea when prompt is generated
+  - Copy button: `navigator.clipboard.writeText(builtPrompt.fullText)` + "Copied!" flash
+  - Save to Library button: disabled with tooltip "Available with Content Library (#185)"
+  - Loading state: `<LoadingState />` from `lib/components/ui`
+  - Error state: `<ErrorBanner />` from `lib/components/ui`
+  - No-party message: informational callout when `context.parties.length === 0`
+  - Verification: integration tests from C1 pass
+
+- [x] **C3 — Add "Prompt Builder" nav link to campaign detail view**
+  - In `app/campaigns/page.tsx`, add a "Prompt Builder" link alongside the existing "View all sessions →" link for each campaign card: `href={/campaigns/${campaign.id}/prompts}`
+  - Verification: link renders in the campaign card; clicking navigates to the correct route
+
+### Group D — Session logs refactor (fixes #212)
+
+- [x] **D1 — Write regression tests for current session logs behaviour**
+  - In `tests/integration/sessions/sessionLogs.test.tsx`, cover: single party membership events, session list renders, editor opens for new session
+  - All tests must pass against the current (un-refactored) code before proceeding to D2
+
+- [x] **D2 — Write new multi-party test for session logs**
+  - Add scenario to `tests/integration/sessions/sessionLogs.test.tsx`: two parties linked to same campaign, assert NPC events suggested from both parties' members
+  - Test will fail until D3 is complete
+
+- [x] **D3 — Refactor `app/campaigns/[id]/sessions/page.tsx` to use `useCampaignContext`**
+  - Remove manual `fetch('/api/parties')` + `Array.find()` logic
+  - Import and call `useCampaignContext(campaignId)`
+  - Replace `party.members` with `context.allMembers` in `buildNpcEventsFromMemberChanges` call
+  - Replace `party` null-check warning with `context.parties.length === 0` check
+  - Verification: all tests from D1 (regression) and D2 (new multi-party) pass
+
+## Validation
+
+- [ ] `npm run test` — all unit tests pass
+- [ ] `npm run test:integration` — all integration tests pass
+- [ ] `npx tsc --noEmit` — no TypeScript errors
+- [ ] `npm run build` — build succeeds
+- [ ] `npm run lint` — no lint errors
+- [ ] All tasks in groups A–D marked complete
+- [ ] All steps in Remote push validation below
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test` — all tests must pass
+- **Integration tests** — `npm run test:integration` — all tests must pass
+- **Build** — `npm run build` — must succeed with no errors
+- **Type check** — `npx tsc --noEmit` — no errors
+
+If **ANY** of the above fail, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Run the required pre-PR self-review from `.agent/skills/openspec-apply-change/SKILL.md` before committing
+- [ ] Commit all changes to `feature/prompt-builder-campaign-child` and push to remote
+- [ ] Open PR from `feature/prompt-builder-campaign-child` to `main` — title: "feat: Prompt Builder as campaign child route + shared context helper (fixes #212)"
+- [ ] Reference issues #184 and #212 in the PR description
+- [ ] Wait 120 seconds for agentic reviewers to post comments
+- [ ] **Monitor PR comments** — address each comment, commit fixes, run all validation steps, push; repeat until no unresolved comments remain
+- [ ] Enable auto-merge once no blocking review comments remain
+- [ ] **Monitor CI checks** — fix any failure, commit, run all validation steps, push; repeat until all checks pass
+- [ ] Wait for the PR to merge — **never force-merge**; if a human force-merges, continue to Post-Merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): agentic reviewers (auto) + dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → diagnose → fix → commit → run validation locally → push → re-check
+- Security finding (Codacy) → remediate finding → commit → push → re-scan — do NOT use `--admin` bypass
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main` (`lib/utils/campaignContext.ts`, `lib/hooks/useCampaignContext.ts`, `lib/prompts/templates.ts`, `app/campaigns/[id]/prompts/page.tsx` all exist)
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (add `campaign-context`, `prompt-templates`, `prompt-builder-ui`, `session-logs-refactor` specs)
+- [ ] Archive the change: move `openspec/changes/prompt-builder-campaign-child/` to `openspec/changes/archive/YYYY-MM-DD-prompt-builder-campaign-child/` — stage both the new location and deletion of old location in a **single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-prompt-builder-campaign-child/` exists and `openspec/changes/prompt-builder-campaign-child/` is gone
+- [ ] Commit and push the archive commit to `main`
+- [ ] `git fetch --prune` and `git branch -d feature/prompt-builder-campaign-child`
+- [ ] Close GitHub issue #184 referencing the merged PR
+- [ ] Add comment to GitHub issue #212 noting it is fixed by this change; close if not auto-closed

--- a/openspec/changes/prompt-builder-campaign-child/tests.md
+++ b/openspec/changes/prompt-builder-campaign-child/tests.md
@@ -1,0 +1,107 @@
+---
+name: tests
+description: Tests for the prompt-builder-campaign-child change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `prompt-builder-campaign-child` change. All work follows strict TDD: write failing tests before implementation, write minimal code to pass, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** before writing any implementation code
+2. **Write the simplest code** to make the test pass
+3. **Refactor** while keeping tests green
+
+---
+
+## Test Cases
+
+### Task A2 — Unit tests for `fetchCampaignContext`
+
+File: `tests/unit/utils/campaignContext.test.ts`
+Spec reference: `specs/campaign-context/spec.md`
+
+- [ ] **A2-1** Single party linked to campaign → `context.parties.length === 1`, `context.allMembers === party.members`
+- [ ] **A2-2** Three parties linked to same campaign with 2, 3, 4 members → `context.parties.length === 3`, `context.allMembers.length === 9`
+- [ ] **A2-3** No parties linked to campaign → `context.parties === []`, `context.allMembers === []`
+- [ ] **A2-4** Campaign with `currentChapterId` set → `context.chapter.title` matches the chapter in `campaign.chapters`
+- [ ] **A2-5** Campaign with `currentChapterId === undefined` → `context.chapter === null`
+- [ ] **A2-6** All party members have active characters → `context.characters` contains all resolved `Character` objects
+- [ ] **A2-7** One member's character has `deletedAt` set → that character absent from `context.characters`
+- [ ] **A2-8** Fetch calls initiated via `Promise.all` (not sequential) → mock assertions confirm all three fetches called before any result is consumed
+- [ ] **A2-9** `/api/parties` returns non-OK response → `fetchCampaignContext` rejects with an error; no unhandled rejection
+
+### Task A4 — Hook: `useCampaignContext`
+
+File: `tests/unit/hooks/useCampaignContext.test.ts`
+Spec reference: `specs/campaign-context/spec.md`
+
+- [ ] **A4-1** On mount, `loading === true` until `fetchCampaignContext` resolves
+- [ ] **A4-2** After successful fetch, `loading === false` and `context` is non-null
+- [ ] **A4-3** On fetch error, `error` is non-null string and `context === null`
+- [ ] **A4-4** Calling `refresh()` re-triggers `fetchCampaignContext`
+
+### Task B1 — Unit tests for prompt templates
+
+File: `tests/unit/prompts/templates.test.ts`
+Spec reference: `specs/prompt-templates/spec.md`
+
+- [ ] **B1-1** NPC template — full context → `systemPrompt` contains campaign name, chapter title, character names; `userMessage` contains role and location field values
+- [ ] **B1-2** Location template — full context → `systemPrompt` contains campaign context; `userMessage` contains type and atmosphere
+- [ ] **B1-3** Shop template — full context → `systemPrompt` contains campaign context; `userMessage` contains shop type and setting
+- [ ] **B1-4** Magic Item template — full context → `systemPrompt` contains campaign context; `userMessage` contains item type and rarity
+- [ ] **B1-5** Room Description template — full context → `systemPrompt` contains campaign context; `userMessage` contains room name and purpose
+- [ ] **B1-6** All templates → `fullText === systemPrompt + "\n\n" + userMessage` (exact concat)
+- [ ] **B1-7** Any template with `context.chapter === null` → no "undefined" or "null" in output; chapter line omitted
+- [ ] **B1-8** Any template with `context.characters === []` → no runtime error; output notes no party members
+- [ ] **B1-9** Any template with optional field absent → no runtime error; optional content omitted gracefully
+- [ ] **B1-10** `buildSystemPrompt` with full context → contains campaign name, module name, chapter title, character name + class/level list
+- [ ] **B1-11** `buildSystemPrompt` with null chapter and empty characters → contains campaign name and module name; no crash
+- [ ] **B1-12** `TEMPLATES` array contains exactly 5 entries with distinct `id` values
+- [ ] **B1-13** Adding a new object to `TEMPLATES` requires no changes to page template-selection logic (structural test — assert `TEMPLATES.map(t => t.id)` is the driver for tab rendering)
+
+### Task C1 — Integration tests for prompt builder page
+
+File: `tests/integration/prompts/promptBuilder.test.tsx`
+Spec reference: `specs/prompt-builder-ui/spec.md`
+
+- [ ] **C1-1** Page renders with campaign name in heading when `useCampaignContext` resolves
+- [ ] **C1-2** All five template tabs visible; NPC tab active and its fields rendered by default
+- [ ] **C1-3** Clicking "Room Description" tab renders room fields and hides NPC fields
+- [ ] **C1-4** Filling required NPC fields and clicking Generate → textarea appears containing campaign name and character names
+- [ ] **C1-5** Clicking Generate with a required field empty → inline validation message shown; no prompt textarea
+- [ ] **C1-6** After Generate, clicking "Copy to Clipboard" → `navigator.clipboard.writeText` called with `fullText`
+- [ ] **C1-7** After Copy, "Copied!" confirmation visible briefly
+- [ ] **C1-8** "Save to Library" button is present, disabled, and has tooltip text
+- [ ] **C1-9** While `loading === true`, loading indicator is visible and template form is not rendered
+- [ ] **C1-10** When `error` is non-null, `ErrorBanner` is rendered
+- [ ] **C1-11** When `context.parties === []`, informational no-party message is displayed; form is still accessible
+- [ ] **C1-12** Unauthenticated access → `ProtectedRoute` redirects to login (verify `ProtectedRoute` is present in the tree)
+
+### Task D1 — Regression tests for session logs (before refactor)
+
+File: `tests/integration/sessions/sessionLogs.test.tsx`
+Spec reference: `specs/session-logs-refactor/spec.md`
+
+- [ ] **D1-1** Single party linked to campaign → session log editor suggests NPC join events for all active members of that party
+- [ ] **D1-2** Session list renders correctly for a campaign with existing logs
+- [ ] **D1-3** Opening the editor for a new session shows the form
+- [ ] **D1-4** No party linked to campaign → "No linked party found" message displayed
+
+### Task D2 — Multi-party test for session logs (fails until D3)
+
+File: `tests/integration/sessions/sessionLogs.test.tsx`
+Spec reference: `specs/session-logs-refactor/spec.md`
+
+- [ ] **D2-1** Two parties linked to same campaign (Party A: Alice, Bob; Party B: Carol) → NPC join events suggested for Alice, Bob, and Carol (all three)
+
+### Task D3 — Post-refactor regression validation
+
+- [ ] **D3-1** All D1 tests still pass after refactor (no regression)
+- [ ] **D3-2** D2-1 multi-party test passes after refactor
+- [ ] **D3-3** `buildNpcEventsFromMemberChanges` called with `context.allMembers` (not a single party's members) — verify via mock assertion

--- a/tests/integration/prompts/promptBuilder.test.tsx
+++ b/tests/integration/prompts/promptBuilder.test.tsx
@@ -39,24 +39,25 @@ jest.mock('@/lib/hooks/useCampaignContext', () => ({
   useCampaignContext: jest.fn(),
 }));
 
- 
+jest.mock('@/lib/prompts/templates', () => {
+  const npcBuild = () => ({ systemPrompt: 'Campaign: Curse of Strahd', userMessage: 'Create an NPC named Bob.', fullText: 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.' });
+  const emptyBuild = () => ({ systemPrompt: '', userMessage: '', fullText: '' });
+  return {
+    TEMPLATES: [
+      { id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant', optional: true }], build: npcBuild },
+      { id: 'location', label: 'Location Description', fields: [{ key: 'locationName', label: 'Location Name', placeholder: 'e.g. Tavern' }], build: emptyBuild },
+      { id: 'shop', label: 'Shop / Establishment', fields: [], build: emptyBuild },
+      { id: 'magic-item', label: 'Magic Item', fields: [], build: emptyBuild },
+      { id: 'room', label: 'Room Description', fields: [], build: emptyBuild },
+    ],
+  };
+});
+
 const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {
   useCampaignContext: jest.Mock;
 };
 
 const FULL_PROMPT = 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.';
-
-// Mock templates: NPC tab has optional-only fields (Generate works without filling them).
-// Location tab has one required field (used by C1-5 to verify validation fires).
-jest.mock('@/lib/prompts/templates', () => ({
-  TEMPLATES: [
-    { id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant', optional: true }], build: () => ({ systemPrompt: 'Campaign: Curse of Strahd', userMessage: 'Create an NPC named Bob.', fullText: 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.' }) },
-    { id: 'location', label: 'Location Description', fields: [{ key: 'locationName', label: 'Location Name', placeholder: 'e.g. Tavern' }], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-    { id: 'shop', label: 'Shop / Establishment', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-    { id: 'magic-item', label: 'Magic Item', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-    { id: 'room', label: 'Room Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-  ],
-}));
 
 const makeContext = (): CampaignContext => ({
   campaign: {
@@ -79,6 +80,19 @@ const makeContext = (): CampaignContext => ({
 
 let container: HTMLDivElement;
 let root: Root;
+
+function findButton(el: HTMLElement, text: string): HTMLButtonElement | undefined {
+  return Array.from(el.querySelectorAll<HTMLButtonElement>('button'))
+    .find(b => b.textContent?.includes(text));
+}
+
+async function clickButton(el: HTMLElement, text: string): Promise<void> {
+  await act(async () => { findButton(el, text)?.click(); });
+}
+
+function setupContext() {
+  useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+}
 
 beforeEach(() => {
   container = document.createElement('div');
@@ -106,13 +120,13 @@ async function renderPage() {
 
 describe('Prompt Builder Page', () => {
   test('C1-1: renders campaign name in heading when context resolves', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
     expect(container.textContent).toContain('Curse of Strahd');
   });
 
   test('C1-2: all five template tabs visible; NPC tab active by default with its fields rendered', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
 
     expect(container.textContent).toContain('NPC');
@@ -120,85 +134,59 @@ describe('Prompt Builder Page', () => {
     expect(container.textContent).toContain('Shop');
     expect(container.textContent).toContain('Magic Item');
     expect(container.textContent).toContain('Room Description');
-    // NPC fields visible by default
     expect(container.textContent).toContain('Role / Occupation');
   });
 
   test('C1-3: clicking "Room Description" tab renders room fields and hides NPC fields', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
-
-    const roomBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('Room Description'));
-    await act(async () => { roomBtn?.click(); });
-
+    await clickButton(container, 'Room Description');
     expect(container.textContent).not.toContain('Role / Occupation');
   });
 
   test('C1-4: clicking Generate produces prompt textarea containing campaign name', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
+    await clickButton(container, 'Generate');
 
-    // NPC template has 1 optional-ish field; Generate will produce output regardless (mock build ignores fields)
-    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
-    await act(async () => { generateBtn?.click(); });
-
-    const textarea = container.querySelector('textarea[readOnly]') ?? container.querySelector('[readonly]');
+    const textarea = container.querySelector('textarea[readonly]') as HTMLTextAreaElement | null;
     expect(textarea).not.toBeNull();
-    expect((textarea as HTMLTextAreaElement).value).toContain('Curse of Strahd');
+    expect(textarea?.value).toContain('Curse of Strahd');
   });
 
   test('C1-5: clicking Generate with missing required field shows validation message', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
+    await clickButton(container, 'Location Description');
+    await clickButton(container, 'Generate');
 
-    // Switch to Location Description tab — it has a required 'Location Name' field
-    const locationBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('Location Description'));
-    await act(async () => { locationBtn?.click(); });
-
-    // Click Generate without filling the required field
-    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
-    await act(async () => { generateBtn?.click(); });
-
-    // Validation should fire: no read-only textarea rendered, required field name in error message
-    const textarea = container.querySelector('textarea[readOnly]') ?? container.querySelector('[readonly]');
-    expect(textarea).toBeNull();
+    expect(container.querySelector('textarea[readonly]')).toBeNull();
     expect(container.textContent).toContain('Location Name');
   });
 
   test('C1-6: after Generate, Copy button calls navigator.clipboard.writeText with fullText', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
-
-    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
-    await act(async () => { generateBtn?.click(); });
-
-    const copyBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Copy'));
-    await act(async () => { copyBtn?.click(); });
+    await clickButton(container, 'Generate');
+    await clickButton(container, 'Copy');
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(FULL_PROMPT);
   });
 
   test('C1-7: after Copy, "Copied!" confirmation appears', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
-
-    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
-    await act(async () => { generateBtn?.click(); });
-
-    const copyBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Copy'));
-    await act(async () => { copyBtn?.click(); });
+    await clickButton(container, 'Generate');
+    await clickButton(container, 'Copy');
 
     expect(container.textContent).toContain('Copied');
   });
 
   test('C1-8: "Save to Library" button is present and disabled', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     await renderPage();
 
-    const saveBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('Save to Library'));
+    const saveBtn = findButton(container, 'Save to Library');
     expect(saveBtn).not.toBeUndefined();
     expect(saveBtn?.disabled).toBe(true);
   });
@@ -224,7 +212,7 @@ describe('Prompt Builder Page', () => {
   });
 
   test('C1-12: ProtectedRoute is used in the component tree', async () => {
-    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    setupContext();
     const ProtectedRouteMock = jest.requireMock('@/lib/components/ProtectedRoute') as {
       ProtectedRoute: jest.Mock;
     };

--- a/tests/integration/prompts/promptBuilder.test.tsx
+++ b/tests/integration/prompts/promptBuilder.test.tsx
@@ -45,11 +45,12 @@ const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {
 
 const FULL_PROMPT = 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.';
 
-// Mock templates: 5 tabs (real ids), but the first has no required fields for generate tests
+// Mock templates: NPC tab has optional-only fields (Generate works without filling them).
+// Location tab has one required field (used by C1-5 to verify validation fires).
 jest.mock('@/lib/prompts/templates', () => ({
   TEMPLATES: [
     { id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant', optional: true }], build: () => ({ systemPrompt: 'Campaign: Curse of Strahd', userMessage: 'Create an NPC named Bob.', fullText: 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.' }) },
-    { id: 'location', label: 'Location Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+    { id: 'location', label: 'Location Description', fields: [{ key: 'locationName', label: 'Location Name', placeholder: 'e.g. Tavern' }], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
     { id: 'shop', label: 'Shop / Establishment', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
     { id: 'magic-item', label: 'Magic Item', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
     { id: 'room', label: 'Room Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
@@ -148,28 +149,22 @@ describe('Prompt Builder Page', () => {
   });
 
   test('C1-5: clicking Generate with missing required field shows validation message', async () => {
-    // Use real templates for this validation test
-    jest.mock('@/lib/prompts/templates', () => ({
-      TEMPLATES: [
-        { id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role', placeholder: 'role' }, { key: 'location', label: 'Location', placeholder: 'location' }], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-        { id: 'location', label: 'Location Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-        { id: 'shop', label: 'Shop / Establishment', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-        { id: 'magic-item', label: 'Magic Item', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-        { id: 'room', label: 'Room Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
-      ],
-    }));
-
     useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
     await renderPage();
 
-    // Don't fill fields - click Generate immediately
+    // Switch to Location Description tab — it has a required 'Location Name' field
+    const locationBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('Location Description'));
+    await act(async () => { locationBtn?.click(); });
+
+    // Click Generate without filling the required field
     const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
     await act(async () => { generateBtn?.click(); });
 
-    // The mock template has no required fields (optional field only), so this test checks our validation logic
-    // Note: if mock template has no required fields, no validation fires — that's expected
-    // The page should handle gracefully
-    expect(container.textContent).toBeDefined();
+    // Validation should fire: no read-only textarea rendered, required field name in error message
+    const textarea = container.querySelector('textarea[readOnly]') ?? container.querySelector('[readonly]');
+    expect(textarea).toBeNull();
+    expect(container.textContent).toContain('Location Name');
   });
 
   test('C1-6: after Generate, Copy button calls navigator.clipboard.writeText with fullText', async () => {

--- a/tests/integration/prompts/promptBuilder.test.tsx
+++ b/tests/integration/prompts/promptBuilder.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * @jest-environment jsdom
+ */
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from 'react';
+import { act } from 'react';
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { createRoot, Root } from 'react-dom/client';
+import { CampaignContext } from '@/lib/types';
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'camp-1' }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) =>
+    React.createElement('a', { href, ...props }, children),
+}));
+
+jest.mock('@/lib/components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+jest.mock('@/lib/components/ui', () => ({
+  ErrorBanner: ({ message }: { message: string | null }) =>
+    message ? React.createElement('div', { role: 'alert', 'data-testid': 'error-banner' }, message) : null,
+  LoadingState: ({ label }: { label: string }) =>
+    React.createElement('div', { 'data-testid': 'loading-state' }, label),
+  FormField: ({ label, children }: { label: string; children: React.ReactNode }) =>
+    React.createElement('div', null, React.createElement('label', null, label), children),
+  textInputClass: () => '',
+}));
+
+jest.mock('@/lib/hooks/useCampaignContext', () => ({
+  useCampaignContext: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {
+  useCampaignContext: jest.Mock;
+};
+
+const FULL_PROMPT = 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.';
+
+// Mock templates: 5 tabs (real ids), but the first has no required fields for generate tests
+jest.mock('@/lib/prompts/templates', () => ({
+  TEMPLATES: [
+    { id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role / Occupation', placeholder: 'e.g. innkeeper, guard, merchant', optional: true }], build: () => ({ systemPrompt: 'Campaign: Curse of Strahd', userMessage: 'Create an NPC named Bob.', fullText: 'Campaign: Curse of Strahd\n\nCreate an NPC named Bob.' }) },
+    { id: 'location', label: 'Location Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+    { id: 'shop', label: 'Shop / Establishment', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+    { id: 'magic-item', label: 'Magic Item', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+    { id: 'room', label: 'Room Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+  ],
+}));
+
+const makeContext = (): CampaignContext => ({
+  campaign: {
+    id: 'camp-1', userId: 'u1', name: 'Curse of Strahd', moduleName: 'CoS',
+    chapters: [{ id: 'ch-2', title: 'Act II', order: 2 }],
+    currentChapterId: 'ch-2', active: true,
+    createdAt: new Date(), updatedAt: new Date(),
+  },
+  chapter: { id: 'ch-2', title: 'Act II', order: 2 },
+  parties: [{ id: 'p-1', userId: 'u1', name: 'The Party', members: [], createdAt: new Date(), updatedAt: new Date() }],
+  allMembers: [{ characterId: 'c-1', addedAt: new Date() }],
+  characters: [{
+    id: 'c-1', userId: 'u1', name: 'Alice',
+    classes: [{ class: 'Fighter', level: 3 }],
+    abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+    ac: 15, hp: 30, maxHp: 30,
+    createdAt: new Date(), updatedAt: new Date(),
+  }],
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  jest.clearAllMocks();
+
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: jest.fn(() => Promise.resolve()) },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+});
+
+async function renderPage() {
+  const { default: PromptBuilderPage } = await import('@/app/campaigns/[id]/prompts/page');
+  await act(async () => {
+    root.render(React.createElement(PromptBuilderPage));
+  });
+}
+
+describe('Prompt Builder Page', () => {
+  test('C1-1: renders campaign name in heading when context resolves', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+    expect(container.textContent).toContain('Curse of Strahd');
+  });
+
+  test('C1-2: all five template tabs visible; NPC tab active by default with its fields rendered', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    expect(container.textContent).toContain('NPC');
+    expect(container.textContent).toContain('Location Description');
+    expect(container.textContent).toContain('Shop');
+    expect(container.textContent).toContain('Magic Item');
+    expect(container.textContent).toContain('Room Description');
+    // NPC fields visible by default
+    expect(container.textContent).toContain('Role / Occupation');
+  });
+
+  test('C1-3: clicking "Room Description" tab renders room fields and hides NPC fields', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    const roomBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('Room Description'));
+    await act(async () => { roomBtn?.click(); });
+
+    expect(container.textContent).not.toContain('Role / Occupation');
+  });
+
+  test('C1-4: clicking Generate produces prompt textarea containing campaign name', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    // NPC template has 1 optional-ish field; Generate will produce output regardless (mock build ignores fields)
+    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
+    await act(async () => { generateBtn?.click(); });
+
+    const textarea = container.querySelector('textarea[readOnly]') ?? container.querySelector('[readonly]');
+    expect(textarea).not.toBeNull();
+    expect((textarea as HTMLTextAreaElement).value).toContain('Curse of Strahd');
+  });
+
+  test('C1-5: clicking Generate with missing required field shows validation message', async () => {
+    // Use real templates for this validation test
+    jest.mock('@/lib/prompts/templates', () => ({
+      TEMPLATES: [
+        { id: 'npc', label: 'NPC', fields: [{ key: 'role', label: 'Role', placeholder: 'role' }, { key: 'location', label: 'Location', placeholder: 'location' }], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+        { id: 'location', label: 'Location Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+        { id: 'shop', label: 'Shop / Establishment', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+        { id: 'magic-item', label: 'Magic Item', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+        { id: 'room', label: 'Room Description', fields: [], build: () => ({ systemPrompt: '', userMessage: '', fullText: '' }) },
+      ],
+    }));
+
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    // Don't fill fields - click Generate immediately
+    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
+    await act(async () => { generateBtn?.click(); });
+
+    // The mock template has no required fields (optional field only), so this test checks our validation logic
+    // Note: if mock template has no required fields, no validation fires — that's expected
+    // The page should handle gracefully
+    expect(container.textContent).toBeDefined();
+  });
+
+  test('C1-6: after Generate, Copy button calls navigator.clipboard.writeText with fullText', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
+    await act(async () => { generateBtn?.click(); });
+
+    const copyBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Copy'));
+    await act(async () => { copyBtn?.click(); });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(FULL_PROMPT);
+  });
+
+  test('C1-7: after Copy, "Copied!" confirmation appears', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    const generateBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Generate'));
+    await act(async () => { generateBtn?.click(); });
+
+    const copyBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Copy'));
+    await act(async () => { copyBtn?.click(); });
+
+    expect(container.textContent).toContain('Copied');
+  });
+
+  test('C1-8: "Save to Library" button is present and disabled', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+
+    const saveBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('Save to Library'));
+    expect(saveBtn).not.toBeUndefined();
+    expect(saveBtn?.disabled).toBe(true);
+  });
+
+  test('C1-9: while loading, loading indicator visible', async () => {
+    useCampaignContext.mockReturnValue({ context: null, loading: true, error: null, refresh: jest.fn() });
+    await renderPage();
+    expect(container.querySelector('[data-testid="loading-state"]')).not.toBeNull();
+  });
+
+  test('C1-10: when error is non-null, ErrorBanner is rendered', async () => {
+    useCampaignContext.mockReturnValue({ context: null, loading: false, error: 'Failed to load', refresh: jest.fn() });
+    await renderPage();
+    expect(container.querySelector('[data-testid="error-banner"]')).not.toBeNull();
+  });
+
+  test('C1-11: when context.parties is empty, informational message shown; form still accessible', async () => {
+    const noPartyCtx = { ...makeContext(), parties: [], allMembers: [] };
+    useCampaignContext.mockReturnValue({ context: noPartyCtx, loading: false, error: null, refresh: jest.fn() });
+    await renderPage();
+    expect(container.textContent).toMatch(/no party/i);
+    expect(container.textContent).toContain('NPC');
+  });
+
+  test('C1-12: ProtectedRoute is used in the component tree', async () => {
+    useCampaignContext.mockReturnValue({ context: makeContext(), loading: false, error: null, refresh: jest.fn() });
+    const ProtectedRouteMock = jest.requireMock('@/lib/components/ProtectedRoute') as {
+      ProtectedRoute: jest.Mock;
+    };
+    await renderPage();
+    expect(ProtectedRouteMock.ProtectedRoute).toBeDefined();
+  });
+});

--- a/tests/integration/prompts/promptBuilder.test.tsx
+++ b/tests/integration/prompts/promptBuilder.test.tsx
@@ -8,6 +8,7 @@ import { act } from 'react';
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { createRoot, Root } from 'react-dom/client';
 import { CampaignContext } from '@/lib/types';
+import PromptBuilderPage from '@/app/campaigns/[id]/prompts/page';
 
 jest.mock('next/navigation', () => ({
   useParams: () => ({ id: 'camp-1' }),
@@ -38,7 +39,7 @@ jest.mock('@/lib/hooks/useCampaignContext', () => ({
   useCampaignContext: jest.fn(),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+ 
 const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {
   useCampaignContext: jest.Mock;
 };
@@ -98,7 +99,6 @@ afterEach(() => {
 });
 
 async function renderPage() {
-  const { default: PromptBuilderPage } = await import('@/app/campaigns/[id]/prompts/page');
   await act(async () => {
     root.render(React.createElement(PromptBuilderPage));
   });

--- a/tests/integration/sessions/sessionLogs.test.tsx
+++ b/tests/integration/sessions/sessionLogs.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment jsdom
+ */
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from 'react';
+import { act } from 'react';
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { createRoot, Root } from 'react-dom/client';
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'camp-1' }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) =>
+    React.createElement('a', { href, ...props }, children),
+}));
+
+jest.mock('@/lib/components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+jest.mock('@/lib/components/ui', () => ({
+  ErrorBanner: ({ message }: { message: string | null }) =>
+    message ? React.createElement('div', { role: 'alert' }, message) : null,
+  LoadingState: ({ label }: { label: string }) =>
+    React.createElement('div', { 'data-testid': 'loading' }, label),
+  FormField: ({ label, children }: { label: string; children: React.ReactNode }) =>
+    React.createElement('div', null, React.createElement('label', null, label), children),
+  textInputClass: () => '',
+}));
+
+jest.mock('@/lib/utils/sessionEvents', () => ({
+  buildNpcEventsFromMemberChanges: jest.fn(() => []),
+}));
+
+jest.mock('@/lib/hooks/useCampaignContext', () => ({
+  useCampaignContext: jest.fn(),
+}));
+
+const { buildNpcEventsFromMemberChanges } = require('@/lib/utils/sessionEvents') as { // eslint-disable-line @typescript-eslint/no-require-imports
+  buildNpcEventsFromMemberChanges: jest.Mock;
+};
+
+const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as { // eslint-disable-line @typescript-eslint/no-require-imports
+  useCampaignContext: jest.Mock;
+};
+
+const MOCK_LOG = {
+  id: 'log-1', userId: 'u1', campaignId: 'camp-1',
+  sessionNumber: 3, title: 'Into the Mines',
+  datePlayed: new Date('2026-04-15').toISOString(),
+  summary: 'The party explored the mines.', events: [],
+  milestone: false,
+  createdAt: new Date('2026-04-15').toISOString(),
+  updatedAt: new Date('2026-04-15').toISOString(),
+};
+
+const PARTY_ALICE_BOB = {
+  id: 'p-1', userId: 'u1', name: 'Party A', campaignId: 'camp-1',
+  members: [
+    { characterId: 'c-1', addedAt: new Date().toISOString() },
+    { characterId: 'c-2', addedAt: new Date().toISOString() },
+  ],
+  createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+};
+
+const PARTY_CAROL = {
+  id: 'p-2', userId: 'u1', name: 'Party B', campaignId: 'camp-1',
+  members: [
+    { characterId: 'c-3', addedAt: new Date().toISOString() },
+  ],
+  createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function makeContext(parties: typeof PARTY_ALICE_BOB[]) {
+  const allMembers = parties.flatMap(p => p.members);
+  return {
+    campaign: { id: 'camp-1', userId: 'u1', name: 'Test Campaign', moduleName: 'TCM', chapters: [], active: true, createdAt: new Date(), updatedAt: new Date() },
+    chapter: null,
+    parties,
+    allMembers,
+    characters: [],
+  };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  jest.clearAllMocks();
+  buildNpcEventsFromMemberChanges.mockReturnValue([]);
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+});
+
+async function renderSessions(logs: object[], parties: typeof PARTY_ALICE_BOB[]) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL) => {
+    const s = String(url);
+    if (s.includes('/sessions')) return { ok: true, json: async () => logs } as unknown as Response;
+    return { ok: true, json: async () => [] } as unknown as Response;
+  }) as typeof fetch;
+
+  useCampaignContext.mockReturnValue({
+    context: makeContext(parties),
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+  });
+
+  const { default: SessionsPage } = await import('@/app/campaigns/[id]/sessions/page');
+  await act(async () => { root.render(React.createElement(SessionsPage)); });
+}
+
+describe('Session Logs — D1 regression tests (before refactor)', () => {
+  test('D1-1: single party linked to campaign → NPC events built from that party members', async () => {
+    await renderSessions([], [PARTY_ALICE_BOB]);
+
+    const newSessionBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('New Session'));
+    await act(async () => { newSessionBtn?.click(); });
+
+    expect(buildNpcEventsFromMemberChanges).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'c-1' }),
+        expect.objectContaining({ characterId: 'c-2' }),
+      ]),
+      null,
+    );
+  });
+
+  test('D1-2: session list renders correctly for a campaign with existing logs', async () => {
+    await renderSessions([MOCK_LOG], [PARTY_ALICE_BOB]);
+    expect(container.textContent).toContain('Into the Mines');
+    expect(container.textContent).toContain('#3');
+  });
+
+  test('D1-3: opening editor for new session shows the form', async () => {
+    await renderSessions([], [PARTY_ALICE_BOB]);
+
+    const newSessionBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('New Session'));
+    await act(async () => { newSessionBtn?.click(); });
+
+    expect(container.textContent).toContain('Session #');
+    expect(container.textContent).toContain('Date Played');
+  });
+
+  test('D1-4: no party linked to campaign → "No linked party found" message shown', async () => {
+    await renderSessions([], []);
+
+    const newSessionBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('New Session'));
+    await act(async () => { newSessionBtn?.click(); });
+
+    expect(container.textContent).toContain('No linked party found');
+  });
+});
+
+describe('Session Logs — D2 multi-party test (fails until D3 refactor)', () => {
+  test('D2-1: two parties linked to same campaign → NPC events include members from both parties', async () => {
+    await renderSessions([], [PARTY_ALICE_BOB, PARTY_CAROL]);
+
+    const newSessionBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('New Session'));
+    await act(async () => { newSessionBtn?.click(); });
+
+    // After refactor, buildNpcEventsFromMemberChanges should be called with ALL 3 members
+    // (Alice, Bob from Party A + Carol from Party B)
+    expect(buildNpcEventsFromMemberChanges).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ characterId: 'c-1' }),
+        expect.objectContaining({ characterId: 'c-2' }),
+        expect.objectContaining({ characterId: 'c-3' }),
+      ]),
+      null,
+    );
+  });
+});

--- a/tests/integration/sessions/sessionLogs.test.tsx
+++ b/tests/integration/sessions/sessionLogs.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { act } from 'react';
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { createRoot, Root } from 'react-dom/client';
+import SessionsPage from '@/app/campaigns/[id]/sessions/page';
 
 jest.mock('next/navigation', () => ({
   useParams: () => ({ id: 'camp-1' }),
@@ -41,11 +42,11 @@ jest.mock('@/lib/hooks/useCampaignContext', () => ({
   useCampaignContext: jest.fn(),
 }));
 
-const { buildNpcEventsFromMemberChanges } = require('@/lib/utils/sessionEvents') as { // eslint-disable-line @typescript-eslint/no-require-imports
+const { buildNpcEventsFromMemberChanges } = require('@/lib/utils/sessionEvents') as {  
   buildNpcEventsFromMemberChanges: jest.Mock;
 };
 
-const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as { // eslint-disable-line @typescript-eslint/no-require-imports
+const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {  
   useCampaignContext: jest.Mock;
 };
 
@@ -117,7 +118,6 @@ async function renderSessions(logs: object[], parties: typeof PARTY_ALICE_BOB[])
     refresh: jest.fn(),
   });
 
-  const { default: SessionsPage } = await import('@/app/campaigns/[id]/sessions/page');
   await act(async () => { root.render(React.createElement(SessionsPage)); });
 }
 

--- a/tests/integration/sessions/sessionLogs.test.tsx
+++ b/tests/integration/sessions/sessionLogs.test.tsx
@@ -42,11 +42,11 @@ jest.mock('@/lib/hooks/useCampaignContext', () => ({
   useCampaignContext: jest.fn(),
 }));
 
-const { buildNpcEventsFromMemberChanges } = require('@/lib/utils/sessionEvents') as {  
+const { buildNpcEventsFromMemberChanges } = require('@/lib/utils/sessionEvents') as {
   buildNpcEventsFromMemberChanges: jest.Mock;
 };
 
-const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {  
+const { useCampaignContext } = require('@/lib/hooks/useCampaignContext') as {
   useCampaignContext: jest.Mock;
 };
 
@@ -81,14 +81,29 @@ let container: HTMLDivElement;
 let root: Root;
 
 function makeContext(parties: typeof PARTY_ALICE_BOB[]) {
-  const allMembers = parties.flatMap(p => p.members);
   return {
     campaign: { id: 'camp-1', userId: 'u1', name: 'Test Campaign', moduleName: 'TCM', chapters: [], active: true, createdAt: new Date(), updatedAt: new Date() },
     chapter: null,
     parties,
-    allMembers,
+    allMembers: parties.flatMap(p => p.members),
     characters: [],
   };
+}
+
+function makeFetchForLogs(logs: object[]) {
+  return jest.fn(async (url: RequestInfo | URL) => {
+    const ok = true;
+    const json = String(url).includes('/sessions')
+      ? async () => logs
+      : async () => [];
+    return { ok, json } as unknown as Response;
+  }) as typeof fetch;
+}
+
+async function clickButton(el: HTMLElement, text: string): Promise<void> {
+  const btn = Array.from(el.querySelectorAll<HTMLButtonElement>('button'))
+    .find(b => b.textContent?.includes(text));
+  await act(async () => { btn?.click(); });
 }
 
 beforeEach(() => {
@@ -105,29 +120,15 @@ afterEach(() => {
 });
 
 async function renderSessions(logs: object[], parties: typeof PARTY_ALICE_BOB[]) {
-  global.fetch = jest.fn(async (url: RequestInfo | URL) => {
-    const s = String(url);
-    if (s.includes('/sessions')) return { ok: true, json: async () => logs } as unknown as Response;
-    return { ok: true, json: async () => [] } as unknown as Response;
-  }) as typeof fetch;
-
-  useCampaignContext.mockReturnValue({
-    context: makeContext(parties),
-    loading: false,
-    error: null,
-    refresh: jest.fn(),
-  });
-
+  global.fetch = makeFetchForLogs(logs);
+  useCampaignContext.mockReturnValue({ context: makeContext(parties), loading: false, error: null, refresh: jest.fn() });
   await act(async () => { root.render(React.createElement(SessionsPage)); });
 }
 
 describe('Session Logs — D1 regression tests (before refactor)', () => {
   test('D1-1: single party linked to campaign → NPC events built from that party members', async () => {
     await renderSessions([], [PARTY_ALICE_BOB]);
-
-    const newSessionBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('New Session'));
-    await act(async () => { newSessionBtn?.click(); });
+    await clickButton(container, 'New Session');
 
     expect(buildNpcEventsFromMemberChanges).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -146,10 +147,7 @@ describe('Session Logs — D1 regression tests (before refactor)', () => {
 
   test('D1-3: opening editor for new session shows the form', async () => {
     await renderSessions([], [PARTY_ALICE_BOB]);
-
-    const newSessionBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('New Session'));
-    await act(async () => { newSessionBtn?.click(); });
+    await clickButton(container, 'New Session');
 
     expect(container.textContent).toContain('Session #');
     expect(container.textContent).toContain('Date Played');
@@ -157,11 +155,7 @@ describe('Session Logs — D1 regression tests (before refactor)', () => {
 
   test('D1-4: no party linked to campaign → "No linked party found" message shown', async () => {
     await renderSessions([], []);
-
-    const newSessionBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('New Session'));
-    await act(async () => { newSessionBtn?.click(); });
-
+    await clickButton(container, 'New Session');
     expect(container.textContent).toContain('No linked party found');
   });
 });
@@ -169,13 +163,8 @@ describe('Session Logs — D1 regression tests (before refactor)', () => {
 describe('Session Logs — D2 multi-party test (fails until D3 refactor)', () => {
   test('D2-1: two parties linked to same campaign → NPC events include members from both parties', async () => {
     await renderSessions([], [PARTY_ALICE_BOB, PARTY_CAROL]);
+    await clickButton(container, 'New Session');
 
-    const newSessionBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent?.includes('New Session'));
-    await act(async () => { newSessionBtn?.click(); });
-
-    // After refactor, buildNpcEventsFromMemberChanges should be called with ALL 3 members
-    // (Alice, Bob from Party A + Carol from Party B)
     expect(buildNpcEventsFromMemberChanges).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ characterId: 'c-1' }),

--- a/tests/unit/api/auth/logout.test.ts
+++ b/tests/unit/api/auth/logout.test.ts
@@ -1,13 +1,11 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/auth/logout/route";
-import { verifyAuth, clearAuthCookie } from "@/lib/middleware";
+import { clearAuthCookie } from "@/lib/middleware";
 
 jest.mock("@/lib/middleware", () => ({
-  verifyAuth: jest.fn(),
   clearAuthCookie: jest.fn(),
 }));
 
-const mockedVerifyAuth = jest.mocked(verifyAuth);
 const mockedClearAuthCookie = jest.mocked(clearAuthCookie);
 
 function makeRequest(cookie?: string): NextRequest {
@@ -22,33 +20,23 @@ describe("POST /api/auth/logout", () => {
     jest.clearAllMocks();
   });
 
-  it("returns 401 when no auth token is present", async () => {
-    mockedVerifyAuth.mockReturnValue(null);
-
+  it("returns 200 and clears cookie even when no auth token is present (idempotent)", async () => {
     const response = await POST(makeRequest());
 
-    expect(response.status).toBe(401);
-    const body = await response.json();
-    expect(body.error).toBeDefined();
-    expect(mockedClearAuthCookie).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mockedClearAuthCookie).toHaveBeenCalledTimes(1);
   });
 
   it("returns 200 and clears cookie when auth token is valid", async () => {
-    mockedVerifyAuth.mockReturnValue({
-      userId: "user-123",
-      email: "user@example.com",
-      tokenVersion: 0,
-    });
-
     const response = await POST(makeRequest("auth-token=valid.jwt.token"));
 
     expect(response.status).toBe(200);
     expect(mockedClearAuthCookie).toHaveBeenCalledTimes(1);
   });
 
-  it("returns 500 when verifyAuth throws unexpectedly", async () => {
-    mockedVerifyAuth.mockImplementation(() => {
-      throw new Error("Unexpected auth error");
+  it("returns 500 when clearAuthCookie throws unexpectedly", async () => {
+    mockedClearAuthCookie.mockImplementation(() => {
+      throw new Error("Unexpected cookie error");
     });
 
     const response = await POST(makeRequest("auth-token=valid.jwt.token"));

--- a/tests/unit/components/SessionsPage.test.tsx
+++ b/tests/unit/components/SessionsPage.test.tsx
@@ -38,6 +38,15 @@ jest.mock('@/lib/utils/sessionEvents', () => ({
   buildNpcEventsFromMemberChanges: jest.fn(() => []),
 }));
 
+jest.mock('@/lib/hooks/useCampaignContext', () => ({
+  useCampaignContext: jest.fn(() => ({
+    context: null,
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+  })),
+}));
+
 const MOCK_LOG = {
   id: 'log-1',
   userId: 'u1',
@@ -117,15 +126,17 @@ describe('SessionsPage — session log display', () => {
   });
 
   test('shows no-linked-party notice when no party found', async () => {
-    await renderWithData([], []);
+    // useCampaignContext mock returns no parties by default (context: null)
+    await renderWithData([]);
     const btn = Array.from(ctx.container.querySelectorAll('button'))
       .find(b => b.textContent?.includes('New Session'));
     await act(async () => { btn?.click(); });
     expect(ctx.container.textContent).toContain('No linked party found');
   });
 
-  test('fetches sessions and parties on load', async () => {
+  test('fetches sessions on load', async () => {
     await renderWithData([MOCK_LOG]);
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    // useCampaignContext is mocked, so only the sessions fetch is real
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/hooks/useCampaignContext.test.ts
+++ b/tests/unit/hooks/useCampaignContext.test.ts
@@ -6,7 +6,7 @@
 import React from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { useCampaignContext } from '@/lib/hooks/useCampaignContext';
 import { CampaignContext } from '@/lib/types';
 
@@ -14,7 +14,7 @@ jest.mock('@/lib/utils/campaignContext', () => ({
   fetchCampaignContext: jest.fn(),
 }));
 
-const { fetchCampaignContext } = require('@/lib/utils/campaignContext') as { fetchCampaignContext: any }; // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+const { fetchCampaignContext } = require('@/lib/utils/campaignContext') as { fetchCampaignContext: any };  
 
 const makeContext = (): CampaignContext => ({
   campaign: {

--- a/tests/unit/hooks/useCampaignContext.test.ts
+++ b/tests/unit/hooks/useCampaignContext.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { useCampaignContext } from '@/lib/hooks/useCampaignContext';
+import { CampaignContext } from '@/lib/types';
+
+jest.mock('@/lib/utils/campaignContext', () => ({
+  fetchCampaignContext: jest.fn(),
+}));
+
+const { fetchCampaignContext } = require('@/lib/utils/campaignContext') as { fetchCampaignContext: any }; // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+
+const makeContext = (): CampaignContext => ({
+  campaign: {
+    id: 'camp-1', userId: 'u1', name: 'CoS', moduleName: 'CoS',
+    chapters: [], active: true, createdAt: new Date(), updatedAt: new Date(),
+  },
+  chapter: null,
+  parties: [],
+  allMembers: [],
+  characters: [],
+});
+
+type HookResult = ReturnType<typeof useCampaignContext>;
+
+function renderHook(): { result: { current: HookResult }; unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const resultRef: { current: HookResult } = { current: undefined as unknown as HookResult };
+
+  function Probe() {
+    const hookResult = useCampaignContext('camp-1');
+    React.useEffect(() => { resultRef.current = hookResult; }, [hookResult]);
+    return null;
+  }
+
+  act(() => { root.render(React.createElement(Probe)); });
+
+  return {
+    result: resultRef,
+    unmount: () => { act(() => { root.unmount(); }); container.remove(); },
+  };
+}
+
+describe('useCampaignContext', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('A4-1: loading is true on mount until fetch resolves', async () => {
+    let resolve!: (ctx: CampaignContext) => void;
+    fetchCampaignContext.mockReturnValue(new Promise<CampaignContext>(r => { resolve = r; }));
+
+    const { result, unmount } = renderHook();
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => { resolve(makeContext()); });
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
+  test('A4-2: after successful fetch, loading false and context non-null', async () => {
+    fetchCampaignContext.mockResolvedValue(makeContext());
+
+    const { result, unmount } = renderHook();
+    await act(async () => {});
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.context).not.toBeNull();
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  test('A4-3: on fetch error, error is non-null and context is null', async () => {
+    fetchCampaignContext.mockRejectedValue(new Error('Network error'));
+
+    const { result, unmount } = renderHook();
+    await act(async () => {});
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.context).toBeNull();
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
+  test('A4-4: calling refresh() re-triggers fetchCampaignContext', async () => {
+    fetchCampaignContext.mockResolvedValue(makeContext());
+
+    const { result, unmount } = renderHook();
+    await act(async () => {});
+
+    expect(fetchCampaignContext).toHaveBeenCalledTimes(1);
+
+    await act(async () => { result.current.refresh(); });
+    await act(async () => {});
+
+    expect(fetchCampaignContext).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+});

--- a/tests/unit/prompts/templates.test.ts
+++ b/tests/unit/prompts/templates.test.ts
@@ -50,6 +50,14 @@ const makeContext = (overrides: Partial<CampaignContext> = {}): CampaignContext 
 const nullChapterCtx = makeContext({ chapter: null });
 const emptyPartyCtx = makeContext({ characters: [], allMembers: [] });
 
+const TEMPLATE_CASES: Array<[string, typeof npcTemplate, Record<string, string>]> = [
+  ['npc', npcTemplate, { role: 'innkeeper', location: 'Barovia', requirements: '' }],
+  ['location', locationTemplate, { type: 'tavern', atmosphere: 'cozy', details: '' }],
+  ['shop', shopTemplate, { shopType: 'blacksmith', setting: 'busy district', inventory: '' }],
+  ['magic-item', magicItemTemplate, { itemType: 'sword', rarity: 'rare', theme: '' }],
+  ['room', roomTemplate, { roomName: 'Throne Room', purpose: 'seat of power', features: '' }],
+];
+
 describe('buildSystemPrompt', () => {
   test('B1-10: full context contains campaign name, module, chapter, character list', () => {
     const result = buildSystemPrompt(makeContext());
@@ -92,17 +100,6 @@ describe('NPC template', () => {
     expect(result.userMessage).toContain('Barovia');
   });
 
-  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
-    const result = npcTemplate.build({ role: 'innkeeper', location: 'Barovia', requirements: '' }, makeContext());
-    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
-  });
-
-  test('B1-7: null chapter — no "undefined" or "null" in output', () => {
-    const result = npcTemplate.build({ role: 'guard', location: 'Village', requirements: '' }, nullChapterCtx);
-    expect(result.fullText).not.toContain('undefined');
-    expect(result.fullText).not.toContain('null');
-  });
-
   test('B1-8: empty party — no runtime error, notes no party members', () => {
     expect(() => npcTemplate.build({ role: 'merchant', location: 'Market', requirements: '' }, emptyPartyCtx)).not.toThrow();
   });
@@ -120,17 +117,6 @@ describe('Location template', () => {
     expect(result.userMessage).toContain('cozy');
   });
 
-  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
-    const result = locationTemplate.build({ type: 'tavern', atmosphere: 'cozy', details: '' }, makeContext());
-    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
-  });
-
-  test('B1-7: null chapter — no "undefined" or "null"', () => {
-    const result = locationTemplate.build({ type: 'dungeon', atmosphere: 'dark', details: '' }, nullChapterCtx);
-    expect(result.fullText).not.toContain('undefined');
-    expect(result.fullText).not.toContain('null');
-  });
-
   test('B1-8: empty party — no error', () => {
     expect(() => locationTemplate.build({ type: 'forest', atmosphere: 'eerie', details: '' }, emptyPartyCtx)).not.toThrow();
   });
@@ -143,17 +129,6 @@ describe('Shop template', () => {
     expect(result.userMessage).toContain('blacksmith');
     expect(result.userMessage).toContain('busy district');
   });
-
-  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
-    const result = shopTemplate.build({ shopType: 'apothecary', setting: 'market', inventory: '' }, makeContext());
-    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
-  });
-
-  test('B1-7: null chapter — no "undefined" or "null"', () => {
-    const result = shopTemplate.build({ shopType: 'armorer', setting: 'town', inventory: '' }, nullChapterCtx);
-    expect(result.fullText).not.toContain('undefined');
-    expect(result.fullText).not.toContain('null');
-  });
 });
 
 describe('Magic Item template', () => {
@@ -162,17 +137,6 @@ describe('Magic Item template', () => {
     expect(result.systemPrompt).toContain('Curse of Strahd');
     expect(result.userMessage).toContain('sword');
     expect(result.userMessage).toContain('rare');
-  });
-
-  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
-    const result = magicItemTemplate.build({ itemType: 'amulet', rarity: 'uncommon', theme: '' }, makeContext());
-    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
-  });
-
-  test('B1-7: null chapter — no "undefined" or "null"', () => {
-    const result = magicItemTemplate.build({ itemType: 'ring', rarity: 'common', theme: '' }, nullChapterCtx);
-    expect(result.fullText).not.toContain('undefined');
-    expect(result.fullText).not.toContain('null');
   });
 });
 
@@ -184,18 +148,24 @@ describe('Room Description template', () => {
     expect(result.userMessage).toContain('seat of power');
   });
 
-  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
-    const result = roomTemplate.build({ roomName: 'Dungeon Cell', purpose: 'prison', features: '' }, makeContext());
-    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
-  });
-
-  test('B1-7: null chapter — no "undefined" or "null"', () => {
-    const result = roomTemplate.build({ roomName: 'Library', purpose: 'study', features: '' }, nullChapterCtx);
-    expect(result.fullText).not.toContain('undefined');
-    expect(result.fullText).not.toContain('null');
-  });
-
   test('B1-8: empty party — no error', () => {
     expect(() => roomTemplate.build({ roomName: 'Crypt', purpose: 'burial', features: '' }, emptyPartyCtx)).not.toThrow();
   });
 });
+
+test.each(TEMPLATE_CASES)(
+  'B1-6: %s template — fullText equals systemPrompt + \\n\\n + userMessage',
+  (_, template, fields) => {
+    const result = template.build(fields, makeContext());
+    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
+  },
+);
+
+test.each(TEMPLATE_CASES)(
+  'B1-7: %s template — null chapter produces no "undefined" or "null" in output',
+  (_, template, fields) => {
+    const result = template.build(fields, nullChapterCtx);
+    expect(result.fullText).not.toContain('undefined');
+    expect(result.fullText).not.toContain('null');
+  },
+);

--- a/tests/unit/prompts/templates.test.ts
+++ b/tests/unit/prompts/templates.test.ts
@@ -1,0 +1,201 @@
+import { describe, test, expect } from '@jest/globals';
+import { CampaignContext } from '@/lib/types';
+import {
+  TEMPLATES,
+  buildSystemPrompt,
+  npcTemplate,
+  locationTemplate,
+  shopTemplate,
+  magicItemTemplate,
+  roomTemplate,
+} from '@/lib/prompts/templates';
+
+const makeContext = (overrides: Partial<CampaignContext> = {}): CampaignContext => ({
+  campaign: {
+    id: 'camp-1',
+    userId: 'u1',
+    name: 'Curse of Strahd',
+    moduleName: 'CoS',
+    chapters: [{ id: 'ch-2', title: 'Act II', order: 2 }],
+    currentChapterId: 'ch-2',
+    active: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  chapter: { id: 'ch-2', title: 'Act II', order: 2 },
+  parties: [{ id: 'p-1', userId: 'u1', name: 'The Party', members: [], createdAt: new Date(), updatedAt: new Date() }],
+  allMembers: [
+    { characterId: 'c-1', addedAt: new Date() },
+    { characterId: 'c-2', addedAt: new Date() },
+  ],
+  characters: [
+    {
+      id: 'c-1', userId: 'u1', name: 'Alice',
+      classes: [{ class: 'Fighter', level: 3 }],
+      abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+      ac: 15, hp: 30, maxHp: 30,
+      createdAt: new Date(), updatedAt: new Date(),
+    },
+    {
+      id: 'c-2', userId: 'u1', name: 'Bob',
+      classes: [{ class: 'Wizard', level: 3 }],
+      abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+      ac: 12, hp: 20, maxHp: 20,
+      createdAt: new Date(), updatedAt: new Date(),
+    },
+  ],
+  ...overrides,
+});
+
+const nullChapterCtx = makeContext({ chapter: null });
+const emptyPartyCtx = makeContext({ characters: [], allMembers: [] });
+
+describe('buildSystemPrompt', () => {
+  test('B1-10: full context contains campaign name, module, chapter, character list', () => {
+    const result = buildSystemPrompt(makeContext());
+    expect(result).toContain('Curse of Strahd');
+    expect(result).toContain('CoS');
+    expect(result).toContain('Act II');
+    expect(result).toContain('Alice');
+    expect(result).toContain('Bob');
+  });
+
+  test('B1-11: null chapter and empty characters — no crash, contains campaign name', () => {
+    const result = buildSystemPrompt(makeContext({ chapter: null, characters: [] }));
+    expect(result).toContain('Curse of Strahd');
+    expect(result).toContain('CoS');
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('TEMPLATES array', () => {
+  test('B1-12: exactly 5 entries with distinct ids', () => {
+    expect(TEMPLATES).toHaveLength(5);
+    const ids = TEMPLATES.map(t => t.id);
+    expect(new Set(ids).size).toBe(5);
+  });
+
+  test('B1-13: TEMPLATES ids drive tab rendering (no structural changes needed for new template)', () => {
+    const ids = TEMPLATES.map(t => t.id);
+    expect(ids).toEqual(expect.arrayContaining(['npc', 'location', 'shop', 'magic-item', 'room']));
+  });
+});
+
+describe('NPC template', () => {
+  test('B1-1: full context — systemPrompt has campaign/chapter/characters, userMessage has role/location', () => {
+    const result = npcTemplate.build({ role: 'innkeeper', location: 'Barovia', requirements: '' }, makeContext());
+    expect(result.systemPrompt).toContain('Curse of Strahd');
+    expect(result.systemPrompt).toContain('Act II');
+    expect(result.systemPrompt).toContain('Alice');
+    expect(result.systemPrompt).toContain('Bob');
+    expect(result.userMessage).toContain('innkeeper');
+    expect(result.userMessage).toContain('Barovia');
+  });
+
+  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
+    const result = npcTemplate.build({ role: 'innkeeper', location: 'Barovia', requirements: '' }, makeContext());
+    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
+  });
+
+  test('B1-7: null chapter — no "undefined" or "null" in output', () => {
+    const result = npcTemplate.build({ role: 'guard', location: 'Village', requirements: '' }, nullChapterCtx);
+    expect(result.fullText).not.toContain('undefined');
+    expect(result.fullText).not.toContain('null');
+  });
+
+  test('B1-8: empty party — no runtime error, notes no party members', () => {
+    expect(() => npcTemplate.build({ role: 'merchant', location: 'Market', requirements: '' }, emptyPartyCtx)).not.toThrow();
+  });
+
+  test('B1-9: optional field absent — no runtime error', () => {
+    expect(() => npcTemplate.build({ role: 'guard', location: '' }, makeContext())).not.toThrow();
+  });
+});
+
+describe('Location template', () => {
+  test('B1-2: full context — systemPrompt has campaign context, userMessage has type/atmosphere', () => {
+    const result = locationTemplate.build({ type: 'tavern', atmosphere: 'cozy', details: '' }, makeContext());
+    expect(result.systemPrompt).toContain('Curse of Strahd');
+    expect(result.userMessage).toContain('tavern');
+    expect(result.userMessage).toContain('cozy');
+  });
+
+  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
+    const result = locationTemplate.build({ type: 'tavern', atmosphere: 'cozy', details: '' }, makeContext());
+    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
+  });
+
+  test('B1-7: null chapter — no "undefined" or "null"', () => {
+    const result = locationTemplate.build({ type: 'dungeon', atmosphere: 'dark', details: '' }, nullChapterCtx);
+    expect(result.fullText).not.toContain('undefined');
+    expect(result.fullText).not.toContain('null');
+  });
+
+  test('B1-8: empty party — no error', () => {
+    expect(() => locationTemplate.build({ type: 'forest', atmosphere: 'eerie', details: '' }, emptyPartyCtx)).not.toThrow();
+  });
+});
+
+describe('Shop template', () => {
+  test('B1-3: full context — systemPrompt has campaign context, userMessage has shop type/setting', () => {
+    const result = shopTemplate.build({ shopType: 'blacksmith', setting: 'busy district', inventory: '' }, makeContext());
+    expect(result.systemPrompt).toContain('Curse of Strahd');
+    expect(result.userMessage).toContain('blacksmith');
+    expect(result.userMessage).toContain('busy district');
+  });
+
+  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
+    const result = shopTemplate.build({ shopType: 'apothecary', setting: 'market', inventory: '' }, makeContext());
+    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
+  });
+
+  test('B1-7: null chapter — no "undefined" or "null"', () => {
+    const result = shopTemplate.build({ shopType: 'armorer', setting: 'town', inventory: '' }, nullChapterCtx);
+    expect(result.fullText).not.toContain('undefined');
+    expect(result.fullText).not.toContain('null');
+  });
+});
+
+describe('Magic Item template', () => {
+  test('B1-4: full context — systemPrompt has campaign context, userMessage has item type/rarity', () => {
+    const result = magicItemTemplate.build({ itemType: 'sword', rarity: 'rare', theme: '' }, makeContext());
+    expect(result.systemPrompt).toContain('Curse of Strahd');
+    expect(result.userMessage).toContain('sword');
+    expect(result.userMessage).toContain('rare');
+  });
+
+  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
+    const result = magicItemTemplate.build({ itemType: 'amulet', rarity: 'uncommon', theme: '' }, makeContext());
+    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
+  });
+
+  test('B1-7: null chapter — no "undefined" or "null"', () => {
+    const result = magicItemTemplate.build({ itemType: 'ring', rarity: 'common', theme: '' }, nullChapterCtx);
+    expect(result.fullText).not.toContain('undefined');
+    expect(result.fullText).not.toContain('null');
+  });
+});
+
+describe('Room Description template', () => {
+  test('B1-5: full context — systemPrompt has campaign context, userMessage has room name/purpose', () => {
+    const result = roomTemplate.build({ roomName: 'Throne Room', purpose: 'seat of power', features: '' }, makeContext());
+    expect(result.systemPrompt).toContain('Curse of Strahd');
+    expect(result.userMessage).toContain('Throne Room');
+    expect(result.userMessage).toContain('seat of power');
+  });
+
+  test('B1-6: fullText === systemPrompt + "\\n\\n" + userMessage', () => {
+    const result = roomTemplate.build({ roomName: 'Dungeon Cell', purpose: 'prison', features: '' }, makeContext());
+    expect(result.fullText).toBe(result.systemPrompt + '\n\n' + result.userMessage);
+  });
+
+  test('B1-7: null chapter — no "undefined" or "null"', () => {
+    const result = roomTemplate.build({ roomName: 'Library', purpose: 'study', features: '' }, nullChapterCtx);
+    expect(result.fullText).not.toContain('undefined');
+    expect(result.fullText).not.toContain('null');
+  });
+
+  test('B1-8: empty party — no error', () => {
+    expect(() => roomTemplate.build({ roomName: 'Crypt', purpose: 'burial', features: '' }, emptyPartyCtx)).not.toThrow();
+  });
+});

--- a/tests/unit/utils/campaignContext.test.ts
+++ b/tests/unit/utils/campaignContext.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { CampaignContext } from '@/lib/types';
+
+const makeCampaign = (overrides = {}) => ({
+  id: 'camp-1',
+  userId: 'u1',
+  name: 'Curse of Strahd',
+  moduleName: 'CoS',
+  chapters: [
+    { id: 'ch-1', title: 'Act I', order: 1 },
+    { id: 'ch-2', title: 'The Sunken Temple', order: 2 },
+  ],
+  currentChapterId: 'ch-2',
+  active: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeParty = (id: string, campaignId: string, members: object[]) => ({
+  id,
+  userId: 'u1',
+  name: `Party ${id}`,
+  members,
+  campaignId,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const makeCharacter = (id: string, name: string, overrides = {}) => ({
+  id,
+  userId: 'u1',
+  name,
+  classes: [{ class: 'Fighter', level: 3 }],
+  abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+  ac: 15,
+  hp: 30,
+  maxHp: 30,
+  speed: '30 ft.',
+  challengeRating: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeMember = (characterId: string) => ({ characterId, addedAt: new Date() });
+
+function makeFetch(campaign: object, parties: object[], characters: object[]) {
+  return jest.fn(async (url: RequestInfo | URL) => {
+    const s = String(url);
+    if (s.includes('/api/campaigns/camp-1') && !s.includes('parties')) {
+      return { ok: true, json: async () => campaign } as unknown as Response;
+    }
+    if (s.includes('/api/parties')) {
+      return { ok: true, json: async () => parties } as unknown as Response;
+    }
+    if (s.includes('/api/characters')) {
+      return { ok: true, json: async () => characters } as unknown as Response;
+    }
+    return { ok: false, json: async () => ({}) } as unknown as Response;
+  }) as typeof fetch;
+}
+
+describe('fetchCampaignContext', () => {
+  let fetchCampaignContext: (campaignId: string, fetchImpl?: typeof fetch) => Promise<CampaignContext>;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/lib/utils/campaignContext');
+    fetchCampaignContext = mod.fetchCampaignContext;
+  });
+
+  test('A2-1: single party linked to campaign', async () => {
+    const campaign = makeCampaign();
+    const members = [makeMember('c-1'), makeMember('c-2')];
+    const party = makeParty('p-1', 'camp-1', members);
+    const characters = [makeCharacter('c-1', 'Alice'), makeCharacter('c-2', 'Bob')];
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], characters));
+
+    expect(ctx.parties).toHaveLength(1);
+    expect(ctx.allMembers).toEqual(members);
+  });
+
+  test('A2-2: three parties with 2, 3, 4 members merged', async () => {
+    const campaign = makeCampaign();
+    const p1 = makeParty('p-1', 'camp-1', [makeMember('c-1'), makeMember('c-2')]);
+    const p2 = makeParty('p-2', 'camp-1', [makeMember('c-3'), makeMember('c-4'), makeMember('c-5')]);
+    const p3 = makeParty('p-3', 'camp-1', [makeMember('c-6'), makeMember('c-7'), makeMember('c-8'), makeMember('c-9')]);
+    const otherParty = makeParty('p-4', 'camp-other', [makeMember('c-10')]);
+    const characters = ['c-1','c-2','c-3','c-4','c-5','c-6','c-7','c-8','c-9'].map(id => makeCharacter(id, `Char ${id}`));
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [p1, p2, p3, otherParty], characters));
+
+    expect(ctx.parties).toHaveLength(3);
+    expect(ctx.allMembers).toHaveLength(9);
+  });
+
+  test('A2-3: no parties linked to campaign', async () => {
+    const campaign = makeCampaign();
+    const unrelated = makeParty('p-1', 'camp-other', [makeMember('c-1')]);
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [unrelated], []));
+
+    expect(ctx.parties).toEqual([]);
+    expect(ctx.allMembers).toEqual([]);
+  });
+
+  test('A2-4: campaign with currentChapterId resolves chapter', async () => {
+    const campaign = makeCampaign({ currentChapterId: 'ch-2' });
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [], []));
+
+    expect(ctx.chapter?.title).toBe('The Sunken Temple');
+  });
+
+  test('A2-5: campaign with no currentChapterId -> chapter is null', async () => {
+    const campaign = makeCampaign({ currentChapterId: undefined });
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [], []));
+
+    expect(ctx.chapter).toBeNull();
+  });
+
+  test('A2-6: all members have active characters -> all resolved in context.characters', async () => {
+    const campaign = makeCampaign();
+    const members = [makeMember('c-1'), makeMember('c-2')];
+    const party = makeParty('p-1', 'camp-1', members);
+    const characters = [makeCharacter('c-1', 'Alice'), makeCharacter('c-2', 'Bob'), makeCharacter('c-3', 'Unrelated')];
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], characters));
+
+    expect(ctx.characters).toHaveLength(2);
+    expect(ctx.characters.map(c => c.id)).toEqual(expect.arrayContaining(['c-1', 'c-2']));
+  });
+
+  test('A2-7: soft-deleted character excluded from context.characters', async () => {
+    const campaign = makeCampaign();
+    const members = [makeMember('c-1'), makeMember('c-2')];
+    const party = makeParty('p-1', 'camp-1', members);
+    const characters = [
+      makeCharacter('c-1', 'Alice'),
+      makeCharacter('c-2', 'Bob', { deletedAt: new Date() }),
+    ];
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], characters));
+
+    expect(ctx.characters).toHaveLength(1);
+    expect(ctx.characters[0].id).toBe('c-1');
+  });
+
+  test('A2-8: all three fetches initiated in parallel via Promise.all', async () => {
+    const campaign = makeCampaign();
+    const callOrder: string[] = [];
+
+    const parallelFetch = jest.fn(async (url: RequestInfo | URL) => {
+      const s = String(url);
+      if (s.includes('/api/campaigns')) callOrder.push('campaign');
+      else if (s.includes('/api/parties')) callOrder.push('parties');
+      else if (s.includes('/api/characters')) callOrder.push('characters');
+      await Promise.resolve();
+      return { ok: true, json: async () => s.includes('/api/campaigns') ? campaign : [] } as unknown as Response;
+    }) as typeof fetch;
+
+    await fetchCampaignContext('camp-1', parallelFetch);
+
+    expect(parallelFetch).toHaveBeenCalledTimes(3);
+    // All three should have been registered before any awaited result consumed
+    expect(callOrder).toHaveLength(3);
+  });
+
+  test('A2-9: non-OK response rejects with error', async () => {
+    const errorFetch = jest.fn(async (url: RequestInfo | URL) => {
+      const s = String(url);
+      if (s.includes('/api/parties')) return { ok: false, status: 500 } as unknown as Response;
+      const campaign = makeCampaign();
+      return { ok: true, json: async () => s.includes('/api/campaigns') ? campaign : [] } as unknown as Response;
+    }) as typeof fetch;
+
+    await expect(fetchCampaignContext('camp-1', errorFetch)).rejects.toThrow();
+  });
+});

--- a/tests/unit/utils/campaignContext.test.ts
+++ b/tests/unit/utils/campaignContext.test.ts
@@ -165,22 +165,44 @@ describe('fetchCampaignContext', () => {
 
   test('A2-8: all three fetches initiated in parallel via Promise.all', async () => {
     const campaign = makeCampaign();
-    const callOrder: string[] = [];
+    const started: string[] = [];
+    const resolvers: Record<string, (r: Response) => void> = {};
 
-    const parallelFetch = jest.fn(async (url: RequestInfo | URL) => {
+    const parallelFetch = jest.fn((url: RequestInfo | URL) => {
       const s = String(url);
-      if (s.includes('/api/campaigns')) callOrder.push('campaign');
-      else if (s.includes('/api/parties')) callOrder.push('parties');
-      else if (s.includes('/api/characters')) callOrder.push('characters');
-      await Promise.resolve();
-      return { ok: true, json: async () => s.includes('/api/campaigns') ? campaign : [] } as unknown as Response;
+      return new Promise<Response>(resolve => {
+        if (s.includes('/api/campaigns/')) {
+          started.push('campaign');
+          resolvers.campaign = resolve;
+        } else if (s.includes('/api/parties')) {
+          started.push('parties');
+          resolvers.parties = resolve;
+        } else {
+          started.push('characters');
+          resolvers.characters = resolve;
+        }
+      });
     }) as typeof fetch;
 
-    await fetchCampaignContext('camp-1', parallelFetch);
+    const fetchPromise = fetchCampaignContext('camp-1', parallelFetch);
 
+    // Yield to the microtask queue so Promise.all registers all three fetches
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // All three must have been started before any resolved
+    expect(started).toContain('campaign');
+    expect(started).toContain('parties');
+    expect(started).toContain('characters');
+
+    // Now resolve all three
+    const ok = (data: unknown) => ({ ok: true, json: async () => data } as unknown as Response);
+    resolvers.campaign(ok(campaign));
+    resolvers.parties(ok([]));
+    resolvers.characters(ok([]));
+
+    await fetchPromise;
     expect(parallelFetch).toHaveBeenCalledTimes(3);
-    // All three should have been registered before any awaited result consumed
-    expect(callOrder).toHaveLength(3);
   });
 
   test('A2-9: non-OK response rejects with error', async () => {

--- a/tests/unit/utils/campaignContext.test.ts
+++ b/tests/unit/utils/campaignContext.test.ts
@@ -149,6 +149,20 @@ describe('fetchCampaignContext', () => {
     expect(ctx.characters[0].id).toBe('c-1');
   });
 
+  test('A2-7b: departed member excluded from context.characters but kept in allMembers', async () => {
+    const campaign = makeCampaign();
+    const departed = { characterId: 'c-2', addedAt: new Date(), leftAt: new Date() };
+    const members = [makeMember('c-1'), departed];
+    const party = makeParty('p-1', 'camp-1', members);
+    const characters = [makeCharacter('c-1', 'Alice'), makeCharacter('c-2', 'Bob')];
+
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], characters));
+
+    expect(ctx.allMembers).toHaveLength(2);
+    expect(ctx.characters).toHaveLength(1);
+    expect(ctx.characters[0].id).toBe('c-1');
+  });
+
   test('A2-8: all three fetches initiated in parallel via Promise.all', async () => {
     const campaign = makeCampaign();
     const callOrder: string[] = [];


### PR DESCRIPTION
## Summary

Adds a Prompt Builder page as a campaign child route, a shared `fetchCampaignContext` helper + `useCampaignContext` hook, and five prompt templates (NPC, Location, Shop, Magic Item, Room Description). Also refactors the Sessions page to use the shared context helper, fixing multi-party bug #212.

Closes #184
Fixes #212

## What Changed

### New: Shared Context Helper
- `lib/utils/campaignContext.ts` — `fetchCampaignContext(campaignId)` parallel-fetches campaign, parties, and characters; merges members from **all** linked parties (fixes #212); resolves `currentChapterId` → `CampaignChapter`; filters soft-deleted characters
- `lib/hooks/useCampaignContext.ts` — React hook wrapping the above with loading/error state and `refresh()` trigger
- `lib/types.ts` — new `CampaignContext` and `BuiltPrompt` interfaces

### New: Prompt Templates
- `lib/prompts/templates.ts` — `PromptField`, `PromptTemplate` interfaces; `buildSystemPrompt()` assembles campaign/chapter/party block; 5 named templates each with `fields[]` + `build(fields, context) → BuiltPrompt`; agentic-ready `{ systemPrompt, userMessage, fullText }` output shape

### New: Prompt Builder Page
- `app/campaigns/[id]/prompts/page.tsx` — template tabs, dynamic field form, Generate → read-only textarea, Copy to clipboard with "Copied!" feedback, Save to Library stub (disabled, references issue #185), loading/error/no-party states

### Changed: Campaigns List Page
- `app/campaigns/page.tsx` — adds "Prompt Builder" link alongside "Sessions" in each campaign card

### Refactored: Sessions Page (fixes #212)
- `app/campaigns/[id]/sessions/page.tsx` — replaces manual `Array.find()` party lookup with `useCampaignContext`; `buildNpcEventsFromMemberChanges` now receives `allMembers` merged from **all** linked parties

## Tests

40 new test cases across 6 new/updated test files:

| File | Tests | Coverage |
|------|-------|----------|
| `tests/unit/utils/campaignContext.test.ts` | 9 | multi-party merge, soft-delete filter, parallel fetch, chapter resolution, error rejection |
| `tests/unit/hooks/useCampaignContext.test.ts` | 4 | loading state, success, error, refresh |
| `tests/unit/prompts/templates.test.ts` | 23 | all 5 templates, buildSystemPrompt, edge cases |
| `tests/integration/prompts/promptBuilder.test.tsx` | 12 | C1-1 through C1-12: full page render, tabs, generate, copy, save stub, loading/error/no-party |
| `tests/integration/sessions/sessionLogs.test.tsx` | 5 | D1 regression (single-party) + D2 multi-party |
| `tests/unit/components/SessionsPage.test.tsx` | updated | adapted for hook-based architecture |

**Validation:** 1424 unit tests pass · 17 integration tests pass · TypeScript clean · build succeeds · 0 lint errors