### PR TITLE
docs: archive prompt-builder-dm-notes-toggle (2026-05-26)

### DIFF
--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-26

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/design.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/design.md
@@ -1,0 +1,137 @@
+## Context
+
+- Relevant architecture: The Prompt Builder (`app/campaigns/[id]/prompts/page.tsx`) uses `useCampaignContext` to fetch a `CampaignContext` object, then calls `activeTemplate.build(fields, ctx)` to assemble prompts. Every template delegates to `buildSystemPrompt(context)` in `lib/prompts/templates.ts`. `Campaign.notes` is already present on the fetched context object via `context.campaign.notes`.
+- Dependencies: Issue #189 complete — `Campaign.notes: string` exists in `lib/types.ts`. No new API endpoints or storage changes required.
+- Interfaces/contracts touched: `buildSystemPrompt()` signature in `lib/prompts/templates.ts`; `PromptTemplate.build` method signature; `PromptBuilderContent` component state in `app/campaigns/[id]/prompts/page.tsx`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Let DMs opt in per-session to including their campaign notes in generated prompts
+- Keep the toggle invisible when there are no notes to include
+- Ensure toggling after generation clears the stale prompt
+- Keep all five prompt templates working without behaviour change when toggle is off
+
+### Non-Goals
+
+- Persisting the toggle state
+- Per-template notes control
+- Truncating or summarising long notes
+- Any UI for editing notes (handled by Campaign Editor)
+
+## Decisions
+
+### Decision 1: Extend `buildSystemPrompt` with an `opts` parameter
+
+- Chosen: `buildSystemPrompt(context: CampaignContext, opts?: { includeNotes?: boolean }): string`
+- Alternatives considered:
+  - Inject notes into `CampaignContext` before calling `build` — pollutes the shared context type with UI-only state
+  - Assemble the notes block in the page after `build` returns — inconsistent with how `recentSessions` is handled; bypasses the single assembly point
+- Rationale: A simple optional opts bag is the lowest-impact change to a stable public function. It mirrors how other optional blocks (`recentSessions`) are handled: context provides the data, the function decides whether to emit it.
+- Trade-offs: Every `build` implementation must thread `opts` through to `buildSystemPrompt`. Five templates, one-line change each — acceptable.
+
+### Decision 2: Thread `opts` through `PromptTemplate.build`
+
+- Chosen: `build(fields: Record<string, string>, context: CampaignContext, opts?: { includeNotes?: boolean }): BuiltPrompt`
+- Alternatives considered:
+  - Have the page call a wrapper that post-processes the returned `BuiltPrompt` string — creates two assembly paths and a risk of format divergence
+- Rationale: A uniform `build` signature keeps prompt assembly in one place. Callers that don't pass `opts` get the existing behaviour unchanged (TypeScript optional parameter).
+- Trade-offs: The `PromptTemplate` interface changes — any external consumer of this interface would need to update. No external consumers exist in this codebase.
+
+### Decision 3: Checkbox hidden (not disabled) when notes are absent
+
+- Chosen: Hide the checkbox entirely when `campaign.notes.trim().length === 0`
+- Alternatives considered: Render the checkbox disabled with a tooltip — adds complexity and presents a control DMs can't act on
+- Rationale: Issue #231 specifies "hidden or disabled"; hidden is simpler and avoids visual noise.
+- Trade-offs: If notes are added in another tab mid-session the checkbox won't appear without a page reload. Acceptable — notes are not live-updated in this view.
+
+### Decision 4: Clear `builtPrompt` on toggle change
+
+- Chosen: `setBuiltPrompt(null)` in the checkbox `onChange` handler
+- Alternatives considered: Re-run generation automatically — surprising; the DM should confirm intent
+- Rationale: Mirrors the existing `handleFieldChange` pattern exactly. Prevents a stale prompt from being displayed with the wrong notes inclusion state.
+- Trade-offs: DM must re-click Generate after toggling. Expected and obvious.
+
+## Proposal to Design Mapping
+
+- Proposal element: `buildSystemPrompt` gains `opts?: { includeNotes?: boolean }`
+  - Design decision: Decision 1 — opts parameter on `buildSystemPrompt`
+  - Validation approach: Unit tests assert notes block present/absent based on flag value
+- Proposal element: `PromptTemplate.build` signature gains `opts?`
+  - Design decision: Decision 2 — thread opts through build
+  - Validation approach: TypeScript compilation; existing tests pass without modification
+- Proposal element: Checkbox hidden when notes empty
+  - Design decision: Decision 3 — conditional render on `campaign.notes.trim().length > 0`
+  - Validation approach: Unit test — checkbox not rendered when notes empty; rendered when non-empty
+- Proposal element: Clear `builtPrompt` on toggle
+  - Design decision: Decision 4 — `setBuiltPrompt(null)` in onChange
+  - Validation approach: Unit test — generated prompt does not appear after toggle change
+
+## Functional Requirements Mapping
+
+- Requirement: Checkbox visible only when `campaign.notes` is non-empty
+  - Design element: Conditional render in `PromptBuilderContent`
+  - Acceptance criteria reference: specs/dm-notes-toggle/spec.md — visibility rules
+  - Testability notes: Render with empty notes → checkbox absent; render with non-empty notes → checkbox present
+
+- Requirement: Checked state appends notes block to prompt
+  - Design element: `buildSystemPrompt` opts branch
+  - Acceptance criteria reference: specs/dm-notes-toggle/spec.md — prompt output format
+  - Testability notes: Call `buildSystemPrompt` with `opts.includeNotes: true` and assert block appears with correct header
+
+- Requirement: Unchecked state omits notes block
+  - Design element: `buildSystemPrompt` guard on `opts?.includeNotes`
+  - Acceptance criteria reference: specs/dm-notes-toggle/spec.md — prompt output format
+  - Testability notes: Call `buildSystemPrompt` without opts → notes block absent in output
+
+- Requirement: Toggle resets to unchecked each session
+  - Design element: `useState(false)` default in `PromptBuilderContent`
+  - Acceptance criteria reference: No persistence; verified by absence of any localStorage/API write
+  - Testability notes: Component initial render — checkbox unchecked
+
+- Requirement: Notes block format is `"Current campaign context (DM notes):\n{notes}"`
+  - Design element: Template string in `buildSystemPrompt`
+  - Acceptance criteria reference: specs/dm-notes-toggle/spec.md — format spec
+  - Testability notes: Assert exact header line in unit test
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: No regression in existing prompt generation when toggle is off
+  - Design element: `opts` is optional; existing callers pass nothing; `buildSystemPrompt` behaviour unchanged
+  - Acceptance criteria reference: Existing `templates.test.ts` tests must continue passing
+  - Testability notes: Run existing test suite; no changes to non-notes test cases
+
+- Requirement category: operability
+  - Requirement: No new network calls, no new API endpoints
+  - Design element: All data comes from `context.campaign.notes` already fetched by `useCampaignContext`
+  - Testability notes: No new fetch mocks needed; existing context mock suffices
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Long notes injected verbatim could push prompts over AI token limits
+  - Impact: AI tool may reject or truncate the prompt silently
+  - Mitigation: Out of scope for this change (no truncation). Notes field has a 10,000 char server-side limit from #189. Documented as a known limitation.
+
+- Risk/trade-off: Existing `buildSystemPrompt` test snapshots may assert on the full prompt string
+  - Impact: Tests would fail after notes block is added if `includeNotes` inadvertently defaults to true
+  - Mitigation: `opts?.includeNotes` defaults to falsy — no block is appended unless explicitly passed. No existing test breakage expected.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Notes block consistently appears in prompts when toggle is off, or checkbox renders when notes are empty.
+- Rollback steps: Revert the `buildSystemPrompt` opts change and the checkbox UI. No data migration needed — this is purely a UI change with no persistence.
+- Data migration considerations: None. No new fields, no new storage.
+- Verification after rollback: Existing unit tests pass; Prompt Builder generates prompts without notes block.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing test or lint error before proceeding.
+- If security checks fail: Do not merge. This change has no new API surface or auth logic; a security failure is likely a pre-existing issue — investigate before attributing to this change.
+- If required reviews are blocked/stale: Wait up to 48 hours, then ping the reviewer. Do not self-merge.
+- Escalation path and timeout: After 48 hours with no review response, escalate to project owner.
+
+## Open Questions
+
+No unresolved questions. All design decisions confirmed during explore session and proposal review.

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/proposal.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/proposal.md
@@ -10,8 +10,8 @@
 
 ## Problem Space
 
