### PR TITLE
test: add RTL tests for CombatantCard HP coverage

### DIFF
--- a/openspec/changes/combatant-card-hp-coverage/.openspec.yaml
+++ b/openspec/changes/combatant-card-hp-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-27

--- a/openspec/changes/combatant-card-hp-coverage/design.md
+++ b/openspec/changes/combatant-card-hp-coverage/design.md
@@ -1,0 +1,141 @@
+## Context
+
+- Relevant architecture: `lib/components/CombatantCard.tsx` (486 lines) is the primary combat UI component. Damage logic delegates to `applyTypedDamage` (module-local wrapper) → `calcApplyDamage` / `calcApplyDamageWithType` (imported). HP history is persisted to localStorage via `pushHpHistory`/`getHpHistoryStack`.
+- Dependencies: `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event` — all installed via #254.
+- Interfaces/contracts touched: `CombatantCard` props (`combatant: CombatantState`, `onUpdate`, `combatId`). No production code changes.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Exercise all uncovered lines in `CombatantCard.tsx` lines 518–735 with RTL tests
+- Reach ≥65% branch coverage for `CombatantCard.tsx`
+- Tests pass in CI with `npm test`
+
+### Non-Goals
+
+- Migrating existing tests to RTL
+- Testing damage math at unit level
+- Production code changes
+
+## Decisions
+
+### Decision 1: Split into a new test file
+
+- Chosen: `tests/unit/components/CombatantCard.hp.test.tsx`
+- Alternatives considered: Extend `CombatantCard.test.tsx` in place
+- Rationale: The existing file uses a local `render()` function that conflicts with RTL's `render`. Mixing patterns creates confusion and import conflicts. A clean file is easier to review and extend.
+- Trade-offs: Two files to maintain; mitigated by the fact that they cover distinct areas (badges/undo vs. HP/damage/conditions).
+
+### Decision 2: Use `userEvent.setup()` for all interactions
+
+- Chosen: `const user = userEvent.setup()` + `await user.type(...)`, `await user.selectOptions(...)`, `await user.click(...)`
+- Alternatives considered: Bare `fireEvent` calls (faster, but doesn't simulate real browser events)
+- Rationale: `userEvent` fires the full event sequence (focus, input, change, blur) matching how a real user interacts with the HP number input and damage type select. `fireEvent` would miss React synthetic event handling quirks.
+- Trade-offs: Async `await` required throughout; tests are slightly slower but more realistic.
+
+### Decision 3: Assert HP bar width via inline style, not Tailwind class
+
+- Chosen: `expect(healthBar).toHaveStyle({ width: '100%' })` (or the computed percent string)
+- Alternatives considered: Asserting `bg-green-500` / `bg-red-500` class presence
+- Rationale: jsdom does not process Tailwind's CSS, so class-based color assertions always pass vacuously. Inline style (set via `style={{ width: \`${hpPercent}%\` }}`) is the only reliable assertion surface.
+- Trade-offs: Color thresholds (green/yellow/red) cannot be directly asserted — documented as a known gap.
+
+### Decision 4: Dead state asserted via emoji text content
+
+- Chosen: `expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('☠️')`
+- Alternatives considered: `data-testid="dead-indicator"` attribute on the emoji
+- Rationale: The emoji is rendered inline in the `<h3>` when `hp <= 0`. No `data-testid` exists and adding one would be a production code change (out of scope). Text content assertion is sufficient.
+- Trade-offs: Brittle to emoji changes in the component; acceptable since the emoji is a stable design choice.
+
+### Decision 5: Condition toggle tested via text + button queries
+
+- Chosen: `screen.getByRole('button', { name: /Conditions \(1\)/ })` to expand, then `screen.getByRole('button', { name: 'Remove' })` to assert removal calls `onUpdate`
+- Alternatives considered: `data-testid` on condition rows
+- Rationale: No `data-testid` on condition markup; RTL role/text queries are the correct RTL-idiomatic approach and work without production code changes.
+- Trade-offs: Query relies on condition count format string — stable given the component template.
+
+## Proposal to Design Mapping
+
+- Proposal element: HP bar width/color coverage
+  - Design decision: Decision 3 (inline style assertion)
+  - Validation approach: `data-testid="health-bar"` style.width checked at 100%, ~50%, and near-zero ratios
+
+- Proposal element: Dead state (☠️ emoji)
+  - Design decision: Decision 4 (emoji text content)
+  - Validation approach: Render combatant with `hp: 0`, assert heading contains ☠️
+
+- Proposal element: Damage application (normal/resistance/immunity/vulnerability)
+  - Design decision: Decision 2 (userEvent interactions)
+  - Validation approach: `userEvent.type` HP input → `userEvent.selectOptions` damage type → `userEvent.click` Damage button → assert `onUpdate` called with expected `{ hp, tempHp }`
+
+- Proposal element: Temp HP drain
+  - Design decision: Decision 2 (userEvent interactions)
+  - Validation approach: Fixture with `tempHp: 5`, apply damage ≤ 5 (drains only temp), apply damage > 5 (spills to real HP)
+
+- Proposal element: Condition display and toggle
+  - Design decision: Decision 5 (text + button queries)
+  - Validation approach: Render with `conditions: [...]`, expand panel, assert text, click Remove, assert `onUpdate` called with filtered array
+
+- Proposal element: New file vs. extending existing
+  - Design decision: Decision 1 (new file)
+  - Validation approach: CI runs both test files; both pass
+
+## Functional Requirements Mapping
+
+- Requirement: HP bar reflects hp/maxHp ratio
+  - Design element: `data-testid="health-bar"` inline style assertion
+  - Acceptance criteria reference: specs/hp-display/spec.md
+  - Testability notes: Three cases — full (100%), half (~50%), near-zero (<25%)
+
+- Requirement: Dead state visible when hp ≤ 0
+  - Design element: ☠️ emoji text content in `<h3>`
+  - Acceptance criteria reference: specs/hp-display/spec.md
+  - Testability notes: Render with `hp: 0`; assert emoji present. Render with `hp: 1`; assert emoji absent.
+
+- Requirement: Damage application with type modifiers
+  - Design element: userEvent UI interactions → onUpdate assertion
+  - Acceptance criteria reference: specs/damage-application/spec.md
+  - Testability notes: One test per modifier type. Fixture controls modifiers via `damageResistances` etc.
+
+- Requirement: Temp HP drains before real HP
+  - Design element: userEvent UI interactions → onUpdate assertion
+  - Acceptance criteria reference: specs/temp-hp/spec.md
+  - Testability notes: Fixture with `tempHp` set; assert resulting `{ hp, tempHp }` in onUpdate call
+
+- Requirement: Conditions display and removal
+  - Design element: RTL role/text queries → onUpdate assertion
+  - Acceptance criteria reference: specs/conditions/spec.md
+  - Testability notes: Assert count button renders; expand panel; click Remove; assert onUpdate called with empty conditions array
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: All tests pass in CI (jsdom environment)
+  - Design element: `@jest-environment jsdom` directive in new test file; localStorage.clear() in beforeEach
+  - Acceptance criteria reference: All specs
+  - Testability notes: CI runs `npm test` which includes both test files
+
+## Risks / Trade-offs
+
+- Risk/trade-off: HP color branch coverage gap (Tailwind classes not assertable in jsdom)
+  - Impact: ~3 branches (green/yellow/red threshold) remain visually untested
+  - Mitigation: HP bar width ratios still exercise the `hpPercent` calculation branches; color class assignment is a single ternary that can be tested if a `data-testid` is added in a future change
+
+## Rollback / Mitigation
+
+- Rollback trigger: CI fails on the new test file
+- Rollback steps: Delete `tests/unit/components/CombatantCard.hp.test.tsx`; no production code changes to revert
+- Data migration considerations: None
+- Verification after rollback: `npm test` passes
+
+## Operational Blocking Policy
+
+- If CI checks fail: Fix the failing tests before merging; do not merge with failing tests
+- If security checks fail: N/A — test-only change
+- If required reviews are blocked/stale: Request re-review; do not bypass branch protection
+- Escalation path and timeout: If blocked >48h, flag in the Testing Quality Initiative project board
+
+## Open Questions
+
+No open questions. All design decisions are resolved.

--- a/openspec/changes/combatant-card-hp-coverage/proposal.md
+++ b/openspec/changes/combatant-card-hp-coverage/proposal.md
@@ -1,0 +1,64 @@
+## GitHub Issues
+
+- #256
+
+## Why
+
+- Problem statement: `CombatantCard.tsx` has 53.5% statement / 36.7% branch / 45.5% function coverage. The damage-application logic (resistance, immunity, vulnerability, temp HP drain) was the subject of a full OpenSpec change; UI-layer bugs in prop threading or state updates are currently undetectable by the test suite.
+- Why now: RTL infrastructure (#254) closed today — the prerequisite is met and the issue is unblocked.
+- Business/user impact: Silent regressions in HP and damage display are the highest-risk failure mode in the core combat flow. Every combat session depends on this component.
+
+## Problem Space
+
+- Current behavior: Lines 518–735 of `CombatantCard.tsx` are untested. The existing 486-line test file uses the old `createRoot`/`act`/`container.querySelector` pattern and covers modifier badges, the effects panel, and undo — not HP display or damage application.
+- Desired behavior: Branch coverage for `CombatantCard.tsx` reaches ≥65%. All uncovered lines in the HP bar, damage buttons, temp HP logic, and conditions panel are exercised with RTL tests.
+- Constraints: New tests must use `@testing-library/react` + `userEvent` (RTL). The existing test file must not be modified. Tests must pass in CI.
+- Assumptions: `calcApplyDamage` and `calcApplyDamageWithType` are already unit-tested at the logic level; we are testing the UI layer (prop threading, state updates, rendered output).
+- Edge cases considered: immunity (zero damage, no history entry), vulnerability (double damage), temp HP absorbing partial damage, temp HP = 0 edge, HP exactly 0 triggering dead state.
+
+## Scope
+
+### In Scope
+
+- New file `tests/unit/components/CombatantCard.hp.test.tsx` with RTL tests
+- HP bar width via `data-testid="health-bar"` inline style
+- Dead state via ☠️ emoji appearing in `<h3>` when `hp <= 0`
+- Damage application: normal, resistance (half), immunity (zero), vulnerability (double)
+- Temp HP draining before real HP, with spillover
+- Condition display (count button) and individual condition removal calling `onUpdate`
+
+### Out of Scope
+
+- Migrating existing tests in `CombatantCard.test.tsx` to RTL
+- Testing `applyTypedDamage` or `calcApplyDamage` at the unit level (already covered elsewhere)
+- Targeting panel, lair slot, or initiative UI
+- Raising coverage in any other component
+
+## What Changes
+
+- New file: `tests/unit/components/CombatantCard.hp.test.tsx`
+- No production code changes
+
+## Risks
+
+- Risk: jsdom doesn't apply Tailwind classes, so HP color (green/yellow/red) cannot be asserted via computed style.
+  - Impact: Low — HP bar width (inline style) and dead emoji provide sufficient coverage of the color-branch logic.
+  - Mitigation: Assert `data-testid="health-bar"` style.width for ratio coverage; note the limitation in a comment.
+- Risk: `userEvent` async interactions may behave differently from the old `act()` + `.click()` pattern.
+  - Impact: Low — RTL's `userEvent.setup()` with `await` handles this correctly.
+  - Mitigation: Use `userEvent.setup()` pattern consistently; wrap renders in RTL's `render` (not the local legacy helper).
+
+## Open Questions
+
+No unresolved ambiguity. The component markup, test infrastructure, and coverage targets are fully understood from exploration.
+
+## Non-Goals
+
+- Achieving 100% coverage
+- Refactoring `CombatantCard.tsx` production code
+- Adding `data-testid` attributes to conditions markup (text queries are sufficient)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/combatant-card-hp-coverage/proposal.md
+++ b/openspec/changes/combatant-card-hp-coverage/proposal.md
@@ -27,11 +27,15 @@
 - Temp HP draining before real HP, with spillover
 - Condition display (count button) and individual condition removal calling `onUpdate`
 
+### In Scope (expanded for ≥65% branch coverage)
+
+- Additional RTL tests covering initiative roll display (rolled/manual/advantage), set temp HP, healing, active combatant (onNextTurn), notes, legendary action badge, and targeting UI — all added because the T1–T4 tests alone reached only 42.74% branch coverage, and these high-value branches were needed to cross the 65% threshold.
+
 ### Out of Scope
 
 - Migrating existing tests in `CombatantCard.test.tsx` to RTL
 - Testing `applyTypedDamage` or `calcApplyDamage` at the unit level (already covered elsewhere)
-- Targeting panel, lair slot, or initiative UI
+- Lair slot rendering
 - Raising coverage in any other component
 
 ## What Changes

--- a/openspec/changes/combatant-card-hp-coverage/specs/conditions/spec.md
+++ b/openspec/changes/combatant-card-hp-coverage/specs/conditions/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Active conditions display with count
+
+The system SHALL render a button showing the condition count when the combatant has at least one condition.
+
+#### Scenario: Conditions button shows count
+
+- **Given** a combatant with `conditions: [{ id: 'c1', name: 'Poisoned' }]`
+- **When** `CombatantCard` renders
+- **Then** a button with text matching `"Conditions (1)"` is visible
+
+#### Scenario: No conditions — conditions button absent
+
+- **Given** a combatant with `conditions: []`
+- **When** `CombatantCard` renders
+- **Then** no button matching `"Conditions"` is present
+
+### Requirement: ADDED Condition list expands on click
+
+The system SHALL toggle a condition list panel when the conditions count button is clicked.
+
+#### Scenario: Expand condition list
+
+- **Given** a combatant with one condition and the conditions panel collapsed
+- **When** the user clicks the "Conditions (1)" button
+- **Then** the condition name (e.g., "Poisoned") is visible in the DOM
+
+### Requirement: ADDED Removing a condition calls onUpdate with filtered array
+
+The system SHALL call `onUpdate` with a `conditions` array that excludes the removed condition when the user clicks "Remove" on a condition.
+
+#### Scenario: Remove the only condition
+
+- **Given** a combatant with `conditions: [{ id: 'c1', name: 'Poisoned' }]` and the panel expanded
+- **When** the user clicks the "Remove" button next to "Poisoned"
+- **Then** `onUpdate` is called with `{ conditions: [] }`
+
+#### Scenario: Remove one of multiple conditions
+
+- **Given** a combatant with two conditions (`Poisoned`, `Blinded`) and the panel expanded
+- **When** the user clicks "Remove" next to "Poisoned"
+- **Then** `onUpdate` is called with `{ conditions: [{ id: 'c2', name: 'Blinded', ... }] }`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (condition display and toggle) → all requirements above
+- Design decision 5 (text + button queries) → all requirements above
+- Requirements → Task T4 (conditions tests)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Condition queries work without data-testid
+
+- **Given** condition elements have no `data-testid` attributes
+- **When** tests query by role and text content
+- **Then** RTL finds the elements correctly without production code changes

--- a/openspec/changes/combatant-card-hp-coverage/specs/damage-application/spec.md
+++ b/openspec/changes/combatant-card-hp-coverage/specs/damage-application/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Normal damage reduces HP by full amount
+
+The system SHALL call `onUpdate` with `hp` reduced by the exact input value when no damage type modifier applies.
+
+#### Scenario: Normal damage (no type selected)
+
+- **Given** a combatant with `hp: 30`, `maxHp: 30`, no damage modifiers
+- **When** the user types `10` in the HP input and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 20 }` (and `tempHp: 0`)
+
+### Requirement: ADDED Resistance halves damage (rounded down)
+
+The system SHALL call `onUpdate` with `hp` reduced by `floor(damage / 2)` when the combatant has resistance to the selected damage type.
+
+#### Scenario: Fire resistance — odd damage
+
+- **Given** a combatant with `hp: 30`, `maxHp: 30`, `damageResistances: ['fire']`
+- **When** the user types `10`, selects damage type "fire", and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 25 }` (10 / 2 = 5 damage)
+
+#### Scenario: Fire resistance — zero damage on minimal input
+
+- **Given** a combatant with `hp: 30`, `damageResistances: ['fire']`
+- **When** the user types `1`, selects "fire", and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 30 }` (floor(1/2) = 0 damage)
+
+### Requirement: ADDED Immunity prevents all damage
+
+The system SHALL call `onUpdate` with unchanged `hp` when the combatant is immune to the selected damage type.
+
+#### Scenario: Fire immunity — no HP change
+
+- **Given** a combatant with `hp: 30`, `damageImmunities: ['fire']`
+- **When** the user types `20`, selects "fire", and clicks "Damage"
+- **Then** `onUpdate` is not called (or is called with `{ hp: 30, tempHp: 0 }` — no change)
+
+### Requirement: ADDED Vulnerability doubles damage
+
+The system SHALL call `onUpdate` with `hp` reduced by `damage * 2` when the combatant is vulnerable to the selected damage type.
+
+#### Scenario: Fire vulnerability — damage doubled
+
+- **Given** a combatant with `hp: 30`, `damageVulnerabilities: ['fire']`
+- **When** the user types `5`, selects "fire", and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 20 }` (5 * 2 = 10 damage)
+
+#### Scenario: Vulnerability — HP floored at 0
+
+- **Given** a combatant with `hp: 5`, `damageVulnerabilities: ['fire']`
+- **When** the user types `10`, selects "fire", and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 0 }` (would be -15, clamped to 0)
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (damage application: normal/resistance/immunity/vulnerability) → all requirements above
+- Design decision 2 (userEvent interactions) → all requirements above
+- Requirements → Task T2 (damage application tests)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Damage type select is accessible
+
+- **Given** the damage type `<select>` element
+- **When** queried by `aria-label="Damage type (for resistance/immunity/vulnerability)"`
+- **Then** RTL can find and interact with it via `userEvent.selectOptions`

--- a/openspec/changes/combatant-card-hp-coverage/specs/hp-display/spec.md
+++ b/openspec/changes/combatant-card-hp-coverage/specs/hp-display/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED HP bar width reflects hp/maxHp ratio
+
+The system SHALL render `data-testid="health-bar"` with an inline `width` style proportional to `hp / (maxHp + tempHp)`.
+
+#### Scenario: Full HP
+
+- **Given** a combatant with `hp: 30`, `maxHp: 30`, no temp HP
+- **When** `CombatantCard` renders
+- **Then** the element with `data-testid="health-bar"` has `style.width` of `"100%"`
+
+#### Scenario: Half HP
+
+- **Given** a combatant with `hp: 15`, `maxHp: 30`, no temp HP
+- **When** `CombatantCard` renders
+- **Then** `data-testid="health-bar"` has `style.width` of approximately `"50%"`
+
+#### Scenario: Near-zero HP (less than 25% threshold)
+
+- **Given** a combatant with `hp: 5`, `maxHp: 30`, no temp HP
+- **When** `CombatantCard` renders
+- **Then** `data-testid="health-bar"` has `style.width` less than `"25%"`
+
+### Requirement: ADDED Dead state indicator visible when hp ≤ 0
+
+The system SHALL display a ☠️ emoji in the combatant name heading when `hp <= 0`.
+
+#### Scenario: HP is zero — dead indicator shown
+
+- **Given** a combatant with `hp: 0`, `maxHp: 30`
+- **When** `CombatantCard` renders
+- **Then** the `<h3>` heading contains the text `☠️`
+
+#### Scenario: HP is positive — dead indicator absent
+
+- **Given** a combatant with `hp: 1`, `maxHp: 30`
+- **When** `CombatantCard` renders
+- **Then** the `<h3>` heading does not contain `☠️`
+
+### Requirement: ADDED Temp HP bar renders when tempHp > 0
+
+The system SHALL render `data-testid="temp-hp-bar"` only when `tempHp > 0`.
+
+#### Scenario: Temp HP present
+
+- **Given** a combatant with `tempHp: 5`, `maxHp: 30`
+- **When** `CombatantCard` renders
+- **Then** an element with `data-testid="temp-hp-bar"` is present in the DOM
+
+#### Scenario: No temp HP
+
+- **Given** a combatant with no `tempHp` (or `tempHp: 0`)
+- **When** `CombatantCard` renders
+- **Then** no element with `data-testid="temp-hp-bar"` is present
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (HP bar width/color) → Requirement: HP bar width reflects hp/maxHp ratio
+- Proposal element (dead state) → Requirement: Dead state indicator visible when hp ≤ 0
+- Proposal element (temp HP bar) → Requirement: Temp HP bar renders when tempHp > 0
+- Design decision 3 (inline style assertion) → HP bar width requirement
+- Design decision 4 (emoji text content) → Dead state requirement
+- Requirements → Task T1 (HP display tests)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Tests pass in jsdom CI environment
+
+- **Given** the jsdom test environment (Tailwind classes not applied)
+- **When** `npm test` runs
+- **Then** all HP display tests pass without relying on computed CSS color values

--- a/openspec/changes/combatant-card-hp-coverage/specs/temp-hp/spec.md
+++ b/openspec/changes/combatant-card-hp-coverage/specs/temp-hp/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Damage drains temp HP before real HP
+
+The system SHALL absorb damage into `tempHp` first, reducing `hp` only after `tempHp` reaches zero.
+
+#### Scenario: Damage fully absorbed by temp HP
+
+- **Given** a combatant with `hp: 30`, `maxHp: 30`, `tempHp: 5`
+- **When** the user types `3` and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 30, tempHp: 2 }` (temp absorbs all damage)
+
+#### Scenario: Damage partially absorbed — spillover hits real HP
+
+- **Given** a combatant with `hp: 30`, `maxHp: 30`, `tempHp: 5`
+- **When** the user types `8` and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 27, tempHp: 0 }` (5 absorbed, 3 spills to real HP)
+
+#### Scenario: Zero temp HP — all damage hits real HP
+
+- **Given** a combatant with `hp: 30`, `maxHp: 30`, `tempHp: 0` (or no tempHp field)
+- **When** the user types `10` and clicks "Damage"
+- **Then** `onUpdate` is called with `{ hp: 20, tempHp: 0 }`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (temp HP drain mechanics) → all requirements above
+- Design decision 2 (userEvent interactions) → all requirements above
+- Requirements → Task T3 (temp HP tests)
+
+## Non-Functional Acceptance Criteria
+
+None — temp HP behavior is purely functional with no performance or security implications.

--- a/openspec/changes/combatant-card-hp-coverage/tasks.md
+++ b/openspec/changes/combatant-card-hp-coverage/tasks.md
@@ -1,0 +1,109 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/combatant-card-hp-coverage` then immediately `git push -u origin feat/combatant-card-hp-coverage`
+
+## Execution
+
+### T1 — HP display tests
+
+- [x] Create `tests/unit/components/CombatantCard.hp.test.tsx` with `@jest-environment jsdom` directive and RTL imports (`render`, `screen` from `@testing-library/react`, `userEvent` from `@testing-library/user-event`)
+- [x] Define `BASE` fixture (same shape as existing test file) and a `renderCard(overrides)` helper using RTL `render`
+- [x] Write test: full HP → `data-testid="health-bar"` has `style.width: "100%"`
+- [x] Write test: half HP → width ≈ 50%
+- [x] Write test: near-zero HP → width < 25%
+- [x] Write test: `hp: 0` → `<h3>` heading contains `☠️`
+- [x] Write test: `hp: 1` → `<h3>` heading does not contain `☠️`
+- [x] Write test: `tempHp: 5` → `data-testid="temp-hp-bar"` is present
+- [x] Write test: no tempHp → `data-testid="temp-hp-bar"` is absent
+- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+
+### T2 — Damage application tests
+
+- [x] Write test: normal damage (no type) → `onUpdate` called with `{ hp: 20 }` (30 - 10)
+- [x] Write test: fire resistance → `onUpdate` called with `{ hp: 25 }` (10 / 2 = 5 damage)
+- [x] Write test: fire immunity → `onUpdate` not called (or called with unchanged HP)
+- [x] Write test: fire vulnerability → `onUpdate` called with `{ hp: 20 }` (5 * 2 = 10 damage)
+- [x] Write test: vulnerability floors HP at 0 (no negative HP)
+- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+
+### T3 — Temp HP drain tests
+
+- [x] Write test: damage ≤ tempHp → `onUpdate` called with `{ hp: 30, tempHp: 2 }` (3 damage into 5 temp)
+- [x] Write test: damage > tempHp → `onUpdate` called with `{ hp: 27, tempHp: 0 }` (8 damage into 5 temp + 3 spill)
+- [x] Write test: tempHp: 0 → all damage hits real HP → `{ hp: 20, tempHp: 0 }`
+- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+
+### T4 — Conditions tests
+
+- [x] Write test: `conditions: [{ id: 'c1', name: 'Poisoned' }]` → button "Conditions (1)" is present
+- [x] Write test: `conditions: []` → no "Conditions" button present
+- [x] Write test: click "Conditions (1)" → "Poisoned" text appears in DOM
+- [x] Write test: expand panel → click "Remove" → `onUpdate` called with `{ conditions: [] }`
+- [x] Write test: two conditions → remove first → `onUpdate` called with array containing only second
+- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+
+### T5 — Coverage verification
+
+- [x] Run `npm test -- --coverage --collectCoverageFrom='lib/components/CombatantCard.tsx' --testPathPattern=CombatantCard` and confirm branch coverage ≥ 65%
+- [x] Confirm existing `CombatantCard.test.tsx` tests still pass (no regressions)
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Review its report and apply fixes for duplication, complexity, and completeness before committing.
+
+## Validation
+
+- [x] Run `npm test` — all tests pass
+- [x] Run `npx tsc --noEmit` — no type errors
+- [x] Run `npm run build` — build succeeds
+- [x] Branch coverage for `CombatantCard.tsx` ≥ 65% confirmed
+- [x] All execution tasks marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Type check** — `npx tsc --noEmit`; must succeed
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run before the final commit
+- [ ] Commit all changes and push to `feat/combatant-card-hp-coverage`
+- [ ] Open PR from `feat/combatant-card-hp-coverage` to `main`. PR body must include `Closes #256`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address, commit fixes, follow remote push validation, push, wait 180s, repeat until no unresolved comments
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failures, commit, validate, push, wait 180s, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): automated CI + agentic reviewers
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → diagnose → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm thread resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify `tests/unit/components/CombatantCard.hp.test.tsx` appears on main
+- [ ] Mark all remaining tasks complete (`- [x]`)
+- [ ] No doc changes required — test-only change
+- [ ] Sync approved spec deltas: copy `openspec/changes/combatant-card-hp-coverage/specs/` contents into `openspec/specs/` (hp-display, damage-application, temp-hp, conditions capability specs)
+- [ ] Archive the change: move `openspec/changes/combatant-card-hp-coverage/` to `openspec/changes/archive/YYYY-MM-DD-combatant-card-hp-coverage/` — stage both copy and deletion in a single atomic commit
+- [ ] Confirm archive exists and original change dir is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-combatant-card-hp-coverage` then `git push -u origin doc/archive-YYYY-MM-DD-combatant-card-hp-coverage`
+- [ ] Open PR from doc branch to `main` with title `docs: archive combatant-card-hp-coverage (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on doc PR
+- [ ] Monitor doc PR until merged (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/combatant-card-hp-coverage doc/archive-YYYY-MM-DD-combatant-card-hp-coverage`

--- a/openspec/changes/combatant-card-hp-coverage/tasks.md
+++ b/openspec/changes/combatant-card-hp-coverage/tasks.md
@@ -18,23 +18,23 @@
 - [x] Write test: `hp: 1` → `<h3>` heading does not contain `☠️`
 - [x] Write test: `tempHp: 5` → `data-testid="temp-hp-bar"` is present
 - [x] Write test: no tempHp → `data-testid="temp-hp-bar"` is absent
-- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+- [x] Run `npm run test:unit -- --testPathPattern=CombatantCard.hp` to confirm all pass
 
 ### T2 — Damage application tests
 
 - [x] Write test: normal damage (no type) → `onUpdate` called with `{ hp: 20 }` (30 - 10)
 - [x] Write test: fire resistance → `onUpdate` called with `{ hp: 25 }` (10 / 2 = 5 damage)
-- [x] Write test: fire immunity → `onUpdate` not called (or called with unchanged HP)
+- [x] Write test: fire immunity → `onUpdate` called with unchanged HP (`{ hp: 30, tempHp: 0 }` — component always calls onUpdate even on no-op)
 - [x] Write test: fire vulnerability → `onUpdate` called with `{ hp: 20 }` (5 * 2 = 10 damage)
 - [x] Write test: vulnerability floors HP at 0 (no negative HP)
-- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+- [x] Run `npm run test:unit -- --testPathPattern=CombatantCard.hp` to confirm all pass
 
 ### T3 — Temp HP drain tests
 
 - [x] Write test: damage ≤ tempHp → `onUpdate` called with `{ hp: 30, tempHp: 2 }` (3 damage into 5 temp)
 - [x] Write test: damage > tempHp → `onUpdate` called with `{ hp: 27, tempHp: 0 }` (8 damage into 5 temp + 3 spill)
 - [x] Write test: tempHp: 0 → all damage hits real HP → `{ hp: 20, tempHp: 0 }`
-- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+- [x] Run `npm run test:unit -- --testPathPattern=CombatantCard.hp` to confirm all pass
 
 ### T4 — Conditions tests
 
@@ -43,11 +43,11 @@
 - [x] Write test: click "Conditions (1)" → "Poisoned" text appears in DOM
 - [x] Write test: expand panel → click "Remove" → `onUpdate` called with `{ conditions: [] }`
 - [x] Write test: two conditions → remove first → `onUpdate` called with array containing only second
-- [x] Run `npm test -- --testPathPattern=CombatantCard.hp` to confirm all pass
+- [x] Run `npm run test:unit -- --testPathPattern=CombatantCard.hp` to confirm all pass
 
 ### T5 — Coverage verification
 
-- [x] Run `npm test -- --coverage --collectCoverageFrom='lib/components/CombatantCard.tsx' --testPathPattern=CombatantCard` and confirm branch coverage ≥ 65%
+- [x] Run `npm run test:unit -- --coverage --collectCoverageFrom='lib/components/CombatantCard.tsx' --testPathPattern=CombatantCard` and confirm branch coverage ≥ 65%
 - [x] Confirm existing `CombatantCard.test.tsx` tests still pass (no regressions)
 
 ## Pre-Commit Code Review
@@ -56,7 +56,7 @@
 
 ## Validation
 
-- [x] Run `npm test` — all tests pass
+- [x] Run `npm run test:unit` — all tests pass
 - [x] Run `npx tsc --noEmit` — no type errors
 - [x] Run `npm run build` — build succeeds
 - [x] Branch coverage for `CombatantCard.tsx` ≥ 65% confirmed
@@ -73,10 +73,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run before the final commit
-- [ ] Commit all changes and push to `feat/combatant-card-hp-coverage`
-- [ ] Open PR from `feat/combatant-card-hp-coverage` to `main`. PR body must include `Closes #256`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [x] Ensure the `openspec-review-code` sub-agent was run before the final commit
+- [x] Commit all changes and push to `feat/combatant-card-hp-coverage`
+- [x] Open PR from `feat/combatant-card-hp-coverage` to `main`. PR body must include `Closes #256`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
 - [ ] **Monitor PR comments** — poll autonomously; address, commit fixes, follow remote push validation, push, wait 180s, repeat until no unresolved comments
 - [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failures, commit, validate, push, wait 180s, repeat

--- a/openspec/changes/combatant-card-hp-coverage/tests.md
+++ b/openspec/changes/combatant-card-hp-coverage/tests.md
@@ -1,0 +1,57 @@
+---
+name: tests
+description: RTL test cases for CombatantCard HP display, damage application, temp HP, and conditions coverage
+---
+
+# Tests
+
+## Overview
+
+All tests live in `tests/unit/components/CombatantCard.hp.test.tsx`. This is a new file (RTL pattern) separate from the existing `CombatantCard.test.tsx` (legacy createRoot pattern). All work follows TDD: write a failing test → implement → confirm passing.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Write the RTL test against the unimplemented behavior. Run `npm test -- --testPathPattern=CombatantCard.hp` and confirm it fails.
+2. **Write code to pass:** Since this is test-only work, "implementation" means writing the test correctly so it passes against the existing production code.
+3. **Refactor:** Consolidate shared setup (fixtures, `renderCard` helper) and remove duplication between test cases.
+
+## Test Cases
+
+### T1 — HP Display
+
+- [ ] `health-bar width is 100% when hp equals maxHp` → spec: hp-display full HP scenario
+- [ ] `health-bar width is ~50% when hp is half maxHp` → spec: hp-display half HP scenario
+- [ ] `health-bar width is <25% when hp is near zero` → spec: hp-display near-zero scenario
+- [ ] `skull emoji appears in heading when hp is 0` → spec: hp-display dead state (hp=0)
+- [ ] `skull emoji absent from heading when hp is positive` → spec: hp-display dead state (hp=1)
+- [ ] `temp-hp-bar is present when tempHp > 0` → spec: hp-display temp HP bar present
+- [ ] `temp-hp-bar is absent when tempHp is 0` → spec: hp-display temp HP bar absent
+
+### T2 — Damage Application
+
+- [ ] `normal damage reduces hp by full amount` → spec: damage-application normal damage
+- [ ] `fire resistance halves damage (rounded down)` → spec: damage-application resistance scenario
+- [ ] `fire resistance — 1 damage becomes 0 (floor)` → spec: damage-application resistance floor scenario
+- [ ] `fire immunity — hp unchanged, onUpdate not called` → spec: damage-application immunity scenario
+- [ ] `fire vulnerability — damage doubled` → spec: damage-application vulnerability scenario
+- [ ] `vulnerability — hp floored at 0, not negative` → spec: damage-application vulnerability floor scenario
+
+### T3 — Temp HP Drain
+
+- [ ] `damage ≤ tempHp — real hp unchanged, tempHp reduced` → spec: temp-hp drain absorbed
+- [ ] `damage > tempHp — temp HP zeroed, excess hits real HP` → spec: temp-hp drain spillover
+- [ ] `tempHp: 0 — all damage hits real HP` → spec: temp-hp zero temp scenario
+
+### T4 — Conditions
+
+- [ ] `"Conditions (1)" button present when combatant has one condition` → spec: conditions display count
+- [ ] `no Conditions button when combatant has no conditions` → spec: conditions absent
+- [ ] `clicking Conditions button expands condition list` → spec: conditions expand on click
+- [ ] `clicking Remove on only condition calls onUpdate with empty array` → spec: conditions remove only
+- [ ] `clicking Remove on one of two conditions preserves the other` → spec: conditions remove one of many
+
+### T5 — Coverage Gate
+
+- [ ] `branch coverage for CombatantCard.tsx ≥ 65% with all test files combined` → coverage report confirms target

--- a/tests/unit/components/CombatantCard.hp.test.tsx
+++ b/tests/unit/components/CombatantCard.hp.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string; [k: string]: unknown }) =>
+    React.createElement('a', { href, ...rest }, children),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CombatantCard } from '@/lib/components/CombatantCard';
+import type { CombatantState } from '@/lib/types';
+
+const BASE: CombatantState = {
+  id: 'c1',
+  name: 'Test Fighter',
+  type: 'player',
+  initiative: 10,
+  conditions: [],
+  hp: 30,
+  maxHp: 30,
+  ac: 15,
+  abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+};
+
+const ENEMY: CombatantState = { ...BASE, id: 'e1', name: 'Goblin', type: 'monster' };
+
+function renderCard(overrides: Partial<CombatantState> = {}, onUpdate = jest.fn(), extra: Record<string, unknown> = {}) {
+  const combatant = { ...BASE, ...overrides };
+  render(
+    <CombatantCard
+      combatId="test-combat"
+      combatant={combatant}
+      isActive={false}
+      onUpdate={onUpdate as any}
+      onRemove={jest.fn() as any}
+      {...(extra as any)}
+    />
+  );
+  return onUpdate;
+}
+
+async function applyDamageHelper(
+  amount: string,
+  overrides: Partial<CombatantState> = {},
+  damageType?: string,
+): Promise<jest.Mock> {
+  const user = userEvent.setup();
+  const onUpdate = renderCard({ hp: 30, maxHp: 30, ...overrides });
+  await user.type(screen.getByRole('spinbutton'), amount);
+  if (damageType) {
+    await user.selectOptions(
+      screen.getByLabelText('Damage type (for resistance/immunity/vulnerability)'),
+      damageType,
+    );
+  }
+  await user.click(screen.getByRole('button', { name: 'Damage' }));
+  return onUpdate as jest.Mock;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// T1 — HP display
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.hp — HP display', () => {
+  test('health-bar width is 100% when hp equals maxHp', () => {
+    renderCard({ hp: 30, maxHp: 30 });
+    expect(screen.getByTestId('health-bar')).toHaveStyle({ width: '100%' });
+  });
+
+  test('health-bar width is ~50% when hp is half maxHp', () => {
+    renderCard({ hp: 15, maxHp: 30 });
+    expect(screen.getByTestId('health-bar')).toHaveStyle({ width: '50%' });
+  });
+
+  test('health-bar width is <25% when hp is near zero', () => {
+    renderCard({ hp: 5, maxHp: 30 });
+    const width = parseFloat(screen.getByTestId('health-bar').style.width);
+    expect(width).toBeLessThan(25);
+  });
+
+  test('skull emoji appears in heading when hp is 0', () => {
+    renderCard({ hp: 0 });
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('☠️');
+  });
+
+  test('skull emoji absent from heading when hp is positive', () => {
+    renderCard({ hp: 1 });
+    expect(screen.getByRole('heading', { level: 3 })).not.toHaveTextContent('☠️');
+  });
+
+  test('temp-hp-bar is present when tempHp > 0', () => {
+    renderCard({ tempHp: 5 });
+    expect(screen.getByTestId('temp-hp-bar')).toBeInTheDocument();
+  });
+
+  test('temp-hp-bar is absent when tempHp is 0', () => {
+    renderCard();
+    expect(screen.queryByTestId('temp-hp-bar')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T2 — Damage application
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.hp — damage application', () => {
+  test('normal damage reduces hp by full amount', async () => {
+    const onUpdate = await applyDamageHelper('10');
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 20 }));
+  });
+
+  test('fire resistance halves damage (rounded down)', async () => {
+    const onUpdate = await applyDamageHelper('10', { damageResistances: ['fire'] }, 'fire');
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 25 }));
+  });
+
+  test('fire resistance — 1 damage becomes 0 (floor)', async () => {
+    const onUpdate = await applyDamageHelper('1', { damageResistances: ['fire'] }, 'fire');
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 30 }));
+  });
+
+  test('fire immunity — hp unchanged', async () => {
+    const onUpdate = await applyDamageHelper('20', { damageImmunities: ['fire'] }, 'fire');
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 30 }));
+  });
+
+  test('fire vulnerability — damage doubled', async () => {
+    const onUpdate = await applyDamageHelper('5', { damageVulnerabilities: ['fire'] }, 'fire');
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 20 }));
+  });
+
+  test('vulnerability floors HP at 0, not negative', async () => {
+    const onUpdate = await applyDamageHelper('10', { hp: 5, damageVulnerabilities: ['fire'] }, 'fire');
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 0 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3 — Temp HP drain
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.hp — temp HP drain', () => {
+  test('damage ≤ tempHp — real hp unchanged, tempHp reduced', async () => {
+    const onUpdate = await applyDamageHelper('3', { tempHp: 5 });
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 30, tempHp: 2 }));
+  });
+
+  test('damage > tempHp — temp HP zeroed, excess hits real HP', async () => {
+    const onUpdate = await applyDamageHelper('8', { tempHp: 5 });
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 27, tempHp: 0 }));
+  });
+
+  test('tempHp: 0 — all damage hits real HP', async () => {
+    const onUpdate = await applyDamageHelper('10', { tempHp: 0 });
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 20, tempHp: 0 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T4 — Conditions
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.hp — conditions', () => {
+  test('"Conditions (1)" button present when combatant has one condition', () => {
+    renderCard({ conditions: [{ id: 'c1', name: 'Poisoned', description: '' }] });
+    expect(screen.getByRole('button', { name: /Conditions \(1\)/ })).toBeInTheDocument();
+  });
+
+  test('no Conditions button when combatant has no conditions', () => {
+    renderCard({ conditions: [] });
+    expect(screen.queryByRole('button', { name: /Conditions/ })).not.toBeInTheDocument();
+  });
+
+  test('clicking Conditions button expands condition list', async () => {
+    const user = userEvent.setup();
+    renderCard({ conditions: [{ id: 'c1', name: 'Poisoned', description: '' }] });
+    await user.click(screen.getByRole('button', { name: /Conditions \(1\)/ }));
+    expect(screen.getByText('Poisoned')).toBeInTheDocument();
+  });
+
+  test('clicking Remove on only condition calls onUpdate with empty array', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderCard({ conditions: [{ id: 'c1', name: 'Poisoned', description: '' }] });
+    await user.click(screen.getByRole('button', { name: /Conditions \(1\)/ }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(onUpdate).toHaveBeenCalledWith({ conditions: [] });
+  });
+
+  test('two conditions — remove first — onUpdate called with only second', async () => {
+    const user = userEvent.setup();
+    const conditions = [
+      { id: 'c1', name: 'Poisoned', description: '' },
+      { id: 'c2', name: 'Blinded', description: '' },
+    ];
+    const onUpdate = renderCard({ conditions });
+    await user.click(screen.getByRole('button', { name: /Conditions \(2\)/ }));
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(removeButtons[0]);
+    expect(onUpdate).toHaveBeenCalledWith({
+      conditions: [{ id: 'c2', name: 'Blinded', description: '' }],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T5 — Additional branch coverage
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.hp — healing', () => {
+  test('Heal button calls onUpdate with increased hp', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderCard({ hp: 20, maxHp: 30 });
+    await user.type(screen.getByRole('spinbutton'), '5');
+    await user.click(screen.getByRole('button', { name: 'Heal' }));
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 25 }));
+  });
+
+  test('Heal button caps hp at maxHp', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderCard({ hp: 28, maxHp: 30 });
+    await user.type(screen.getByRole('spinbutton'), '10');
+    await user.click(screen.getByRole('button', { name: 'Heal' }));
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 30 }));
+  });
+});
+
+describe('CombatantCard.hp — set temp HP', () => {
+  test('Temp checkbox toggles button label to Set Temp', async () => {
+    const user = userEvent.setup();
+    renderCard();
+    await user.click(screen.getByRole('checkbox', { name: /Temp/ }));
+    expect(screen.getByRole('button', { name: 'Set Temp' })).toBeInTheDocument();
+  });
+
+  test('Set Temp button calls onUpdate with tempHp', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderCard({ hp: 30, maxHp: 30 });
+    await user.click(screen.getByRole('checkbox', { name: /Temp/ }));
+    await user.type(screen.getByRole('spinbutton'), '10');
+    await user.click(screen.getByRole('button', { name: 'Set Temp' }));
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ tempHp: 10 }));
+  });
+});
+
+describe('CombatantCard.hp — active combatant', () => {
+  test('isActive combatant shows Current Turn button', () => {
+    renderCard({}, jest.fn(), { isActive: true, onNextTurn: jest.fn() });
+    expect(screen.getByRole('button', { name: /Current Turn/ })).toBeInTheDocument();
+  });
+
+  test('clicking Current Turn calls onNextTurn', async () => {
+    const user = userEvent.setup();
+    const onNextTurn = jest.fn();
+    renderCard({}, jest.fn(), { isActive: true, onNextTurn });
+    await user.click(screen.getByRole('button', { name: /Current Turn/ }));
+    expect(onNextTurn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CombatantCard.hp — misc display', () => {
+  test('notes text is rendered when provided', () => {
+    renderCard({ notes: 'Flanking bonus active' });
+    expect(screen.getByText('Flanking bonus active')).toBeInTheDocument();
+  });
+
+  test('tempHp amount shown in hp text when tempHp > 0', () => {
+    renderCard({ tempHp: 5 });
+    expect(screen.getByText(/\+5 tmp/)).toBeInTheDocument();
+  });
+
+  test('legendary action badge shown when legendaryActionCount > 0', () => {
+    renderCard({ legendaryActionCount: 3, legendaryActionsRemaining: 2 });
+    expect(screen.getByTestId('legendary-action-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('legendary-action-badge')).toHaveTextContent('2/3');
+  });
+
+  test('health-bar width is between 25% and 50% when hp is in yellow range', () => {
+    renderCard({ hp: 10, maxHp: 30 });
+    const width = parseFloat(screen.getByTestId('health-bar').style.width);
+    expect(width).toBeGreaterThan(25);
+    expect(width).toBeLessThan(50);
+  });
+
+  test('hpPercent is 0 when maxHp and tempHp are both 0', () => {
+    renderCard({ hp: 0, maxHp: 0 });
+    expect(screen.getByTestId('health-bar')).toHaveStyle({ width: '0%' });
+  });
+});
+
+describe('CombatantCard.hp — initiative roll display', () => {
+  test('shows rolled initiative details when method is rolled', () => {
+    renderCard({
+      initiative: 15,
+      initiativeRoll: { method: 'rolled', roll: 12, bonus: 3, total: 15 },
+    });
+    expect(screen.getByText(/d20:12\+3/)).toBeInTheDocument();
+  });
+
+  test('shows rolled initiative with advantage indicator', () => {
+    renderCard({
+      initiative: 18,
+      initiativeRoll: { method: 'rolled', roll: 15, bonus: 3, total: 18, advantage: true },
+    });
+    expect(screen.getByText(/d20:15↑\+3/)).toBeInTheDocument();
+  });
+
+  test('shows manual initiative with roll and flatBonus', () => {
+    renderCard({
+      initiative: 15,
+      initiativeRoll: { method: 'manual', roll: 13, bonus: 0, total: 15, flatBonus: 2 },
+    });
+    expect(screen.getByText(/13\+2/)).toBeInTheDocument();
+  });
+
+  test('shows manual initiative bonus when non-zero', () => {
+    renderCard({
+      initiative: 14,
+      initiativeRoll: { method: 'manual', roll: 12, bonus: 2, total: 14 },
+    });
+    expect(screen.getByText(/12\+2/)).toBeInTheDocument();
+  });
+});
+
+describe('CombatantCard.hp — targeting UI', () => {
+  function renderWithAllCombatants(overrides: Partial<CombatantState> = {}, onUpdate = jest.fn()) {
+    const combatant = { ...BASE, ...overrides };
+    return renderCard(overrides, onUpdate, {
+      allCombatants: [combatant, ENEMY],
+      onUpdateCombatant: jest.fn(),
+    });
+  }
+
+  test('Add Target(s) button opens targeting panel', async () => {
+    const user = userEvent.setup();
+    renderWithAllCombatants();
+    await user.click(screen.getByRole('button', { name: /Add Target/ }));
+    expect(screen.getByText(/Select targets for Test Fighter/)).toBeInTheDocument();
+  });
+
+  test('targeting panel shows Enemies and Party sections', async () => {
+    const user = userEvent.setup();
+    renderWithAllCombatants();
+    await user.click(screen.getByRole('button', { name: /Add Target/ }));
+    expect(screen.getByText('Enemies')).toBeInTheDocument();
+    expect(screen.getByText('Party')).toBeInTheDocument();
+  });
+
+  test('clicking Add Target(s) again collapses the panel', async () => {
+    const user = userEvent.setup();
+    renderWithAllCombatants();
+    await user.click(screen.getByRole('button', { name: /Add Target/ }));
+    await user.click(screen.getByRole('button', { name: /Add Target/ }));
+    expect(screen.queryByText(/Select targets for Test Fighter/)).not.toBeInTheDocument();
+  });
+
+  test('checking enemy in targeting panel calls onUpdate with targetIds', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderWithAllCombatants();
+    await user.click(screen.getByRole('button', { name: /Add Target/ }));
+    await user.click(screen.getByRole('checkbox', { name: 'Goblin' }));
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ targetIds: ['e1'] }));
+  });
+
+  test('target chips rendered when combatant has targetIds', () => {
+    renderWithAllCombatants({ targetIds: ['e1'] });
+    expect(screen.getByText('Targets:')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Goblin' })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/CombatantCard.hp.test.tsx
+++ b/tests/unit/components/CombatantCard.hp.test.tsx
@@ -64,7 +64,9 @@ async function applyDamageHelper(
 ): Promise<jest.Mock> {
   const user = userEvent.setup();
   const onUpdate = renderCard({ hp: 30, maxHp: 30, ...overrides });
-  await user.type(screen.getByRole('spinbutton'), amount);
+  const input = screen.getByRole('spinbutton');
+  await user.clear(input);
+  await user.type(input, amount);
   if (damageType) {
     await user.selectOptions(
       screen.getByLabelText('Damage type (for resistance/immunity/vulnerability)'),
@@ -205,7 +207,7 @@ describe('CombatantCard.hp — conditions', () => {
     const onUpdate = renderCard({ conditions: [{ id: 'c1', name: 'Poisoned', description: '' }] });
     await user.click(screen.getByRole('button', { name: /Conditions \(1\)/ }));
     await user.click(screen.getByRole('button', { name: 'Remove' }));
-    expect(onUpdate).toHaveBeenCalledWith({ conditions: [] });
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ conditions: [] }));
   });
 
   test('two conditions — remove first — onUpdate called with only second', async () => {
@@ -218,9 +220,9 @@ describe('CombatantCard.hp — conditions', () => {
     await user.click(screen.getByRole('button', { name: /Conditions \(2\)/ }));
     const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
     await user.click(removeButtons[0]);
-    expect(onUpdate).toHaveBeenCalledWith({
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({
       conditions: [{ id: 'c2', name: 'Blinded', description: '' }],
-    });
+    }));
   });
 });
 
@@ -232,7 +234,9 @@ describe('CombatantCard.hp — healing', () => {
   test('Heal button calls onUpdate with increased hp', async () => {
     const user = userEvent.setup();
     const onUpdate = renderCard({ hp: 20, maxHp: 30 });
-    await user.type(screen.getByRole('spinbutton'), '5');
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '5');
     await user.click(screen.getByRole('button', { name: 'Heal' }));
     expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 25 }));
   });
@@ -240,7 +244,9 @@ describe('CombatantCard.hp — healing', () => {
   test('Heal button caps hp at maxHp', async () => {
     const user = userEvent.setup();
     const onUpdate = renderCard({ hp: 28, maxHp: 30 });
-    await user.type(screen.getByRole('spinbutton'), '10');
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '10');
     await user.click(screen.getByRole('button', { name: 'Heal' }));
     expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ hp: 30 }));
   });
@@ -258,7 +264,9 @@ describe('CombatantCard.hp — set temp HP', () => {
     const user = userEvent.setup();
     const onUpdate = renderCard({ hp: 30, maxHp: 30 });
     await user.click(screen.getByRole('checkbox', { name: /Temp/ }));
-    await user.type(screen.getByRole('spinbutton'), '10');
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '10');
     await user.click(screen.getByRole('button', { name: 'Set Temp' }));
     expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ tempHp: 10 }));
   });

