### PR TITLE
feat: add DM notes toggle to Prompt Builder

### DIFF
--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -279,6 +279,7 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
                   onChange={e => {
                     setIncludeNotes(e.target.checked);
                     setBuiltPrompt(null);
+                    setShowSavePanel(false);
                   }}
                   className="w-4 h-4"
                 />

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -196,7 +196,7 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
   const [includeNotes, setIncludeNotes] = useState(false);
 
   const activeTemplate = TEMPLATES.find(t => t.id === activeTemplateId) ?? TEMPLATES[0];
-  const hasNotes = Boolean(context?.campaign.notes.trim());
+  const hasNotes = Boolean(context?.campaign?.notes?.trim());
 
   function selectTemplate(template: PromptTemplate) {
     setActiveTemplateId(template.id);

--- a/app/campaigns/[id]/prompts/page.tsx
+++ b/app/campaigns/[id]/prompts/page.tsx
@@ -193,8 +193,10 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
   const [builtPrompt, setBuiltPrompt] = useState<BuiltPrompt | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [showSavePanel, setShowSavePanel] = useState(false);
+  const [includeNotes, setIncludeNotes] = useState(false);
 
   const activeTemplate = TEMPLATES.find(t => t.id === activeTemplateId) ?? TEMPLATES[0];
+  const hasNotes = Boolean(context?.campaign.notes.trim());
 
   function selectTemplate(template: PromptTemplate) {
     setActiveTemplateId(template.id);
@@ -220,7 +222,7 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
       setBuiltPrompt(null);
       return;
     }
-    setBuiltPrompt(activeTemplate.build(fields, ctx));
+    setBuiltPrompt(activeTemplate.build(fields, ctx, { includeNotes }));
     setValidationError(null);
   }
 
@@ -268,6 +270,21 @@ function PromptBuilderContent({ campaignId }: { campaignId: string }) {
                 </button>
               ))}
             </div>
+
+            {hasNotes && (
+              <label className="flex items-center gap-2 text-sm text-gray-300 mb-4">
+                <input
+                  type="checkbox"
+                  checked={includeNotes}
+                  onChange={e => {
+                    setIncludeNotes(e.target.checked);
+                    setBuiltPrompt(null);
+                  }}
+                  className="w-4 h-4"
+                />
+                Include DM notes in prompt
+              </label>
+            )}
 
             <TemplateForm
               template={activeTemplate}

