### PR TITLE
feat: password reset infrastructure (rate-limit, email, token store, DB index)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Optional offline-first feature toggle.
 # Defaults to disabled when absent; only set to true to enable offline-first data routing.
 # NEXT_PUBLIC_OFFLINE_MODE_ENABLED=true
+
+# Password reset — Mailtrap email delivery
+# MAILTRAP_TOKEN=your-mailtrap-api-token
+# MAILTRAP_FROM_EMAIL=noreply@yourdomain.com
+# APP_URL=https://yourdomain.com

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -27,10 +27,10 @@ async function initializeDatabase(db: Db): Promise<void> {
     await db
       .collection("password_reset_tokens")
       .createIndex({ tokenHash: 1 }, { unique: true });
-    // Index on userId for efficient upsert in storeResetToken
+    // Unique index on userId ensures replaceOne+upsert is atomic — only one token per user
     await db
       .collection("password_reset_tokens")
-      .createIndex({ userId: 1 });
+      .createIndex({ userId: 1 }, { unique: true });
     console.log("Created indexes on password_reset_tokens.tokenHash and userId");
 
     // Check if characters_active already exists as a view; only drop views,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -23,6 +23,12 @@ async function initializeDatabase(db: Db): Promise<void> {
     await db.collection("characters").createIndex({ deletedAt: 1 });
     console.log("Created index on characters.deletedAt");
 
+    // Unique index on tokenHash for O(1) reset-token lookup
+    await db
+      .collection("password_reset_tokens")
+      .createIndex({ tokenHash: 1 }, { unique: true });
+    console.log("Created unique index on password_reset_tokens.tokenHash");
+
     // Check if characters_active already exists as a view; only drop views,
     // never a real collection, to avoid accidental data loss during re-initialization.
     const existing = await db

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -27,7 +27,11 @@ async function initializeDatabase(db: Db): Promise<void> {
     await db
       .collection("password_reset_tokens")
       .createIndex({ tokenHash: 1 }, { unique: true });
-    console.log("Created unique index on password_reset_tokens.tokenHash");
+    // Index on userId for efficient upsert in storeResetToken
+    await db
+      .collection("password_reset_tokens")
+      .createIndex({ userId: 1 });
+    console.log("Created indexes on password_reset_tokens.tokenHash and userId");
 
     // Check if characters_active already exists as a view; only drop views,
     // never a real collection, to avoid accidental data loss during re-initialization.

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -19,6 +19,11 @@ export async function sendPasswordResetEmail(
   resetUrl: string
 ): Promise<void> {
   const client = getClient();
+  if (!process.env.MAILTRAP_FROM_EMAIL) {
+    console.warn(
+      "MAILTRAP_FROM_EMAIL is not set — falling back to noreply@session-combat.app. Set this in production to avoid unverified-sender failures."
+    );
+  }
   const fromEmail = process.env.MAILTRAP_FROM_EMAIL || "noreply@session-combat.app";
 
   await client.send({

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,29 @@
+import { MailtrapClient } from "mailtrap";
+
+function getClient(): MailtrapClient {
+  const token = process.env.MAILTRAP_TOKEN;
+  if (!token) {
+    throw new Error(
+      "MAILTRAP_TOKEN environment variable is not set. Email sending is unavailable."
+    );
+  }
+  return new MailtrapClient({ token });
+}
+
+export async function sendPasswordResetEmail(
+  to: string,
+  resetUrl: string
+): Promise<void> {
+  const client = getClient();
+  const fromEmail = process.env.MAILTRAP_FROM_EMAIL || "noreply@session-combat.app";
+
+  await client.send({
+    from: { email: fromEmail, name: "Session Combat" },
+    to: [{ email: to }],
+    subject: "Reset your Session Combat password",
+    html: `<p>You requested a password reset.</p>
+<p><a href="${resetUrl}">Click here to reset your password</a></p>
+<p>This link expires in 15 minutes. If you did not request a reset, ignore this email.</p>`,
+    text: `You requested a password reset.\n\nReset your password: ${resetUrl}\n\nThis link expires in 15 minutes. If you did not request a reset, ignore this email.`,
+  });
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,13 +1,17 @@
 import { MailtrapClient } from "mailtrap";
 
+let client: MailtrapClient | null = null;
+
 function getClient(): MailtrapClient {
+  if (client) return client;
   const token = process.env.MAILTRAP_TOKEN;
   if (!token) {
     throw new Error(
       "MAILTRAP_TOKEN environment variable is not set. Email sending is unavailable."
     );
   }
-  return new MailtrapClient({ token });
+  client = new MailtrapClient({ token });
+  return client;
 }
 
 export async function sendPasswordResetEmail(

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -6,10 +6,21 @@
 
 interface RateLimitEntry {
   count: number;
-  windowStart: number;
+  resetAt: number;
 }
 
 const store = new Map<string, RateLimitEntry>();
+
+// Periodically clean up expired entries to prevent memory leaks.
+// .unref() allows Node to exit even if this timer is still pending (not available in jsdom).
+(setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of store.entries()) {
+    if (now >= entry.resetAt) {
+      store.delete(key);
+    }
+  }
+}, 60_000) as unknown as { unref?: () => void }).unref?.();
 
 /**
  * Throws a 429-ready error when `key` has exceeded `limit` calls within
@@ -23,8 +34,8 @@ export function checkRateLimit(
   const now = Date.now();
   const entry = store.get(key);
 
-  if (!entry || now - entry.windowStart >= windowMs) {
-    store.set(key, { count: 1, windowStart: now });
+  if (!entry || now >= entry.resetAt) {
+    store.set(key, { count: 1, resetAt: now + windowMs });
     return;
   }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,45 @@
+// In-memory rate limiter backed by a Map. State is wiped on cold start.
+// On Fly.io (auto_stop_machines = 'stop'), machines can be stopped between
+// requests — rate-limit counts reset on each cold start. Acceptable at
+// current single-instance scale; replace with Redis if horizontal scaling
+// or stronger guarantees are required.
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+/**
+ * Throws a 429-ready error when `key` has exceeded `limit` calls within
+ * `windowMs` milliseconds. Resets the counter automatically after the window.
+ */
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): void {
+  const now = Date.now();
+  const entry = store.get(key);
+
+  if (!entry || now - entry.windowStart >= windowMs) {
+    store.set(key, { count: 1, windowStart: now });
+    return;
+  }
+
+  if (entry.count >= limit) {
+    throw new RateLimitError("Too many requests. Please try again later.");
+  }
+
+  entry.count += 1;
+}
+
+export class RateLimitError extends Error {
+  readonly status = 429;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}

--- a/lib/reset-tokens.ts
+++ b/lib/reset-tokens.ts
@@ -1,0 +1,66 @@
+import crypto from "crypto";
+import { getDatabase } from "@/lib/db";
+
+const COLLECTION = "password_reset_tokens";
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+export interface ResetTokenDocument {
+  userId: string;
+  tokenHash: string;
+  expiresAt: Date;
+  consumedAt?: Date;
+  createdAt: Date;
+}
+
+export function generateResetToken(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+export function hashToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export async function storeResetToken(
+  userId: string,
+  tokenHash: string
+): Promise<void> {
+  const db = await getDatabase();
+  const col = db.collection<ResetTokenDocument>(COLLECTION);
+
+  // Delete all prior active tokens for this user before inserting new one
+  await col.deleteMany({ userId });
+
+  await col.insertOne({
+    userId,
+    tokenHash,
+    expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+    createdAt: new Date(),
+  });
+}
+
+export async function validateResetToken(token: string): Promise<string> {
+  const db = await getDatabase();
+  const col = db.collection<ResetTokenDocument>(COLLECTION);
+
+  const tokenHash = hashToken(token);
+  const doc = await col.findOne({ tokenHash });
+
+  if (!doc) {
+    throw new Error("Invalid or unknown reset token.");
+  }
+  if (doc.expiresAt < new Date()) {
+    throw new Error("Reset token has expired.");
+  }
+  if (doc.consumedAt) {
+    throw new Error("Reset token has already been used.");
+  }
+
+  return doc.userId;
+}
+
+export async function consumeResetToken(tokenHash: string): Promise<void> {
+  const db = await getDatabase();
+  const col = db.collection<ResetTokenDocument>(COLLECTION);
+
+  await col.updateOne({ tokenHash }, { $set: { consumedAt: new Date() } });
+}

--- a/lib/reset-tokens.ts
+++ b/lib/reset-tokens.ts
@@ -27,18 +27,25 @@ export async function storeResetToken(
   const db = await getDatabase();
   const col = db.collection<ResetTokenDocument>(COLLECTION);
 
-  // Delete all prior active tokens for this user before inserting new one
-  await col.deleteMany({ userId });
-
-  await col.insertOne({
-    userId,
-    tokenHash,
-    expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
-    createdAt: new Date(),
-  });
+  // Atomically replace any existing token for this user (or insert if none exists),
+  // ensuring only one active reset token per user at any time.
+  await col.replaceOne(
+    { userId },
+    {
+      userId,
+      tokenHash,
+      expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+      createdAt: new Date(),
+    },
+    { upsert: true }
+  );
 }
 
 export async function validateResetToken(token: string): Promise<string> {
+  if (!token || typeof token !== "string") {
+    throw new Error("Invalid or unknown reset token.");
+  }
+
   const db = await getDatabase();
   const col = db.collection<ResetTokenDocument>(COLLECTION);
 
@@ -62,5 +69,12 @@ export async function consumeResetToken(tokenHash: string): Promise<void> {
   const db = await getDatabase();
   const col = db.collection<ResetTokenDocument>(COLLECTION);
 
-  await col.updateOne({ tokenHash }, { $set: { consumedAt: new Date() } });
+  const result = await col.updateOne(
+    { tokenHash, consumedAt: { $exists: false }, expiresAt: { $gt: new Date() } },
+    { $set: { consumedAt: new Date() } }
+  );
+
+  if (result.modifiedCount === 0) {
+    throw new Error("Reset token has already been used or has expired.");
+  }
 }

--- a/openspec/changes/add-password-reset-ability/design.md
+++ b/openspec/changes/add-password-reset-ability/design.md
@@ -34,7 +34,7 @@
 ### D3: Token lifecycle and validity
 
 - Token TTL: 15 minutes.
-- New forgot request invalidates prior active tokens for same user.
+- New forgot request **deletes** all prior token documents for the same user before inserting the new one (no audit trail; keeps the collection lean).
 - Reset consumes token atomically (`consumedAt` set in same update path as password change).
 - Expired/consumed/unknown tokens return generic invalid-token error.
 
@@ -83,7 +83,18 @@
 - Feature-flag password reset routes/pages.
 - If incident occurs, disable reset endpoints and purge outstanding reset tokens.
 
+### D7: Forgot-endpoint timing safety (anti-enumeration)
+
+- The forgot endpoint performs `findOne({ email })` before deciding whether to send an email.
+- The 200 response is returned **immediately after the DB lookup** — before any email work begins.
+- If the user exists, `generateAndSendResetEmail()` is fired without `await` (fire-and-forget), with `.catch(err => console.error(...))` for silent failure logging.
+- Both branches (known / unknown email) return the response at the same code point, after the same single indexed `findOne`. No timing oracle.
+- Response message: `"If an account with that email exists, a password reset link has been sent."`
+- Works correctly on Fly.io: long-lived Node.js process means the background Promise continues in the event loop after response is returned; the machine will not auto-stop mid-request.
+
 ## Resolved Decisions
 
 - **Email provider:** Mailtrap.io (official Node.js SDK: `mailtrap`). Use the Email Sending API for production delivery.
-- **Rate limiter backing store:** In-memory (`Map` + TTL). Acceptable for current single-instance deployment. Document as a known limitation for horizontal scaling if Fly.io instance count grows.
+- **Rate limiter backing store:** In-memory (`Map` + TTL). Acceptable for current single-instance deployment. Document as a known limitation in `lib/rate-limit.ts`. Note: `auto_stop_machines = 'stop'` in `fly.toml` means rate-limit state is wiped on cold start — risk window is narrow at current scale.
+- **DB index for reset tokens:** Unique index on `tokenHash` only, added in `lib/db.ts` `initializeDatabase()`. No TTL index — expiry enforced in application logic via `expiresAt` checks.
+- **Forgot-endpoint timing:** Async fire-and-forget email send after immediate response (D7). Eliminates timing oracle between known and unknown email paths.

--- a/openspec/changes/password-reset-api/.openspec.yaml
+++ b/openspec/changes/password-reset-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-27

--- a/openspec/changes/password-reset-api/design.md
+++ b/openspec/changes/password-reset-api/design.md
@@ -1,0 +1,96 @@
+## Context
+
+- Infrastructure modules (`lib/rate-limit.ts`, `lib/email.ts`, `lib/reset-tokens.ts`) available from Part 1 (#265).
+- Existing auth: JWT cookies via `lib/auth.ts`; `withAuth` middleware; `tokenVersion` on User (from #207).
+- Parent design decisions (D1–D7) in `openspec/changes/add-password-reset-ability/design.md`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Implement the two reset endpoints that form the security-critical core of the password reset flow.
+- Ensure no user enumeration, timing oracle, or token-reuse vulnerability.
+
+### Non-Goals
+
+- UI pages (Part 3 — `password-reset-ui`).
+- Changes to infrastructure libs (Part 1 — `password-reset-infrastructure`).
+- Retry logic for email delivery.
+
+## Decisions
+
+### D-A1: Forgot endpoint response timing — fire-and-forget email send
+
+- **Chosen:** Return 200 immediately after `findOne({ email })`. If user found, `generateAndSendResetEmail()` runs without `await` with `.catch(err => console.error(...))`.
+- **Alternatives considered:** Await email send before responding; add artificial delay.
+- **Rationale:** Both known and unknown email paths execute the same indexed `findOne` and return at the same code point — no timing oracle (parent D7).
+- **Trade-offs:** Email send failure is silent to the caller. Logged via `.catch`.
+
+### D-A2: Reset endpoint — atomic password + tokenVersion + consumeResetToken
+
+- **Chosen:** Single `updateOne` that sets `passwordHash`, increments `tokenVersion`, and sets `updatedAt`. Then `consumeResetToken(tokenHash)` in a second call.
+- **Alternatives considered:** Transaction wrapping both writes.
+- **Rationale:** MongoDB transactions add complexity; the risk window between the two operations is narrow and non-exploitable (consumed token check happens first in `validateResetToken`).
+- **Trade-offs:** Tiny non-atomic gap between password update and token consume. Acceptable per parent design D3.
+
+### D-A3: Rate limiting keys
+
+- **Chosen:** Forgot endpoint: `ip:${ip}` and `email:${normalizedEmail}`. Reset endpoint: `ip:${ip}` only.
+- **Rationale:** Forgot is the high-abuse surface (email enumeration, spam). Reset tokens are already one-time-use and short-lived.
+- **Trade-offs:** Reset endpoint could still be brute-forced for token format — mitigated by 256-bit token entropy (D-I3).
+
+### D-A4: Input validation — reuse existing validators
+
+- **Chosen:** Reuse `validateEmail` from `lib/auth.ts` for forgot; `validatePassword` for reset.
+- **Rationale:** Consistency with existing auth endpoints; single source of validation logic.
+- **Trade-offs:** None.
+
+### D-A5: Route location — Next.js App Router
+
+- **Chosen:** `app/api/auth/password/forgot/route.ts` and `app/api/auth/password/reset/route.ts`.
+- **Rationale:** Follows existing API route conventions in the project.
+- **Trade-offs:** None.
+
+## Proposal to Design Mapping
+
+- Anti-enumeration (D4 + D7) → D-A1 (fire-and-forget, same response for known/unknown).
+- Atomic reset with session invalidation (D5 + D6) → D-A2.
+- Abuse protection → D-A3 (rate limit keys).
+- Input validation → D-A4.
+
+## Functional Requirements Mapping
+
+- Forgot: identical 200 for known and unknown email → D-A1.
+- Forgot: 400 on invalid email format → D-A4.
+- Forgot: 429 on rate limit exceeded → D-A3.
+- Reset: 400 on expired/consumed/unknown token → `validateResetToken` from Part 1.
+- Reset: 400 on weak password → D-A4.
+- Reset: 200 + password updated + sessions invalidated → D-A2.
+
+## Non-Functional Requirements Mapping
+
+- **Security:** No timing oracle (D-A1); one-time tokens; tokenVersion invalidates sessions.
+- **Reliability:** Atomic password+tokenVersion update prevents partial state.
+- **Operability:** Email failures logged; rate limit exceeded returns 429 with clear message.
+
+## Risks / Trade-offs
+
+- Non-atomic gap between password update and token consume (D-A2) — narrow, acceptable.
+- Silent email failure — logged, does not affect 200 response (by design, D7).
+
+## Rollback / Mitigation
+
+- Rollback trigger: security finding in endpoint logic.
+- Rollback steps: remove `app/api/auth/password/forgot/route.ts` and `app/api/auth/password/reset/route.ts`.
+- Data migration: none; tokens in DB are harmless without the endpoints.
+- Verification after rollback: integration tests for endpoints return 404.
+
+## Operational Blocking Policy
+
+- If CI checks fail: fix, commit, push; do not merge with failing checks.
+- If security checks fail: remediate before merge.
+- If required reviews are blocked/stale: escalate to maintainer within 24 h.
+
+## Open Questions
+
+- None — all decisions resolved in parent design or above.

--- a/openspec/changes/password-reset-api/proposal.md
+++ b/openspec/changes/password-reset-api/proposal.md
@@ -1,0 +1,69 @@
+## GitHub Issue
+
+- dougis-org/session-combat#266 (this change — Part 2 of 3)
+- Parent: dougis-org/session-combat#208 (full password reset feature)
+- Prerequisite: dougis-org/session-combat#265 (password-reset-infrastructure)
+
+## Why
+
+With the rate limiter, email sender, and token store in place, the two
+password reset API endpoints can be implemented. These are the security-critical
+pieces of the flow — correct handling of the forgot/reset contract determines
+whether the feature is safe to ship.
+
+## Problem Space
+
+- `POST /api/auth/password/forgot` must return an identical response for known
+  and unknown emails, with no timing oracle (D7 — async fire-and-forget send).
+- `POST /api/auth/password/reset` must atomically consume the token and
+  increment `tokenVersion` so existing sessions are immediately invalidated.
+
+## Scope
+
+### In Scope
+
+- `app/api/auth/password/forgot/route.ts`
+- `app/api/auth/password/reset/route.ts`
+- Integration tests for both endpoints (full reset flow, edge cases, rate limits).
+
+### Out of Scope
+
+- UI pages (Part 3 — #267).
+- Changes to the infrastructure libs (Part 1 — #265).
+
+## Key Design Decisions (from add-password-reset-ability design.md)
+
+**D4 + D7 — Forgot endpoint anti-enumeration:**
+```
+1. Validate email format → 400
+2. Rate limit (IP + email) → 429
+3. findOne({ email })            ← same indexed cost known/unknown
+4. Return 200 immediately        ← response sent before any email work
+5. If user found: fire-and-forget sendPasswordResetEmail()
+```
+Response message: "If an account with that email exists, a password reset link has been sent."
+
+**D3 + D5 + D6 — Reset endpoint:**
+```
+1. Validate inputs → 400
+2. Rate limit (IP) → 429
+3. validateResetToken(token) → 400 on invalid/expired/consumed
+4. validatePassword(password) → 400 on weak password
+5. Atomically: update passwordHash + increment tokenVersion + consumeResetToken
+6. Return 200
+```
+
+## Risks
+
+- Non-atomic update between password and tokenVersion could leave a window where
+  old sessions still work. Must use a single `updateOne` that sets both fields.
+- Silent email failure (Mailtrap down) should log but not affect the 200 response.
+
+## Non-Goals
+
+- Retry logic for email delivery failures.
+- Audit log beyond console error logging.
+
+## Change Control
+
+Design reference: `openspec/changes/add-password-reset-ability/design.md` (D1–D7).

--- a/openspec/changes/password-reset-api/specs/password-reset-api/spec.md
+++ b/openspec/changes/password-reset-api/specs/password-reset-api/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+This document details changes to requirements and is additive to `openspec/changes/add-password-reset-ability/design.md`.
+
+### Requirement: ADDED POST /api/auth/password/forgot endpoint
+
+The system SHALL accept a forgot-password request, return an identical response for known and unknown email addresses, and fire off a reset email asynchronously when the email is registered.
+
+#### Scenario: Known email returns generic 200
+
+- **Given** an email address that matches a registered user
+- **When** `POST /api/auth/password/forgot` is called with that email
+- **Then** the response is 200 with the generic message "If an account with that email exists, a password reset link has been sent."
+
+#### Scenario: Unknown email returns the same generic 200
+
+- **Given** an email address that does not match any registered user
+- **When** `POST /api/auth/password/forgot` is called with that email
+- **Then** the response is 200 with the same generic message (no user enumeration)
+
+#### Scenario: Invalid email format returns 400
+
+- **Given** a malformed email address
+- **When** `POST /api/auth/password/forgot` is called
+- **Then** the response is 400 with a validation error
+
+#### Scenario: Rate limit exceeded returns 429
+
+- **Given** the caller has exceeded the forgot-endpoint rate limit for their IP or email
+- **When** `POST /api/auth/password/forgot` is called
+- **Then** the response is 429
+
+#### Scenario: Known email triggers async token generation and email send
+
+- **Given** a registered user's email address
+- **When** `POST /api/auth/password/forgot` is called and a 200 is returned
+- **Then** a reset token document is present in `password_reset_tokens` for that user's `userId`
+
+---
+
+### Requirement: ADDED POST /api/auth/password/reset endpoint
+
+The system SHALL accept a reset-password request, validate the token and new password, atomically update the password and invalidate all existing sessions, then consume the token.
+
+#### Scenario: Valid token and strong password returns 200
+
+- **Given** a valid unexpired unconsumed reset token and a password meeting strength requirements
+- **When** `POST /api/auth/password/reset` is called with `{ token, password }`
+- **Then** the response is 200 and the user's password is updated in the DB
+
+#### Scenario: Successful reset invalidates existing sessions
+
+- **Given** a user has an active JWT session
+- **When** `POST /api/auth/password/reset` succeeds for that user
+- **Then** subsequent requests using the old JWT are rejected with 401
+
+#### Scenario: Old password no longer works after reset
+
+- **Given** a successful password reset
+- **When** the user attempts to log in with the old password
+- **Then** login fails; the new password succeeds
+
+#### Scenario: Expired token returns 400
+
+- **Given** a reset token whose `expiresAt` is in the past
+- **When** `POST /api/auth/password/reset` is called
+- **Then** the response is 400 with a safe error message (no token details leaked)
+
+#### Scenario: Consumed token returns 400 (prevents replay)
+
+- **Given** a reset token that has already been used (`consumedAt` set)
+- **When** `POST /api/auth/password/reset` is called with the same token
+- **Then** the response is 400
+
+#### Scenario: Invalid or malformed token returns 400
+
+- **Given** a token string that does not match any document in the DB
+- **When** `POST /api/auth/password/reset` is called
+- **Then** the response is 400
+
+#### Scenario: Weak password returns 400
+
+- **Given** a valid reset token but a password that fails strength validation
+- **When** `POST /api/auth/password/reset` is called
+- **Then** the response is 400 with validation details from `validatePassword`
+
+#### Scenario: Rate limit exceeded returns 429
+
+- **Given** the caller has exceeded the reset-endpoint rate limit for their IP
+- **When** `POST /api/auth/password/reset` is called
+- **Then** the response is 429
+
+## MODIFIED Requirements
+
+None — this change is additive only.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Anti-enumeration (D4 + D7) → same-response scenarios for known/unknown email
+- Atomic reset (D5 + D6) → session invalidation + old-password-fails scenarios
+- Rate limiting (D4) → 429 scenarios
+- Input validation (D-A4) → 400 scenarios
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+#### Scenario: No timing oracle on forgot endpoint
+
+- **Given** known and unknown email requests
+- **When** both are processed
+- **Then** both responses are returned at the same logical code point (after a single indexed DB lookup), with email send happening asynchronously after the response
+
+### Requirement: Reliability
+
+#### Scenario: Email send failure does not affect 200 response
+
+- **Given** the Mailtrap service is unavailable
+- **When** `POST /api/auth/password/forgot` is called with a known email
+- **Then** the response is still 200; the error is logged server-side

--- a/openspec/changes/password-reset-api/tasks.md
+++ b/openspec/changes/password-reset-api/tasks.md
@@ -1,0 +1,93 @@
+# Tasks
+
+## Preparation
+
+- [ ] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [ ] **Step 2 — Create and publish working branch:** `git checkout -b feat/password-reset-api` then `git push -u origin feat/password-reset-api`
+
+## Prerequisites
+
+- [ ] #265 (password-reset-infrastructure) merged — rate-limit, email, token store available
+
+## Implementation
+
+- [ ] Implement `app/api/auth/password/forgot/route.ts`:
+  - Validate email format (reuse `validateEmail` from `lib/auth.ts`)
+  - Rate limit by IP + normalized email
+  - `findOne({ email })` on users collection
+  - Return 200 with generic message immediately
+  - If user found: `generateResetToken()` → `storeResetToken()` → fire-and-forget `sendPasswordResetEmail()`
+- [ ] Implement `app/api/auth/password/reset/route.ts`:
+  - Validate `token` and `password` present → 400
+  - Rate limit by IP
+  - `validateResetToken(token)` → 400 on failure
+  - `validatePassword(password)` → 400 with details on failure
+  - Atomic `updateOne`: set `passwordHash`, increment `tokenVersion`, set `updatedAt`
+  - `consumeResetToken(tokenHash)`
+  - Return 200 with success message
+
+## Tests (Integration)
+
+- [ ] `POST /api/auth/password/forgot` — unknown email → 200 generic message
+- [ ] `POST /api/auth/password/forgot` — known email → 200 same generic message; token row in DB
+- [ ] `POST /api/auth/password/forgot` — invalid email format → 400
+- [ ] `POST /api/auth/password/forgot` — rate limit exceeded → 429
+- [ ] `POST /api/auth/password/reset` — valid token + strong password → 200; password updated; token consumed
+- [ ] `POST /api/auth/password/reset` — successful reset → old session JWT rejected with 401
+- [ ] `POST /api/auth/password/reset` — login with new password succeeds; old password fails
+- [ ] `POST /api/auth/password/reset` — expired token → 400 safe error
+- [ ] `POST /api/auth/password/reset` — consumed token (reuse) → 400 safe error
+- [ ] `POST /api/auth/password/reset` — invalid/malformed token → 400 safe error
+- [ ] `POST /api/auth/password/reset` — weak password → 400 with validation details
+- [ ] `POST /api/auth/password/reset` — rate limit exceeded → 429
+
+## Validation
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] Integration test suite passes
+
+## Pre-Commit Code Review
+
+- [ ] Run `openspec-review-code` sub-agent before every commit
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Commit all changes to `feat/password-reset-api` and push to remote
+- [ ] Open PR from `feat/password-reset-api` to `main`; reference `Closes #266`
+- [ ] Wait 180 seconds for CI and agentic reviewers to post comments
+- [ ] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [ ] **Monitor PR comments** — address comments, commit fixes, follow Remote push validation, push, wait 180 s, repeat until no unresolved comments
+- [ ] **Monitor CI checks** — diagnose and fix failures, commit, follow Remote push validation, push, wait 180 s, repeat until all checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; never force-merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive: move `openspec/changes/password-reset-api/` → `openspec/changes/archive/YYYY-MM-DD-password-reset-api/` in a single commit
+- [ ] Confirm archive location exists and original directory is gone
+- [ ] Commit and push the archive to `main`
+- [ ] Prune merged branch: `git fetch --prune` and `git branch -d feat/password-reset-api`

--- a/openspec/changes/password-reset-api/tests.md
+++ b/openspec/changes/password-reset-api/tests.md
@@ -1,0 +1,35 @@
+---
+name: tests
+description: Test plan for password-reset-api
+---
+
+# Tests
+
+## Scope
+
+Integration tests against a real test database (follow pattern in
+`tests/integration/auth.test.helpers.ts`). Both endpoints tested end-to-end.
+
+## Planned test cases
+
+### `POST /api/auth/password/forgot`
+- [ ] Integration: unknown email returns 200 with generic message (no token created).
+- [ ] Integration: known email returns 200 with same generic message; token row exists in DB.
+- [ ] Integration: invalid email format returns 400.
+- [ ] Integration: missing email body returns 400.
+- [ ] Integration: rate limit — N+1 request returns 429.
+
+### `POST /api/auth/password/reset`
+- [ ] Integration: valid token + strong password → 200; `passwordHash` updated in DB.
+- [ ] Integration: valid token + strong password → token `consumedAt` set in DB.
+- [ ] Integration: valid token + strong password → `tokenVersion` incremented in DB.
+- [ ] Integration: old JWT rejected with 401 after successful reset.
+- [ ] Integration: login with new password succeeds after reset.
+- [ ] Integration: login with old password fails after reset.
+- [ ] Integration: expired token → 400 with safe error message.
+- [ ] Integration: consumed token (second use) → 400 with safe error message.
+- [ ] Integration: invalid/random token → 400 with safe error message.
+- [ ] Integration: weak password → 400 with `details` array.
+- [ ] Integration: missing token → 400.
+- [ ] Integration: missing password → 400.
+- [ ] Integration: rate limit — N+1 reset attempt returns 429.

--- a/openspec/changes/password-reset-infrastructure/.openspec.yaml
+++ b/openspec/changes/password-reset-infrastructure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-27

--- a/openspec/changes/password-reset-infrastructure/design.md
+++ b/openspec/changes/password-reset-infrastructure/design.md
@@ -1,0 +1,100 @@
+## Context
+
+- Auth: JWT cookies, MongoDB, bcryptjs password hashing (`lib/auth.ts`).
+- No email sending or rate limiting infrastructure exists yet.
+- No token lifecycle exists yet.
+- Parent design decisions (D1–D7) live in `openspec/changes/add-password-reset-ability/design.md`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Implement the three library modules (rate-limit, email, reset-tokens) that the API endpoints (Part 2) and UI (Part 3) depend on.
+- Add the DB index that makes token lookup O(1).
+
+### Non-Goals
+
+- API endpoints (Part 2 — `password-reset-api`).
+- UI pages (Part 3 — `password-reset-ui`).
+- Redis/MongoDB-backed rate limiting.
+
+## Decisions
+
+### D-I1: Rate limiter — in-memory Map + TTL
+
+- **Chosen:** `Map<string, { count, windowStart }>` keyed by caller-supplied string (IP, normalized email, etc.). Window resets after `windowMs`. Throws `RateLimitError` (status 429) when over threshold.
+- **Alternatives considered:** Redis-backed limiter.
+- **Rationale:** Single-instance Fly.io deployment; Redis adds operational cost for negligible benefit at current scale.
+- **Trade-offs:** State wiped on cold start (`auto_stop_machines = stop`). Documented in `lib/rate-limit.ts`. Acceptable at current scale.
+
+### D-I2: Email sender — Mailtrap official SDK
+
+- **Chosen:** `MailtrapClient` from `mailtrap` npm package. `sendPasswordResetEmail(to, resetUrl)` receives a fully-formed URL; does not read `APP_URL` itself.
+- **Alternatives considered:** Nodemailer with SMTP, SendGrid SDK.
+- **Rationale:** Mailtrap is the resolved provider (see parent design). Official SDK reduces custom SMTP config.
+- **Trade-offs:** Vendor-specific SDK. Migration to another provider requires replacing `lib/email.ts` only.
+
+### D-I3: Token generation — crypto.randomBytes(32)
+
+- **Chosen:** 32-byte crypto-random hex string. Hash stored via SHA-256 (`crypto.createHash`). Raw token never persisted.
+- **Alternatives considered:** UUID v4 (lower entropy).
+- **Rationale:** 256-bit entropy per parent design D2. Node built-ins; no extra dependency.
+- **Trade-offs:** None material.
+
+### D-I4: storeResetToken invalidation strategy — deleteMany before insert
+
+- **Chosen:** Delete all prior token documents for the `userId` before inserting a new one.
+- **Alternatives considered:** Upsert on userId (would require compound unique index).
+- **Rationale:** Keeps collection lean; no audit trail needed per parent design D3.
+- **Trade-offs:** Brief window between delete and insert where no token exists for the user (acceptable — not a critical consistency window).
+
+### D-I5: mailtrap placed in dependencies (not devDependencies)
+
+- **Chosen:** `dependencies` in `package.json`.
+- **Alternatives considered:** `devDependencies` (as originally noted in the issue).
+- **Rationale:** `sendPasswordResetEmail` is called at runtime in production; the SDK must be present in the deployed bundle.
+- **Trade-offs:** Slightly larger production bundle. Correct over the alternative.
+
+## Proposal to Design Mapping
+
+- Rate limiting needed for forgot/reset endpoints → D-I1 (in-memory Map).
+- Email delivery for reset links → D-I2 (Mailtrap SDK).
+- Token generation, hashing, lifecycle → D-I3, D-I4.
+- DB index for O(1) token lookup → unique index on `tokenHash` in `initializeDatabase()`.
+
+## Functional Requirements Mapping
+
+- `checkRateLimit(key, limit, windowMs)` throws `RateLimitError` when over threshold → D-I1.
+- `sendPasswordResetEmail(to, resetUrl)` sends via Mailtrap; throws if `MAILTRAP_TOKEN` missing → D-I2.
+- `generateResetToken()` returns 64-char hex; `hashToken()` is deterministic and never equals input → D-I3.
+- `storeResetToken` invalidates prior tokens for same user → D-I4.
+- `validateResetToken` rejects expired, consumed, or unknown tokens → parent D3.
+- `consumeResetToken` sets `consumedAt` atomically → parent D3.
+
+## Non-Functional Requirements Mapping
+
+- **Security:** Raw token never stored; SHA-256 hash only. `checkRateLimit` is the abuse surface for the forgot/reset endpoints.
+- **Reliability:** `storeResetToken` deletes before insert — no duplicate-token scenario.
+- **Operability:** `MAILTRAP_TOKEN` missing throws a clear configuration error at call time.
+
+## Risks / Trade-offs
+
+- In-memory rate limiter reset on cold start — documented in `lib/rate-limit.ts`. Acceptable at current scale.
+- Mailtrap misconfiguration silently drops emails — `sendPasswordResetEmail` throws on missing token; fire-and-forget caller in Part 2 logs `.catch`.
+
+## Rollback / Mitigation
+
+- Rollback trigger: email delivery failures or rate-limit bypass discovered.
+- Rollback steps: remove `lib/rate-limit.ts`, `lib/email.ts`, `lib/reset-tokens.ts`; revert `lib/db.ts` index addition.
+- Data migration: drop `password_reset_tokens` collection.
+- Verification after rollback: unit test suite passes; `initializeDatabase()` no longer creates the collection/index.
+
+## Operational Blocking Policy
+
+- If CI checks fail: fix, commit, push; do not merge with failing checks.
+- If security checks fail: remediate before merge.
+- If required reviews are blocked/stale: escalate to maintainer within 24 h.
+
+## Open Questions
+
+- None — all decisions resolved in parent design.

--- a/openspec/changes/password-reset-infrastructure/proposal.md
+++ b/openspec/changes/password-reset-infrastructure/proposal.md
@@ -1,0 +1,51 @@
+## GitHub Issue
+
+- dougis-org/session-combat#265 (this change — Part 1 of 3)
+- Parent: dougis-org/session-combat#208 (full password reset feature)
+- Prerequisite: dougis-org/session-combat#207 ✅ merged
+
+## Why
+
+The password reset flow (#208) requires three backend library modules and a DB
+index before any endpoint or UI work can begin. Implementing these as a
+standalone unit keeps the PR small, independently reviewable, and fully testable
+without the HTTP layer.
+
+## Problem Space
+
+- No rate limiting infrastructure exists — needed to protect forgot/reset endpoints from abuse.
+- No email sending infrastructure exists — needed to deliver reset links.
+- No reset-token lifecycle exists — needed to generate, hash, store, validate, and consume one-time tokens.
+- The `password_reset_tokens` MongoDB collection needs a unique index on `tokenHash` for O(1) lookup.
+
+## Scope
+
+### In Scope
+
+- `lib/rate-limit.ts` — in-memory IP + email keyed rate limiter (Map + TTL).
+- `lib/email.ts` — Mailtrap.io sender via `mailtrap` npm SDK.
+- `lib/reset-tokens.ts` — token generate / hash / store / validate / consume helpers.
+- `lib/db.ts` — add unique index on `password_reset_tokens.tokenHash` in `initializeDatabase()`.
+- Unit tests for all three lib modules.
+- `.env.example` entries for `MAILTRAP_TOKEN`, `MAILTRAP_FROM_EMAIL`, `APP_URL`.
+
+### Out of Scope
+
+- API endpoints (Part 2 — #266).
+- UI pages (Part 3 — #267).
+- Redis/MongoDB-backed rate limiting (future, if horizontal scaling required).
+
+## Risks
+
+- In-memory rate limiter state is wiped on cold start (`auto_stop_machines = stop` in fly.toml). Acceptable at current scale; document in `lib/rate-limit.ts`.
+- Mailtrap misconfiguration could silently drop emails. Covered by `.catch(log)` in the forgot endpoint (Part 2).
+
+## Non-Goals
+
+- Production email provider migration (Mailtrap is the chosen provider).
+- TTL index on `password_reset_tokens` (expiry handled in application logic).
+
+## Change Control
+
+Design reference: `openspec/changes/add-password-reset-ability/design.md` (D1–D7).
+If requirements change, update that design document before modifying this change's tasks.

--- a/openspec/changes/password-reset-infrastructure/specs/password-reset-infrastructure/spec.md
+++ b/openspec/changes/password-reset-infrastructure/specs/password-reset-infrastructure/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+This document details changes to requirements and is additive to `openspec/changes/add-password-reset-ability/design.md`.
+
+### Requirement: ADDED Rate limiting infrastructure
+
+The system SHALL reject callers that exceed a configured request threshold within a time window, returning a 429-class error.
+
+#### Scenario: Requests under threshold are allowed
+
+- **Given** a rate-limit key has made fewer calls than the configured limit within the window
+- **When** `checkRateLimit(key, limit, windowMs)` is called
+- **Then** the function returns without throwing
+
+#### Scenario: Request at or over threshold is rejected
+
+- **Given** a rate-limit key has reached the configured call limit within the current window
+- **When** `checkRateLimit(key, limit, windowMs)` is called
+- **Then** a `RateLimitError` is thrown with `status === 429`
+
+#### Scenario: Window expiry resets counter
+
+- **Given** a key has reached the limit within a window
+- **When** the window duration has elapsed and `checkRateLimit` is called again
+- **Then** the call succeeds (counter reset)
+
+#### Scenario: Distinct keys do not share counts
+
+- **Given** two different rate-limit keys
+- **When** one key reaches its limit
+- **Then** calls with the other key are not affected
+
+---
+
+### Requirement: ADDED Email delivery infrastructure
+
+The system SHALL send a password reset email containing the reset URL to the specified recipient.
+
+#### Scenario: Successful email send
+
+- **Given** `MAILTRAP_TOKEN` is set in the environment
+- **When** `sendPasswordResetEmail(to, resetUrl)` is called
+- **Then** the Mailtrap SDK `send` method is invoked with the recipient's address, a password-related subject, and the reset URL in both html and text bodies
+
+#### Scenario: Missing API token raises a configuration error
+
+- **Given** `MAILTRAP_TOKEN` is not set
+- **When** `sendPasswordResetEmail` is called
+- **Then** an error referencing `MAILTRAP_TOKEN` is thrown before any send attempt
+
+---
+
+### Requirement: ADDED Reset token lifecycle
+
+The system SHALL generate, store, validate, and consume one-time password reset tokens.
+
+#### Scenario: Token generation produces unique, high-entropy values
+
+- **Given** `generateResetToken()` is called twice in succession
+- **When** both results are compared
+- **Then** they are different 64-character hex strings
+
+#### Scenario: Token hashing is deterministic
+
+- **Given** the same raw token string
+- **When** `hashToken` is called twice
+- **Then** both calls return the same output, and the output does not equal the input
+
+#### Scenario: Storing a second token for the same user invalidates the first
+
+- **Given** `storeResetToken(userId, hashA)` has been called
+- **When** `storeResetToken(userId, hashB)` is called
+- **Then** prior token documents for the same `userId` are deleted before the new token is inserted
+
+#### Scenario: Expired token is rejected
+
+- **Given** a token document exists with `expiresAt` in the past
+- **When** `validateResetToken(rawToken)` is called
+- **Then** an error indicating the token has expired is thrown
+
+#### Scenario: Consumed token is rejected
+
+- **Given** a token document exists with `consumedAt` set
+- **When** `validateResetToken(rawToken)` is called
+- **Then** an error indicating the token has already been used is thrown
+
+#### Scenario: Unknown token is rejected
+
+- **Given** no token document matching the hash exists in the DB
+- **When** `validateResetToken(rawToken)` is called
+- **Then** an error indicating the token is invalid is thrown
+
+#### Scenario: Valid token returns userId
+
+- **Given** a token document exists with `expiresAt` in the future and no `consumedAt`
+- **When** `validateResetToken(rawToken)` is called
+- **Then** the associated `userId` string is returned
+
+#### Scenario: Token consumption sets consumedAt
+
+- **Given** a token document identified by `tokenHash`
+- **When** `consumeResetToken(tokenHash)` is called
+- **Then** `updateOne` is called with `{ $set: { consumedAt: <Date> } }` on the matching document
+
+---
+
+### Requirement: ADDED DB index for token lookup
+
+The system SHALL maintain a unique index on `password_reset_tokens.tokenHash` to support O(1) token lookup.
+
+#### Scenario: Index created on DB initialization
+
+- **Given** `initializeDatabase()` is called
+- **When** the function completes
+- **Then** a unique index on `{ tokenHash: 1 }` exists on the `password_reset_tokens` collection
+
+## MODIFIED Requirements
+
+None — this change is additive only.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal (rate limiting) → D-I1 → `checkRateLimit` tests
+- Proposal (email delivery) → D-I2 → `sendPasswordResetEmail` tests
+- Proposal (token lifecycle) → D-I3, D-I4 → `generateResetToken`, `hashToken`, `storeResetToken`, `validateResetToken`, `consumeResetToken` tests
+- Proposal (DB index) → `initializeDatabase()` change
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+#### Scenario: Raw token never stored
+
+- **Given** `storeResetToken(userId, tokenHash)` is called
+- **When** the DB write completes
+- **Then** the stored document contains only the SHA-256 hash, not the raw token
+
+### Requirement: Reliability
+
+#### Scenario: storeResetToken is idempotent per user
+
+- **Given** `storeResetToken` has been called for a user
+- **When** it is called again for the same user
+- **Then** only one active token document exists for that user

--- a/openspec/changes/password-reset-infrastructure/tasks.md
+++ b/openspec/changes/password-reset-infrastructure/tasks.md
@@ -2,8 +2,8 @@
 
 ## Preparation
 
-- [ ] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
-- [ ] **Step 2 — Create and publish working branch:** `git checkout -b feat/password-reset-infrastructure` then `git push -u origin feat/password-reset-infrastructure`
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/password-reset-infrastructure` then `git push -u origin feat/password-reset-infrastructure`
 
 ## Prerequisites
 

--- a/openspec/changes/password-reset-infrastructure/tasks.md
+++ b/openspec/changes/password-reset-infrastructure/tasks.md
@@ -42,7 +42,7 @@
 
 - [x] `npm run lint` passes
 - [x] `npm run typecheck` passes
-- [x] `npm test` (unit suite) passes
+- [x] `npm run test:unit` (unit suite) passes
 
 ## Pre-Commit Code Review
 

--- a/openspec/changes/password-reset-infrastructure/tasks.md
+++ b/openspec/changes/password-reset-infrastructure/tasks.md
@@ -1,0 +1,90 @@
+# Tasks
+
+## Preparation
+
+- [ ] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [ ] **Step 2 — Create and publish working branch:** `git checkout -b feat/password-reset-infrastructure` then `git push -u origin feat/password-reset-infrastructure`
+
+## Prerequisites
+
+- [x] #207 (session-invalidation-foundation) merged — tokenVersion auth in place
+
+## Implementation
+
+- [x] Install `mailtrap` npm package (`npm install mailtrap`)
+- [x] Add `MAILTRAP_TOKEN`, `MAILTRAP_FROM_EMAIL`, `APP_URL` to `.env.example`
+  (`APP_URL` is consumed by the forgot endpoint in Part 2 to construct the reset link; `lib/email.ts` receives a fully-formed `resetUrl` string and does not read `APP_URL` itself.)
+- [x] Implement `lib/rate-limit.ts` — in-memory Map + TTL rate limiter; document cold-start limitation.
+  Exported API: `checkRateLimit(key: string, limit: number, windowMs: number): void` — throws (or returns a 429-ready `Response`) when the key has exceeded `limit` calls within `windowMs` milliseconds.
+- [x] Implement `lib/email.ts` — `sendPasswordResetEmail(to, resetUrl)` via Mailtrap SDK
+- [x] Implement `lib/reset-tokens.ts`:
+  - `generateResetToken()` — crypto.randomBytes(32).toString('hex')
+  - `hashToken(token)` — SHA-256 hex digest
+  - `storeResetToken(userId, tokenHash)` — insert new token document; **delete** any prior active token documents for the same `userId` before inserting
+  - `validateResetToken(token)` — hash lookup; check expiresAt and consumedAt; return userId or throw
+  - `consumeResetToken(tokenHash)` — set consumedAt atomically
+- [x] Add to `lib/db.ts` `initializeDatabase()`:
+  ```ts
+  await db.collection('password_reset_tokens').createIndex({ tokenHash: 1 }, { unique: true });
+  ```
+
+## Tests
+
+- [x] Unit: `generateResetToken()` returns 64-char hex string, never repeats across calls
+- [x] Unit: `hashToken()` is deterministic; output never equals input
+- [x] Unit: `validateResetToken()` throws on expired token (`expiresAt` in past)
+- [x] Unit: `validateResetToken()` throws on consumed token (`consumedAt` set)
+- [x] Unit: `storeResetToken()` called twice for same userId invalidates the first token
+- [x] Unit: rate limiter allows N requests under threshold; throws/rejects at threshold
+- [x] Unit: rate limiter resets after TTL window
+
+## Validation
+
+- [x] `npm run lint` passes
+- [x] `npm run typecheck` passes
+- [x] `npm test` (unit suite) passes
+
+## Pre-Commit Code Review
+
+- [ ] Run `openspec-review-code` sub-agent before every commit
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Commit all changes to `feat/password-reset-infrastructure` and push to remote
+- [ ] Open PR from `feat/password-reset-infrastructure` to `main`; reference `Closes #265`
+- [ ] Wait 180 seconds for CI and agentic reviewers to post comments
+- [ ] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [ ] **Monitor PR comments** — address comments, commit fixes, follow Remote push validation, push, wait 180 s, repeat until no unresolved comments
+- [ ] **Monitor CI checks** — diagnose and fix failures, commit, follow Remote push validation, push, wait 180 s, repeat until all checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; never force-merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive: move `openspec/changes/password-reset-infrastructure/` → `openspec/changes/archive/YYYY-MM-DD-password-reset-infrastructure/` in a single commit
+- [ ] Confirm archive location exists and original directory is gone
+- [ ] Commit and push the archive to `main`
+- [ ] Prune merged branch: `git fetch --prune` and `git branch -d feat/password-reset-infrastructure`

--- a/openspec/changes/password-reset-infrastructure/tasks.md
+++ b/openspec/changes/password-reset-infrastructure/tasks.md
@@ -46,7 +46,7 @@
 
 ## Pre-Commit Code Review
 
-- [ ] Run `openspec-review-code` sub-agent before every commit
+- [x] Run `openspec-review-code` sub-agent before every commit
 
 ## Remote push validation
 
@@ -59,10 +59,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Commit all changes to `feat/password-reset-infrastructure` and push to remote
-- [ ] Open PR from `feat/password-reset-infrastructure` to `main`; reference `Closes #265`
+- [x] Commit all changes to `feat/password-reset-infrastructure` and push to remote
+- [x] Open PR from `feat/password-reset-infrastructure` to `main`; reference `Closes #265`
 - [ ] Wait 180 seconds for CI and agentic reviewers to post comments
-- [ ] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [x] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
 - [ ] **Monitor PR comments** — address comments, commit fixes, follow Remote push validation, push, wait 180 s, repeat until no unresolved comments
 - [ ] **Monitor CI checks** — diagnose and fix failures, commit, follow Remote push validation, push, wait 180 s, repeat until all checks pass
 - [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; never force-merge

--- a/openspec/changes/password-reset-infrastructure/tests.md
+++ b/openspec/changes/password-reset-infrastructure/tests.md
@@ -1,0 +1,36 @@
+---
+name: tests
+description: Test plan for password-reset-infrastructure
+---
+
+# Tests
+
+## Scope
+
+Unit tests only. No HTTP layer, no DB container required for this change.
+MongoDB interactions in `reset-tokens.ts` can use an in-memory mock or a
+real test DB (follow existing pattern in `tests/unit/`).
+
+## Planned test cases
+
+### `lib/rate-limit.ts`
+- [ ] Unit: requests under threshold are allowed.
+- [ ] Unit: request at threshold is rejected with appropriate error/response.
+- [ ] Unit: counter resets after TTL window expires.
+- [ ] Unit: separate keys (different IPs) do not share counts.
+
+### `lib/reset-tokens.ts`
+- [ ] Unit: `generateResetToken()` returns a 64-character hex string.
+- [ ] Unit: two successive calls return different values (randomness check).
+- [ ] Unit: `hashToken(token)` is deterministic — same input, same output.
+- [ ] Unit: `hashToken(token)` output does not equal input (not identity function).
+- [ ] Unit: `validateResetToken()` throws for a token hash not found in the database (unknown token).
+- [ ] Unit: `validateResetToken()` throws for a token whose `expiresAt` is in the past.
+- [ ] Unit: `validateResetToken()` throws for a token with `consumedAt` set.
+- [ ] Unit: `validateResetToken()` returns `userId` for a valid unexpired unconsumed token.
+- [ ] Unit: `storeResetToken()` called twice for same `userId` — first token is invalidated.
+- [ ] Unit: `consumeResetToken()` sets `consumedAt`; subsequent `validateResetToken()` throws.
+
+### `lib/email.ts`
+- [ ] Unit: `sendPasswordResetEmail()` calls Mailtrap SDK with correct `to`, `subject`, and reset URL.
+- [ ] Unit: missing env var (`MAILTRAP_TOKEN`) causes a clear configuration error, not a silent failure.

--- a/openspec/changes/password-reset-ui/.openspec.yaml
+++ b/openspec/changes/password-reset-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-27

--- a/openspec/changes/password-reset-ui/design.md
+++ b/openspec/changes/password-reset-ui/design.md
@@ -1,0 +1,97 @@
+## Context
+
+- API endpoints (`POST /api/auth/password/forgot`, `POST /api/auth/password/reset`) available from Part 2 (#266).
+- Existing UI: Next.js App Router, Tailwind CSS, existing login page at `app/login/page.tsx`.
+- Parent design decisions (D1–D7) in `openspec/changes/add-password-reset-ability/design.md`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Implement the two user-facing pages that complete the password reset flow.
+- Handle all UX states gracefully, including the most common real-world case (expired link).
+
+### Non-Goals
+
+- Email template design (handled by `lib/email.ts` in Part 1).
+- Password strength meter UI (existing `validatePassword` error list is sufficient).
+- Animated state transitions.
+- Resend-link functionality on the reset page.
+
+## Decisions
+
+### D-U1: forgot-password page — stateless email form with confirmation state
+
+- **Chosen:** Single-page component with `idle | loading | success | error` state. On success (200), replace form with confirmation message. On error, show inline or banner message per state table in proposal.
+- **Alternatives considered:** Separate confirmation page (extra route, unnecessary complexity).
+- **Rationale:** Simpler; one route, one component, all states handled inline.
+- **Trade-offs:** None material.
+
+### D-U2: reset-password page — token from URL query param; redirect on missing token
+
+- **Chosen:** Read `?token=` from `useSearchParams()`. If missing on mount, redirect to `/forgot-password`. Render new-password + confirm-password fields otherwise.
+- **Alternatives considered:** Hash-based token (not indexable but less conventional for Next.js).
+- **Rationale:** Standard pattern; query params are easy to parse in App Router.
+- **Trade-offs:** Token visible in browser history and server logs — acceptable given 15-minute TTL (noted in proposal).
+
+### D-U3: Client-side confirm-password validation before submit
+
+- **Chosen:** Validate password === confirmPassword in the submit handler before calling the API. Show "Passwords do not match" inline without a round-trip.
+- **Rationale:** Improves UX; avoids unnecessary API calls.
+- **Trade-offs:** None.
+
+### D-U4: Success state on reset page — message + link to login
+
+- **Chosen:** On 200 response, replace form with "Password reset successfully. You can now log in." and a link to `/login`.
+- **Rationale:** Clear completion state; avoids auto-redirect which could confuse users.
+- **Trade-offs:** None.
+
+### D-U5: Login page link to forgot-password
+
+- **Chosen:** Add "Forgot password?" link below the login form pointing to `/forgot-password`.
+- **Rationale:** Discoverability — users need an obvious path from the login screen.
+- **Trade-offs:** Minor login page change; low risk.
+
+## Proposal to Design Mapping
+
+- Forgot page UX states → D-U1.
+- Reset page token handling → D-U2.
+- Client-side mismatch check → D-U3.
+- Reset success UX → D-U4.
+- Login page discoverability → D-U5.
+
+## Functional Requirements Mapping
+
+- Forgot page: renders email form; on 200 shows confirmation; on 400 shows field error; on 429 shows rate-limit message → D-U1.
+- Reset page: redirects to `/forgot-password` if no token in URL → D-U2.
+- Reset page: validates password match client-side before submit → D-U3.
+- Reset page: on 200 shows success + login link → D-U4.
+- Login page: has "Forgot password?" link → D-U5.
+
+## Non-Functional Requirements Mapping
+
+- **Security:** Token only in URL param, never stored in component state beyond what's needed for the API call.
+- **Accessibility:** Error messages associated with form fields via aria-describedby or similar; buttons disabled during loading.
+- **Operability:** All API error states have user-visible messages; no silent failures.
+
+## Risks / Trade-offs
+
+- Token in browser history (D-U2) — mitigated by 15-minute TTL and one-time-use token.
+- `useSearchParams()` requires a Suspense boundary in Next.js App Router — must wrap reset page in `<Suspense>` or use a client component pattern.
+
+## Rollback / Mitigation
+
+- Rollback trigger: UI defect or security finding in page behavior.
+- Rollback steps: remove `app/forgot-password/page.tsx` and `app/reset-password/page.tsx`; revert login page change.
+- Data migration: none.
+- Verification after rollback: routes return 404; login page has no forgot link.
+
+## Operational Blocking Policy
+
+- If CI checks fail: fix, commit, push; do not merge with failing checks.
+- If security checks fail: remediate before merge.
+- If required reviews are blocked/stale: escalate to maintainer within 24 h.
+
+## Open Questions
+
+- Confirm whether `useSearchParams()` requires an explicit Suspense boundary in this project's Next.js version — check `app/login/page.tsx` for precedent.

--- a/openspec/changes/password-reset-ui/proposal.md
+++ b/openspec/changes/password-reset-ui/proposal.md
@@ -1,0 +1,72 @@
+## GitHub Issue
+
+- dougis-org/session-combat#267 (this change — Part 3 of 3)
+- Parent: dougis-org/session-combat#208 (full password reset feature)
+- Prerequisite: dougis-org/session-combat#266 (password-reset-api)
+
+## Why
+
+With the API endpoints live, the user-facing pages complete the password reset
+flow. These are the two screens a user sees when recovering their account.
+
+## Problem Space
+
+- Users need a way to request a reset link without exposing whether their email
+  is registered (the page cannot reveal this either).
+- The reset page receives the one-time token via URL query param and must handle
+  all failure states gracefully — expired links are the most common real-world case.
+
+## Scope
+
+### In Scope
+
+- `app/forgot-password/page.tsx` — email form, confirmation state, error states.
+- `app/reset-password/page.tsx` — new password form, reads `?token=` from URL,
+  all error states, redirect on missing token.
+- Integration tests for both pages.
+- Link from login page to forgot-password page.
+
+### Out of Scope
+
+- Email template design (handled by `lib/email.ts` in Part 1).
+- Password strength meter UI (existing `validatePassword` error list is sufficient).
+- Magic-link / social recovery flows.
+
+## UX States
+
+### forgot-password page
+| State | Display |
+|---|---|
+| Initial | Email input + submit button |
+| Loading | Button disabled + spinner |
+| Success (200) | "If an account with that email exists, a reset link has been sent. Check your inbox." |
+| Invalid email (400) | Inline field error |
+| Rate limited (429) | "Too many requests. Please wait before trying again." |
+| Server error (5xx) | Generic error banner |
+
+### reset-password page
+| State | Display |
+|---|---|
+| Missing token in URL | Redirect to `/forgot-password` |
+| Initial | New password + confirm password fields + submit |
+| Mismatch (client) | "Passwords do not match" before submit |
+| Loading | Button disabled + spinner |
+| Success (200) | "Password reset successfully. You can now log in." + link to login |
+| Invalid/expired token (400) | "This link is invalid or has expired." + link to request new one |
+| Weak password (400) | Inline error from API `details` array |
+| Rate limited (429) | "Too many requests." |
+| Server error (5xx) | Generic error banner |
+
+## Risks
+
+- Token in URL is visible in browser history and server logs. This is standard
+  practice for reset flows and acceptable given the 15-minute TTL.
+
+## Non-Goals
+
+- Animated transitions between states.
+- Resend-link functionality on the reset page (user returns to forgot-password instead).
+
+## Change Control
+
+Design reference: `openspec/changes/add-password-reset-ability/design.md`.

--- a/openspec/changes/password-reset-ui/specs/password-reset-ui/spec.md
+++ b/openspec/changes/password-reset-ui/specs/password-reset-ui/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+This document details changes to requirements and is additive to `openspec/changes/add-password-reset-ability/design.md`.
+
+### Requirement: ADDED Forgot-password page
+
+The system SHALL provide a page at `/forgot-password` where users can request a password reset link by entering their email address.
+
+#### Scenario: Initial state renders email form
+
+- **Given** a user navigates to `/forgot-password`
+- **When** the page loads
+- **Then** an email input field and a submit button are visible
+
+#### Scenario: Successful submission shows confirmation message
+
+- **Given** the user submits a valid email address
+- **When** the API responds with 200
+- **Then** the form is replaced with a confirmation message indicating a reset link may have been sent
+
+#### Scenario: Invalid email format shows inline error
+
+- **Given** the user submits a malformed email address
+- **When** the API responds with 400
+- **Then** an inline validation error is shown without replacing the form
+
+#### Scenario: Rate limit exceeded shows appropriate message
+
+- **Given** the user has exceeded the forgot-endpoint rate limit
+- **When** the API responds with 429
+- **Then** a "Too many requests. Please wait before trying again." message is shown
+
+#### Scenario: Button disabled and loading indicator shown during submission
+
+- **Given** the form is submitted
+- **When** the API response is pending
+- **Then** the submit button is disabled and a loading indicator is visible
+
+#### Scenario: Server error shows generic error banner
+
+- **Given** the API responds with a 5xx status
+- **When** the response is processed
+- **Then** a generic error banner is shown and the form remains available for retry
+
+---
+
+### Requirement: ADDED Reset-password page
+
+The system SHALL provide a page at `/reset-password` where users can set a new password using a one-time token from a reset link.
+
+#### Scenario: Missing token in URL redirects to forgot-password
+
+- **Given** a user navigates to `/reset-password` without a `?token=` query parameter
+- **When** the page mounts
+- **Then** the user is redirected to `/forgot-password`
+
+#### Scenario: Valid token in URL renders new-password form
+
+- **Given** a user navigates to `/reset-password?token=<value>`
+- **When** the page loads
+- **Then** new-password and confirm-password fields and a submit button are visible
+
+#### Scenario: Client-side mismatch shows error before submit
+
+- **Given** the user has entered different values in the new-password and confirm-password fields
+- **When** the form is submitted
+- **Then** a "Passwords do not match" error is shown inline without calling the API
+
+#### Scenario: Successful reset shows confirmation and login link
+
+- **Given** the user submits a valid token and a strong, matching password
+- **When** the API responds with 200
+- **Then** the form is replaced with "Password reset successfully. You can now log in." and a link to `/login`
+
+#### Scenario: Invalid or expired token shows user-friendly error with link
+
+- **Given** the submitted token is invalid or expired
+- **When** the API responds with 400
+- **Then** "This link is invalid or has expired." is shown with a link to request a new reset
+
+#### Scenario: Weak password shows inline validation details
+
+- **Given** the submitted password does not meet strength requirements
+- **When** the API responds with 400 including validation details
+- **Then** the details from the API response are shown inline
+
+#### Scenario: Rate limit exceeded shows appropriate message
+
+- **Given** the caller has exceeded the reset-endpoint rate limit
+- **When** the API responds with 429
+- **Then** a "Too many requests." message is shown
+
+#### Scenario: Button disabled during submission
+
+- **Given** the form is submitted
+- **When** the API response is pending
+- **Then** the submit button is disabled
+
+---
+
+### Requirement: MODIFIED Login page — add forgot-password link
+
+The system SHALL display a "Forgot password?" link on the login page that navigates to `/forgot-password`.
+
+#### Scenario: Forgot password link is visible on login page
+
+- **Given** a user is on the login page at `/login`
+- **When** the page renders
+- **Then** a "Forgot password?" link pointing to `/forgot-password` is visible below the login form
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal (forgot page UX states) → D-U1 → all forgot-page scenarios
+- Proposal (reset page token from URL) → D-U2 → missing-token redirect + valid-token scenarios
+- Proposal (client-side mismatch) → D-U3 → mismatch scenario
+- Proposal (success state) → D-U4 → successful-reset scenario
+- Proposal (login page link) → D-U5 → forgot-password link scenario
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Accessibility
+
+#### Scenario: Form controls are accessible during loading
+
+- **Given** the form is in a loading state
+- **When** a screen reader inspects the submit button
+- **Then** the button is marked as disabled and the loading state is communicated
+
+### Requirement: Security
+
+#### Scenario: Token not persisted beyond the API call
+
+- **Given** the reset page reads `?token=` from the URL
+- **When** the form is submitted
+- **Then** the token is passed directly to the API call and not stored in localStorage or sessionStorage

--- a/openspec/changes/password-reset-ui/tasks.md
+++ b/openspec/changes/password-reset-ui/tasks.md
@@ -1,0 +1,90 @@
+# Tasks
+
+## Preparation
+
+- [ ] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [ ] **Step 2 — Create and publish working branch:** `git checkout -b feat/password-reset-ui` then `git push -u origin feat/password-reset-ui`
+
+## Prerequisites
+
+- [ ] #266 (password-reset-api) merged — forgot and reset endpoints live
+
+## Implementation
+
+- [ ] Implement `app/forgot-password/page.tsx`:
+  - Email input form with validation
+  - POST to `/api/auth/password/forgot` on submit
+  - Handle: 200 (show confirmation), 400 (inline error), 429 (rate limit message), 5xx (error banner)
+  - Disable form during in-flight request
+- [ ] Implement `app/reset-password/page.tsx`:
+  - Read `token` from `useSearchParams()`
+  - Redirect to `/forgot-password` if token missing
+  - New password + confirm password fields with client-side match validation
+  - POST `{ token, password }` to `/api/auth/password/reset`
+  - Handle: 200 (success + login link), 400 invalid token (re-request link), 400 weak password (inline details), 429, 5xx
+  - Disable form during in-flight request
+- [ ] Add "Forgot password?" link on login page pointing to `/forgot-password`
+
+## Tests (Integration)
+
+- [ ] forgot-password page renders email form
+- [ ] Submitting valid email shows confirmation message (mock API returns 200)
+- [ ] Submitting invalid email format shows inline field error
+- [ ] 429 response shows rate-limit message
+- [ ] reset-password page with valid `?token=` renders new password form
+- [ ] Mismatched confirm password shows client-side error before submit
+- [ ] Successful reset (mock 200) shows success state with login link
+- [ ] Invalid/expired token (mock 400) shows re-request message with link to forgot-password
+- [ ] Weak password (mock 400 with details) shows inline error
+- [ ] Missing `?token=` in URL redirects to `/forgot-password`
+
+## Validation
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] Integration test suite passes
+
+## Pre-Commit Code Review
+
+- [ ] Run `openspec-review-code` sub-agent before every commit
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Commit all changes to `feat/password-reset-ui` and push to remote
+- [ ] Open PR from `feat/password-reset-ui` to `main`; reference `Closes #267`
+- [ ] Wait 180 seconds for CI and agentic reviewers to post comments
+- [ ] Enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [ ] **Monitor PR comments** — address comments, commit fixes, follow Remote push validation, push, wait 180 s, repeat until no unresolved comments
+- [ ] **Monitor CI checks** — diagnose and fix failures, commit, follow Remote push validation, push, wait 180 s, repeat until all checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; never force-merge
+
+Ownership metadata:
+
+- Implementer: dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive: move `openspec/changes/password-reset-ui/` → `openspec/changes/archive/YYYY-MM-DD-password-reset-ui/` in a single commit
+- [ ] Confirm archive location exists and original directory is gone
+- [ ] Commit and push the archive to `main`
+- [ ] Prune merged branch: `git fetch --prune` and `git branch -d feat/password-reset-ui`

--- a/openspec/changes/password-reset-ui/tests.md
+++ b/openspec/changes/password-reset-ui/tests.md
@@ -1,0 +1,31 @@
+---
+name: tests
+description: Test plan for password-reset-ui
+---
+
+# Tests
+
+## Scope
+
+Integration tests for both pages. Mock the API responses at the fetch boundary
+to exercise all UX states without requiring a live backend.
+
+## Planned test cases
+
+### `app/forgot-password/page.tsx`
+- [ ] Integration: page renders with email input and submit button.
+- [ ] Integration: submitting a valid email → confirmation message shown; form hidden.
+- [ ] Integration: submitting an invalid email format → inline field error shown.
+- [ ] Integration: API returns 429 → rate-limit message shown.
+- [ ] Integration: API returns 500 → generic error banner shown.
+- [ ] Integration: submit button is disabled while request is in-flight.
+
+### `app/reset-password/page.tsx`
+- [ ] Integration: page with valid `?token=abc` renders new password form.
+- [ ] Integration: page with no `?token=` redirects to `/forgot-password`.
+- [ ] Integration: confirm password mismatch shows client-side error before submit.
+- [ ] Integration: API returns 200 → success message and login link shown.
+- [ ] Integration: API returns 400 (invalid token) → "link is invalid or expired" message shown with link to forgot-password.
+- [ ] Integration: API returns 400 with `details` (weak password) → inline validation errors shown.
+- [ ] Integration: API returns 429 → rate-limit message shown.
+- [ ] Integration: submit button disabled while request is in-flight.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "bcryptjs": "^2.4.3",
         "fuse.js": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
+        "mailtrap": "^4.6.0",
         "mongodb": "^6.3.0",
         "next": "^16.2.6",
         "react": "^19.2.4",
@@ -4405,7 +4406,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -4795,7 +4795,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -4859,6 +4858,18 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5384,7 +5395,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5398,7 +5408,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5571,7 +5580,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5900,7 +5908,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5993,7 +6000,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6201,7 +6207,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6375,7 +6380,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6385,7 +6389,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6423,7 +6426,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6436,7 +6438,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7214,6 +7215,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7264,7 +7285,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7337,7 +7357,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7417,7 +7436,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7465,7 +7483,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7588,7 +7605,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7682,7 +7698,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7695,7 +7710,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7711,7 +7725,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7776,7 +7789,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -10570,6 +10582,32 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mailtrap": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.6.0.tgz",
+      "integrity": "sha512-H9gJ7J5aKTI4eyoJ+Y66NmDEzyxZTiZ+A7OAIeM5xzsapw2IJH1+9RqDe+1R93W2RkFUo5SaXZWlGjXTWUgU4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": ">=0.27",
+        "qs": "^6.15.0"
+      },
+      "engines": {
+        "node": ">=16.20.1",
+        "yarn": ">=1.22.17"
+      },
+      "peerDependencies": {
+        "@types/nodemailer": "^6.4.9",
+        "nodemailer": "^8.0.5"
+      },
+      "peerDependenciesMeta": {
+        "@types/nodemailer": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -10620,7 +10658,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10667,7 +10704,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10677,7 +10713,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -11111,7 +11146,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11929,6 +11963,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -11978,6 +12021,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -12524,7 +12582,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12544,7 +12601,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12561,7 +12617,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12580,7 +12635,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bcryptjs": "^2.4.3",
     "fuse.js": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
+    "mailtrap": "^4.6.0",
     "mongodb": "^6.3.0",
     "next": "^16.2.6",
     "react": "^19.2.4",

--- a/tests/unit/lib/email.test.ts
+++ b/tests/unit/lib/email.test.ts
@@ -1,0 +1,42 @@
+const mockSend = jest.fn().mockResolvedValue({});
+const mockMailtrapClient = jest.fn().mockImplementation(() => ({ send: mockSend }));
+
+jest.mock("mailtrap", () => ({
+  MailtrapClient: mockMailtrapClient,
+}));
+
+describe("lib/email.ts", () => {
+  const RESET_URL = "https://app.example.com/reset?token=abc123";
+  const RECIPIENT = "user@example.com";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  describe("sendPasswordResetEmail", () => {
+    it("calls MailtrapClient.send with correct to, subject, and reset URL", async () => {
+      process.env.MAILTRAP_TOKEN = "test-token";
+      const { sendPasswordResetEmail } = await import("@/lib/email");
+
+      await sendPasswordResetEmail(RECIPIENT, RESET_URL);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const call = mockSend.mock.calls[0][0];
+      expect(call.to).toEqual([{ email: RECIPIENT }]);
+      expect(call.subject).toMatch(/password/i);
+      expect(call.html).toContain(RESET_URL);
+      expect(call.text).toContain(RESET_URL);
+    });
+
+    it("throws a clear configuration error when MAILTRAP_TOKEN is missing", async () => {
+      delete process.env.MAILTRAP_TOKEN;
+      const { sendPasswordResetEmail } = await import("@/lib/email");
+
+      await expect(sendPasswordResetEmail(RECIPIENT, RESET_URL)).rejects.toThrow(
+        /MAILTRAP_TOKEN/
+      );
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/lib/rate-limit.test.ts
+++ b/tests/unit/lib/rate-limit.test.ts
@@ -1,0 +1,57 @@
+import { checkRateLimit, RateLimitError } from "@/lib/rate-limit";
+
+// Re-import the module fresh for each test so the in-memory Map is clean
+jest.resetModules();
+
+describe("lib/rate-limit.ts", () => {
+  // Use a unique key prefix per test to avoid cross-test state
+  let keyCounter = 0;
+  function uniqueKey(): string {
+    return `test-key-${Date.now()}-${keyCounter++}`;
+  }
+
+  describe("checkRateLimit", () => {
+    it("allows requests under the threshold", () => {
+      const key = uniqueKey();
+      expect(() => checkRateLimit(key, 3, 60_000)).not.toThrow();
+      expect(() => checkRateLimit(key, 3, 60_000)).not.toThrow();
+      expect(() => checkRateLimit(key, 3, 60_000)).not.toThrow();
+    });
+
+    it("throws RateLimitError at the threshold", () => {
+      const key = uniqueKey();
+      checkRateLimit(key, 2, 60_000);
+      checkRateLimit(key, 2, 60_000);
+      expect(() => checkRateLimit(key, 2, 60_000)).toThrow(RateLimitError);
+    });
+
+    it("throws with status 429", () => {
+      const key = uniqueKey();
+      checkRateLimit(key, 1, 60_000);
+      try {
+        checkRateLimit(key, 1, 60_000);
+        fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RateLimitError);
+        expect((err as RateLimitError).status).toBe(429);
+      }
+    });
+
+    it("separate keys do not share counts", () => {
+      const key1 = uniqueKey();
+      const key2 = uniqueKey();
+      checkRateLimit(key1, 1, 60_000);
+      expect(() => checkRateLimit(key2, 1, 60_000)).not.toThrow();
+    });
+
+    it("resets counter after TTL window expires", async () => {
+      const key = uniqueKey();
+      const windowMs = 50; // very short window for testing
+      checkRateLimit(key, 1, windowMs);
+      // At threshold now — would throw if window not expired
+      await new Promise((r) => setTimeout(r, windowMs + 10));
+      // Window has expired; counter should reset
+      expect(() => checkRateLimit(key, 1, windowMs)).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/lib/reset-tokens.test.ts
+++ b/tests/unit/lib/reset-tokens.test.ts
@@ -1,0 +1,154 @@
+import {
+  generateResetToken,
+  hashToken,
+  storeResetToken,
+  validateResetToken,
+  consumeResetToken,
+  ResetTokenDocument,
+} from "@/lib/reset-tokens";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+import { getDatabase } from "@/lib/db";
+
+const mockedDb = { collection: jest.fn() };
+jest.mocked(getDatabase).mockResolvedValue(mockedDb as any);
+
+function makeCollection(overrides: Partial<{
+  findOne: jest.Mock;
+  insertOne: jest.Mock;
+  deleteMany: jest.Mock;
+  updateOne: jest.Mock;
+}> = {}) {
+  return {
+    findOne: jest.fn(),
+    insertOne: jest.fn().mockResolvedValue({}),
+    deleteMany: jest.fn().mockResolvedValue({}),
+    updateOne: jest.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe("lib/reset-tokens.ts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("generateResetToken", () => {
+    it("returns a 64-character hex string", () => {
+      const token = generateResetToken();
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("never returns the same value on successive calls", () => {
+      const a = generateResetToken();
+      const b = generateResetToken();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("hashToken", () => {
+    it("is deterministic — same input produces same output", () => {
+      const token = "abc123";
+      expect(hashToken(token)).toBe(hashToken(token));
+    });
+
+    it("output does not equal input", () => {
+      const token = generateResetToken();
+      expect(hashToken(token)).not.toBe(token);
+    });
+  });
+
+  describe("storeResetToken", () => {
+    it("deletes prior tokens for the userId before inserting", async () => {
+      const col = makeCollection();
+      mockedDb.collection.mockReturnValue(col);
+
+      await storeResetToken("user-1", "hash-a");
+      expect(col.deleteMany).toHaveBeenCalledWith({ userId: "user-1" });
+      expect(col.insertOne).toHaveBeenCalledTimes(1);
+    });
+
+    it("calling twice for the same userId invalidates the first token", async () => {
+      const col = makeCollection();
+      mockedDb.collection.mockReturnValue(col);
+
+      await storeResetToken("user-1", "hash-a");
+      await storeResetToken("user-1", "hash-b");
+
+      // deleteMany called twice (once per storeResetToken call)
+      expect(col.deleteMany).toHaveBeenCalledTimes(2);
+      expect(col.deleteMany).toHaveBeenNthCalledWith(2, { userId: "user-1" });
+    });
+  });
+
+  describe("validateResetToken", () => {
+    it("throws for an unknown token (not found in DB)", async () => {
+      const col = makeCollection({ findOne: jest.fn().mockResolvedValue(null) });
+      mockedDb.collection.mockReturnValue(col);
+
+      await expect(validateResetToken("unknown-token")).rejects.toThrow(
+        /invalid|unknown/i
+      );
+    });
+
+    it("throws for an expired token (expiresAt in the past)", async () => {
+      const col = makeCollection({
+        findOne: jest.fn().mockResolvedValue({
+          userId: "user-1",
+          tokenHash: "some-hash",
+          expiresAt: new Date(Date.now() - 1000),
+          createdAt: new Date(),
+        } satisfies ResetTokenDocument),
+      });
+      mockedDb.collection.mockReturnValue(col);
+
+      await expect(validateResetToken("expired-token")).rejects.toThrow(/expired/i);
+    });
+
+    it("throws for a consumed token (consumedAt set)", async () => {
+      const col = makeCollection({
+        findOne: jest.fn().mockResolvedValue({
+          userId: "user-1",
+          tokenHash: "some-hash",
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: new Date(),
+          createdAt: new Date(),
+        } satisfies ResetTokenDocument),
+      });
+      mockedDb.collection.mockReturnValue(col);
+
+      await expect(validateResetToken("consumed-token")).rejects.toThrow(/used|consumed/i);
+    });
+
+    it("returns userId for a valid unexpired unconsumed token", async () => {
+      const col = makeCollection({
+        findOne: jest.fn().mockResolvedValue({
+          userId: "user-42",
+          tokenHash: "some-hash",
+          expiresAt: new Date(Date.now() + 60_000),
+          createdAt: new Date(),
+        } satisfies ResetTokenDocument),
+      });
+      mockedDb.collection.mockReturnValue(col);
+
+      const userId = await validateResetToken("valid-token");
+      expect(userId).toBe("user-42");
+    });
+  });
+
+  describe("consumeResetToken", () => {
+    it("sets consumedAt on the document", async () => {
+      const col = makeCollection();
+      mockedDb.collection.mockReturnValue(col);
+
+      await consumeResetToken("some-hash");
+      expect(col.updateOne).toHaveBeenCalledWith(
+        { tokenHash: "some-hash" },
+        { $set: { consumedAt: expect.any(Date) } }
+      );
+    });
+  });
+});

--- a/tests/unit/lib/reset-tokens.test.ts
+++ b/tests/unit/lib/reset-tokens.test.ts
@@ -18,15 +18,13 @@ jest.mocked(getDatabase).mockResolvedValue(mockedDb as any);
 
 function makeCollection(overrides: Partial<{
   findOne: jest.Mock;
-  insertOne: jest.Mock;
-  deleteMany: jest.Mock;
+  replaceOne: jest.Mock;
   updateOne: jest.Mock;
 }> = {}) {
   return {
     findOne: jest.fn(),
-    insertOne: jest.fn().mockResolvedValue({}),
-    deleteMany: jest.fn().mockResolvedValue({}),
-    updateOne: jest.fn().mockResolvedValue({}),
+    replaceOne: jest.fn().mockResolvedValue({ upsertedCount: 1 }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
     ...overrides,
   };
 }
@@ -62,25 +60,32 @@ describe("lib/reset-tokens.ts", () => {
   });
 
   describe("storeResetToken", () => {
-    it("deletes prior tokens for the userId before inserting", async () => {
+    it("atomically upserts a token document keyed by userId", async () => {
       const col = makeCollection();
       mockedDb.collection.mockReturnValue(col);
 
       await storeResetToken("user-1", "hash-a");
-      expect(col.deleteMany).toHaveBeenCalledWith({ userId: "user-1" });
-      expect(col.insertOne).toHaveBeenCalledTimes(1);
+      expect(col.replaceOne).toHaveBeenCalledWith(
+        { userId: "user-1" },
+        expect.objectContaining({ userId: "user-1", tokenHash: "hash-a" }),
+        { upsert: true }
+      );
     });
 
-    it("calling twice for the same userId invalidates the first token", async () => {
+    it("calling twice for the same userId replaces the first token", async () => {
       const col = makeCollection();
       mockedDb.collection.mockReturnValue(col);
 
       await storeResetToken("user-1", "hash-a");
       await storeResetToken("user-1", "hash-b");
 
-      // deleteMany called twice (once per storeResetToken call)
-      expect(col.deleteMany).toHaveBeenCalledTimes(2);
-      expect(col.deleteMany).toHaveBeenNthCalledWith(2, { userId: "user-1" });
+      expect(col.replaceOne).toHaveBeenCalledTimes(2);
+      expect(col.replaceOne).toHaveBeenNthCalledWith(
+        2,
+        { userId: "user-1" },
+        expect.objectContaining({ userId: "user-1", tokenHash: "hash-b" }),
+        { upsert: true }
+      );
     });
   });
 
@@ -140,14 +145,29 @@ describe("lib/reset-tokens.ts", () => {
   });
 
   describe("consumeResetToken", () => {
-    it("sets consumedAt on the document", async () => {
+    it("sets consumedAt using a compare-and-set filter", async () => {
       const col = makeCollection();
       mockedDb.collection.mockReturnValue(col);
 
       await consumeResetToken("some-hash");
       expect(col.updateOne).toHaveBeenCalledWith(
-        { tokenHash: "some-hash" },
+        {
+          tokenHash: "some-hash",
+          consumedAt: { $exists: false },
+          expiresAt: { $gt: expect.any(Date) },
+        },
         { $set: { consumedAt: expect.any(Date) } }
+      );
+    });
+
+    it("throws when token was already consumed or expired", async () => {
+      const col = makeCollection({
+        updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      });
+      mockedDb.collection.mockReturnValue(col);
+
+      await expect(consumeResetToken("some-hash")).rejects.toThrow(
+        /used|expired/i
       );
     });
   });


### PR DESCRIPTION
## Summary

Implements the three library modules and DB index forming the foundation for the password reset flow. No endpoints or UI — pure backend infrastructure that Parts 2 and 3 build on.

**Part 1 of 3** for #208.

Closes #265

## Changes

### Implementation

- **`lib/rate-limit.ts`** — In-memory Map+TTL rate limiter. Exports `checkRateLimit(key, limit, windowMs)` (throws `RateLimitError` with `status 429` when over threshold) and `RateLimitError`. Cold-start limitation documented in file.
- **`lib/email.ts`** — `sendPasswordResetEmail(to, resetUrl)` via Mailtrap official SDK. Throws a clear configuration error if `MAILTRAP_TOKEN` is missing.
- **`lib/reset-tokens.ts`** — Full token lifecycle: `generateResetToken`, `hashToken`, `storeResetToken`, `validateResetToken`, `consumeResetToken`. Raw token never stored.
- **`lib/db.ts`** — Adds unique index on `password_reset_tokens.tokenHash` in `initializeDatabase()`.
- **`package.json`** — `mailtrap ^4.6.0` in `dependencies` (runtime, not devDeps — email send runs in production).
- **`.env.example`** — `MAILTRAP_TOKEN`, `MAILTRAP_FROM_EMAIL`, `APP_URL` documented.

### Tests

18 unit tests across 3 suites — all pass:

- `tests/unit/lib/rate-limit.test.ts` — under threshold, at threshold, status 429, separate keys, window expiry
- `tests/unit/lib/email.test.ts` — correct send payload, throws on missing token
- `tests/unit/lib/reset-tokens.test.ts` — token generation (unique, 64-char hex), hash (deterministic, ≠ input), store (invalidates prior), validate (expired, consumed, unknown, valid), consume (sets consumedAt)

### OpenSpec schema gaps fixed

This change was implemented without completing all `sdd-with-feedback-loop` schema artifacts. Added in this PR:

- `openspec/changes/password-reset-infrastructure/design.md` — technical design decisions (D-I1 through D-I5)
- `openspec/changes/password-reset-infrastructure/specs/password-reset-infrastructure/spec.md` — BDD scenarios for all modules
- `openspec/changes/password-reset-infrastructure/tasks.md` — updated with Preparation, Pre-Commit Review, Remote push validation, PR and Merge, Post-Merge sections
- `openspec/changes/add-password-reset-ability/design.md` — resolved decisions added (D7 timing detail, rate-limit cold-start, DB index rationale)

Also adds missing `design.md` and `specs/` for the two downstream changes (no implementation, planning docs only):

- `openspec/changes/password-reset-api/` — D-A1–D-A5 + BDD for forgot/reset endpoints
- `openspec/changes/password-reset-ui/` — D-U1–D-U5 + BDD for both UI pages

## Validation

- `npm run test:unit` — all 18 new tests pass (existing suite unaffected)
- `npm run build` — succeeds
- `npx tsc --noEmit` — no errors