### PR TITLE
feat: inject recent sessions into Prompt Builder context

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"4e4d57fc-d36c-4d53-a764-1df048122360","pid":18365,"procStart":"67535","acquiredAt":1779812775216}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"4e4d57fc-d36c-4d53-a764-1df048122360","pid":18365,"procStart":"67535","acquiredAt":1779812775216}

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ regression-test-output.txt
 .github\instructions\codacy.instructions.md
 
 .wolf/
+.claude/scheduled_tasks.lock

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -228,7 +228,7 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
     return (
       <div className="min-h-screen bg-gray-900 text-white">
         <div className="container mx-auto px-4 py-8">
-          <LoadingState label="Loading campaign context..." />
+          <LoadingState label="Loading campaign and session history..." />
         </div>
       </div>
     );

--- a/lib/prompts/templates.ts
+++ b/lib/prompts/templates.ts
@@ -22,7 +22,7 @@ function formatCharacter(c: Character): string {
 }
 
 function formatSessionEntry(session: SessionLog): string {
-  const date = new Date(session.datePlayed).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const date = new Date(session.datePlayed).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
   const title = session.title || 'Untitled Session';
   let suffix = '';
   if (session.milestone) {

--- a/lib/prompts/templates.ts
+++ b/lib/prompts/templates.ts
@@ -1,4 +1,4 @@
-import { BuiltPrompt, CampaignContext, Character, SavedContent, calculateTotalLevel } from '@/lib/types';
+import { BuiltPrompt, CampaignContext, Character, SavedContent, SessionLog, calculateTotalLevel } from '@/lib/types';
 
 export interface PromptField {
   key: string;
@@ -21,19 +21,33 @@ function formatCharacter(c: Character): string {
   return `${c.name} (Level ${level} ${classNames})`;
 }
 
+function formatSessionEntry(session: SessionLog): string {
+  const date = new Date(session.datePlayed).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const title = session.title || 'Untitled Session';
+  let suffix = '';
+  if (session.milestone) {
+    suffix = session.newLevel != null ? ` — party reached Level ${session.newLevel}.` : ' — milestone reached.';
+  }
+  return `- Session ${session.sessionNumber} (${date}): ${title}${suffix}`;
+}
+
 export function buildSystemPrompt(context: CampaignContext): string {
-  const { campaign, chapter, characters } = context;
+  const { campaign, chapter, characters, recentSessions } = context;
 
   const chapterLine = chapter ? `Current Chapter: ${chapter.title}` : '';
   const partySection = characters.length > 0
     ? `Party Members:\n${characters.map(c => `- ${formatCharacter(c)}`).join('\n')}`
     : 'Party Members: None currently linked.';
+  const sessionSection = recentSessions?.length
+    ? `Recent sessions:\n${recentSessions.map(formatSessionEntry).join('\n')}`
+    : '';
 
   return [
     `You are a creative assistant helping a Dungeon Master run a D&D 5e campaign.`,
     `Campaign: ${campaign.name} (${campaign.moduleName})`,
     chapterLine,
     partySection,
+    sessionSection,
   ].filter(Boolean).join('\n');
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -576,6 +576,7 @@ export interface CampaignContext {
   parties: Party[];
   allMembers: PartyMember[];
   characters: Character[];
+  recentSessions?: SessionLog[];
 }
 
 export interface BuiltPrompt {

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -50,7 +50,8 @@ export async function fetchCampaignContext(
   let recentSessions: SessionLog[] = [];
   try {
     if (sessionsRes?.ok) {
-      recentSessions = await sessionsRes.json() as SessionLog[];
+      const data = await sessionsRes.json();
+      recentSessions = Array.isArray(data) ? data as SessionLog[] : [];
     } else if (sessionsRes) {
       console.error('Sessions fetch failed with status:', sessionsRes.status);
     }

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -1,13 +1,17 @@
-import { Campaign, Character, CampaignContext, Party, PartyMember } from '@/lib/types';
+import { Campaign, Character, CampaignContext, Party, PartyMember, SessionLog } from '@/lib/types';
 
 export async function fetchCampaignContext(
   campaignId: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<CampaignContext> {
-  const [campaignRes, partiesRes, charactersRes] = await Promise.all([
+  const [campaignRes, partiesRes, charactersRes, sessionsRes] = await Promise.all([
     fetchImpl(`/api/campaigns/${campaignId}`),
     fetchImpl('/api/parties'),
     fetchImpl('/api/characters'),
+    fetchImpl(`/api/campaigns/${campaignId}/sessions?limit=3`).catch((e: unknown) => {
+      console.error('Sessions fetch error:', e);
+      return null;
+    }),
   ]);
 
   if (!campaignRes.ok) throw new Error('Failed to fetch campaign');
@@ -43,5 +47,16 @@ export async function fetchCampaignContext(
     c => memberIds.has(c.id) && !c.deletedAt,
   );
 
-  return { campaign, chapter, parties, allMembers, characters };
+  let recentSessions: SessionLog[] = [];
+  try {
+    if (sessionsRes?.ok) {
+      recentSessions = await sessionsRes.json() as SessionLog[];
+    } else if (sessionsRes) {
+      console.error('Sessions fetch failed with status:', sessionsRes.status);
+    }
+  } catch (e) {
+    console.error('Sessions response parse error:', e);
+  }
+
+  return { campaign, chapter, parties, allMembers, characters, recentSessions };
 }

--- a/openspec/changes/archive/2026-05-25-upgrade-nextjs-to-16-2-6/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-25-upgrade-nextjs-to-16-2-6/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-25

--- a/openspec/changes/prompt-builder-session-context/.openspec.yaml
+++ b/openspec/changes/prompt-builder-session-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-26

--- a/openspec/changes/prompt-builder-session-context/design.md
+++ b/openspec/changes/prompt-builder-session-context/design.md
@@ -1,0 +1,149 @@
+## Context
+
+- Relevant architecture: `fetchCampaignContext()` in `lib/utils/campaignContext.ts` is the single fetch entry point for all campaign-scoped page contexts. It feeds `useCampaignContext()` hook, which feeds the Prompt Builder page. All five prompt templates call `buildSystemPrompt(context: CampaignContext)` to produce the system prompt portion of every generated prompt.
+- Dependencies: Sessions API (`GET /api/campaigns/[id]/sessions?limit=N`) is fully implemented. `SessionLog` and `CampaignContext` types exist in `lib/types.ts`. No new infrastructure required.
+- Interfaces/contracts touched: `CampaignContext` (type), `fetchCampaignContext` (function signature unchanged, return value extended), `buildSystemPrompt` (function — output extended, signature unchanged).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Enrich every prompt template's system prompt with the last 3 session summaries when they exist
+- Keep the fetch blocking so the Prompt Builder shows a single loading state
+- Degrade gracefully: a failed sessions fetch yields an empty list, not an error
+- Reflect the additional fetch in the loading label
+
+### Non-Goals
+
+- Per-template opt-in/opt-out
+- User-configurable session count
+- Changes to sessions API, storage, or journal UI
+
+## Decisions
+
+### Decision 1: Extend `CampaignContext`, not template signatures
+
+- Chosen: Add `recentSessions?: SessionLog[]` to `CampaignContext` and inject context in `buildSystemPrompt()`. All template `build()` signatures remain `(fields, context)` unchanged.
+- Alternatives considered: Pass sessions as a third argument to each template's `build()` function; add a separate `buildSessionBlock()` utility called per-template.
+- Rationale: `CampaignContext` is already the single carrier of all campaign-scoped runtime data. Extending it keeps every template automatically enriched without per-template changes. All templates already delegate to `buildSystemPrompt(context)`.
+- Trade-offs: `CampaignContext` grows by one optional field. Any future consumer of `fetchCampaignContext` will receive session data even if unused — acceptable since the field is optional and the data is small.
+
+### Decision 2: Fetch sessions in main `Promise.all` (blocking)
+
+- Chosen: Add the sessions fetch to the existing `Promise.all` inside `fetchCampaignContext()`. The Prompt Builder loading spinner covers all four fetches at once.
+- Alternatives considered: Secondary `useEffect` after main context loads (non-blocking, as used by the dashboard).
+- Rationale: The Prompt Builder cannot generate until context is fully loaded anyway. A single loading state is simpler and avoids a partial-render where the form appears but session context arrives later mid-session.
+- Trade-offs: If the sessions endpoint is slow, the Prompt Builder load is slightly longer. Mitigated by the `?limit=3` cap and the graceful-degradation error handler.
+
+### Decision 3: Graceful degradation on sessions fetch failure
+
+- Chosen: Wrap the sessions fetch in a try/catch inside `fetchCampaignContext()`. On failure, `recentSessions` is set to `[]` and an error is logged to the console. The overall context load succeeds.
+- Alternatives considered: Propagate the error and surface it to the DM; omit the try/catch and let a sessions failure block the whole page.
+- Rationale: Session history is enrichment data. A temporary API hiccup should not prevent a DM from using the Prompt Builder. This matches the pattern established in #186 where session data absence never blocks the dashboard.
+- Trade-offs: Silent failure if sessions are consistently unavailable — the console log is the only signal. Acceptable for enrichment-tier data.
+
+### Decision 4: Session block format in system prompt
+
+- Chosen:
+  ```
+  Recent sessions:
+  - Session 11 (May 14, 2026): The Betrayer Revealed — party reached Level 11.
+  - Session 10 (May 7, 2026): Explored the War of Pandesmos.
+  ```
+  Format per entry: `Session {N} ({date}): {title or "Untitled Session"}{milestone suffix}`.
+  Milestone suffix: ` — party reached Level {newLevel}.` when `milestone: true`.
+- Alternatives considered: Freeform summary injection (includes the `summary` field); structured JSON block for the AI to parse.
+- Rationale: The issue spec provides this exact format. Concise single-line entries keep prompt token cost low. The `summary` field can be long and unstructured — including it risks bloating the system prompt. The title and milestone flag carry the highest signal-to-token ratio.
+- Trade-offs: DMs who write detailed summaries lose that detail in the prompt. They can always paste extra context in the template's optional fields.
+
+## Proposal to Design Mapping
+
+- Proposal element: Add `recentSessions?: SessionLog[]` to `CampaignContext`
+  - Design decision: Decision 1
+  - Validation approach: TypeScript compilation; unit test asserting field present in returned context
+
+- Proposal element: Fetch sessions in main `Promise.all` (blocking)
+  - Design decision: Decision 2
+  - Validation approach: Unit test mocking all four endpoints; assert sessions endpoint called once per `fetchCampaignContext` invocation
+
+- Proposal element: Failed sessions fetch → empty list
+  - Design decision: Decision 3
+  - Validation approach: Unit test simulating sessions endpoint 500 response; assert context returns with `recentSessions: []` and no thrown error
+
+- Proposal element: `buildSystemPrompt()` session block
+  - Design decision: Decision 4
+  - Validation approach: Unit tests for zero sessions (block absent), one session (block present, no milestone), one session with `milestone: true` (milestone suffix appended)
+
+- Proposal element: Loading label update
+  - Design decision: n/a (cosmetic string change)
+  - Validation approach: String value verified in component test or visual inspection
+
+## Functional Requirements Mapping
+
+- Requirement: All five templates include recent sessions in their system prompt when sessions exist
+  - Design element: Decision 1 — `buildSystemPrompt()` receives sessions via `CampaignContext`
+  - Acceptance criteria reference: specs/prompt-context/spec.md
+  - Testability notes: Unit test `buildSystemPrompt()` with `recentSessions` array; all templates share this path, no per-template tests needed
+
+- Requirement: Zero sessions → no session block in prompt
+  - Design element: Decision 4 — `buildSystemPrompt()` filters on `recentSessions?.length`
+  - Acceptance criteria reference: specs/prompt-context/spec.md
+  - Testability notes: Unit test with `recentSessions: []` asserts "Recent sessions:" absent from output
+
+- Requirement: Milestone sessions show level attained
+  - Design element: Decision 4 — milestone suffix appended when `milestone: true`
+  - Acceptance criteria reference: specs/prompt-context/spec.md
+  - Testability notes: Unit test with `milestone: true` and `newLevel: 11` asserts "Level 11" present in output
+
+- Requirement: Sessions fetch failure does not break Prompt Builder
+  - Design element: Decision 3 — try/catch in `fetchCampaignContext`
+  - Acceptance criteria reference: specs/prompt-context/spec.md
+  - Testability notes: Unit test with mocked 500 on sessions endpoint; assert function resolves with empty `recentSessions`
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: performance
+  - Requirement: Sessions fetch must not measurably increase Prompt Builder load time beyond network latency of `GET /api/campaigns/[id]/sessions?limit=3`
+  - Design element: Decision 2 — parallel fetch in `Promise.all` with `?limit=3` cap
+  - Acceptance criteria reference: n/a (no hard SLA; `limit=3` keeps payload small)
+  - Testability notes: Manual observation; no automated performance test required
+
+- Requirement category: reliability
+  - Requirement: Sessions endpoint failure must not degrade Prompt Builder availability
+  - Design element: Decision 3 — graceful degradation
+  - Acceptance criteria reference: specs/prompt-context/spec.md
+  - Testability notes: Unit test with 500 mock
+
+- Requirement category: operability
+  - Requirement: Loading state accurately describes what is being fetched
+  - Design element: Loading label change in `app/campaigns/[id]/prompts/page.tsx`
+  - Acceptance criteria reference: n/a
+  - Testability notes: String verified in component snapshot or manual review
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Existing `fetchCampaignContext` tests do not mock the sessions endpoint and will fail with an unmatched fetch call.
+  - Impact: CI failure.
+  - Mitigation: Audit `tests/unit/utils/campaignContext.test.ts` before implementing; add sessions mock returning `[]` to all existing test cases.
+
+- Risk/trade-off: System prompt length increases for campaigns with active session logs.
+  - Impact: Higher token cost per prompt; possible truncation if context window is tight.
+  - Mitigation: Only 3 sessions max; each entry is a single short line. Total addition is under 300 tokens in the worst case.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Sessions fetch consistently errors in production, or system prompt bloat causes AI quality regression.
+- Rollback steps: Revert the four file changes (types, campaignContext, templates, prompts page) in a single commit. No DB migration needed — sessions data is untouched.
+- Data migration considerations: None — this change is purely read-path enrichment. No schema changes.
+- Verification after rollback: Prompt Builder loads, generates prompts without session block, sessions journal unchanged.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Fix failing tests before merging. Do not bypass CI with `--no-verify` or equivalent.
+- If security checks fail: Treat as a blocker; the sessions fetch uses the existing `withAuthAndParams` middleware — investigate any unexpected auth failure.
+- If required reviews are blocked/stale: Re-request review after 24 hours; escalate to repo owner after 48 hours.
+- Escalation path and timeout: Tag @dougis in the PR if unreviewed after 48 hours.
+
+## Open Questions
+
+No open questions. All design decisions are resolved and confirmed.

--- a/openspec/changes/prompt-builder-session-context/proposal.md
+++ b/openspec/changes/prompt-builder-session-context/proposal.md
@@ -1,0 +1,73 @@
+## GitHub Issues
+
+- #188
+
+## Why
+
+- Problem statement: The Prompt Builder generates AI prompts with campaign name, chapter, and party composition, but has no awareness of what actually happened in recent sessions. A DM writing a prompt for a new NPC or location has to mentally re-type context ("the party just defeated the Betrayer and reached level 11") every single time.
+- Why now: Steps 1–4 and 6–7 of issue #188 are fully implemented. Session logs exist in the database and the API supports fetching them. Step 5 (Prompt Builder integration) is the only remaining gap.
+- Business/user impact: Prompts become dramatically more relevant without extra DM effort. The AI has enough context to reference recent events, adjust tone to current story beats, and avoid narrative contradictions.
+
+## Problem Space
+
+- Current behavior: `buildSystemPrompt()` in `lib/prompts/templates.ts` emits campaign name, module, current chapter, and active party members. No session history is included. All five prompt templates (`npc`, `location`, `shop`, `magic-item`, `room`) use this function.
+- Desired behavior: When session logs exist for a campaign, `buildSystemPrompt()` appends a "Recent sessions:" block summarising the last 3 sessions. All templates benefit automatically since they all call `buildSystemPrompt()`.
+- Constraints: Sessions are fetched from an already-existing API endpoint (`GET /api/campaigns/[id]/sessions?limit=3`). `recentSessions` must be optional on `CampaignContext` so no existing consumer breaks.
+- Assumptions: 3 recent sessions is the right default (matches issue spec). Sessions are already sorted descending by `sessionNumber` from the API. The Prompt Builder page's loading state is user-visible and should reflect the additional fetch.
+- Edge cases considered: Campaign with zero session logs — block is omitted entirely. Sessions with no title — fall back to "Untitled Session". Sessions with `milestone: true` — milestone note is appended. The `?limit` query param already exists in the sessions API route.
+
+## Scope
+
+### In Scope
+
+- Add `recentSessions?: SessionLog[]` to `CampaignContext` in `lib/types.ts`
+- Fetch `GET /api/campaigns/[id]/sessions?limit=3` inside `fetchCampaignContext()` in `lib/utils/campaignContext.ts` (blocking, in the main `Promise.all`)
+- Extend `buildSystemPrompt()` in `lib/prompts/templates.ts` to append a formatted "Recent sessions:" block when `recentSessions` is present and non-empty
+- Update the loading label in `app/campaigns/[id]/prompts/page.tsx` from `"Loading campaign context..."` to `"Loading campaign and session history..."`
+- Unit tests: sessions endpoint mock in `fetchCampaignContext` tests, `buildSystemPrompt` session block rendering
+
+### Out of Scope
+
+- Changing the number of sessions fetched (3 is fixed per issue spec; a user control is a future enhancement)
+- Per-template control over whether sessions appear
+- Saving sessions as part of the Content Library
+- Combat event auto-capture (#190, explicitly deferred)
+- Any changes to the sessions API, storage layer, or session journal UI (all done in prior steps)
+
+## What Changes
+
+- `lib/types.ts` — `CampaignContext` gains `recentSessions?: SessionLog[]`
+- `lib/utils/campaignContext.ts` — `fetchCampaignContext()` adds sessions to `Promise.all`, includes result in return value
+- `lib/prompts/templates.ts` — `buildSystemPrompt()` appends session block when `recentSessions` present
+- `app/campaigns/[id]/prompts/page.tsx` — loading label string updated
+- `tests/unit/utils/campaignContext.test.ts` (or equivalent) — sessions mock added
+- `tests/unit/prompts/templates.test.ts` (or equivalent) — session block rendering tested
+
+## Risks
+
+- Risk: Existing tests for `fetchCampaignContext` or `buildSystemPrompt` may not mock the sessions endpoint, causing them to fail after this change.
+  - Impact: CI failure.
+  - Mitigation: Audit existing test files before implementing; add sessions mock upfront.
+- Risk: Sessions API response fails (e.g. network error) and blocks the entire Prompt Builder load.
+  - Impact: DM cannot use Prompt Builder if sessions endpoint is temporarily unavailable.
+  - Mitigation: Treat a failed sessions fetch as an empty list rather than a hard error — `recentSessions` defaults to `[]` on failure. Log the error but do not propagate it.
+
+## Open Questions
+
+No unresolved ambiguity. All decisions have been confirmed:
+- Blocking fetch (not secondary useEffect): confirmed by user.
+- Sessions context available for all templates (via `buildSystemPrompt`): confirmed by user.
+- 3 sessions limit: specified in issue #188.
+- Failed sessions fetch → empty list, not error propagation: derived from the "non-blocking dashboard" pattern established in #186 and the principle that sessions are enrichment, not required data.
+
+## Non-Goals
+
+- Per-template opt-in/opt-out of session context
+- User-configurable session count
+- Surfacing session context outside the Prompt Builder (dashboard already handles its own session fetch independently)
+- Any UI changes to the session journal itself
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/prompt-builder-session-context/specs/prompt-context/spec.md
+++ b/openspec/changes/prompt-builder-session-context/specs/prompt-context/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Session context in CampaignContext
+
+The system SHALL include `recentSessions?: SessionLog[]` as an optional field on `CampaignContext`, populated with up to 3 recent session logs for the campaign.
+
+#### Scenario: Sessions exist for campaign
+
+- **Given** a campaign with 5 session logs stored in the database
+- **When** `fetchCampaignContext(campaignId)` is called
+- **Then** the returned `CampaignContext` includes a `recentSessions` array containing the 3 most recent sessions (descending by `sessionNumber`)
+
+#### Scenario: Campaign has no session logs
+
+- **Given** a campaign with zero session logs
+- **When** `fetchCampaignContext(campaignId)` is called
+- **Then** the returned `CampaignContext` includes `recentSessions` as an empty array
+
+#### Scenario: Sessions endpoint returns an error
+
+- **Given** the sessions API returns a 500 response
+- **When** `fetchCampaignContext(campaignId)` is called
+- **Then** the function resolves successfully with `recentSessions: []` and does not throw
+- **And** the error is logged to the console
+
+---
+
+### Requirement: ADDED Recent sessions block in generated prompts
+
+The system SHALL append a "Recent sessions:" block to the system prompt produced by `buildSystemPrompt()` when `recentSessions` is non-empty.
+
+#### Scenario: One or more sessions present
+
+- **Given** a `CampaignContext` with `recentSessions` containing at least one entry
+- **When** `buildSystemPrompt(context)` is called
+- **Then** the returned string contains a "Recent sessions:" heading followed by one line per session in the format `- Session {N} ({date}): {title or "Untitled Session"}`
+
+#### Scenario: Session with milestone
+
+- **Given** a `CampaignContext` with a session where `milestone: true` and `newLevel: 11`
+- **When** `buildSystemPrompt(context)` is called
+- **Then** the session line includes the suffix ` — party reached Level 11.`
+
+#### Scenario: Session with milestone but no newLevel
+
+- **Given** a `CampaignContext` with a session where `milestone: true` and `newLevel` is absent
+- **When** `buildSystemPrompt(context)` is called
+- **Then** the session line includes the suffix ` — milestone reached.`
+
+#### Scenario: Session with no title
+
+- **Given** a session with no `title` field set
+- **When** `buildSystemPrompt(context)` is called
+- **Then** the session line uses `"Untitled Session"` in place of a title
+
+#### Scenario: No sessions present
+
+- **Given** a `CampaignContext` with `recentSessions: []` or `recentSessions` undefined
+- **When** `buildSystemPrompt(context)` is called
+- **Then** the returned string does not contain the text "Recent sessions:"
+
+---
+
+### Requirement: ADDED Prompt Builder loading label reflects sessions fetch
+
+The system SHALL display `"Loading campaign and session history..."` as the loading label while `useCampaignContext` is resolving.
+
+#### Scenario: Prompt Builder page is loading
+
+- **Given** the Prompt Builder page for a campaign is opened
+- **When** `useCampaignContext` has not yet resolved
+- **Then** the `LoadingState` component renders with label `"Loading campaign and session history..."`
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `fetchCampaignContext` fetches four endpoints in parallel
+
+The system SHALL fetch `GET /api/campaigns/[id]/sessions?limit=3` in the same `Promise.all` as the campaign, parties, and characters fetches.
+
+#### Scenario: All endpoints succeed
+
+- **Given** all four endpoints return 200
+- **When** `fetchCampaignContext(campaignId)` is called
+- **Then** the returned context includes `campaign`, `chapter`, `parties`, `allMembers`, `characters`, and `recentSessions`
+
+#### Scenario: Sessions endpoint called with correct limit
+
+- **Given** `fetchCampaignContext` is invoked for campaign `"abc123"`
+- **When** the sessions fetch fires
+- **Then** the URL called is `/api/campaigns/abc123/sessions?limit=3`
+
+## REMOVED Requirements
+
+None. No existing requirements are removed by this change.
+
+## Traceability
+
+- Proposal element "Add `recentSessions?: SessionLog[]` to `CampaignContext`" → Requirement: ADDED Session context in CampaignContext
+- Proposal element "Fetch sessions in main `Promise.all`" → Requirement: MODIFIED `fetchCampaignContext` fetches four endpoints in parallel
+- Proposal element "`buildSystemPrompt()` session block" → Requirement: ADDED Recent sessions block in generated prompts
+- Proposal element "Loading label update" → Requirement: ADDED Prompt Builder loading label reflects sessions fetch
+- Design Decision 1 → ADDED Session context in CampaignContext, ADDED Recent sessions block
+- Design Decision 2 → MODIFIED `fetchCampaignContext`
+- Design Decision 3 → ADDED Session context (error scenario)
+- Design Decision 4 → ADDED Recent sessions block (all scenarios)
+- All requirements → tasks.md (implementation tasks)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Sessions endpoint unavailable
+
+- **Given** the sessions API returns a network error or 5xx
+- **When** `fetchCampaignContext` runs
+- **Then** the Prompt Builder page loads successfully with an empty session block
+- **And** no error banner is shown to the DM for the sessions failure specifically
+
+### Requirement: Performance
+
+#### Scenario: Sessions fetch runs in parallel
+
+- **Given** the campaign, parties, and characters fetches are already in a `Promise.all`
+- **When** the sessions fetch is added
+- **Then** all four requests fire simultaneously and the total load time is bounded by the slowest single request, not the sum of all four
+
+### Requirement: Security
+
+#### Scenario: Sessions fetch is user-scoped
+
+- **Given** an authenticated DM
+- **When** `GET /api/campaigns/[id]/sessions?limit=3` is called
+- **Then** the endpoint (already implemented) returns only session logs belonging to that user's campaign, enforced by `withAuthAndParams` middleware

--- a/openspec/changes/prompt-builder-session-context/tasks.md
+++ b/openspec/changes/prompt-builder-session-context/tasks.md
@@ -1,0 +1,129 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/prompt-builder-session-context` then immediately `git push -u origin feat/prompt-builder-session-context`
+
+## Execution
+
+### Task 1 — Audit existing tests for `fetchCampaignContext` and `buildSystemPrompt`
+
+Before touching any implementation file, read the existing test files so the sessions mock can be added without breaking anything:
+
+- [x] Read `tests/unit/utils/campaignContext.test.ts` — identify every test case; note which mock for `fetch` is used
+- [x] Read `tests/unit/prompts/templates.test.ts` (or equivalent) — confirm `buildSystemPrompt` test coverage exists and note current assertions
+
+### Task 2 — Extend `CampaignContext` type (`lib/types.ts`)
+
+- [x] Add `recentSessions?: SessionLog[]` to the `CampaignContext` interface
+- [x] Confirm `SessionLog` is already imported in scope (it is — no new import needed for the interface)
+- [x] Run `npx tsc --noEmit` — must pass with zero new errors
+
+### Task 3 — Extend `fetchCampaignContext` to fetch sessions (`lib/utils/campaignContext.ts`)
+
+- [x] Add `SessionLog` to the import from `@/lib/types`
+- [x] Add `fetchImpl(`/api/campaigns/${campaignId}/sessions?limit=3`)` to the `Promise.all` (fourth parallel fetch)
+- [x] Wrap the sessions response handling in try/catch: on any error or non-OK response, set `recentSessions = []` and `console.error` the failure
+- [x] Parse the sessions response JSON as `SessionLog[]` on success
+- [x] Include `recentSessions` in the returned `CampaignContext` object
+- [x] Run `npx tsc --noEmit` — must pass
+
+### Task 4 — Extend `buildSystemPrompt` to render session block (`lib/prompts/templates.ts`)
+
+- [x] Import `SessionLog` type at the top of the file (needed for the helper function signature)
+- [x] After the existing `partySection` block, build a `sessionSection` string:
+  - If `context.recentSessions` is absent or empty → `sessionSection = ''`
+  - Otherwise, format each entry as: `- Session {N} ({date}): {title || "Untitled Session"}{milestoneSuffix}`
+    - `milestoneSuffix` when `milestone: true` and `newLevel` present: ` — party reached Level {newLevel}.`
+    - `milestoneSuffix` when `milestone: true` and no `newLevel`: ` — milestone reached.`
+    - `milestoneSuffix` otherwise: `''`
+  - Date format: `new Date(datePlayed).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })` (e.g. `May 14, 2026`)
+  - Heading line: `Recent sessions:`
+- [x] Add `sessionSection` to the `.filter(Boolean).join('\n')` array (after `partySection`)
+- [x] Run `npx tsc --noEmit` — must pass
+
+### Task 5 — Update Prompt Builder loading label (`app/campaigns/[id]/prompts/page.tsx`)
+
+- [x] Change the `LoadingState` label string from `"Loading campaign context..."` to `"Loading campaign and session history..."`
+- [x] Run `npx tsc --noEmit` — must pass
+
+### Task 6 — Update `fetchCampaignContext` tests
+
+- [x] In the existing test file, add a sessions mock to the `fetch` mock for every test case: `GET /api/campaigns/${campaignId}/sessions?limit=3` → return `[]`
+- [x] Add a new test: **sessions fetch returns data** — mock returns 2 sessions, assert `context.recentSessions` has length 2 and matches the mocked data
+- [x] Add a new test: **sessions fetch fails (500)** — mock returns 500, assert `context.recentSessions` is `[]` and the function resolves (does not throw)
+- [x] Add a new test: **sessions URL includes `?limit=3`** — assert the mocked fetch was called with the correct URL
+- [x] Run `npm test -- --testPathPattern=campaignContext` — all tests must pass
+
+### Task 7 — Add `buildSystemPrompt` tests for session block
+
+- [x] In the existing templates test file (or a new `tests/unit/prompts/templates.test.ts` if it doesn't cover `buildSystemPrompt`):
+  - **No sessions** — `recentSessions: []` → assert output does not contain `"Recent sessions:"`
+  - **Undefined sessions** — `recentSessions` field absent → assert output does not contain `"Recent sessions:"`
+  - **One session, no milestone** — assert output contains `"Recent sessions:"` and the session line with title and date
+  - **One session, milestone with newLevel** — assert output contains `"party reached Level 11"`
+  - **One session, milestone without newLevel** — assert output contains `"milestone reached"`
+  - **Session with no title** — assert output contains `"Untitled Session"`
+- [x] Run `npm test -- --testPathPattern=templates` — all tests must pass
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Review its report and apply fixes for duplication, complexity, and completeness before committing.
+
+## Validation
+
+- [x] `npx tsc --noEmit` — zero errors
+- [x] `npm run lint` — zero new lint errors
+- [x] `npm test` — all unit tests pass
+- [ ] `npm run test:integration` — all integration tests pass (sessions API routes already tested; confirm no regression)
+- [ ] Manual smoke test: open Prompt Builder for a campaign that has session logs → generate an NPC prompt → confirm "Recent sessions:" block appears in the generated prompt
+- [ ] Manual smoke test: open Prompt Builder for a campaign with zero session logs → generate prompt → confirm no session block in output
+- [ ] All tasks in Execution marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test` — all tests must pass
+- **Integration tests** — `npm run test:integration` — all tests must pass
+- **Build** — `npm run build` — must succeed with no errors
+- **Type check** — `npx tsc --noEmit` — zero errors
+
+If **ANY** of the above fail, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run before the final commit
+- [ ] Commit all changes to `feat/prompt-builder-session-context` and push to remote
+- [ ] Open PR from `feat/prompt-builder-session-context` to `main`. PR body must include: **`Closes #188`**
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address each comment, commit fixes, follow Remote push validation steps, push to `feat/prompt-builder-session-context`, wait 180 seconds, repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required check, follow Remote push validation steps, push, wait 180 seconds, repeat until all required checks pass
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user — never wait for a human to report the merge; never force-merge
+
+Ownership metadata:
+- Implementer: claude (agent)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (none expected)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/prompt-builder-session-context/` to `openspec/changes/archive/YYYY-MM-DD-prompt-builder-session-context/` **and stage both the new location and the deletion of the old location in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-prompt-builder-session-context/` exists and `openspec/changes/prompt-builder-session-context/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-prompt-builder-session-context` then `git push -u origin doc/archive-YYYY-MM-DD-prompt-builder-session-context`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-prompt-builder-session-context` to `main` with title `docs: archive prompt-builder-session-context (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to the same doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/prompt-builder-session-context doc/archive-YYYY-MM-DD-prompt-builder-session-context`

--- a/openspec/changes/prompt-builder-session-context/tests.md
+++ b/openspec/changes/prompt-builder-session-context/tests.md
@@ -1,0 +1,158 @@
+---
+name: tests
+description: Tests for the prompt-builder-session-context change
+---
+
+# Tests
+
+## Overview
+
+Tests for injecting recent session logs into Prompt Builder context. All work follows strict TDD: write a failing test first, then implement, then refactor.
+
+Test files involved:
+- `tests/unit/utils/campaignContext.test.ts` — `fetchCampaignContext` tests
+- `tests/unit/prompts/templates.test.ts` — `buildSystemPrompt` tests (create if absent)
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** before writing any implementation code.
+2. **Write the simplest code to make the test pass.**
+3. **Refactor** while keeping the test green.
+
+---
+
+## Test Cases
+
+### Task 2 — `CampaignContext` type extension
+
+- [ ] **TC-2-1:** TypeScript compilation passes after adding `recentSessions?: SessionLog[]` to `CampaignContext`
+  - Verify: `npx tsc --noEmit` exits 0
+  - Spec: ADDED "Session context in CampaignContext"
+
+---
+
+### Task 3 — `fetchCampaignContext` sessions fetch
+
+- [ ] **TC-3-1:** Sessions endpoint called with correct URL
+  - Test file: `tests/unit/utils/campaignContext.test.ts`
+  - Given: mock fetch for all four endpoints
+  - When: `fetchCampaignContext("abc123")` is called
+  - Then: fetch was called with `/api/campaigns/abc123/sessions?limit=3`
+  - TDD: add assertion to existing fetch-mock before adding sessions to `Promise.all`
+  - Spec: MODIFIED "fetchCampaignContext fetches four endpoints in parallel"
+
+- [ ] **TC-3-2:** Sessions data is included in returned context
+  - Given: sessions endpoint returns `[{ id: "s1", sessionNumber: 5, title: "The Siege", datePlayed: "2026-05-14", milestone: false, ... }]`
+  - When: `fetchCampaignContext` resolves
+  - Then: `context.recentSessions` has length 1 and `context.recentSessions[0].sessionNumber === 5`
+  - Spec: ADDED "Session context in CampaignContext" — happy path scenario
+
+- [ ] **TC-3-3:** Zero sessions returns empty array
+  - Given: sessions endpoint returns `[]`
+  - When: `fetchCampaignContext` resolves
+  - Then: `context.recentSessions` is `[]`
+  - Spec: ADDED "Session context in CampaignContext" — no sessions scenario
+
+- [ ] **TC-3-4:** Sessions endpoint 500 → resolves with empty array, does not throw
+  - Given: sessions endpoint returns status 500
+  - When: `fetchCampaignContext` is awaited
+  - Then: promise resolves (does not reject), `context.recentSessions` is `[]`
+  - Spec: ADDED "Session context in CampaignContext" — error scenario
+  - Non-functional: reliability scenario
+
+- [ ] **TC-3-5:** Sessions endpoint network error → resolves with empty array, does not throw
+  - Given: sessions fetch mock throws `new Error("Network error")`
+  - When: `fetchCampaignContext` is awaited
+  - Then: promise resolves, `context.recentSessions` is `[]`
+  - Spec: ADDED "Session context in CampaignContext" — error scenario
+
+- [ ] **TC-3-6:** Existing tests pass with sessions mock added
+  - All pre-existing test cases in `campaignContext.test.ts` must continue to pass after sessions mock is added to their setup
+  - Spec: regression guard
+
+---
+
+### Task 4 — `buildSystemPrompt` session block
+
+- [ ] **TC-4-1:** No session block when `recentSessions` is `[]`
+  - Test file: `tests/unit/prompts/templates.test.ts`
+  - Given: `context.recentSessions = []`
+  - When: `buildSystemPrompt(context)` is called
+  - Then: returned string does not contain `"Recent sessions:"`
+  - Spec: ADDED "Recent sessions block" — no sessions scenario
+
+- [ ] **TC-4-2:** No session block when `recentSessions` is undefined
+  - Given: `recentSessions` field is absent from context
+  - When: `buildSystemPrompt(context)` is called
+  - Then: returned string does not contain `"Recent sessions:"`
+  - Spec: ADDED "Recent sessions block" — no sessions scenario
+
+- [ ] **TC-4-3:** Session block present with correct heading
+  - Given: `recentSessions` contains one entry
+  - When: `buildSystemPrompt(context)` is called
+  - Then: returned string contains `"Recent sessions:"` on its own line
+  - Spec: ADDED "Recent sessions block" — happy path
+
+- [ ] **TC-4-4:** Session line format — title and date
+  - Given: one session with `sessionNumber: 11`, `title: "The Betrayer Revealed"`, `datePlayed: new Date("2026-05-14")`, `milestone: false`
+  - When: `buildSystemPrompt(context)` is called
+  - Then: output contains `"- Session 11 (May 14, 2026): The Betrayer Revealed"`
+  - Spec: ADDED "Recent sessions block" — happy path
+
+- [ ] **TC-4-5:** Milestone with newLevel appends correct suffix
+  - Given: session with `milestone: true`, `newLevel: 11`
+  - When: `buildSystemPrompt(context)` is called
+  - Then: session line ends with `"— party reached Level 11."`
+  - Spec: ADDED "Recent sessions block" — milestone with newLevel scenario
+
+- [ ] **TC-4-6:** Milestone without newLevel appends fallback suffix
+  - Given: session with `milestone: true`, `newLevel` absent or undefined
+  - When: `buildSystemPrompt(context)` is called
+  - Then: session line ends with `"— milestone reached."`
+  - Spec: ADDED "Recent sessions block" — milestone without newLevel scenario
+
+- [ ] **TC-4-7:** Session with no title uses "Untitled Session"
+  - Given: session with `title` absent or empty string
+  - When: `buildSystemPrompt(context)` is called
+  - Then: session line contains `"Untitled Session"`
+  - Spec: ADDED "Recent sessions block" — no title scenario
+
+- [ ] **TC-4-8:** Multiple sessions render in order
+  - Given: `recentSessions` contains sessions with `sessionNumber` 10, 11, 12
+  - When: `buildSystemPrompt(context)` is called
+  - Then: all three sessions appear in the output; Session 12 appears before Session 10 (order matches array order from API)
+  - Spec: ADDED "Recent sessions block" — happy path
+
+---
+
+### Task 5 — Loading label
+
+- [ ] **TC-5-1:** Loading label string is updated
+  - Verify by code search: `grep -r "Loading campaign and session history" app/campaigns/\[id\]/prompts/page.tsx` returns a match
+  - Verify old string is absent: `grep -r "Loading campaign context\.\.\." app/campaigns/\[id\]/prompts/page.tsx` returns no match
+  - Spec: ADDED "Prompt Builder loading label reflects sessions fetch"
+
+---
+
+## Coverage Summary
+
+| Test Case | Task | Spec Scenario | Type |
+|---|---|---|---|
+| TC-2-1 | Task 2 | Type extension | TypeScript |
+| TC-3-1 | Task 3 | Sessions URL | Unit |
+| TC-3-2 | Task 3 | Sessions data in context | Unit |
+| TC-3-3 | Task 3 | Zero sessions | Unit |
+| TC-3-4 | Task 3 | 500 error → empty array | Unit |
+| TC-3-5 | Task 3 | Network error → empty array | Unit |
+| TC-3-6 | Task 3 | Regression guard | Unit |
+| TC-4-1 | Task 4 | No block, empty array | Unit |
+| TC-4-2 | Task 4 | No block, undefined | Unit |
+| TC-4-3 | Task 4 | Block heading present | Unit |
+| TC-4-4 | Task 4 | Line format | Unit |
+| TC-4-5 | Task 4 | Milestone + newLevel | Unit |
+| TC-4-6 | Task 4 | Milestone, no newLevel | Unit |
+| TC-4-7 | Task 4 | No title fallback | Unit |
+| TC-4-8 | Task 4 | Multiple sessions order | Unit |
+| TC-5-1 | Task 5 | Loading label string | Static |

--- a/tests/e2e/characters.spec.ts
+++ b/tests/e2e/characters.spec.ts
@@ -251,7 +251,10 @@ test.describe("Character gender field", () => {
     await card.getByRole("button", { name: "Edit" }).click();
     await page.getByLabel("Character gender").clear();
     await page.getByRole("button", { name: /Save Character/i }).click();
-    await expect(card.getByText(/\bHuman\b/)).toBeVisible({ timeout: 15000 });
+    // Wait for editor to close before checking card — ancestor divs matched by the
+    // card locator would otherwise include the race <option> from the still-mounted editor
+    await expect(page.getByRole("button", { name: /Save Character/i })).not.toBeVisible({ timeout: 15000 });
+    await expect(card.getByText(/\bHuman\b/)).toBeVisible();
     await expect(card.getByText("Non-binary Human")).toHaveCount(0);
   });
 });

--- a/tests/unit/fixtures/sessions.ts
+++ b/tests/unit/fixtures/sessions.ts
@@ -1,0 +1,16 @@
+import { SessionLog } from '@/lib/types';
+
+export const makeSession = (overrides: Partial<SessionLog> = {}): SessionLog => ({
+  id: 's-1',
+  userId: 'u1',
+  campaignId: 'camp-1',
+  sessionNumber: 11,
+  title: 'The Betrayer Revealed',
+  datePlayed: new Date(2026, 4, 14),
+  summary: '',
+  events: [],
+  milestone: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});

--- a/tests/unit/fixtures/sessions.ts
+++ b/tests/unit/fixtures/sessions.ts
@@ -6,7 +6,7 @@ export const makeSession = (overrides: Partial<SessionLog> = {}): SessionLog => 
   campaignId: 'camp-1',
   sessionNumber: 11,
   title: 'The Betrayer Revealed',
-  datePlayed: new Date(2026, 4, 14),
+  datePlayed: new Date('2026-05-14T12:00:00Z'),
   summary: '',
   events: [],
   milestone: false,

--- a/tests/unit/prompts/templates.test.ts
+++ b/tests/unit/prompts/templates.test.ts
@@ -111,6 +111,11 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('Untitled Session');
   });
 
+  test('TC-4-9: datePlayed as ISO string (runtime JSON shape) renders correct date', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [makeSession({ datePlayed: '2026-05-14' as unknown as Date })] }));
+    expect(result).toContain('May 14, 2026');
+  });
+
   test('TC-4-8: multiple sessions render in array order', () => {
     const sessions = [makeSession({ sessionNumber: 12, title: 'S12' }), makeSession({ sessionNumber: 11, title: 'S11' }), makeSession({ sessionNumber: 10, title: 'S10' })];
     const result = buildSystemPrompt(makeContext({ recentSessions: sessions }));

--- a/tests/unit/prompts/templates.test.ts
+++ b/tests/unit/prompts/templates.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { CampaignContext } from '@/lib/types';
+import { makeSession } from '../fixtures/sessions';
 import {
   TEMPLATES,
   buildSystemPrompt,
@@ -73,6 +74,50 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('Curse of Strahd');
     expect(result).toContain('CoS');
     expect(typeof result).toBe('string');
+  });
+
+  test('TC-4-1: no session block when recentSessions is []', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [] }));
+    expect(result).not.toContain('Recent sessions:');
+  });
+
+  test('TC-4-2: no session block when recentSessions is undefined', () => {
+    const result = buildSystemPrompt(makeContext());
+    expect(result).not.toContain('Recent sessions:');
+  });
+
+  test('TC-4-3: session block present with correct heading when sessions exist', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [makeSession()] }));
+    expect(result).toContain('Recent sessions:');
+  });
+
+  test('TC-4-4: session line format — title and date', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [makeSession()] }));
+    expect(result).toContain('- Session 11 (May 14, 2026): The Betrayer Revealed');
+  });
+
+  test('TC-4-5: milestone with newLevel appends correct suffix', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [makeSession({ milestone: true, newLevel: 11 })] }));
+    expect(result).toContain('— party reached Level 11.');
+  });
+
+  test('TC-4-6: milestone without newLevel appends fallback suffix', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [makeSession({ milestone: true, newLevel: undefined })] }));
+    expect(result).toContain('— milestone reached.');
+  });
+
+  test('TC-4-7: session with no title uses "Untitled Session"', () => {
+    const result = buildSystemPrompt(makeContext({ recentSessions: [makeSession({ title: undefined })] }));
+    expect(result).toContain('Untitled Session');
+  });
+
+  test('TC-4-8: multiple sessions render in array order', () => {
+    const sessions = [makeSession({ sessionNumber: 12, title: 'S12' }), makeSession({ sessionNumber: 11, title: 'S11' }), makeSession({ sessionNumber: 10, title: 'S10' })];
+    const result = buildSystemPrompt(makeContext({ recentSessions: sessions }));
+    const s12pos = result.indexOf('Session 12');
+    const s10pos = result.indexOf('Session 10');
+    expect(result).toContain('Recent sessions:');
+    expect(s12pos).toBeLessThan(s10pos);
   });
 });
 

--- a/tests/unit/utils/campaignContext.test.ts
+++ b/tests/unit/utils/campaignContext.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { CampaignContext } from '@/lib/types';
+import { makeSession } from '../fixtures/sessions';
 
 const makeCampaign = (overrides = {}) => ({
   id: 'camp-1',
@@ -45,19 +46,24 @@ const makeCharacter = (id: string, name: string, overrides = {}) => ({
 
 const makeMember = (characterId: string) => ({ characterId, addedAt: new Date() });
 
-function makeFetch(campaign: object, parties: object[], characters: object[]) {
+function routeFetch(url: RequestInfo | URL, campaign: object, parties: object[], characters: object[], sessions: object[]): Response {
+  const s = String(url);
+  if (s.includes('/sessions')) return { ok: true, json: async () => sessions } as unknown as Response;
+  if (s.includes('/api/campaigns/') && !s.includes('parties')) return { ok: true, json: async () => campaign } as unknown as Response;
+  if (s.includes('/api/parties')) return { ok: true, json: async () => parties } as unknown as Response;
+  if (s.includes('/api/characters')) return { ok: true, json: async () => characters } as unknown as Response;
+  return { ok: false, json: async () => ({}) } as unknown as Response;
+}
+
+function makeFetch(campaign: object, parties: object[], characters: object[], sessions: object[] = []) {
+  return jest.fn(async (url: RequestInfo | URL) => routeFetch(url, campaign, parties, characters, sessions));
+}
+
+function makeFetchWithSessionOverride(campaign: object, sessionHandler: (url: string) => Promise<Response>) {
   return jest.fn(async (url: RequestInfo | URL) => {
     const s = String(url);
-    if (s.includes('/api/campaigns/camp-1') && !s.includes('parties')) {
-      return { ok: true, json: async () => campaign } as unknown as Response;
-    }
-    if (s.includes('/api/parties')) {
-      return { ok: true, json: async () => parties } as unknown as Response;
-    }
-    if (s.includes('/api/characters')) {
-      return { ok: true, json: async () => characters } as unknown as Response;
-    }
-    return { ok: false, json: async () => ({}) } as unknown as Response;
+    if (s.includes('/sessions')) return sessionHandler(s);
+    return routeFetch(url, campaign, [], [], []);
   }) as typeof fetch;
 }
 
@@ -163,7 +169,7 @@ describe('fetchCampaignContext', () => {
     expect(ctx.characters[0].id).toBe('c-1');
   });
 
-  test('A2-8: all three fetches initiated in parallel via Promise.all', async () => {
+  test('A2-8: all four fetches initiated in parallel via Promise.all', async () => {
     const campaign = makeCampaign();
     const started: string[] = [];
     const resolvers: Record<string, (r: Response) => void> = {};
@@ -171,7 +177,10 @@ describe('fetchCampaignContext', () => {
     const parallelFetch = jest.fn((url: RequestInfo | URL) => {
       const s = String(url);
       return new Promise<Response>(resolve => {
-        if (s.includes('/api/campaigns/')) {
+        if (s.includes('/sessions')) {
+          started.push('sessions');
+          resolvers.sessions = resolve;
+        } else if (s.includes('/api/campaigns/')) {
           started.push('campaign');
           resolvers.campaign = resolve;
         } else if (s.includes('/api/parties')) {
@@ -186,23 +195,63 @@ describe('fetchCampaignContext', () => {
 
     const fetchPromise = fetchCampaignContext('camp-1', parallelFetch);
 
-    // Yield to the microtask queue so Promise.all registers all three fetches
+    // Yield to the microtask queue so Promise.all registers all four fetches
     await Promise.resolve();
     await Promise.resolve();
 
-    // All three must have been started before any resolved
+    // All four must have been started before any resolved
     expect(started).toContain('campaign');
     expect(started).toContain('parties');
     expect(started).toContain('characters');
+    expect(started).toContain('sessions');
 
-    // Now resolve all three
+    // Now resolve all four
     const ok = (data: unknown) => ({ ok: true, json: async () => data } as unknown as Response);
     resolvers.campaign(ok(campaign));
     resolvers.parties(ok([]));
     resolvers.characters(ok([]));
+    resolvers.sessions(ok([]));
 
     await fetchPromise;
-    expect(parallelFetch).toHaveBeenCalledTimes(3);
+    expect(parallelFetch).toHaveBeenCalledTimes(4);
+  });
+
+  test('TC-3-1: sessions URL includes ?limit=3', async () => {
+    const campaign = makeCampaign();
+    const fetchMock = makeFetch(campaign, [], []);
+    await fetchCampaignContext('camp-1', fetchMock as typeof fetch);
+    const urls = fetchMock.mock.calls.map(([u]) => String(u));
+    expect(urls).toContain('/api/campaigns/camp-1/sessions?limit=3');
+  });
+
+  test('TC-3-2: sessions fetch returns data — included in context', async () => {
+    const campaign = makeCampaign();
+    const sessions = [makeSession({ sessionNumber: 5 }), makeSession({ sessionNumber: 4 })];
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [], [], sessions));
+    expect(ctx.recentSessions).toHaveLength(2);
+    expect(ctx.recentSessions![0].sessionNumber).toBe(5);
+  });
+
+  test('TC-3-3: zero sessions returns empty array', async () => {
+    const campaign = makeCampaign();
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [], [], []));
+    expect(ctx.recentSessions).toEqual([]);
+  });
+
+  test('TC-3-4: sessions fetch 500 — resolves with empty recentSessions, does not throw', async () => {
+    const ctx = await fetchCampaignContext(
+      'camp-1',
+      makeFetchWithSessionOverride(makeCampaign(), async () => ({ ok: false, status: 500 } as unknown as Response)),
+    );
+    expect(ctx.recentSessions).toEqual([]);
+  });
+
+  test('TC-3-5: sessions fetch network error — resolves with empty recentSessions, does not throw', async () => {
+    const ctx = await fetchCampaignContext(
+      'camp-1',
+      makeFetchWithSessionOverride(makeCampaign(), async () => { throw new Error('Network error'); }),
+    );
+    expect(ctx.recentSessions).toEqual([]);
   });
 
   test('A2-9: non-OK response rejects with error', async () => {

--- a/tests/unit/utils/campaignContext.test.ts
+++ b/tests/unit/utils/campaignContext.test.ts
@@ -254,6 +254,17 @@ describe('fetchCampaignContext', () => {
     expect(ctx.recentSessions).toEqual([]);
   });
 
+  test('TC-3-6: sessions fetch returns malformed JSON — resolves with empty recentSessions, does not throw', async () => {
+    const ctx = await fetchCampaignContext(
+      'camp-1',
+      makeFetchWithSessionOverride(makeCampaign(), async () => ({
+        ok: true,
+        json: async () => { throw new SyntaxError('Unexpected token'); },
+      } as unknown as Response)),
+    );
+    expect(ctx.recentSessions).toEqual([]);
+  });
+
   test('A2-9: non-OK response rejects with error', async () => {
     const errorFetch = jest.fn(async (url: RequestInfo | URL) => {
       const s = String(url);


### PR DESCRIPTION
## Summary

Implements step 5 of issue #188: surfaces the last 3 session logs inside every Prompt Builder template's system prompt.

## Changes

- **`lib/types.ts`** — `CampaignContext` gains `recentSessions?: SessionLog[]`
- **`lib/utils/campaignContext.ts`** — `fetchCampaignContext` adds sessions to `Promise.all`; degrades gracefully to `[]` on any error
- **`lib/prompts/templates.ts`** — `buildSystemPrompt` appends a "Recent sessions:" block when sessions present
- **`app/campaigns/[id]/prompts/page.tsx`** — loading label updated to reflect sessions fetch
- **`tests/unit/fixtures/sessions.ts`** — new shared `makeSession` fixture
- **`tests/unit/utils/campaignContext.test.ts`** — sessions mock added to all existing tests; 5 new session-specific test cases
- **`tests/unit/prompts/templates.test.ts`** — 8 new test cases for session block rendering

## Session block format

```
Recent sessions:
- Session 11 (May 14, 2026): The Betrayer Revealed — party reached Level 11.
- Session 10 (May 7, 2026): Explored the War of Pandesmos.
```

Closes #188