--- a/tests/unit/components/CombatantCard.hp.test.tsx
+++ b/tests/unit/components/CombatantCard.hp.test.tsx
@@ -30,7 +30,14 @@ const BASE: CombatantState = {
   hp: 30,
   maxHp: 30,
   ac: 15,
-  abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+  abilityScores: {
+    strength: 10,
+    dexterity: 10,
+    constitution: 10,
+    intelligence: 10,
+    wisdom: 10,
+    charisma: 10,
+  },
 };
 
 const ENEMY: CombatantState = { ...BASE, id: 'e1', name: 'Goblin', type: 'monster' };
@@ -108,7 +115,7 @@ describe('CombatantCard.hp — HP display', () => {
     expect(screen.getByTestId('temp-hp-bar')).toBeInTheDocument();
   });
 
-  test('temp-hp-bar is absent when tempHp is 0', () => {
+  test('temp-hp-bar is absent when tempHp is undefined', () => {
     renderCard();
     expect(screen.queryByTestId('temp-hp-bar')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Adds 41 React Testing Library tests for `CombatantCard` covering HP display, damage application, temp HP drain, conditions, healing, set temp HP, active combatant state, initiative roll display, and targeting UI.

## Coverage

Branch coverage for `lib/components/CombatantCard.tsx`: **67.74%** (≥65% target met).

## Test Groups

- **T1 — HP display**: health-bar width ratios, skull emoji dead state, temp-hp-bar presence
- **T2 — Damage application**: normal damage, fire resistance (including floor), fire immunity, fire vulnerability, vulnerability floor at 0
- **T3 — Temp HP drain**: damage absorbed by temp HP, spillover to real HP, zero temp HP
- **T4 — Conditions**: count button, expand/collapse, remove single condition, remove one of many
- **T5 — Additional coverage**: healing, set temp HP, active combatant (onNextTurn), notes, legendary action badge, initiative roll display (rolled/manual/advantage), targeting UI open/close/check, target chips

Closes #256