--- a/lib/prompts/templates.ts
+++ b/lib/prompts/templates.ts
@@ -41,7 +41,7 @@ export function buildSystemPrompt(context: CampaignContext, opts?: { includeNote
   const sessionSection = recentSessions?.length
     ? `Recent sessions:\n${recentSessions.map(formatSessionEntry).join('\n')}`
     : '';
-  const notesSection = opts?.includeNotes && campaign.notes.trim()
+  const notesSection = opts?.includeNotes && campaign.notes?.trim()
     ? `Current campaign context (DM notes):\n${campaign.notes}`
     : '';
 

--- a/lib/prompts/templates.ts
+++ b/lib/prompts/templates.ts
@@ -12,7 +12,7 @@ export interface PromptTemplate {
   id: SavedContent['type'];
   label: string;
   fields: PromptField[];
-  build(fields: Record<string, string>, context: CampaignContext): BuiltPrompt;
+  build(fields: Record<string, string>, context: CampaignContext, opts?: { includeNotes?: boolean }): BuiltPrompt;
 }
 
 function formatCharacter(c: Character): string {
@@ -31,7 +31,7 @@ function formatSessionEntry(session: SessionLog): string {
   return `- Session ${session.sessionNumber} (${date}): ${title}${suffix}`;
 }
 
-export function buildSystemPrompt(context: CampaignContext): string {
+export function buildSystemPrompt(context: CampaignContext, opts?: { includeNotes?: boolean }): string {
   const { campaign, chapter, characters, recentSessions } = context;
 
   const chapterLine = chapter ? `Current Chapter: ${chapter.title}` : '';
@@ -41,6 +41,9 @@ export function buildSystemPrompt(context: CampaignContext): string {
   const sessionSection = recentSessions?.length
     ? `Recent sessions:\n${recentSessions.map(formatSessionEntry).join('\n')}`
     : '';
+  const notesSection = opts?.includeNotes && campaign.notes.trim()
+    ? `Current campaign context (DM notes):\n${campaign.notes}`
+    : '';
 
   return [
     `You are a creative assistant helping a Dungeon Master run a D&D 5e campaign.`,
@@ -48,6 +51,7 @@ export function buildSystemPrompt(context: CampaignContext): string {
     chapterLine,
     partySection,
     sessionSection,
+    notesSection,
   ].filter(Boolean).join('\n');
 }
 
@@ -63,10 +67,10 @@ export const npcTemplate: PromptTemplate = {
     { key: 'location', label: 'Location', placeholder: 'e.g. Barovia, the keep gates' },
     { key: 'requirements', label: 'Special Requirements', placeholder: 'e.g. hostile, knows a secret', optional: true },
   ],
-  build(fields, context) {
+  build(fields, context, opts) {
     const req = fields.requirements ? `\nSpecial requirements: ${fields.requirements}` : '';
     const userMessage = `Create an NPC with the role of ${fields.role || 'unnamed role'} located at ${fields.location || 'an unspecified location'}.${req}\n\nInclude: name, appearance, personality, a secret or motivation, and 2-3 conversation hooks.`;
-    return makePrompt(buildSystemPrompt(context), userMessage);
+    return makePrompt(buildSystemPrompt(context, opts), userMessage);
   },
 };
 
@@ -78,10 +82,10 @@ export const locationTemplate: PromptTemplate = {
     { key: 'atmosphere', label: 'Atmosphere', placeholder: 'e.g. cozy, foreboding, bustling' },
     { key: 'details', label: 'Additional Details', placeholder: 'e.g. recently ransacked, hidden cellar', optional: true },
   ],
-  build(fields, context) {
+  build(fields, context, opts) {
     const details = fields.details ? `\nAdditional details: ${fields.details}` : '';
     const userMessage = `Describe a ${fields.type || 'location'} with a ${fields.atmosphere || 'neutral'} atmosphere.${details}\n\nInclude: sensory details (sight, sound, smell), notable features, and 2-3 interactive elements the party could investigate.`;
-    return makePrompt(buildSystemPrompt(context), userMessage);
+    return makePrompt(buildSystemPrompt(context, opts), userMessage);
   },
 };
 
@@ -93,10 +97,10 @@ export const shopTemplate: PromptTemplate = {
     { key: 'setting', label: 'Setting / District', placeholder: 'e.g. busy market, seedy docks, noble quarter' },
     { key: 'inventory', label: 'Notable Inventory', placeholder: 'e.g. rare components, military surplus', optional: true },
   ],
-  build(fields, context) {
+  build(fields, context, opts) {
     const inv = fields.inventory ? `\nNotable inventory focus: ${fields.inventory}` : '';
     const userMessage = `Create a ${fields.shopType || 'shop'} located in the ${fields.setting || 'town'}.${inv}\n\nInclude: proprietor name and personality, shop description, 3-5 items for sale with prices, and a rumour the proprietor knows.`;
-    return makePrompt(buildSystemPrompt(context), userMessage);
+    return makePrompt(buildSystemPrompt(context, opts), userMessage);
   },
 };
 
@@ -108,10 +112,10 @@ export const magicItemTemplate: PromptTemplate = {
     { key: 'rarity', label: 'Rarity', placeholder: 'e.g. common, uncommon, rare, very rare, legendary' },
     { key: 'theme', label: 'Thematic Theme', placeholder: 'e.g. shadow, fire, nature, undeath', optional: true },
   ],
-  build(fields, context) {
+  build(fields, context, opts) {
     const theme = fields.theme ? ` with a ${fields.theme} theme` : '';
     const userMessage = `Create a ${fields.rarity || 'uncommon'} magic ${fields.itemType || 'item'}${theme}.\n\nInclude: evocative name, physical description, magical properties (as D&D 5e stat block), lore or history, and any attunement requirements.`;
-    return makePrompt(buildSystemPrompt(context), userMessage);
+    return makePrompt(buildSystemPrompt(context, opts), userMessage);
   },
 };
 
@@ -123,10 +127,10 @@ export const roomTemplate: PromptTemplate = {
     { key: 'purpose', label: 'Purpose / Function', placeholder: 'e.g. seat of power, burial chamber, arcane study' },
     { key: 'features', label: 'Special Features', placeholder: 'e.g. trapped floor, hidden door, magical lighting', optional: true },
   ],
-  build(fields, context) {
+  build(fields, context, opts) {
     const features = fields.features ? `\nSpecial features: ${fields.features}` : '';
     const userMessage = `Describe a room called "${fields.roomName || 'the room'}" that serves as a ${fields.purpose || 'general purpose space'}.${features}\n\nInclude: read-aloud description (2-3 sentences), notable contents, any hazards or traps, and a secret element for observant players.`;
-    return makePrompt(buildSystemPrompt(context), userMessage);
+    return makePrompt(buildSystemPrompt(context, opts), userMessage);
   },
 };
 

--- a/tests/unit/promptBuilderSave.test.tsx
+++ b/tests/unit/promptBuilderSave.test.tsx
@@ -32,6 +32,8 @@ const mockContext = {
     active: true,
     userId: 'u1',
     currentChapterId: undefined,
+    status: 'active',
+    notes: '',
     createdAt: new Date(),
     updatedAt: new Date(),
   },
@@ -41,8 +43,11 @@ const mockContext = {
   characters: [],
 };
 
+type CampaignContextResult = { context: typeof mockContext | null; loading: boolean; error: string | null };
+let mockCampaignContextResult: CampaignContextResult;
+
 jest.mock('@/lib/hooks/useCampaignContext', () => ({
-  useCampaignContext: () => ({ context: mockContext, loading: false, error: null }),
+  useCampaignContext: (_id: string) => mockCampaignContextResult,
 }));
 
 import PromptBuilderPage from '@/app/campaigns/[id]/prompts/page';
@@ -55,6 +60,7 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   originalFetch = global.fetch;
+  mockCampaignContextResult = { context: mockContext, loading: false, error: null };
 });
 
 afterEach(() => {
@@ -113,6 +119,44 @@ async function submitPanelSave() {
   await act(async () => { panelSaveBtn.click(); });
   await act(async () => { await new Promise(r => setTimeout(r, 50)); });
 }
+
+function makeContextWithNotes(notes: string) {
+  return { ...mockContext, campaign: { ...mockContext.campaign, notes } };
+}
+
+describe('Prompt Builder — DM notes checkbox', () => {
+  it('TC-C1: checkbox not rendered when campaign.notes is empty', async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(PromptBuilderPage));
+    });
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox).toBeNull();
+  });
+
+  it('TC-C2: checkbox not rendered when campaign.notes is whitespace only', async () => {
+    mockCampaignContextResult = { context: makeContextWithNotes('   '), loading: false, error: null };
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(PromptBuilderPage));
+    });
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox).toBeNull();
+  });
+
+  it('TC-C3: checkbox rendered when campaign.notes is non-empty, unchecked by default', async () => {
+    mockCampaignContextResult = { context: makeContextWithNotes('Active quest: find the lost relic.'), loading: false, error: null };
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(PromptBuilderPage));
+    });
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).toBeTruthy();
+    expect(checkbox.checked).toBe(false);
+    const label = checkbox.closest('label');
+    expect(label?.textContent).toContain('Include DM notes in prompt');
+  });
+});
 
 describe('Prompt Builder — Save to Library', () => {
   it('"Save to Library" button is disabled before generate', async () => {

--- a/tests/unit/promptBuilderSave.test.tsx
+++ b/tests/unit/promptBuilderSave.test.tsx
@@ -125,17 +125,11 @@ function makeContextWithNotes(notes: string) {
 }
 
 describe('Prompt Builder — DM notes checkbox', () => {
-  it('TC-C1: checkbox not rendered when campaign.notes is empty', async () => {
-    await act(async () => {
-      root = createRoot(container);
-      root.render(React.createElement(PromptBuilderPage));
-    });
-    const checkbox = container.querySelector('input[type="checkbox"]');
-    expect(checkbox).toBeNull();
-  });
-
-  it('TC-C2: checkbox not rendered when campaign.notes is whitespace only', async () => {
-    mockCampaignContextResult = { context: makeContextWithNotes('   '), loading: false, error: null };
+  it.each([
+    ['TC-C1: empty string', ''],
+    ['TC-C2: whitespace only', '   '],
+  ])('%s — checkbox not rendered', async (_label, notes) => {
+    mockCampaignContextResult = { context: makeContextWithNotes(notes), loading: false, error: null };
     await act(async () => {
       root = createRoot(container);
       root.render(React.createElement(PromptBuilderPage));
@@ -155,6 +149,24 @@ describe('Prompt Builder — DM notes checkbox', () => {
     expect(checkbox.checked).toBe(false);
     const label = checkbox.closest('label');
     expect(label?.textContent).toContain('Include DM notes in prompt');
+  });
+
+  it('TC-C4: toggling checkbox after generate clears built prompt and closes save panel', async () => {
+    mockCampaignContextResult = { context: makeContextWithNotes('Active quest: find the lost relic.'), loading: false, error: null };
+    await renderPage();
+    await fillFirstFieldAndGenerate();
+
+    // Save panel should be openable and Save to Library enabled after generate
+    expect(findSaveToLibraryButton().disabled).toBe(false);
+    await act(async () => { findSaveToLibraryButton().click(); });
+    expect(container.querySelector('#save-title')).toBeTruthy();
+
+    // Toggle the checkbox — should clear prompt and close save panel
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => { checkbox.click(); });
+
+    expect(container.querySelector('#save-title')).toBeNull();
+    expect(findSaveToLibraryButton().disabled).toBe(true);
   });
 });
 

--- a/tests/unit/prompts/templates.test.ts
+++ b/tests/unit/prompts/templates.test.ts
@@ -127,6 +127,37 @@ describe('buildSystemPrompt', () => {
   });
 });
 
+describe('buildSystemPrompt — DM notes toggle', () => {
+  const ctxWithNotes = makeContext({ campaign: { id: 'camp-1', userId: 'u1', name: 'Curse of Strahd', moduleName: 'CoS', chapters: [], currentChapterId: undefined, status: 'active', notes: 'Quest hook: the gate is sealed.', createdAt: new Date(), updatedAt: new Date() } });
+  const ctxWhitespaceNotes = makeContext({ campaign: { ...ctxWithNotes.campaign, notes: '   ' } });
+
+  test('TC-N1: notes block absent when opts omitted', () => {
+    const result = buildSystemPrompt(ctxWithNotes);
+    expect(result).not.toContain('Current campaign context (DM notes):');
+  });
+
+  test('TC-N2: notes block absent when opts.includeNotes is false', () => {
+    const result = buildSystemPrompt(ctxWithNotes, { includeNotes: false });
+    expect(result).not.toContain('Current campaign context (DM notes):');
+  });
+
+  test('TC-N3: notes block present when opts.includeNotes is true', () => {
+    const result = buildSystemPrompt(ctxWithNotes, { includeNotes: true });
+    expect(result).toContain('Current campaign context (DM notes):\nQuest hook: the gate is sealed.');
+  });
+
+  test('TC-N4: notes block absent when notes are whitespace only, even with includeNotes: true', () => {
+    const result = buildSystemPrompt(ctxWhitespaceNotes, { includeNotes: true });
+    expect(result).not.toContain('Current campaign context (DM notes):');
+  });
+
+  test('TC-N5: npcTemplate passes opts through — notes block appears in fullText', () => {
+    const result = npcTemplate.build({ role: 'innkeeper', location: 'Barovia', requirements: '' }, ctxWithNotes, { includeNotes: true });
+    expect(result.fullText).toContain('Current campaign context (DM notes):');
+    expect(result.fullText).toContain('Quest hook: the gate is sealed.');
+  });
+});
+
 describe('TEMPLATES array', () => {
   test('B1-12: exactly 5 entries with distinct ids', () => {
     expect(TEMPLATES).toHaveLength(5);


### PR DESCRIPTION
## Summary

Adds an opt-in checkbox to the Prompt Builder that lets DMs include their campaign notes in generated prompts.

## Changes

- **`lib/prompts/templates.ts`** — `buildSystemPrompt` gains `opts?: { includeNotes?: boolean }`; `PromptTemplate.build` signature gains `opts?`; all five `build` implementations thread `opts` through
- **`app/campaigns/[id]/prompts/page.tsx`** — `includeNotes` state, `hasNotes` derived boolean, checkbox UI, `handleGenerate` passes opts
- **`tests/unit/prompts/templates.test.ts`** — 5 new unit tests for the notes toggle behaviour in `buildSystemPrompt`
- **`tests/unit/promptBuilderSave.test.tsx`** — 3 new component tests for checkbox visibility

## Behaviour

- Checkbox labelled "Include DM notes in prompt" is hidden when `campaign.notes` is empty or whitespace-only
- When checked, appends `Current campaign context (DM notes):\n{notes}` block to the generated prompt
- Toggle resets to unchecked on each page load (session-local, no persistence)
- Toggling clears any previously generated prompt to prevent stale output

Closes #231