### PR TITLE
feat: add guard+export to scripts and add test coverage

### DIFF
--- a/lib/scripts/migrateGlobalMonsters.ts
+++ b/lib/scripts/migrateGlobalMonsters.ts
@@ -30,14 +30,15 @@ export async function migrateGlobalMonsters() {
   return result.modifiedCount;
 }
 
+export async function runCli(): Promise<void> {
+  const count = await migrateGlobalMonsters();
+  console.log(`Successfully updated ${count} global monsters`);
+  process.exit(0);
+}
+
 if (require.main === module) {
-  migrateGlobalMonsters()
-    .then((count) => {
-      console.log(`Successfully updated ${count} global monsters`);
-      process.exit(0);
-    })
-    .catch((error) => {
-      console.error("Migration failed:", error);
-      process.exit(1);
-    });
+  runCli().catch((error) => {
+    console.error("Migration failed:", error);
+    process.exit(1);
+  });
 }

--- a/lib/scripts/migrateGlobalMonsters.ts
+++ b/lib/scripts/migrateGlobalMonsters.ts
@@ -2,7 +2,7 @@ import { getDatabase } from "../db";
 import { MonsterTemplate } from "../types";
 import { GLOBAL_USER_ID } from "../constants";
 
-async function migrateGlobalMonsters() {
+export async function migrateGlobalMonsters() {
   const db = await getDatabase();
   const collection = db.collection<MonsterTemplate>("monsterTemplates");
 
@@ -30,12 +30,14 @@ async function migrateGlobalMonsters() {
   return result.modifiedCount;
 }
 
-migrateGlobalMonsters()
-  .then((count) => {
-    console.log(`Successfully updated ${count} global monsters`);
-    process.exit(0);
-  })
-  .catch((error) => {
-    console.error("Migration failed:", error);
-    process.exit(1);
-  });
+if (require.main === module) {
+  migrateGlobalMonsters()
+    .then((count) => {
+      console.log(`Successfully updated ${count} global monsters`);
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error("Migration failed:", error);
+      process.exit(1);
+    });
+}

--- a/lib/scripts/migrateGlobalMonsters.ts
+++ b/lib/scripts/migrateGlobalMonsters.ts
@@ -36,9 +36,11 @@ export async function runCli(): Promise<void> {
   process.exit(0);
 }
 
+export function handleCliError(error: unknown): never {
+  console.error("Migration failed:", error);
+  process.exit(1);
+}
+
 if (require.main === module) {
-  runCli().catch((error) => {
-    console.error("Migration failed:", error);
-    process.exit(1);
-  });
+  runCli().catch(handleCliError);
 }

--- a/lib/scripts/populateMonstersByType.js
+++ b/lib/scripts/populateMonstersByType.js
@@ -320,7 +320,10 @@ async function main() {
 }
 
 if (require.main === module) {
-  main().catch(console.error);
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }
 
 module.exports = { normalizeType, getCRExperience, transformMonster, generateTypeFile };

--- a/lib/scripts/populateMonstersByType.js
+++ b/lib/scripts/populateMonstersByType.js
@@ -319,4 +319,8 @@ async function main() {
   console.log("3. Run the seed script to populate the database");
 }
 
-main().catch(console.error);
+if (require.main === module) {
+  main().catch(console.error);
+}
+
+module.exports = { normalizeType, getCRExperience, transformMonster, generateTypeFile };

--- a/tests/integration/scripts/migrateGlobalMonsters.integration.test.ts
+++ b/tests/integration/scripts/migrateGlobalMonsters.integration.test.ts
@@ -73,6 +73,9 @@ describe("migrateGlobalMonsters", () => {
   });
 
   it("returns modifiedCount equal to number of untagged docs", async () => {
+    // Tag any pre-existing untagged global monsters so they don't skew the count
+    await migrateGlobalMonsters();
+
     await seed({ userId: GLOBAL_USER_ID, isGlobal: true });
     await seed({ userId: GLOBAL_USER_ID, isGlobal: true, source: "" });
     await seed({ userId: GLOBAL_USER_ID, isGlobal: true, source: "SRD" });

--- a/tests/integration/scripts/migrateGlobalMonsters.integration.test.ts
+++ b/tests/integration/scripts/migrateGlobalMonsters.integration.test.ts
@@ -1,0 +1,105 @@
+import { MongoClient, Collection } from "mongodb";
+import { migrateGlobalMonsters } from "../../../lib/scripts/migrateGlobalMonsters";
+import { GLOBAL_USER_ID } from "../../../lib/constants";
+
+const TEST_MARKER_FIELD = "__migrateTestRun";
+const TEST_MARKER_VALUE = `test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+let client: MongoClient;
+let collection: Collection;
+
+beforeAll(async () => {
+  const uri = process.env.MONGODB_URI!;
+  const db = process.env.MONGODB_DB!;
+  if (!uri || !db) throw new Error("MONGODB_URI and MONGODB_DB must be set");
+  client = new MongoClient(uri);
+  await client.connect();
+  collection = client.db(db).collection("monsterTemplates");
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+afterEach(async () => {
+  await collection.deleteMany({ [TEST_MARKER_FIELD]: TEST_MARKER_VALUE });
+});
+
+function seed(overrides: Record<string, unknown> = {}) {
+  return collection.insertOne({
+    [TEST_MARKER_FIELD]: TEST_MARKER_VALUE,
+    ...overrides,
+  });
+}
+
+describe("migrateGlobalMonsters", () => {
+  it("tags a global monster with no source field", async () => {
+    const { insertedId } = await seed({
+      userId: GLOBAL_USER_ID,
+      isGlobal: true,
+    });
+
+    await migrateGlobalMonsters();
+
+    const doc = await collection.findOne({ _id: insertedId });
+    expect(doc?.source).toBe("SRD");
+  });
+
+  it("tags a global monster with empty source string", async () => {
+    const { insertedId } = await seed({
+      userId: GLOBAL_USER_ID,
+      isGlobal: true,
+      source: "",
+    });
+
+    await migrateGlobalMonsters();
+
+    const doc = await collection.findOne({ _id: insertedId });
+    expect(doc?.source).toBe("SRD");
+  });
+
+  it("does not modify an already-tagged monster", async () => {
+    const { insertedId } = await seed({
+      userId: GLOBAL_USER_ID,
+      isGlobal: true,
+      source: "SRD",
+      updatedAt: new Date("2020-01-01"),
+    });
+
+    await migrateGlobalMonsters();
+
+    const doc = await collection.findOne({ _id: insertedId });
+    expect(doc?.updatedAt).toEqual(new Date("2020-01-01"));
+  });
+
+  it("does not touch non-global monsters", async () => {
+    const { insertedId } = await seed({
+      userId: GLOBAL_USER_ID,
+      isGlobal: false,
+    });
+
+    await migrateGlobalMonsters();
+
+    const doc = await collection.findOne({ _id: insertedId });
+    expect(doc?.source).toBeUndefined();
+  });
+
+  it("returns modifiedCount equal to number of untagged docs", async () => {
+    await seed({ userId: GLOBAL_USER_ID, isGlobal: true });
+    await seed({ userId: GLOBAL_USER_ID, isGlobal: true, source: "" });
+    await seed({ userId: GLOBAL_USER_ID, isGlobal: true, source: "SRD" });
+    await seed({ userId: GLOBAL_USER_ID, isGlobal: false });
+
+    const count = await migrateGlobalMonsters();
+    expect(count).toBe(2);
+  });
+
+  it("is idempotent — second run returns 0", async () => {
+    await seed({ userId: GLOBAL_USER_ID, isGlobal: true });
+
+    await migrateGlobalMonsters();
+    const count = await migrateGlobalMonsters();
+
+    expect(count).toBe(0);
+  });
+});

--- a/tests/integration/scripts/migrateGlobalMonsters.integration.test.ts
+++ b/tests/integration/scripts/migrateGlobalMonsters.integration.test.ts
@@ -1,24 +1,21 @@
-import { MongoClient, Collection } from "mongodb";
+import { Collection, Db } from "mongodb";
 import { migrateGlobalMonsters } from "../../../lib/scripts/migrateGlobalMonsters";
 import { GLOBAL_USER_ID } from "../../../lib/constants";
+import { getDatabase, closeDatabase } from "../../../lib/db";
 
 const TEST_MARKER_FIELD = "__migrateTestRun";
-const TEST_MARKER_VALUE = `test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+const TEST_MARKER_VALUE = `test-${Date.now()}-${require("crypto").randomBytes(3).toString("hex")}`;
 
-let client: MongoClient;
+let db: Db;
 let collection: Collection;
 
 beforeAll(async () => {
-  const uri = process.env.MONGODB_URI!;
-  const db = process.env.MONGODB_DB!;
-  if (!uri || !db) throw new Error("MONGODB_URI and MONGODB_DB must be set");
-  client = new MongoClient(uri);
-  await client.connect();
-  collection = client.db(db).collection("monsterTemplates");
+  db = await getDatabase();
+  collection = db.collection("monsterTemplates");
 });
 
 afterAll(async () => {
-  await client.close();
+  await closeDatabase();
 });
 
 afterEach(async () => {
@@ -33,23 +30,14 @@ function seed(overrides: Record<string, unknown> = {}) {
 }
 
 describe("migrateGlobalMonsters", () => {
-  it("tags a global monster with no source field", async () => {
+  it.each([
+    ["no source field", {}],
+    ["empty source string", { source: "" }],
+  ])("tags a global monster with %s", async (_label, overrides) => {
     const { insertedId } = await seed({
       userId: GLOBAL_USER_ID,
       isGlobal: true,
-    });
-
-    await migrateGlobalMonsters();
-
-    const doc = await collection.findOne({ _id: insertedId });
-    expect(doc?.source).toBe("SRD");
-  });
-
-  it("tags a global monster with empty source string", async () => {
-    const { insertedId } = await seed({
-      userId: GLOBAL_USER_ID,
-      isGlobal: true,
-      source: "",
+      ...overrides,
     });
 
     await migrateGlobalMonsters();

--- a/tests/unit/lib/scripts/migrateGlobalMonsters.test.ts
+++ b/tests/unit/lib/scripts/migrateGlobalMonsters.test.ts
@@ -1,4 +1,4 @@
-import { runCli } from "../../../../lib/scripts/migrateGlobalMonsters";
+import { runCli, handleCliError } from "../../../../lib/scripts/migrateGlobalMonsters";
 
 jest.mock("../../../../lib/db", () => ({
   getDatabase: jest.fn(),
@@ -39,5 +39,27 @@ describe("runCli", () => {
 
     expect(logSpy).toHaveBeenCalledWith("Successfully updated 5 global monsters");
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("handleCliError", () => {
+  let exitSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("logs error and exits 1", () => {
+    const err = new Error("DB failed");
+    handleCliError(err);
+
+    expect(errorSpy).toHaveBeenCalledWith("Migration failed:", err);
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/tests/unit/lib/scripts/migrateGlobalMonsters.test.ts
+++ b/tests/unit/lib/scripts/migrateGlobalMonsters.test.ts
@@ -1,0 +1,43 @@
+import { runCli } from "../../../../lib/scripts/migrateGlobalMonsters";
+
+jest.mock("../../../../lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock("../../../../lib/constants", () => ({
+  GLOBAL_USER_ID: "GLOBAL",
+}));
+
+const { getDatabase } = require("../../../../lib/db");
+
+function makeCollection(modifiedCount: number) {
+  return { updateMany: jest.fn().mockResolvedValue({ modifiedCount }) };
+}
+
+function makeDb(modifiedCount: number) {
+  return { collection: jest.fn().mockReturnValue(makeCollection(modifiedCount)) };
+}
+
+describe("runCli", () => {
+  let exitSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("logs count and exits 0 on success", async () => {
+    getDatabase.mockResolvedValue(makeDb(5));
+
+    await runCli();
+
+    expect(logSpy).toHaveBeenCalledWith("Successfully updated 5 global monsters");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/tests/unit/lib/scripts/populateMonstersByType.test.ts
+++ b/tests/unit/lib/scripts/populateMonstersByType.test.ts
@@ -1,0 +1,179 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const {
+  normalizeType,
+  getCRExperience,
+  transformMonster,
+  generateTypeFile,
+} = require("../../../../lib/scripts/populateMonstersByType");
+
+describe("normalizeType", () => {
+  it("converts swarm type to beast", () => {
+    expect(normalizeType("swarm of Tiny beasts")).toBe("beast");
+  });
+
+  it("converts mixed-case swarm to beast", () => {
+    expect(normalizeType("Swarm of Medium Undead")).toBe("beast");
+  });
+
+  it("lowercases a standard type", () => {
+    expect(normalizeType("Humanoid")).toBe("humanoid");
+  });
+
+  it("leaves already-lowercase type unchanged", () => {
+    expect(normalizeType("undead")).toBe("undead");
+  });
+});
+
+describe("getCRExperience", () => {
+  it("returns 10 for CR 0", () => {
+    expect(getCRExperience(0)).toBe(10);
+  });
+
+  it("returns 100 for CR 0.5", () => {
+    expect(getCRExperience(0.5)).toBe(100);
+  });
+
+  it("returns 200 for CR 1", () => {
+    expect(getCRExperience(1)).toBe(200);
+  });
+
+  it("returns 25000 for CR 20", () => {
+    expect(getCRExperience(20)).toBe(25000);
+  });
+
+  it("returns 0 for unknown CR", () => {
+    expect(getCRExperience(99)).toBe(0);
+  });
+});
+
+const FULL_MONSTER = {
+  name: "Goblin",
+  type: "Humanoid",
+  size: "Small",
+  alignment: "Neutral Evil",
+  armor_class: [{ value: 15, type: "leather armor" }],
+  hit_points: 7,
+  hit_dice: "2d6",
+  speed: { walk: "30 ft." },
+  strength: 8,
+  dexterity: 14,
+  constitution: 10,
+  intelligence: 10,
+  wisdom: 8,
+  charisma: 8,
+  proficiencies: [
+    { proficiency: { name: "Saving Throw: Dex" }, value: 4 },
+    { proficiency: { name: "Skill: Stealth" }, value: 6 },
+  ],
+  senses: { darkvision: "60 ft.", passive_perception: 9 },
+  languages: "Common, Goblin",
+  challenge_rating: 0.25,
+  xp: 50,
+  special_abilities: [{ name: "Nimble Escape", desc: "Can Disengage or Hide as bonus action." }],
+  actions: [
+    {
+      name: "Scimitar",
+      desc: "Melee attack",
+      attack_bonus: 4,
+      damage: [{ damage_dice: "1d6+2", damage_type: { name: "Slashing" } }],
+    },
+  ],
+};
+
+describe("transformMonster", () => {
+  it("maps a full fixture correctly", () => {
+    const result = transformMonster(FULL_MONSTER);
+    expect(result.name).toBe("Goblin");
+    expect(result.ac).toBe(15);
+    expect(result.hp).toBe(7);
+    expect(result.abilities).toMatchObject({ strength: 8, dexterity: 14 });
+    expect(result.savingThrows).toMatchObject({ dex: 4 });
+    expect(result.skills).toMatchObject({ stealth: 6 });
+    expect(result.actions).toHaveLength(1);
+    expect(result.traits).toHaveLength(1);
+    expect(result.source).toBe("SRD");
+    expect(result.experiencePoints).toBe(50);
+  });
+
+  it("omits savingThrows and skills when proficiencies is empty", () => {
+    const result = transformMonster({ ...FULL_MONSTER, proficiencies: [] });
+    expect(result).not.toHaveProperty("savingThrows");
+    expect(result).not.toHaveProperty("skills");
+  });
+
+  it("sets senses to empty string when senses is null", () => {
+    const result = transformMonster({ ...FULL_MONSTER, senses: null });
+    expect(result.senses).toBe("");
+  });
+
+  it("sets senses to empty string when senses is absent", () => {
+    const { senses: _senses, ...noSenses } = FULL_MONSTER;
+    const result = transformMonster(noSenses);
+    expect(result.senses).toBe("");
+  });
+
+  it("omits actions when actions is empty", () => {
+    const result = transformMonster({ ...FULL_MONSTER, actions: [] });
+    expect(result).not.toHaveProperty("actions");
+  });
+
+  it("uses getCRExperience when xp is absent", () => {
+    const { xp: _xp, ...noXp } = FULL_MONSTER;
+    const result = transformMonster({ ...noXp, challenge_rating: 5 });
+    expect(result.experiencePoints).toBe(1800);
+  });
+
+  it("maps conditionImmunities array of objects to name strings", () => {
+    const result = transformMonster({
+      ...FULL_MONSTER,
+      condition_immunities: [{ name: "Charmed" }, { name: "Frightened" }],
+    });
+    expect(result.conditionImmunities).toEqual(["Charmed", "Frightened"]);
+  });
+
+  it("includes saveDC and saveType on action with dc", () => {
+    const monsterWithDC = {
+      ...FULL_MONSTER,
+      actions: [
+        {
+          name: "Bite",
+          desc: "Bite attack with save",
+          dc: { dc_value: 12, dc_type: { name: "Strength" } },
+        },
+      ],
+    };
+    const result = transformMonster(monsterWithDC);
+    expect(result.actions[0].saveDC).toBe(12);
+    expect(result.actions[0].saveType).toBe("Strength");
+  });
+});
+
+describe("generateTypeFile", () => {
+  let tmpDir: string;
+  let fileContent: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "monsters-test-"));
+    generateTypeFile("beast", [], tmpDir);
+    fileContent = fs.readFileSync(path.join(tmpDir, "beasts.ts"), "utf8");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates a file in the specified directory", () => {
+    expect(fs.existsSync(path.join(tmpDir, "beasts.ts"))).toBe(true);
+  });
+
+  it("file content contains correct export name", () => {
+    expect(fileContent).toContain("export const BEASTS:");
+  });
+
+  it("file content contains MonsterTemplate import", () => {
+    expect(fileContent).toContain("import { MonsterTemplate } from");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `require.main` guards and exports to both migration scripts, then adds integration and unit test coverage for their core logic.

## Changes

### Script modifications
- `lib/scripts/migrateGlobalMonsters.ts` — wrapped invocation in `if (require.main === module)`, exported `migrateGlobalMonsters`
- `lib/scripts/populateMonstersByType.js` — wrapped `main()` call in `if (require.main === module)`, added `module.exports` for the four pure functions

### New tests
- `tests/integration/scripts/migrateGlobalMonsters.integration.test.ts` — verifies DB tagging behaviour, idempotency, and that non-global/already-tagged docs are untouched
- `tests/unit/lib/scripts/populateMonstersByType.test.ts` — unit tests for `normalizeType`, `getCRExperience`, `transformMonster`, and `generateTypeFile`

## Validation

- `npm run test:unit` — 1569 tests pass
- `npm run test:integration` — 164 tests pass (19 suites)
- `npm run build` — succeeds
- `npm run lint` — no errors

Closes #246