### PR TITLE
docs: archive scripts-test-coverage (2026-05-27)

### DIFF
--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-27

--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/design.md
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/design.md
@@ -1,0 +1,122 @@
+## Context
+
+- Relevant architecture: `lib/scripts/` contains three imperative Node.js scripts that run against MongoDB or the filesystem. They are not imported by any application code — they are CLI-only tools. The integration test suite uses `@testcontainers/mongodb` (already wired via `tests/integration/global.setup.ts`). Unit tests live in `tests/unit/lib/`.
+- Dependencies: `jest.integration.config.js` (testcontainers, 120s timeout), `jest.config.js` (unit), `lib/db.ts` (`getDatabase`), `lib/constants.ts` (`GLOBAL_USER_ID`), `lib/types.ts` (`MonsterTemplate`).
+- Interfaces/contracts touched: `lib/scripts/migrateGlobalMonsters.ts` and `lib/scripts/populateMonstersByType.js` gain exports. No application code imports these files today; adding exports is purely additive.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Make `migrateGlobalMonsters` importable and integration-testable
+- Make `populateMonstersByType` pure functions importable and unit-testable
+- Achieve ≥ 70% statement coverage for `lib/scripts/` (issue #246 AC)
+
+### Non-Goals
+
+- Testing `seedCampaignTemplates.ts`
+- Testing network fetch or disk-write paths in `populateMonstersByType.js`
+- Modifying how scripts are invoked in production
+
+## Decisions
+
+### Decision 1: require.main guard pattern
+
+- Chosen: Wrap the top-level auto-execute call in `if (require.main === module)` (CommonJS) for both files. `migrateGlobalMonsters.ts` uses TypeScript/CommonJS output; `populateMonstersByType.js` is already plain CJS.
+- Alternatives considered: `process.env.JEST_WORKER_ID` guard; separate runner file; no guard (use `jest --testEnvironment` tricks).
+- Rationale: `require.main === module` is the canonical Node.js pattern. It is zero-overhead, universally understood, and does not add a test-only env var dependency.
+- Trade-offs: Slightly changes the runtime shape of the module, but since no application code imports these files, there is no regression risk.
+
+### Decision 2: Export pure functions from populateMonstersByType.js
+
+- Chosen: Add named exports for `normalizeType`, `getCRExperience`, `transformMonster`, `generateTypeFile` at the bottom of the file.
+- Alternatives considered: Separate `lib/scripts/populateMonstersByType.helpers.js` module.
+- Rationale: The functions are already defined in the file; adding `module.exports` at the bottom is the minimal change. A separate helpers file would require refactoring the `main()` function's calls and adds indirection for no benefit.
+- Trade-offs: None significant — the functions are pure and have no circular dependencies.
+
+### Decision 3: Integration test placement for migrateGlobalMonsters
+
+- Chosen: `tests/integration/scripts/migrateGlobalMonsters.integration.test.ts`, using the existing testcontainers MongoDB instance (environment variables `MONGODB_URI` / `MONGODB_DB` set by global setup).
+- Alternatives considered: Unit test with a mocked `getDatabase` — rejected because the point of the test is to verify the MongoDB query filter and `updateMany` semantics, which are only meaningful against a real driver.
+- Rationale: testcontainers is already running for all integration tests. This test just seeds a few documents and runs one function — minimal overhead.
+- Trade-offs: Integration test suite runtime increases slightly (negligible — 2 DB operations).
+
+### Decision 4: generateTypeFile tested on string output only
+
+- Chosen: Call `generateTypeFile` with a temp directory (Node's `os.tmpdir()` + `fs.mkdtempSync`) and assert on the written file's string content.
+- Alternatives considered: `memfs` mock; assert only on return value (but it returns `fileName` not content).
+- Rationale: Writing to a real temp dir is simpler than wiring `memfs` and avoids mocking `fs`. The temp dir is cleaned up in `afterEach`.
+- Trade-offs: Tiny amount of real disk I/O in unit tests — acceptable given the alternative complexity.
+
+## Proposal to Design Mapping
+
+- Proposal element: `require.main === module` guard on both scripts
+  - Design decision: Decision 1
+  - Validation approach: Import the modules in tests — if auto-execute were still wired, the test suite would hang or fail on DB connection
+- Proposal element: Export pure functions from `populateMonstersByType.js`
+  - Design decision: Decision 2
+  - Validation approach: Unit tests import and call them directly
+- Proposal element: Integration test for `migrateGlobalMonsters` (pre/post, idempotency)
+  - Design decision: Decision 3
+  - Validation approach: Seed known documents into containerized MongoDB, call function, assert `source` field and `modifiedCount`
+- Proposal element: Unit tests for `transformMonster` with missing optional fields
+  - Design decision: Decision 2 + Decision 4
+  - Validation approach: Call with minimal API response object, assert no thrown error and correct defaults
+
+## Functional Requirements Mapping
+
+- Requirement: `migrateGlobalMonsters` sets `source: "SRD"` only on untagged global monsters
+  - Design element: Integration test — seed tagged + untagged docs, verify only untagged are updated
+  - Acceptance criteria reference: specs/migrate-global-monsters.md
+  - Testability notes: MongoDB `find` after migration verifies field values
+
+- Requirement: `migrateGlobalMonsters` is idempotent
+  - Design element: Integration test — run function twice, assert `modifiedCount === 0` on second run
+  - Acceptance criteria reference: specs/migrate-global-monsters.md
+  - Testability notes: `modifiedCount` returned by the function
+
+- Requirement: `normalizeType` maps swarm variants to "beast"
+  - Design element: Unit test — several swarm string variants
+  - Acceptance criteria reference: specs/populate-monsters-by-type.md
+  - Testability notes: Pure function, no side effects
+
+- Requirement: `transformMonster` handles missing optional fields gracefully
+  - Design element: Unit test — minimal API response with only required fields
+  - Acceptance criteria reference: specs/populate-monsters-by-type.md
+  - Testability notes: Assert no thrown error; assert default values for ac, senses, languages
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Scripts must still execute correctly when run directly via CLI
+  - Design element: `require.main === module` guard preserves direct execution
+  - Testability notes: Manual smoke test; guard condition is structurally verified by the fact that tests can import without side effects
+
+- Requirement category: operability
+  - Requirement: No new test infrastructure dependencies
+  - Design element: Uses existing `jest.integration.config.js` testcontainers setup and existing `jest.config.js` unit runner
+  - Testability notes: `npm run test:unit` and `npm run test:integration` must both pass
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `generateTypeFile` temp-dir I/O is technically not "pure unit" test
+  - Impact: Negligible — temp dirs are cleaned up; no CI flakiness expected
+  - Mitigation: `afterEach` cleanup; use `os.tmpdir()` which is always writable in CI
+
+## Rollback / Mitigation
+
+- Rollback trigger: New tests introduce flakiness or break existing test suite
+- Rollback steps: Revert test files and the export additions; the `require.main` guards are safe to leave in place permanently
+- Data migration considerations: None — no schema changes
+- Verification after rollback: `npm run test:unit` and `npm run test:integration` pass
+
+## Operational Blocking Policy
+
+- If CI checks fail: Investigate test output; do not merge with failing tests
+- If security checks fail: N/A — no new dependencies introduced
+- If required reviews are blocked/stale: Re-request review after 24h; escalate to repo owner
+- Escalation path and timeout: Tag `dougis` in PR after 48h without review
+
+## Open Questions
+
+No open questions. All decisions confirmed during exploration session.

--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/proposal.md
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/proposal.md
@@ -1,0 +1,69 @@
+## GitHub Issues
+
+- #246
+
+## Why
+
+- Problem statement: `lib/scripts/` has 0% test coverage. These scripts mutate production data (MongoDB) and transform external API responses into stored schema. A bug in them — whether introduced directly or via a type change elsewhere — goes completely undetected.
+- Why now: Issue #246 was filed to track this gap. The testcontainers infrastructure is already in place, making integration tests low-cost to add. The pure transformation logic in `populateMonstersByType.js` is particularly high-value to cover because it's complex, untested, and silently produces corrupt monster data if the Open5E API shape ever diverges.
+- Business/user impact: `migrateGlobalMonsters` is re-run during staging resets and new environment provisioning. A regression here would silently leave global monsters untagged. `transformMonster` maps the Open5E API response to the app's `MonsterTemplate` schema — breakage here corrupts the monster library for all users.
+
+## Problem Space
+
+- Current behavior: All three scripts in `lib/scripts/` execute logic with no test coverage. Running them in tests is impossible today because each auto-executes on import.
+- Desired behavior: `migrateGlobalMonsters.ts` is integration-tested against a real containerized MongoDB instance (pre/post state, idempotency). `populateMonstersByType.js` pure functions are unit-tested. Both scripts are importable without auto-executing.
+- Constraints: Scripts must remain runnable directly via `node` / `ts-node`. The `require.main === module` / `if (import.meta.url === ...)` guard achieves importability without breaking the CLI usage.
+- Assumptions: `seedCampaignTemplates.ts` is out of scope per explicit decision — it is mostly static data with minimal logic risk.
+- Edge cases considered: Running `migrateGlobalMonsters` twice (idempotency); monsters already tagged with `source: "SRD"` must not be double-updated; `transformMonster` with missing optional fields (no proficiencies, no senses, no actions).
+
+## Scope
+
+### In Scope
+
+- Add `require.main === module` guard to `lib/scripts/migrateGlobalMonsters.ts`
+- Add `require.main === module` guard to `lib/scripts/populateMonstersByType.js`
+- Export `migrateGlobalMonsters` function for testability
+- Export pure functions from `populateMonstersByType.js`: `normalizeType`, `getCRExperience`, `transformMonster`, `generateTypeFile`
+- Unit tests for `normalizeType`, `getCRExperience`, `transformMonster`, `generateTypeFile`
+- Integration tests for `migrateGlobalMonsters`: pre-migration seed, post-migration verify, idempotency
+
+### Out of Scope
+
+- `lib/scripts/seedCampaignTemplates.ts` — no tests, no guard change
+- End-to-end testing of the `populateMonstersByType` `main()` function (network + disk)
+- Coverage of `fetchJSON` or file-write paths in `populateMonstersByType.js`
+
+## What Changes
+
+- `lib/scripts/migrateGlobalMonsters.ts`: add `require.main === module` guard, export the function
+- `lib/scripts/populateMonstersByType.js`: add `require.main === module` guard, export pure functions
+- `tests/unit/lib/scripts/migrateGlobalMonsters.test.ts`: new — unit smoke test confirming export shape
+- `tests/unit/lib/scripts/populateMonstersByType.test.ts`: new — unit tests for `normalizeType`, `getCRExperience`, `transformMonster`, `generateTypeFile`
+- `tests/integration/scripts/migrateGlobalMonsters.integration.test.ts`: new — pre/post DB state, idempotency
+
+## Risks
+
+- Risk: Adding exports to scripts could be misread as making them a shared library
+  - Impact: Low — scripts remain in `lib/scripts/`, naming is explicit
+  - Mitigation: No changes to any imports outside test files
+- Risk: Integration test adds to CI time
+  - Impact: Low — testcontainers MongoDB already starts for all integration tests; this just adds a few DB operations
+  - Mitigation: Test is minimal — two DB writes + two reads
+
+## Open Questions
+
+No unresolved ambiguity. All decisions made during exploration:
+- `require.main === module` guard is acceptable (confirmed by user)
+- Integration test for `migrateGlobalMonsters`, unit tests for `populateMonstersByType`
+- `seedCampaignTemplates` explicitly excluded
+
+## Non-Goals
+
+- Achieving 100% coverage of `lib/scripts/`
+- Testing the network fetch or file-write paths in `populateMonstersByType.js`
+- Modifying how scripts are invoked in production (`package.json` scripts, etc.)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/specs/migrate-global-monsters.md
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/specs/migrate-global-monsters.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED migrateGlobalMonsters is importable without auto-executing
+
+The system SHALL allow `migrateGlobalMonsters.ts` to be imported as a module without triggering database connections or side effects.
+
+#### Scenario: Import without execution
+
+- **Given** a test file that imports `migrateGlobalMonsters.ts`
+- **When** the module is loaded
+- **Then** no database connection is attempted and no console output is produced
+
+### Requirement: ADDED migrateGlobalMonsters tags untagged global monsters with source "SRD"
+
+The system SHALL update all global monsters belonging to `GLOBAL_USER_ID` that have no `source`, a null `source`, or an empty string `source` to `source: "SRD"`.
+
+#### Scenario: Untagged global monster is migrated
+
+- **Given** a MongoDB collection containing a global monster with `userId: GLOBAL_USER_ID`, `isGlobal: true`, and `source` absent
+- **When** `migrateGlobalMonsters()` is called
+- **Then** the document has `source: "SRD"` and the function returns `modifiedCount >= 1`
+
+#### Scenario: Already-tagged monster is not re-migrated
+
+- **Given** a MongoDB collection containing a global monster with `source: "SRD"` already set
+- **When** `migrateGlobalMonsters()` is called
+- **Then** that document is not modified and `modifiedCount` does not increase for it
+
+#### Scenario: Non-global monster is not touched
+
+- **Given** a MongoDB collection containing a monster with `isGlobal: false` and no `source`
+- **When** `migrateGlobalMonsters()` is called
+- **Then** that document remains unchanged
+
+### Requirement: ADDED migrateGlobalMonsters is idempotent
+
+The system SHALL produce no additional changes when called a second time after a successful migration.
+
+#### Scenario: Double-run idempotency
+
+- **Given** a collection that has already been fully migrated (all global monsters have `source: "SRD"`)
+- **When** `migrateGlobalMonsters()` is called again
+- **Then** `modifiedCount === 0`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "add require.main guard to migrateGlobalMonsters.ts" -> Requirement: migrateGlobalMonsters is importable without auto-executing
+- Proposal element "integration test: pre/post DB state, idempotency" -> Requirements: tags untagged monsters, idempotency
+- Design decision 1 (require.main guard) -> Requirement: importable without auto-executing
+- Design decision 3 (integration test placement) -> Requirements: tags untagged monsters, idempotency
+- Requirements -> Task: T1 (guard + export), T3 (integration test)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Direct CLI execution still works after guard is added
+
+- **Given** the `require.main === module` guard is in place
+- **When** the script is run directly via `npx ts-node lib/scripts/migrateGlobalMonsters.ts`
+- **Then** the migration executes as before and `process.exit` is called with code 0 on success

--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/specs/populate-monsters-by-type.md
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/specs/populate-monsters-by-type.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED populateMonstersByType is importable without auto-executing
+
+The system SHALL allow `populateMonstersByType.js` to be imported as a module without triggering HTTP requests or file-system writes.
+
+#### Scenario: Import without execution
+
+- **Given** a test file that imports `populateMonstersByType.js`
+- **When** the module is loaded
+- **Then** no HTTP requests are made and no files are written
+
+### Requirement: ADDED normalizeType maps swarm types to "beast"
+
+The system SHALL return `"beast"` for any monster type string that contains the word "swarm" (case-insensitive), and return the lowercased type otherwise.
+
+#### Scenario: Swarm type is normalized
+
+- **Given** a type string `"swarm of Tiny beasts"`
+- **When** `normalizeType` is called
+- **Then** it returns `"beast"`
+
+#### Scenario: Standard type is lowercased
+
+- **Given** a type string `"Humanoid"`
+- **When** `normalizeType` is called
+- **Then** it returns `"humanoid"`
+
+#### Scenario: Already-lowercase type is returned unchanged
+
+- **Given** a type string `"undead"`
+- **When** `normalizeType` is called
+- **Then** it returns `"undead"`
+
+### Requirement: ADDED getCRExperience returns correct XP for known challenge ratings
+
+The system SHALL return the correct XP value for every CR in the standard D&D 5e table, and return 0 for unknown CRs.
+
+#### Scenario: Known CR returns correct XP
+
+- **Given** a challenge rating of `1`
+- **When** `getCRExperience` is called
+- **Then** it returns `200`
+
+#### Scenario: Fractional CR is handled
+
+- **Given** a challenge rating of `0.5`
+- **When** `getCRExperience` is called
+- **Then** it returns `100`
+
+#### Scenario: Unknown CR returns 0
+
+- **Given** a challenge rating of `99`
+- **When** `getCRExperience` is called
+- **Then** it returns `0`
+
+### Requirement: ADDED transformMonster maps Open5E API response to MonsterTemplate schema
+
+The system SHALL produce a correctly structured object from a valid Open5E API monster response, with appropriate defaults when optional fields are absent.
+
+#### Scenario: Full monster response is transformed correctly
+
+- **Given** a mock Open5E API response with all fields populated (AC, proficiencies, senses, actions, traits, languages)
+- **When** `transformMonster` is called
+- **Then** the result has `name`, `type`, `hp`, `ac`, `abilities`, `challengeRating`, `experiencePoints`, `source: "SRD"`, and correctly mapped `actions`, `traits`, `savingThrows`, `skills`
+
+#### Scenario: Monster with no proficiencies is handled
+
+- **Given** a mock API response with `proficiencies: []`
+- **When** `transformMonster` is called
+- **Then** `savingThrows` and `skills` are absent from the result (not empty objects)
+
+#### Scenario: Monster with no senses is handled
+
+- **Given** a mock API response with `senses: null` or `senses` absent
+- **When** `transformMonster` is called
+- **Then** `senses` in the result is an empty string `""`
+
+#### Scenario: Monster with no actions is handled
+
+- **Given** a mock API response with `actions: []` or `actions` absent
+- **When** `transformMonster` is called
+- **Then** `actions` is absent from the result
+
+#### Scenario: transformMonster uses getCRExperience when xp is absent
+
+- **Given** a mock API response with no `xp` field and `challenge_rating: 5`
+- **When** `transformMonster` is called
+- **Then** `experiencePoints === 1800`
+
+### Requirement: ADDED generateTypeFile produces correctly structured TypeScript file content
+
+The system SHALL write a `.ts` file to the specified output directory containing a named array export of the correct type, matching the pluralization convention.
+
+#### Scenario: Generated file has correct export name
+
+- **Given** monster type `"beast"` and an array of transformed monsters
+- **When** `generateTypeFile` is called with a temp directory
+- **Then** the written file contains `export const BEASTS:`
+
+#### Scenario: Already-plural type is not double-pluralized
+
+- **Given** monster type `"undead"` (does not end in "s")
+- **When** `generateTypeFile` is called
+- **Then** the written file contains `export const UNDEADS:` (appends S)
+
+#### Scenario: File is written to specified directory
+
+- **Given** a writable temp directory path
+- **When** `generateTypeFile` is called with type `"beast"` and a monster array
+- **Then** the file `beasts.ts` exists in that directory
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "add require.main guard to populateMonstersByType.js" -> Requirement: importable without auto-executing
+- Proposal element "export normalizeType, getCRExperience, transformMonster, generateTypeFile" -> All unit test requirements
+- Design decision 2 (export pure functions) -> Requirements: normalizeType, getCRExperience, transformMonster, generateTypeFile
+- Design decision 4 (generateTypeFile temp-dir I/O) -> Requirement: generateTypeFile produces correct content
+- Requirements -> Task: T2 (guard + exports), T4 (unit tests)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: CLI direct execution still works after exports are added
+
+- **Given** `module.exports` additions at the bottom of `populateMonstersByType.js`
+- **When** the script is run directly via `node lib/scripts/populateMonstersByType.js`
+- **Then** execution proceeds as before (`require.main === module` is `true`)

--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/tasks.md
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/tasks.md
@@ -1,0 +1,104 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/scripts-test-coverage` then immediately `git push -u origin feat/scripts-test-coverage`
+
+## Execution
+
+### T1 — Guard + export: migrateGlobalMonsters.ts
+
+- [x] In `lib/scripts/migrateGlobalMonsters.ts`, wrap the top-level invocation in `if (require.main === module) { ... }`
+- [x] Export the `migrateGlobalMonsters` function
+- [x] Verify: `npx ts-node -e "import('./lib/scripts/migrateGlobalMonsters').then(m => console.log(typeof m.migrateGlobalMonsters))"` should print `function` without triggering DB connections
+
+### T2 — Guard + exports: populateMonstersByType.js
+
+- [x] In `lib/scripts/populateMonstersByType.js`, wrap the `main()` call in `if (require.main === module) { ... }`
+- [x] Add `module.exports = { normalizeType, getCRExperience, transformMonster, generateTypeFile }` at the bottom of the file
+- [x] Verify: `node -e "const m = require('./lib/scripts/populateMonstersByType'); console.log(Object.keys(m))"` prints the four export names without making HTTP calls
+
+### T3 — Integration test: migrateGlobalMonsters
+
+- [x] Create `tests/integration/scripts/migrateGlobalMonsters.integration.test.ts`
+- [x] Test setup: get a direct MongoDB collection handle using `MONGODB_URI` / `MONGODB_DB` env vars (already set by global test setup)
+- [x] Seed documents: one untagged global monster (`source` absent), one with `source: ""`, one with `source: "SRD"` (already tagged), one non-global monster with no source
+- [x] Test: call `migrateGlobalMonsters()`, assert tagged docs have `source: "SRD"`, assert `modifiedCount === 2` (the two untagged ones), assert already-tagged and non-global docs unchanged
+- [x] Test idempotency: call `migrateGlobalMonsters()` again, assert `modifiedCount === 0`
+- [x] `afterEach`: delete seeded test documents by a unique test-run marker field to avoid polluting other tests
+- [x] Verify: `npm run test:integration -- --testPathPattern=scripts/migrateGlobalMonsters` passes
+
+### T4 — Unit tests: populateMonstersByType
+
+- [x] Create `tests/unit/lib/scripts/populateMonstersByType.test.ts`
+- [x] Test `normalizeType`: swarm strings → `"beast"`, standard type → lowercased, already-lowercase unchanged
+- [x] Test `getCRExperience`: CR `0` → `10`, CR `0.5` → `100`, CR `1` → `200`, CR `20` → `25000`, unknown CR → `0`
+- [x] Test `transformMonster`: full fixture → verify `name`, `ac`, `abilities`, `savingThrows`, `skills`, `actions`, `traits`, `source: "SRD"`
+- [x] Test `transformMonster`: no `proficiencies` → `savingThrows` and `skills` absent from result
+- [x] Test `transformMonster`: no `senses` → `senses === ""`
+- [x] Test `transformMonster`: no `actions` → `actions` absent from result
+- [x] Test `transformMonster`: no `xp`, CR `5` → `experiencePoints === 1800`
+- [x] Test `generateTypeFile`: creates `beasts.ts` in temp dir, file contains `export const BEASTS:`
+- [x] Test `generateTypeFile`: cleanup — `afterEach` removes temp dir
+- [x] Verify: `npm run test:unit -- --testPathPattern=lib/scripts/populateMonstersByType` passes
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Review its report and apply fixes for duplication, complexity, and completeness before committing.
+
+## Validation
+
+- [x] `npm run test:unit` — all unit tests pass
+- [x] `npm run test:integration` — all integration tests pass
+- [x] `npm run build` — TypeScript build succeeds
+- [x] `npm run lint` (if available) — no new lint errors
+- [ ] `lib/scripts/` coverage ≥ 70% (check with `npm run test:unit -- --coverage`)
+- [ ] All execution tasks marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run before the final commit
+- [ ] Commit all changes to `feat/scripts-test-coverage` and push to remote
+- [ ] Open PR from `feat/scripts-test-coverage` to `main`. PR body MUST include `Closes #246`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address, commit, validate locally, push, wait 180s, repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll via `gh pr checks <PR-URL> --json isRequired,state`; fix any blocking failures, push, wait 180s, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): agentic reviewer (auto)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks complete
+- [ ] No documentation updates required for this change
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec directory) — copy `specs/migrate-global-monsters.md` and `specs/populate-monsters-by-type.md` to `openspec/specs/scripts/`
+- [ ] Archive the change: move `openspec/changes/scripts-test-coverage/` to `openspec/changes/archive/YYYY-MM-DD-scripts-test-coverage/` in a single atomic commit (stage both copy and deletion together)
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-scripts-test-coverage/` exists and `openspec/changes/scripts-test-coverage/` is gone
+- [ ] **Create a doc branch**: `git checkout -b doc/archive-YYYY-MM-DD-scripts-test-coverage` then `git push -u origin doc/archive-YYYY-MM-DD-scripts-test-coverage`
+- [ ] Open PR from doc branch to `main` with title `docs: archive scripts-test-coverage (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor doc PR until merged (same loop — address comments/CI, push to doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/scripts-test-coverage doc/archive-YYYY-MM-DD-scripts-test-coverage`

--- a/openspec/changes/archive/2026-05-27-scripts-test-coverage/tests.md
+++ b/openspec/changes/archive/2026-05-27-scripts-test-coverage/tests.md
@@ -1,0 +1,95 @@
+---
+name: tests
+description: Tests for scripts-test-coverage
+---
+
+# Tests
+
+## Overview
+
+Test cases for the `scripts-test-coverage` change. All work follows strict TDD: write a failing test, write code to pass it, refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — before any implementation, write the test and confirm it fails (import fails or assertion fails).
+2. **Write code to pass the test** — add the guard or export, implement the minimum change.
+3. **Refactor** — clean up if needed; re-confirm the test passes.
+
+## Test Cases
+
+### T1 — migrateGlobalMonsters guard + export
+
+- [ ] **Import without side effects** — `import { migrateGlobalMonsters } from 'lib/scripts/migrateGlobalMonsters'` in a test file does not throw, does not connect to DB
+  - File: `tests/integration/scripts/migrateGlobalMonsters.integration.test.ts`
+  - Spec: `specs/migrate-global-monsters.md` — "Import without execution"
+- [ ] **Export is a function** — `typeof migrateGlobalMonsters === 'function'`
+
+### T2 — populateMonstersByType guard + exports
+
+- [ ] **Import without side effects** — `require('lib/scripts/populateMonstersByType')` does not make HTTP calls or write files
+  - File: `tests/unit/lib/scripts/populateMonstersByType.test.ts`
+  - Spec: `specs/populate-monsters-by-type.md` — "Import without execution"
+- [ ] **All four functions exported** — `normalizeType`, `getCRExperience`, `transformMonster`, `generateTypeFile` are all functions
+
+### T3 — Integration: migrateGlobalMonsters DB behavior
+
+- [ ] **Tags untagged global monster (no source field)** — after migration, document has `source: "SRD"`
+  - File: `tests/integration/scripts/migrateGlobalMonsters.integration.test.ts`
+  - Spec: `specs/migrate-global-monsters.md` — "Untagged global monster is migrated"
+- [ ] **Tags untagged global monster (empty source)** — document with `source: ""` gets `source: "SRD"`
+  - Spec: "Untagged global monster is migrated"
+- [ ] **Already-tagged monster not re-updated** — document with `source: "SRD"` has `modifiedCount` contribution of 0
+  - Spec: "Already-tagged monster is not re-migrated"
+- [ ] **Non-global monster not touched** — document with `isGlobal: false` is unchanged
+  - Spec: "Non-global monster is not touched"
+- [ ] **modifiedCount matches number of untagged docs** — function return value equals 2 for the two untagged seeds
+- [ ] **Idempotency — second run returns 0** — calling `migrateGlobalMonsters()` again returns `0`
+  - Spec: "Double-run idempotency"
+
+### T4 — Unit: normalizeType
+
+- [ ] **Swarm type → "beast"** — `normalizeType("swarm of Tiny beasts") === "beast"`
+  - File: `tests/unit/lib/scripts/populateMonstersByType.test.ts`
+  - Spec: `specs/populate-monsters-by-type.md` — "Swarm type is normalized"
+- [ ] **Mixed-case swarm → "beast"** — `normalizeType("Swarm of Medium Undead") === "beast"`
+- [ ] **Standard type → lowercased** — `normalizeType("Humanoid") === "humanoid"`
+  - Spec: "Standard type is lowercased"
+- [ ] **Already-lowercase unchanged** — `normalizeType("undead") === "undead"`
+  - Spec: "Already-lowercase type is returned unchanged"
+
+### T4 — Unit: getCRExperience
+
+- [ ] **CR 0 → 10**
+  - Spec: "Known CR returns correct XP"
+- [ ] **CR 0.5 → 100**
+  - Spec: "Fractional CR is handled"
+- [ ] **CR 1 → 200**
+- [ ] **CR 20 → 25000**
+- [ ] **CR 99 → 0**
+  - Spec: "Unknown CR returns 0"
+
+### T4 — Unit: transformMonster
+
+- [ ] **Full fixture maps correctly** — name, hp, ac, abilities, challengeRating, source "SRD", savingThrows, skills, actions, traits all present
+  - Spec: "Full monster response is transformed correctly"
+- [ ] **No proficiencies → savingThrows absent** — result has no `savingThrows` key
+  - Spec: "Monster with no proficiencies is handled"
+- [ ] **No proficiencies → skills absent** — result has no `skills` key
+- [ ] **No senses → senses is ""** — `result.senses === ""`
+  - Spec: "Monster with no senses is handled"
+- [ ] **No actions → actions absent** — result has no `actions` key
+  - Spec: "Monster with no actions is handled"
+- [ ] **No xp, CR 5 → experiencePoints 1800** — falls back to getCRExperience lookup
+  - Spec: "transformMonster uses getCRExperience when xp is absent"
+- [ ] **Swarm monster → conditionImmunities mapped to name strings** — array of `{name}` objects becomes array of strings
+
+### T4 — Unit: generateTypeFile
+
+- [ ] **Creates file in specified temp dir** — file exists at `tmpDir/beasts.ts`
+  - Spec: "File is written to specified directory"
+- [ ] **Export name is correct** — file content contains `export const BEASTS:`
+  - Spec: "Generated file has correct export name"
+- [ ] **Type import present** — file content contains `import { MonsterTemplate } from`
+- [ ] **afterEach cleans up temp dir** — temp directory is removed after each test

--- a/openspec/specs/scripts/migrate-global-monsters.md
+++ b/openspec/specs/scripts/migrate-global-monsters.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED migrateGlobalMonsters is importable without auto-executing
+
+The system SHALL allow `migrateGlobalMonsters.ts` to be imported as a module without triggering database connections or side effects.
+
+#### Scenario: Import without execution
+
+- **Given** a test file that imports `migrateGlobalMonsters.ts`
+- **When** the module is loaded
+- **Then** no database connection is attempted and no console output is produced
+
+### Requirement: ADDED migrateGlobalMonsters tags untagged global monsters with source "SRD"
+
+The system SHALL update all global monsters belonging to `GLOBAL_USER_ID` that have no `source`, a null `source`, or an empty string `source` to `source: "SRD"`.
+
+#### Scenario: Untagged global monster is migrated
+
+- **Given** a MongoDB collection containing a global monster with `userId: GLOBAL_USER_ID`, `isGlobal: true`, and `source` absent
+- **When** `migrateGlobalMonsters()` is called
+- **Then** the document has `source: "SRD"` and the function returns `modifiedCount >= 1`
+
+#### Scenario: Already-tagged monster is not re-migrated
+
+- **Given** a MongoDB collection containing a global monster with `source: "SRD"` already set
+- **When** `migrateGlobalMonsters()` is called
+- **Then** that document is not modified and `modifiedCount` does not increase for it
+
+#### Scenario: Non-global monster is not touched
+
+- **Given** a MongoDB collection containing a monster with `isGlobal: false` and no `source`
+- **When** `migrateGlobalMonsters()` is called
+- **Then** that document remains unchanged
+
+### Requirement: ADDED migrateGlobalMonsters is idempotent
+
+The system SHALL produce no additional changes when called a second time after a successful migration.
+
+#### Scenario: Double-run idempotency
+
+- **Given** a collection that has already been fully migrated (all global monsters have `source: "SRD"`)
+- **When** `migrateGlobalMonsters()` is called again
+- **Then** `modifiedCount === 0`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "add require.main guard to migrateGlobalMonsters.ts" -> Requirement: migrateGlobalMonsters is importable without auto-executing
+- Proposal element "integration test: pre/post DB state, idempotency" -> Requirements: tags untagged monsters, idempotency
+- Design decision 1 (require.main guard) -> Requirement: importable without auto-executing
+- Design decision 3 (integration test placement) -> Requirements: tags untagged monsters, idempotency
+- Requirements -> Task: T1 (guard + export), T3 (integration test)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Direct CLI execution still works after guard is added
+
+- **Given** the `require.main === module` guard is in place
+- **When** the script is run directly via `npx ts-node lib/scripts/migrateGlobalMonsters.ts`
+- **Then** the migration executes as before and `process.exit` is called with code 0 on success

--- a/openspec/specs/scripts/populate-monsters-by-type.md
+++ b/openspec/specs/scripts/populate-monsters-by-type.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED populateMonstersByType is importable without auto-executing
+
+The system SHALL allow `populateMonstersByType.js` to be imported as a module without triggering HTTP requests or file-system writes.
+
+#### Scenario: Import without execution
+
+- **Given** a test file that imports `populateMonstersByType.js`
+- **When** the module is loaded
+- **Then** no HTTP requests are made and no files are written
+
+### Requirement: ADDED normalizeType maps swarm types to "beast"
+
+The system SHALL return `"beast"` for any monster type string that contains the word "swarm" (case-insensitive), and return the lowercased type otherwise.
+
+#### Scenario: Swarm type is normalized
+
+- **Given** a type string `"swarm of Tiny beasts"`
+- **When** `normalizeType` is called
+- **Then** it returns `"beast"`
+
+#### Scenario: Standard type is lowercased
+
+- **Given** a type string `"Humanoid"`
+- **When** `normalizeType` is called
+- **Then** it returns `"humanoid"`
+
+#### Scenario: Already-lowercase type is returned unchanged
+
+- **Given** a type string `"undead"`
+- **When** `normalizeType` is called
+- **Then** it returns `"undead"`
+
+### Requirement: ADDED getCRExperience returns correct XP for known challenge ratings
+
+The system SHALL return the correct XP value for every CR in the standard D&D 5e table, and return 0 for unknown CRs.
+
+#### Scenario: Known CR returns correct XP
+
+- **Given** a challenge rating of `1`
+- **When** `getCRExperience` is called
+- **Then** it returns `200`
+
+#### Scenario: Fractional CR is handled
+
+- **Given** a challenge rating of `0.5`
+- **When** `getCRExperience` is called
+- **Then** it returns `100`
+
+#### Scenario: Unknown CR returns 0
+
+- **Given** a challenge rating of `99`
+- **When** `getCRExperience` is called
+- **Then** it returns `0`
+
+### Requirement: ADDED transformMonster maps Open5E API response to MonsterTemplate schema
+
+The system SHALL produce a correctly structured object from a valid Open5E API monster response, with appropriate defaults when optional fields are absent.
+
+#### Scenario: Full monster response is transformed correctly
+
+- **Given** a mock Open5E API response with all fields populated (AC, proficiencies, senses, actions, traits, languages)
+- **When** `transformMonster` is called
+- **Then** the result has `name`, `type`, `hp`, `ac`, `abilities`, `challengeRating`, `experiencePoints`, `source: "SRD"`, and correctly mapped `actions`, `traits`, `savingThrows`, `skills`
+
+#### Scenario: Monster with no proficiencies is handled
+
+- **Given** a mock API response with `proficiencies: []`
+- **When** `transformMonster` is called
+- **Then** `savingThrows` and `skills` are absent from the result (not empty objects)
+
+#### Scenario: Monster with no senses is handled
+
+- **Given** a mock API response with `senses: null` or `senses` absent
+- **When** `transformMonster` is called
+- **Then** `senses` in the result is an empty string `""`
+
+#### Scenario: Monster with no actions is handled
+
+- **Given** a mock API response with `actions: []` or `actions` absent
+- **When** `transformMonster` is called
+- **Then** `actions` is absent from the result
+
+#### Scenario: transformMonster uses getCRExperience when xp is absent
+
+- **Given** a mock API response with no `xp` field and `challenge_rating: 5`
+- **When** `transformMonster` is called
+- **Then** `experiencePoints === 1800`
+
+### Requirement: ADDED generateTypeFile produces correctly structured TypeScript file content
+
+The system SHALL write a `.ts` file to the specified output directory containing a named array export of the correct type, matching the pluralization convention.
+
+#### Scenario: Generated file has correct export name
+
+- **Given** monster type `"beast"` and an array of transformed monsters
+- **When** `generateTypeFile` is called with a temp directory
+- **Then** the written file contains `export const BEASTS:`
+
+#### Scenario: Already-plural type is not double-pluralized
+
+- **Given** monster type `"undead"` (does not end in "s")
+- **When** `generateTypeFile` is called
+- **Then** the written file contains `export const UNDEADS:` (appends S)
+
+#### Scenario: File is written to specified directory
+
+- **Given** a writable temp directory path
+- **When** `generateTypeFile` is called with type `"beast"` and a monster array
+- **Then** the file `beasts.ts` exists in that directory
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "add require.main guard to populateMonstersByType.js" -> Requirement: importable without auto-executing
+- Proposal element "export normalizeType, getCRExperience, transformMonster, generateTypeFile" -> All unit test requirements
+- Design decision 2 (export pure functions) -> Requirements: normalizeType, getCRExperience, transformMonster, generateTypeFile
+- Design decision 4 (generateTypeFile temp-dir I/O) -> Requirement: generateTypeFile produces correct content
+- Requirements -> Task: T2 (guard + exports), T4 (unit tests)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: CLI direct execution still works after exports are added
+
+- **Given** `module.exports` additions at the bottom of `populateMonstersByType.js`
+- **When** the script is run directly via `node lib/scripts/populateMonstersByType.js`
+- **Then** execution proceeds as before (`require.main === module` is `true`)


### PR DESCRIPTION
Archives the `scripts-test-coverage` OpenSpec change following merge of #253.

- Moves `openspec/changes/scripts-test-coverage/` → `openspec/changes/archive/2026-05-27-scripts-test-coverage/`
- Syncs approved specs to `openspec/specs/scripts/`