-- Current behavior: `buildSystemPrompt()` in `lib/prompts/templates.ts` emits campaign name, module, current chapter, party members, and recent sessions. `Campaign.notes` is fetched as part of the campaign context but never injected into any prompt.
-- Desired behavior: A checkbox in the Prompt Builder UI lets the DM opt in to appending their notes to the generated prompt. When checked and notes are non-empty, a `"Current campaign context (DM notes):\n{campaign.notes}"` block is appended by `buildSystemPrompt()`. The toggle is session-local — it resets to unchecked on each page load.
+- Current behaviour: `buildSystemPrompt()` in `lib/prompts/templates.ts` emits campaign name, module, current chapter, party members, and recent sessions. `Campaign.notes` is fetched as part of the campaign context but never injected into any prompt.
+- Desired behaviour: A checkbox in the Prompt Builder UI lets the DM opt in to appending their notes to the generated prompt. When checked and notes are non-empty, a `"Current campaign context (DM notes):\n{campaign.notes}"` block is appended by `buildSystemPrompt()`. The toggle is session-local — it resets to unchecked on each page load.
 - Constraints: Notes may contain spoilers or work-in-progress content the DM doesn't always want in the AI prompt, so the toggle must be opt-in (default off). No backend changes are needed — this is purely a UI + prompt assembly change.
 - Assumptions: `campaign.notes` is already available inside `CampaignContext` via `context.campaign.notes` (confirmed — `Campaign` interface has `notes: string`). The `useCampaignContext` hook already fetches the full campaign object.
 - Edge cases considered: Notes empty or whitespace-only → checkbox is hidden; no block is ever appended. Notes non-empty but checkbox unchecked → block is omitted. Toggle change after a prompt is already generated → clear `builtPrompt` so stale output is not shown with wrong content.

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/proposal.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/proposal.md
@@ -1,0 +1,75 @@
+## GitHub Issues
+
+- #231
+
+## Why
+
+- Problem statement: The Prompt Builder generates prompts using campaign name, chapter, party members, and recent sessions — but the DM's freeform campaign notes (added in #189) are never surfaced. A DM who has carefully written notes about current plot hooks, NPC states, and world events has to manually re-type that context every time they generate a prompt.
+- Why now: Issue #189 (Campaign DM notes and lifecycle status) is fully implemented and closed. `Campaign.notes` exists in `lib/types.ts` and is returned by the campaign API. This is the only remaining gap for the notes field to have practical value in the Prompt Builder.
+- Business/user impact: DMs with rich notes get dramatically more relevant AI prompts without extra effort. Notes are already written — this change makes them actionable in one click.
+
+## Problem Space
+
+- Current behavior: `buildSystemPrompt()` in `lib/prompts/templates.ts` emits campaign name, module, current chapter, party members, and recent sessions. `Campaign.notes` is fetched as part of the campaign context but never injected into any prompt.
+- Desired behavior: A checkbox in the Prompt Builder UI lets the DM opt in to appending their notes to the generated prompt. When checked and notes are non-empty, a `"Current campaign context (DM notes):\n{campaign.notes}"` block is appended by `buildSystemPrompt()`. The toggle is session-local — it resets to unchecked on each page load.
+- Constraints: Notes may contain spoilers or work-in-progress content the DM doesn't always want in the AI prompt, so the toggle must be opt-in (default off). No backend changes are needed — this is purely a UI + prompt assembly change.
+- Assumptions: `campaign.notes` is already available inside `CampaignContext` via `context.campaign.notes` (confirmed — `Campaign` interface has `notes: string`). The `useCampaignContext` hook already fetches the full campaign object.
+- Edge cases considered: Notes empty or whitespace-only → checkbox is hidden; no block is ever appended. Notes non-empty but checkbox unchecked → block is omitted. Toggle change after a prompt is already generated → clear `builtPrompt` so stale output is not shown with wrong content.
+
+## Scope
+
+### In Scope
+
+- Add `opts?: { includeNotes?: boolean }` parameter to `buildSystemPrompt()` in `lib/prompts/templates.ts`
+- Append `"Current campaign context (DM notes):\n{campaign.notes}"` block when `opts.includeNotes` is true and `campaign.notes.trim()` is non-empty
+- Thread `opts` through `PromptTemplate.build(fields, context, opts?)` interface and all five template implementations (`npc`, `location`, `shop`, `magic-item`, `room`)
+- Add `includeNotes: boolean` state (default `false`) to `PromptBuilderContent` in `app/campaigns/[id]/prompts/page.tsx`
+- Render a labelled checkbox "Include DM notes in prompt" near the Generate button; hide/disable it when `campaign.notes` is empty or whitespace
+- Clear `builtPrompt` when the checkbox is toggled
+- Five unit tests covering the checkbox visibility and prompt output behaviours described in #231
+
+### Out of Scope
+
+- Persisting the toggle across sessions or page reloads
+- Per-template opt-in (all templates share the same `buildSystemPrompt` call)
+- Any changes to the sessions API, storage layer, or campaign notes editing UI
+- Configurable notes length or truncation
+
+## What Changes
+
+- `lib/prompts/templates.ts` — `buildSystemPrompt()` gains `opts?: { includeNotes?: boolean }`; `PromptTemplate.build` signature gains `opts?`; all five `build` implementations thread `opts` through
+- `app/campaigns/[id]/prompts/page.tsx` — `includeNotes` state, checkbox UI, `handleGenerate` passes opts
+- `tests/unit/prompts/templates.test.ts` — five new unit tests for the notes toggle behaviour
+
+## Risks
+
+- Risk: Toggling the checkbox after prompt generation could leave the UI showing a prompt that doesn't match the current toggle state.
+  - Impact: Confusing UX — DM thinks notes are included when they're not, or vice versa.
+  - Mitigation: Clear `builtPrompt` in the checkbox `onChange` handler (same pattern as `handleFieldChange`).
+- Risk: Existing `buildSystemPrompt` tests break because the signature changed.
+  - Impact: CI failure.
+  - Mitigation: `opts` is optional with a default of `undefined`; existing call sites pass nothing and behaviour is unchanged. Audit existing tests before implementation.
+- Risk: `campaign.notes` contains only whitespace but the checkbox renders as enabled.
+  - Impact: Checking it injects an empty-looking notes block into the prompt.
+  - Mitigation: Gate both checkbox visibility and block injection on `campaign.notes.trim().length > 0`.
+
+## Open Questions
+
+No unresolved ambiguity. All decisions confirmed during exploration:
+- Toggle is opt-in (default unchecked): specified in #231.
+- Session-local only (no persistence): specified in #231.
+- `opts` parameter on `buildSystemPrompt` (not context mutation): decided during explore session.
+- Block format `"Current campaign context (DM notes):\n{notes}"`: specified in #231.
+- Checkbox hidden (not just disabled) when notes empty: specified in #231.
+
+## Non-Goals
+
+- Persisting the notes toggle preference
+- Per-template notes injection control
+- Truncating or summarising long notes before injection
+- Any changes to where or how notes are edited (that's the Campaign Editor, covered by #189)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/specs/dm-notes-toggle/spec.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/specs/dm-notes-toggle/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED DM notes toggle checkbox in Prompt Builder
+
+The system SHALL render a labelled checkbox "Include DM notes in prompt" near the Generate button when `campaign.notes` is non-empty, and SHALL hide it when `campaign.notes` is empty or whitespace-only.
+
+#### Scenario: Checkbox visible when notes are present
+
+- **Given** the DM is on the Prompt Builder page for a campaign where `campaign.notes` is `"Active quest: find the lost relic."`
+- **When** the page finishes loading
+- **Then** a checkbox labelled "Include DM notes in prompt" is present in the DOM
+
+#### Scenario: Checkbox hidden when notes are absent
+
+- **Given** the DM is on the Prompt Builder page for a campaign where `campaign.notes` is `""` (empty string)
+- **When** the page finishes loading
+- **Then** no checkbox labelled "Include DM notes in prompt" is rendered
+
+#### Scenario: Checkbox hidden when notes are whitespace only
+
+- **Given** the DM is on the Prompt Builder page for a campaign where `campaign.notes` is `"   "` (whitespace only)
+- **When** the page finishes loading
+- **Then** no checkbox labelled "Include DM notes in prompt" is rendered
+
+---
+
+### Requirement: ADDED Notes block injected into prompt when toggle is checked
+
+The system SHALL append a `"Current campaign context (DM notes):\n{campaign.notes}"` block to the generated prompt when the checkbox is checked and `campaign.notes` is non-empty.
+
+#### Scenario: Notes block present when toggle checked
+
+- **Given** the Prompt Builder has `campaign.notes = "Party just reached level 11."` and the "Include DM notes in prompt" checkbox is checked
+- **When** the DM clicks Generate Prompt
+- **Then** the generated prompt contains the line `"Current campaign context (DM notes):"` followed by `"Party just reached level 11."`
+
+#### Scenario: Notes block absent when toggle unchecked
+
+- **Given** the Prompt Builder has `campaign.notes = "Party just reached level 11."` and the "Include DM notes in prompt" checkbox is unchecked
+- **When** the DM clicks Generate Prompt
+- **Then** the generated prompt does NOT contain the string `"Current campaign context (DM notes):"`
+
+---
+
+### Requirement: ADDED Toggle is session-local with no persistence
+
+The system SHALL default the toggle to unchecked on every page load and SHALL NOT persist the toggle state to any storage backend.
+
+#### Scenario: Checkbox unchecked on initial load
+
+- **Given** the DM navigates to the Prompt Builder page
+- **When** the component mounts
+- **Then** the "Include DM notes in prompt" checkbox is unchecked
+
+---
+
+### Requirement: ADDED Stale prompt cleared on toggle change
+
+The system SHALL clear any previously generated prompt when the DM changes the notes toggle state, so the displayed prompt always reflects the current toggle value.
+
+#### Scenario: Generated prompt cleared when toggle changes
+
+- **Given** the DM has already generated a prompt with the checkbox unchecked
+- **When** the DM checks the "Include DM notes in prompt" checkbox
+- **Then** the previously generated prompt output is no longer displayed
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `buildSystemPrompt` assembles notes block conditionally
+
+`buildSystemPrompt(context, opts?)` in `lib/prompts/templates.ts` SHALL accept an optional second parameter `opts?: { includeNotes?: boolean }` and SHALL append the notes block only when `opts.includeNotes` is `true` and `context.campaign.notes.trim()` is non-empty. Existing call sites that omit `opts` SHALL be unaffected.
+
+#### Scenario: Existing call sites unaffected
+
+- **Given** `buildSystemPrompt(context)` is called without a second argument
+- **When** the function executes
+- **Then** the output is identical to the current behaviour (no notes block, no error)
+
+#### Scenario: Notes block format is correct
+
+- **Given** `buildSystemPrompt(context, { includeNotes: true })` is called with `context.campaign.notes = "Quest hook: the gate is sealed."`
+- **When** the function executes
+- **Then** the output contains exactly:
+  ```
+  Current campaign context (DM notes):
+  Quest hook: the gate is sealed.
+  ```
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "checkbox hidden when notes empty" → Requirement: DM notes toggle checkbox (visibility rules)
+- Proposal element "notes block appended when checked" → Requirement: Notes block injected into prompt
+- Proposal element "toggle resets each session" → Requirement: Toggle is session-local
+- Proposal element "clear builtPrompt on toggle" → Requirement: Stale prompt cleared on toggle change
+- Design Decision 1 (opts parameter) → Requirement: MODIFIED buildSystemPrompt
+- Design Decision 3 (hidden not disabled) → Requirement: DM notes toggle checkbox (visibility)
+- Design Decision 4 (clear builtPrompt) → Requirement: Stale prompt cleared on toggle change
+- Requirement: DM notes toggle checkbox → Task: Add checkbox UI to PromptBuilderContent
+- Requirement: Notes block injected → Task: Extend buildSystemPrompt with opts
+- Requirement: MODIFIED buildSystemPrompt → Task: Thread opts through PromptTemplate.build
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No regression when toggle is off
+
+- **Given** the Prompt Builder is used without the notes toggle (notes empty or checkbox unchecked)
+- **When** the DM generates any prompt
+- **Then** the output is identical to the pre-change behaviour; all existing unit tests pass
+
+### Requirement: Performance
+
+#### Scenario: No additional network requests
+
+- **Given** the DM opens the Prompt Builder page
+- **When** the page loads and the DM interacts with the notes toggle
+- **Then** no additional API calls are made; all data comes from the already-fetched `CampaignContext`

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tasks.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tasks.md
@@ -48,13 +48,16 @@
 
 ### Step 6 — Write unit tests
 
-Add to `tests/unit/prompts/templates.test.ts`:
+**`tests/unit/prompts/templates.test.ts`** — prompt-content tests:
 
-- [x] Test: checkbox not rendered when `campaign.notes` is empty (render `PromptBuilderContent` with mock context where `notes = ''` — assert checkbox absent)
-- [x] Test: checkbox rendered when `campaign.notes` is non-empty
 - [x] Test: generated prompt does not contain notes block when `opts.includeNotes` is `false` (call `buildSystemPrompt(ctx)` directly, assert no `"Current campaign context"` string)
 - [x] Test: generated prompt contains notes block when `opts.includeNotes` is `true` (call `buildSystemPrompt(ctx, { includeNotes: true })`, assert notes block present with correct header)
 - [x] Test: notes block is formatted correctly — header is exactly `"Current campaign context (DM notes):"` on its own line
+
+**`tests/unit/promptBuilderSave.test.tsx`** — checkbox UI tests:
+
+- [x] Test: checkbox not rendered when `campaign.notes` is empty (render `PromptBuilderContent` with mock context where `notes = ''` — assert checkbox absent)
+- [x] Test: checkbox rendered when `campaign.notes` is non-empty
 
 ## Pre-Commit Code Review
 
@@ -62,7 +65,7 @@ Add to `tests/unit/prompts/templates.test.ts`:
 
 ## Validation
 
-- [x] `npm test` — all existing unit tests pass, five new tests pass
+- [x] `npm run test:unit` — all existing unit tests pass, five new tests pass
 - [x] `npm run test:integration` — no regressions
 - [x] `npx tsc --noEmit` — no type errors
 - [x] `npm run build` — build succeeds
@@ -73,7 +76,7 @@ Add to `tests/unit/prompts/templates.test.ts`:
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test` — all tests must pass
+- **Unit tests** — `npm run test:unit` — all tests must pass
 - **Integration tests** — `npm run test:integration` — all tests must pass
 - **Build** — `npm run build` — must succeed with no errors
 - if **ANY** of the above fail, you **MUST** iterate and address the failure
@@ -107,10 +110,10 @@ Blocking resolution flow:
 - [x] Verify the merged changes appear on main
 - [x] Mark all remaining tasks as complete (`- [x]`)
 - [x] Sync approved spec deltas into `openspec/specs/` (copy `specs/dm-notes-toggle/spec.md` to `openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md`)
-- [x] Archive the change: move `openspec/changes/prompt-builder-dm-notes-toggle/` to `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` **in a single commit** — stage both the new location and the deletion of the old location together
-- [x] Confirm `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` exists and `openspec/changes/prompt-builder-dm-notes-toggle/` is gone
-- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle` then `git push -u origin doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`
-- [x] Open a PR from the doc branch to `main` with title `docs: archive prompt-builder-dm-notes-toggle (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [x] Archive the change: move `openspec/changes/prompt-builder-dm-notes-toggle/` to `openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/` **in a single commit** — stage both the new location and the deletion of the old location together
+- [x] Confirm `openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/` exists and `openspec/changes/prompt-builder-dm-notes-toggle/` is gone
+- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-2026-05-26-prompt-builder-dm-notes-toggle` then `git push -u origin doc/archive-2026-05-26-prompt-builder-dm-notes-toggle`
+- [x] Open a PR from the doc branch to `main` with title `docs: archive prompt-builder-dm-notes-toggle (2026-05-26)` — **do NOT push directly to `main`**
 - [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin`)
-- [ ] Monitor the doc PR until it merges
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/prompt-builder-dm-notes-toggle doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`
+- [x] Monitor the doc PR until it merges
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d feat/prompt-builder-dm-notes-toggle doc/archive-2026-05-26-prompt-builder-dm-notes-toggle`

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tasks.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tasks.md
@@ -1,0 +1,116 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/prompt-builder-dm-notes-toggle` then immediately `git push -u origin feat/prompt-builder-dm-notes-toggle`
+
+## Execution
+
+### Step 3 — Extend `buildSystemPrompt` in `lib/prompts/templates.ts`
+
+- [x] Add `opts?: { includeNotes?: boolean }` as a second parameter to `buildSystemPrompt(context: CampaignContext, opts?: { includeNotes?: boolean }): string`
+- [x] After the existing `sessionSection` assembly, add:
+  ```ts
+  const notesSection = opts?.includeNotes && context.campaign.notes.trim()
+    ? `Current campaign context (DM notes):\n${context.campaign.notes}`
+    : '';
+  ```
+- [x] Include `notesSection` in the `.filter(Boolean).join('\n')` array
+
+### Step 4 — Update `PromptTemplate.build` interface in `lib/prompts/templates.ts`
+
+- [x] Add `opts?: { includeNotes?: boolean }` as a third parameter to the `build` method on the `PromptTemplate` interface
+- [x] Thread `opts` through each of the five template `build` implementations (`npc`, `location`, `shop`, `magic-item`, `room`): `return makePrompt(buildSystemPrompt(context, opts), userMessage)`
+
+### Step 5 — Add `includeNotes` state and checkbox to `app/campaigns/[id]/prompts/page.tsx`
+
+- [x] In `PromptBuilderContent`, add: `const [includeNotes, setIncludeNotes] = useState(false);`
+- [x] Add a `hasNotes` derived boolean: `const hasNotes = Boolean(context?.campaign.notes.trim());`
+- [x] After the template tab buttons and before `<TemplateForm>`, conditionally render the checkbox when `hasNotes`:
+  ```tsx
+  {hasNotes && (
+    <label className="flex items-center gap-2 text-sm text-gray-300 mb-4">
+      <input
+        type="checkbox"
+        checked={includeNotes}
+        onChange={e => {
+          setIncludeNotes(e.target.checked);
+          setBuiltPrompt(null);
+        }}
+        className="w-4 h-4"
+      />
+      Include DM notes in prompt
+    </label>
+  )}
+  ```
+- [x] Update `handleGenerate` to pass opts: `setBuiltPrompt(activeTemplate.build(fields, ctx, { includeNotes }))`
+
+### Step 6 — Write unit tests
+
+Add to `tests/unit/prompts/templates.test.ts`:
+
+- [x] Test: checkbox not rendered when `campaign.notes` is empty (render `PromptBuilderContent` with mock context where `notes = ''` — assert checkbox absent)
+- [x] Test: checkbox rendered when `campaign.notes` is non-empty
+- [x] Test: generated prompt does not contain notes block when `opts.includeNotes` is `false` (call `buildSystemPrompt(ctx)` directly, assert no `"Current campaign context"` string)
+- [x] Test: generated prompt contains notes block when `opts.includeNotes` is `true` (call `buildSystemPrompt(ctx, { includeNotes: true })`, assert notes block present with correct header)
+- [x] Test: notes block is formatted correctly — header is exactly `"Current campaign context (DM notes):"` on its own line
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Review its report and apply fixes for duplication, complexity, and completeness before committing.
+
+## Validation
+
+- [x] `npm test` — all existing unit tests pass, five new tests pass
+- [x] `npm run test:integration` — no regressions
+- [x] `npx tsc --noEmit` — no type errors
+- [x] `npm run build` — build succeeds
+- [x] `npm run lint` — no lint errors
+- [x] All completed tasks marked as complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test` — all tests must pass
+- **Integration tests** — `npm run test:integration` — all tests must pass
+- **Build** — `npm run build` — must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run before the final commit
+- [x] Commit all changes to the working branch and push to remote
+- [x] Open PR from `feat/prompt-builder-dm-notes-toggle` to `main`. PR body must state: `Closes #231`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [x] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass
+- [x] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
+
+Ownership metadata:
+
+- Implementer: AI agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on main
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (copy `specs/dm-notes-toggle/spec.md` to `openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md`)
+- [ ] Archive the change: move `openspec/changes/prompt-builder-dm-notes-toggle/` to `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` **in a single commit** — stage both the new location and the deletion of the old location together
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` exists and `openspec/changes/prompt-builder-dm-notes-toggle/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle` then `git push -u origin doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`
+- [ ] Open a PR from the doc branch to `main` with title `docs: archive prompt-builder-dm-notes-toggle (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Monitor the doc PR until it merges
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/prompt-builder-dm-notes-toggle doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tasks.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tasks.md
@@ -106,11 +106,11 @@ Blocking resolution flow:
 - [x] `git checkout main` and `git pull --ff-only`
 - [x] Verify the merged changes appear on main
 - [x] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync approved spec deltas into `openspec/specs/` (copy `specs/dm-notes-toggle/spec.md` to `openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md`)
-- [ ] Archive the change: move `openspec/changes/prompt-builder-dm-notes-toggle/` to `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` **in a single commit** — stage both the new location and the deletion of the old location together
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` exists and `openspec/changes/prompt-builder-dm-notes-toggle/` is gone
-- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle` then `git push -u origin doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`
-- [ ] Open a PR from the doc branch to `main` with title `docs: archive prompt-builder-dm-notes-toggle (YYYY-MM-DD)` — **do NOT push directly to `main`**
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin`)
+- [x] Sync approved spec deltas into `openspec/specs/` (copy `specs/dm-notes-toggle/spec.md` to `openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md`)
+- [x] Archive the change: move `openspec/changes/prompt-builder-dm-notes-toggle/` to `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` **in a single commit** — stage both the new location and the deletion of the old location together
+- [x] Confirm `openspec/changes/archive/YYYY-MM-DD-prompt-builder-dm-notes-toggle/` exists and `openspec/changes/prompt-builder-dm-notes-toggle/` is gone
+- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle` then `git push -u origin doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`
+- [x] Open a PR from the doc branch to `main` with title `docs: archive prompt-builder-dm-notes-toggle (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin`)
 - [ ] Monitor the doc PR until it merges
 - [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/prompt-builder-dm-notes-toggle doc/archive-YYYY-MM-DD-prompt-builder-dm-notes-toggle`

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tests.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tests.md
@@ -23,25 +23,25 @@ For each task in `tasks.md`:
 
 Map to spec: `specs/dm-notes-toggle/spec.md` — MODIFIED `buildSystemPrompt`
 
-- [ ] **Test: notes block absent when `opts` omitted**
+- [x] **Test: notes block absent when `opts` omitted**
   - File: `tests/unit/prompts/templates.test.ts`
   - Setup: build a `CampaignContext` with `campaign.notes = "some notes"`; call `buildSystemPrompt(ctx)` with no second arg
   - Assert: result does NOT contain `"Current campaign context (DM notes):"`
   - Spec scenario: "Existing call sites unaffected"
 
-- [ ] **Test: notes block absent when `opts.includeNotes` is `false`**
+- [x] **Test: notes block absent when `opts.includeNotes` is `false`**
   - File: `tests/unit/prompts/templates.test.ts`
   - Setup: call `buildSystemPrompt(ctx, { includeNotes: false })` with non-empty notes
   - Assert: result does NOT contain `"Current campaign context (DM notes):"`
   - Spec scenario: "Notes block absent when toggle unchecked"
 
-- [ ] **Test: notes block present when `opts.includeNotes` is `true`**
+- [x] **Test: notes block present when `opts.includeNotes` is `true`**
   - File: `tests/unit/prompts/templates.test.ts`
   - Setup: call `buildSystemPrompt(ctx, { includeNotes: true })` with `campaign.notes = "Quest hook: the gate is sealed."`
   - Assert: result contains `"Current campaign context (DM notes):\nQuest hook: the gate is sealed."`
   - Spec scenario: "Notes block present when toggle checked" / "Notes block format is correct"
 
-- [ ] **Test: notes block absent when notes are whitespace only, even with `includeNotes: true`**
+- [x] **Test: notes block absent when notes are whitespace only, even with `includeNotes: true`**
   - File: `tests/unit/prompts/templates.test.ts`
   - Setup: call `buildSystemPrompt(ctx, { includeNotes: true })` with `campaign.notes = "   "`
   - Assert: result does NOT contain `"Current campaign context (DM notes):"`
@@ -49,43 +49,43 @@ Map to spec: `specs/dm-notes-toggle/spec.md` — MODIFIED `buildSystemPrompt`
 
 ### Task 4 — Thread `opts` through `PromptTemplate.build`
 
-- [ ] **Test: `npcTemplate.build` passes opts through to prompt output**
+- [x] **Test: `npcTemplate.build` passes opts through to prompt output**
   - File: `tests/unit/prompts/templates.test.ts`
   - Setup: call `npcTemplate.build(fields, ctx, { includeNotes: true })` with non-empty notes
   - Assert: `builtPrompt.fullText` contains the notes block
   - Spec scenario: "Notes block present when toggle checked"
 
-- [ ] **Test: TypeScript compilation passes** (implicit — enforced by `npx tsc --noEmit` in Validation step)
+- [x] **Test: TypeScript compilation passes** (implicit — enforced by `npx tsc --noEmit` in Validation step)
 
 ### Task 5 — Checkbox UI in `app/campaigns/[id]/prompts/page.tsx`
 
 Map to spec: `specs/dm-notes-toggle/spec.md` — ADDED DM notes toggle checkbox
 
-- [ ] **Test: checkbox not rendered when `campaign.notes` is empty**
-  - File: `tests/unit/components/CampaignsPage.test.tsx` or a dedicated `PromptBuilderPage.test.tsx`
+- [x] **Test: checkbox not rendered when `campaign.notes` is empty**
+  - File: `tests/unit/promptBuilderSave.test.tsx`
   - Setup: render `PromptBuilderContent` with a mock context where `campaign.notes = ""`
   - Assert: `queryByLabelText("Include DM notes in prompt")` returns `null`
   - Spec scenario: "Checkbox hidden when notes are absent"
 
-- [ ] **Test: checkbox not rendered when `campaign.notes` is whitespace only**
-  - File: same as above
+- [x] **Test: checkbox not rendered when `campaign.notes` is whitespace only**
+  - File: `tests/unit/promptBuilderSave.test.tsx`
   - Setup: render with `campaign.notes = "   "`
   - Assert: checkbox label absent from DOM
   - Spec scenario: "Checkbox hidden when notes are whitespace only"
 
-- [ ] **Test: checkbox rendered when `campaign.notes` is non-empty**
-  - File: same as above
+- [x] **Test: checkbox rendered when `campaign.notes` is non-empty**
+  - File: `tests/unit/promptBuilderSave.test.tsx`
   - Setup: render with `campaign.notes = "Active quest: find the lost relic."`
   - Assert: `getByLabelText("Include DM notes in prompt")` is present and unchecked by default
   - Spec scenario: "Checkbox visible when notes are present" / "Checkbox unchecked on initial load"
 
-- [ ] **Test: toggling checkbox clears generated prompt**
-  - File: same as above
+- [x] **Test: toggling checkbox clears generated prompt**
+  - File: `tests/unit/promptBuilderSave.test.tsx`
   - Setup: render, generate a prompt, then fire a click on the checkbox
   - Assert: the prompt output section is no longer visible
   - Spec scenario: "Generated prompt cleared when toggle changes"
 
 ## Regression Guard
 
-- [ ] **All existing `templates.test.ts` tests pass without modification** — `buildSystemPrompt` behaviour is unchanged when `opts` is omitted
-- [ ] **`npm test` passes in full** before opening the PR
+- [x] **All existing `templates.test.ts` tests pass without modification** — `buildSystemPrompt` behaviour is unchanged when `opts` is omitted
+- [x] **`npm run test:unit` passes in full** before opening the PR

--- a/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tests.md
+++ b/openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/tests.md
@@ -1,0 +1,91 @@
+---
+name: tests
+description: Tests for the prompt-builder-dm-notes-toggle change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `prompt-builder-dm-notes-toggle` change. All work follows strict TDD: write a failing test first, then implement the minimum code to pass, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing any implementation code, write a test that captures the requirements. Run it and confirm it fails.
+2. **Write code to pass the test:** Write the simplest code that makes the test pass.
+3. **Refactor:** Improve structure while keeping the test green.
+
+## Test Cases
+
+### Task 3 — Extend `buildSystemPrompt`
+
+Map to spec: `specs/dm-notes-toggle/spec.md` — MODIFIED `buildSystemPrompt`
+
+- [ ] **Test: notes block absent when `opts` omitted**
+  - File: `tests/unit/prompts/templates.test.ts`
+  - Setup: build a `CampaignContext` with `campaign.notes = "some notes"`; call `buildSystemPrompt(ctx)` with no second arg
+  - Assert: result does NOT contain `"Current campaign context (DM notes):"`
+  - Spec scenario: "Existing call sites unaffected"
+
+- [ ] **Test: notes block absent when `opts.includeNotes` is `false`**
+  - File: `tests/unit/prompts/templates.test.ts`
+  - Setup: call `buildSystemPrompt(ctx, { includeNotes: false })` with non-empty notes
+  - Assert: result does NOT contain `"Current campaign context (DM notes):"`
+  - Spec scenario: "Notes block absent when toggle unchecked"
+
+- [ ] **Test: notes block present when `opts.includeNotes` is `true`**
+  - File: `tests/unit/prompts/templates.test.ts`
+  - Setup: call `buildSystemPrompt(ctx, { includeNotes: true })` with `campaign.notes = "Quest hook: the gate is sealed."`
+  - Assert: result contains `"Current campaign context (DM notes):\nQuest hook: the gate is sealed."`
+  - Spec scenario: "Notes block present when toggle checked" / "Notes block format is correct"
+
+- [ ] **Test: notes block absent when notes are whitespace only, even with `includeNotes: true`**
+  - File: `tests/unit/prompts/templates.test.ts`
+  - Setup: call `buildSystemPrompt(ctx, { includeNotes: true })` with `campaign.notes = "   "`
+  - Assert: result does NOT contain `"Current campaign context (DM notes):"`
+  - Spec scenario: "Checkbox hidden when notes are whitespace only" (mirrors server-side guard)
+
+### Task 4 — Thread `opts` through `PromptTemplate.build`
+
+- [ ] **Test: `npcTemplate.build` passes opts through to prompt output**
+  - File: `tests/unit/prompts/templates.test.ts`
+  - Setup: call `npcTemplate.build(fields, ctx, { includeNotes: true })` with non-empty notes
+  - Assert: `builtPrompt.fullText` contains the notes block
+  - Spec scenario: "Notes block present when toggle checked"
+
+- [ ] **Test: TypeScript compilation passes** (implicit — enforced by `npx tsc --noEmit` in Validation step)
+
+### Task 5 — Checkbox UI in `app/campaigns/[id]/prompts/page.tsx`
+
+Map to spec: `specs/dm-notes-toggle/spec.md` — ADDED DM notes toggle checkbox
+
+- [ ] **Test: checkbox not rendered when `campaign.notes` is empty**
+  - File: `tests/unit/components/CampaignsPage.test.tsx` or a dedicated `PromptBuilderPage.test.tsx`
+  - Setup: render `PromptBuilderContent` with a mock context where `campaign.notes = ""`
+  - Assert: `queryByLabelText("Include DM notes in prompt")` returns `null`
+  - Spec scenario: "Checkbox hidden when notes are absent"
+
+- [ ] **Test: checkbox not rendered when `campaign.notes` is whitespace only**
+  - File: same as above
+  - Setup: render with `campaign.notes = "   "`
+  - Assert: checkbox label absent from DOM
+  - Spec scenario: "Checkbox hidden when notes are whitespace only"
+
+- [ ] **Test: checkbox rendered when `campaign.notes` is non-empty**
+  - File: same as above
+  - Setup: render with `campaign.notes = "Active quest: find the lost relic."`
+  - Assert: `getByLabelText("Include DM notes in prompt")` is present and unchecked by default
+  - Spec scenario: "Checkbox visible when notes are present" / "Checkbox unchecked on initial load"
+
+- [ ] **Test: toggling checkbox clears generated prompt**
+  - File: same as above
+  - Setup: render, generate a prompt, then fire a click on the checkbox
+  - Assert: the prompt output section is no longer visible
+  - Spec scenario: "Generated prompt cleared when toggle changes"
+
+## Regression Guard
+
+- [ ] **All existing `templates.test.ts` tests pass without modification** — `buildSystemPrompt` behaviour is unchanged when `opts` is omitted
+- [ ] **`npm test` passes in full** before opening the PR

--- a/openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md
+++ b/openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED DM notes toggle checkbox in Prompt Builder
+
+The system SHALL render a labelled checkbox "Include DM notes in prompt" near the Generate button when `campaign.notes` is non-empty, and SHALL hide it when `campaign.notes` is empty or whitespace-only.
+
+#### Scenario: Checkbox visible when notes are present
+
+- **Given** the DM is on the Prompt Builder page for a campaign where `campaign.notes` is `"Active quest: find the lost relic."`
+- **When** the page finishes loading
+- **Then** a checkbox labelled "Include DM notes in prompt" is present in the DOM
+
+#### Scenario: Checkbox hidden when notes are absent
+
+- **Given** the DM is on the Prompt Builder page for a campaign where `campaign.notes` is `""` (empty string)
+- **When** the page finishes loading
+- **Then** no checkbox labelled "Include DM notes in prompt" is rendered
+
+#### Scenario: Checkbox hidden when notes are whitespace only
+
+- **Given** the DM is on the Prompt Builder page for a campaign where `campaign.notes` is `"   "` (whitespace only)
+- **When** the page finishes loading
+- **Then** no checkbox labelled "Include DM notes in prompt" is rendered
+
+---
+
+### Requirement: ADDED Notes block injected into prompt when toggle is checked
+
+The system SHALL append a `"Current campaign context (DM notes):\n{campaign.notes}"` block to the generated prompt when the checkbox is checked and `campaign.notes` is non-empty.
+
+#### Scenario: Notes block present when toggle checked
+
+- **Given** the Prompt Builder has `campaign.notes = "Party just reached level 11."` and the "Include DM notes in prompt" checkbox is checked
+- **When** the DM clicks Generate Prompt
+- **Then** the generated prompt contains the line `"Current campaign context (DM notes):"` followed by `"Party just reached level 11."`
+
+#### Scenario: Notes block absent when toggle unchecked
+
+- **Given** the Prompt Builder has `campaign.notes = "Party just reached level 11."` and the "Include DM notes in prompt" checkbox is unchecked
+- **When** the DM clicks Generate Prompt
+- **Then** the generated prompt does NOT contain the string `"Current campaign context (DM notes):"`
+
+---
+
+### Requirement: ADDED Toggle is session-local with no persistence
+
+The system SHALL default the toggle to unchecked on every page load and SHALL NOT persist the toggle state to any storage backend.
+
+#### Scenario: Checkbox unchecked on initial load
+
+- **Given** the DM navigates to the Prompt Builder page
+- **When** the component mounts
+- **Then** the "Include DM notes in prompt" checkbox is unchecked
+
+---
+
+### Requirement: ADDED Stale prompt cleared on toggle change
+
+The system SHALL clear any previously generated prompt when the DM changes the notes toggle state, so the displayed prompt always reflects the current toggle value.
+
+#### Scenario: Generated prompt cleared when toggle changes
+
+- **Given** the DM has already generated a prompt with the checkbox unchecked
+- **When** the DM checks the "Include DM notes in prompt" checkbox
+- **Then** the previously generated prompt output is no longer displayed
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `buildSystemPrompt` assembles notes block conditionally
+
+`buildSystemPrompt(context, opts?)` in `lib/prompts/templates.ts` SHALL accept an optional second parameter `opts?: { includeNotes?: boolean }` and SHALL append the notes block only when `opts.includeNotes` is `true` and `context.campaign.notes.trim()` is non-empty. Existing call sites that omit `opts` SHALL be unaffected.
+
+#### Scenario: Existing call sites unaffected
+
+- **Given** `buildSystemPrompt(context)` is called without a second argument
+- **When** the function executes
+- **Then** the output is identical to the current behaviour (no notes block, no error)
+
+#### Scenario: Notes block format is correct
+
+- **Given** `buildSystemPrompt(context, { includeNotes: true })` is called with `context.campaign.notes = "Quest hook: the gate is sealed."`
+- **When** the function executes
+- **Then** the output contains exactly:
+  ```
+  Current campaign context (DM notes):
+  Quest hook: the gate is sealed.
+  ```
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "checkbox hidden when notes empty" → Requirement: DM notes toggle checkbox (visibility rules)
+- Proposal element "notes block appended when checked" → Requirement: Notes block injected into prompt
+- Proposal element "toggle resets each session" → Requirement: Toggle is session-local
+- Proposal element "clear builtPrompt on toggle" → Requirement: Stale prompt cleared on toggle change
+- Design Decision 1 (opts parameter) → Requirement: MODIFIED buildSystemPrompt
+- Design Decision 3 (hidden not disabled) → Requirement: DM notes toggle checkbox (visibility)
+- Design Decision 4 (clear builtPrompt) → Requirement: Stale prompt cleared on toggle change
+- Requirement: DM notes toggle checkbox → Task: Add checkbox UI to PromptBuilderContent
+- Requirement: Notes block injected → Task: Extend buildSystemPrompt with opts
+- Requirement: MODIFIED buildSystemPrompt → Task: Thread opts through PromptTemplate.build
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No regression when toggle is off
+
+- **Given** the Prompt Builder is used without the notes toggle (notes empty or checkbox unchecked)
+- **When** the DM generates any prompt
+- **Then** the output is identical to the pre-change behaviour; all existing unit tests pass
+
+### Requirement: Performance
+
+#### Scenario: No additional network requests
+
+- **Given** the DM opens the Prompt Builder page
+- **When** the page loads and the DM interacts with the notes toggle
+- **Then** no additional API calls are made; all data comes from the already-fetched `CampaignContext`


### PR DESCRIPTION
Archives the completed `prompt-builder-dm-notes-toggle` change and syncs the approved spec.

- Moves `openspec/changes/prompt-builder-dm-notes-toggle/` → `openspec/changes/archive/2026-05-26-prompt-builder-dm-notes-toggle/`
- Syncs approved spec to `openspec/specs/prompt-builder-dm-notes-toggle/dm-notes-toggle/spec.md`

Related: #247