### PR TITLE
test(QuickCombatantModal): add RTL unit test suite (43 tests, 91% coverage)

### DIFF
--- a/openspec/changes/quick-combatant-modal-unit-tests/.openspec.yaml
+++ b/openspec/changes/quick-combatant-modal-unit-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-28

--- a/openspec/changes/quick-combatant-modal-unit-tests/design.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/design.md
@@ -1,0 +1,182 @@
+## Context
+
+- Relevant architecture: `lib/components/QuickCombatantModal.tsx` is a pure React component with no server-side concerns. All data arrives via props (`monsterTemplates`, `characterTemplates`). Internal state is managed with `useState` and `useMemo`; Fuse.js is used for client-side fuzzy search. No hooks require mocking.
+- Dependencies:
+  - `@testing-library/react` — already installed, confirmed in `jest.setup.ts`
+  - `@testing-library/jest-dom` — already installed, imported in `jest.setup.ts`
+  - `@testing-library/user-event` — required for realistic interaction simulation; verify in `package.json`
+  - `fuse.js` — real library used (not mocked)
+  - `next/link` — requires module-level mock in jsdom
+  - `lib/constants` — imports `GLOBAL_USER_ID` for creator-filter fixture setup
+  - `lib/types` — `Monster`, `MonsterTemplate`, `Character` types for fixtures
+- Interfaces/contracts touched: none (test-only change; no production code modified)
+
+## Goals / Non-Goals
+
+### Goals
+
+- Write `tests/unit/components/QuickCombatantModal.test.tsx` using RTL
+- Achieve ≥ 70% statement coverage and ≥ 55% branch coverage on `QuickCombatantModal.tsx`
+- Cover all three tabs, all filter combinations, both selection callbacks, and all custom-form validation branches
+- Follow the RTL pattern established by `tests/unit/CombatStatsRow.rtl.test.tsx` (not the older `createRoot` pattern)
+
+### Non-Goals
+
+- Modifying any production code
+- Achieving 100% branch coverage (two branches are explicitly excluded per proposal)
+- Migrating other test files to RTL
+
+## Decisions
+
+### Decision 1: RTL over createRoot
+
+- Chosen: `@testing-library/react` (`render`, `screen`, `userEvent`)
+- Alternatives considered: `createRoot` + manual DOM querying (used in `TargetActionModal.test.tsx`)
+- Rationale: The codebase is actively migrating to RTL (issues #260–263). All new component tests should follow the RTL pattern to avoid adding to the migration backlog. RTL's accessible queries also make assertions more semantically meaningful.
+- Trade-offs: `userEvent` setup adds a small amount of boilerplate per test (async setup); this is minor compared to the long-term maintenance benefit.
+
+### Decision 2: Real Fuse.js, no mock
+
+- Chosen: Use real Fuse.js with carefully chosen fixture names
+- Alternatives considered: Mock `fuse.js` module to return deterministic results
+- Rationale: Mocking Fuse.js would test that we call it, not that it actually filters correctly. Using real Fuse.js with simple, clearly distinct fixture names ("Goblin", "Orc", "Troll") gives meaningful coverage of the search-filter logic with negligible flakiness risk. The 0.3 threshold is permissive but won't match "Goblin" when searching "Orc".
+- Trade-offs: Fuzzy matching could theoretically produce surprising results for future fixtures. Mitigated by using short, visually distinct names.
+
+### Decision 3: Per-file `@jest-environment jsdom` docblock
+
+- Chosen: Include `@jest-environment jsdom` docblock at top of file
+- Alternatives considered: Rely on global jest config change (issue #264)
+- Rationale: Issue #264 is open but unmerged. The per-file docblock is the current standard used by all 38 existing component tests. Once #264 lands, the docblock becomes harmless redundancy — no refactor needed.
+- Trade-offs: Minor boilerplate; zero maintenance cost.
+
+### Decision 4: Mock `next/link`
+
+- Chosen: `jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }) => <a href={href}>{children}</a> }))`
+- Alternatives considered: Rely on Next.js's test export of Link
+- Rationale: Next.js's Link component uses router context that is unavailable in jsdom. The component only uses Link for navigation hints in empty states — the actual href is not tested. A minimal mock renders the children as an anchor without router dependency.
+- Trade-offs: None for this use case.
+
+### Decision 5: Spy on `crypto.randomUUID`
+
+- Chosen: `jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid')` in `beforeEach`
+- Alternatives considered: Accept any string id (use `expect.any(String)`)
+- Rationale: Asserting the exact returned id value makes the `onAddMonster` payload assertion fully deterministic and easier to read. Spying is preferable to mocking the entire `crypto` module.
+- Trade-offs: If jsdom doesn't expose `crypto.randomUUID`, fall back to `Object.defineProperty(global, 'crypto', ...)`.
+
+### Decision 6: Tab panel query strategy
+
+- Chosen: Use unique `aria-label` values on inputs (`"Search monsters"`, `"Search characters"`) and `aria-label` values on Add buttons (`"Add Goblin to encounter"`) to avoid needing `within()` scoping.
+- Alternatives considered: `within(screen.getByRole('tabpanel', { hidden: false }))` scoping
+- Rationale: The component's elements have unique accessible labels that make them unambiguous without scoping. Accessible-label queries are more readable and self-documenting. `within()` is reserved for cases where labels genuinely collide.
+- Trade-offs: If a future refactor removes or changes aria-labels, tests break with clear error messages (desired behavior).
+
+### Decision 7: Skip toast auto-dismiss
+
+- Chosen: Do not test the `useEffect` 2-second auto-dismiss
+- Alternatives considered: `jest.useFakeTimers()` + `act(() => jest.advanceTimersByTime(2000))`
+- Rationale: Auto-dismiss is well-established browser/React behavior. Testing it adds timer-related async complexity and brings no meaningful safety value. Testing that the toast appears is sufficient.
+- Trade-offs: Zero coverage on lines 38–43. Acceptable per proposal.
+
+## Proposal to Design Mapping
+
+- Proposal element: Tests use RTL pattern
+  - Design decision: Decision 1 (RTL over createRoot)
+  - Validation approach: File imports `render`, `screen`, `userEvent` from RTL; no `createRoot` import
+
+- Proposal element: Fuse.js fuzzy search tested with real library
+  - Design decision: Decision 2 (real Fuse.js)
+  - Validation approach: Type "Goblin" in search → only Goblin row visible; clear → all rows visible
+
+- Proposal element: jsdom environment without #264 dependency
+  - Design decision: Decision 3 (per-file docblock)
+  - Validation approach: `@jest-environment jsdom` docblock at file top; tests pass in CI
+
+- Proposal element: `next/link` doesn't crash in jsdom
+  - Design decision: Decision 4 (mock next/link)
+  - Validation approach: Empty-state renders without router errors
+
+- Proposal element: `onAddMonster` payload shape verification
+  - Design decision: Decision 5 (spy crypto.randomUUID)
+  - Validation approach: `expect(onAddMonster).toHaveBeenCalledWith(expect.objectContaining({ id: 'test-uuid', templateId: 'g1' }))`
+
+- Proposal element: Tab content not confused across tabs
+  - Design decision: Decision 6 (aria-label query strategy)
+  - Validation approach: `getByLabelText('Search monsters')` vs `getByLabelText('Search characters')` — each unique
+
+- Proposal element: Toast auto-dismiss not tested
+  - Design decision: Decision 7 (skip)
+  - Validation approach: N/A — explicitly out of scope
+
+## Functional Requirements Mapping
+
+- Requirement: Modal renders with monsters tab active by default
+  - Design element: `screen.getByRole('tab', { name: 'Monsters' })` has `aria-selected="true"`
+  - Acceptance criteria reference: specs/render-and-navigation.md
+  - Testability notes: Direct aria attribute assertion; no interaction needed
+
+- Requirement: Close button and backdrop call `onClose`
+  - Design element: `userEvent.click` on close button / backdrop element
+  - Acceptance criteria reference: specs/render-and-navigation.md
+  - Testability notes: `onClose` is a jest.fn(); assert `toHaveBeenCalledTimes(1)`
+
+- Requirement: Search filters monster list
+  - Design element: `userEvent.type` into `aria-label="Search monsters"` input
+  - Acceptance criteria reference: specs/search-and-filter.md
+  - Testability notes: Use "Goblin" as search term; assert Goblin row present, Orc absent
+
+- Requirement: Creator filter narrows results
+  - Design element: `userEvent.click` on filter buttons (My / Global / Other)
+  - Acceptance criteria reference: specs/search-and-filter.md
+  - Testability notes: Each filter tested in isolation with fixtures covering all userId combinations
+
+- Requirement: Monster Add calls `onAddMonster` with correct payload
+  - Design element: `userEvent.click` on `aria-label="Add Goblin to encounter"`
+  - Acceptance criteria reference: specs/selection.md
+  - Testability notes: Assert `toHaveBeenCalledWith(expect.objectContaining({ id: 'test-uuid', templateId: 'g1', name: 'Goblin' }))`
+
+- Requirement: Custom form validates and submits
+  - Design element: Fill fields via `userEvent.type`/`userEvent.clear`, submit via button click
+  - Acceptance criteria reference: specs/custom-form.md
+  - Testability notes: Each validation branch tested by omitting or setting invalid field values; error text asserted via `screen.getByText`
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Tests must pass consistently in CI (no flakiness)
+  - Design element: Real Fuse.js with distinct fixture names; no fake timers; deterministic uuid spy
+  - Acceptance criteria reference: All tests pass on `npm test -- QuickCombatantModal`
+  - Testability notes: Run 3× locally before merging to confirm no timer/async flakiness
+
+- Requirement category: operability
+  - Requirement: Test file follows established project conventions
+  - Design element: `@jest-environment jsdom` docblock; `IS_REACT_ACT_ENVIRONMENT = true`; file in `tests/unit/components/`
+  - Acceptance criteria reference: Consistent with `TargetActionModal.test.tsx` header conventions
+  - Testability notes: Code review check
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Fuse.js returns unexpected matches for fixture data
+  - Impact: Search-filter tests produce false positives or false negatives
+  - Mitigation: Verify locally by running the specific describe block; adjust fixture names if needed
+
+- Risk/trade-off: `userEvent` async API adds boilerplate
+  - Impact: Slightly more verbose tests (`const user = userEvent.setup(); await user.type(...)`)
+  - Mitigation: Define `user` in a shared `beforeEach` or as a describe-level constant
+
+## Rollback / Mitigation
+
+- Rollback trigger: New test file causes CI failure (environment, import error, or unexpected coverage regression)
+- Rollback steps: Delete `tests/unit/components/QuickCombatantModal.test.tsx`; no production code was changed
+- Data migration considerations: None
+- Verification after rollback: CI passes without the new file; coverage metrics return to baseline
+
+## Operational Blocking Policy
+
+- If CI checks fail: Diagnose locally with `npx jest tests/unit/components/QuickCombatantModal.test.tsx --verbose`; fix before merging
+- If security checks fail: N/A — no production code changes, no new dependencies
+- If required reviews are blocked/stale: Ping reviewer after 48 hours; escalate to maintainer after 72 hours
+- Escalation path and timeout: Tag `@dougis` in PR if unresolved after 72 hours
+
+## Open Questions
+
+No open questions. All design decisions resolved during explore and proposal phases.

--- a/openspec/changes/quick-combatant-modal-unit-tests/design.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/design.md
@@ -144,7 +144,7 @@
 - Requirement category: reliability
   - Requirement: Tests must pass consistently in CI (no flakiness)
   - Design element: Real Fuse.js with distinct fixture names; no fake timers; deterministic uuid spy
-  - Acceptance criteria reference: All tests pass on `npm test -- QuickCombatantModal`
+  - Acceptance criteria reference: All tests pass on `npm run test:unit -- QuickCombatantModal`
   - Testability notes: Run 3× locally before merging to confirm no timer/async flakiness
 
 - Requirement category: operability

--- a/openspec/changes/quick-combatant-modal-unit-tests/proposal.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/proposal.md
@@ -1,0 +1,102 @@
+## GitHub Issues
+
+- #258
+- #242
+
+## Why
+
+- Problem statement: `QuickCombatantModal.tsx` is 656 lines with 0% test coverage. It is the primary user-facing surface for adding monsters and characters to combat encounters — a high-traffic, high-risk interaction path.
+- Why now: Issue #242 targets `lib/components` statement coverage ≥ 70%. `QuickCombatantModal` is the largest single file holding that metric back. It is explicitly called out in #258 as the highest-priority zero-coverage file.
+- Business/user impact: Bugs in search, filter, or selection logic go undetected until manual QA or production. The component owns Fuse.js fuzzy search, creator-based filtering, and custom combatant form validation — all branchy logic that benefits significantly from automated verification.
+
+## Problem Space
+
+- Current behavior: `QuickCombatantModal.tsx` has no automated test coverage. Regressions in search, filter, tab switching, callback invocation, or form validation are invisible to CI.
+- Desired behavior: A comprehensive RTL unit test suite covers all three tabs (monsters, characters, custom), all filter and search paths, all selection callbacks, and all custom-form validation branches. Statement coverage ≥ 70%, branch coverage ≥ 55%.
+- Constraints:
+  - Issue #264 (switch global jest env to jsdom) is open but not yet merged. The `@jest-environment jsdom` per-file docblock is the current workaround and remains valid until #264 lands.
+  - The issue description mentions a "count spinner" — this control does not exist in the current component. Tests must cover actual code, not speculative UI.
+  - Fuse.js fuzzy search uses a 0.3 threshold — test fixtures must use names that produce predictable match/no-match results.
+- Assumptions:
+  - RTL (`@testing-library/react`) and `@testing-library/jest-dom` are already installed (confirmed via `jest.setup.ts` and `CombatStatsRow.rtl.test.tsx`).
+  - `@testing-library/user-event` is available for interaction simulation.
+  - `next/link` requires a module mock in jsdom.
+  - `crypto.randomUUID` requires a spy for deterministic id assertions.
+- Edge cases considered:
+  - All three creator filter values (`mine`, `global`, `other`) plus the default `all`.
+  - `onAddCharacter` prop omitted (optional) — the component logs to console and does nothing.
+  - `showToast=false` suppresses the success toast.
+  - The duplicate `ac < 1` validation check on line 215 is dead code (line 200 fires first) — no special test needed.
+  - Tab switching resets `searchQuery` and `creatorFilter` — must be verified.
+  - Initiative field is optional — empty string omits it from the Monster payload; a filled value includes it.
+
+## Scope
+
+### In Scope
+
+- New test file: `tests/unit/components/QuickCombatantModal.test.tsx`
+- All three tabs: Monsters, Party Members, Create New
+- Loading and empty states for Monsters and Party Members tabs
+- Fuse.js search filtering (monsters and characters)
+- Creator filter (all / mine / global / other) for both tabs
+- Monster selection callback (`onAddMonster`) with payload shape verification
+- Character selection callback (`onAddCharacter`) with payload shape verification
+- Custom form: happy path, all validation error branches, optional initiative
+- Toast display on success (showToast=true vs showToast=false)
+- Backdrop click and close-button behavior
+- Tab switching resets search and filter state
+- Documentation: update `tests/unit/components/` convention in `.wolf/anatomy.md`
+
+### Out of Scope
+
+- Toast auto-dismiss timer (`useEffect` + `setTimeout`) — well-established browser behavior, not worth fake-timer setup
+- `onAddCharacter` undefined path (console.log branch) — low value, not a user-visible behavior
+- Error path in `handleAddFromLibrary` try/catch — requires forcing `onAddMonster` to throw; low ROI
+- RTL migration of existing tests (tracked in #260–263)
+- Switching global jest env to jsdom (tracked in #264)
+- Any changes to `QuickCombatantModal.tsx` production code
+
+## What Changes
+
+- New file: `tests/unit/components/QuickCombatantModal.test.tsx`
+- `.wolf/anatomy.md`: add entry for the new test file
+- `.wolf/memory.md`: session log entry
+
+## Risks
+
+- Risk: Fuse.js fuzzy matching with test fixtures produces unexpected results
+  - Impact: Search-filter tests become flaky or require exact-match workarounds
+  - Mitigation: Use fixture names that are clearly distinct (e.g., "Goblin", "Orc", "Troll") and search terms that are unambiguous exact prefixes; verify locally before committing
+
+- Risk: `next/link` module mock breaks if Next.js internals change
+  - Impact: Test setup fails; unrelated to coverage goal
+  - Mitigation: Use a minimal mock (`({ href, children }) => <a href={href}>{children}</a>`) that doesn't depend on Next.js internals
+
+- Risk: `crypto.randomUUID` unavailable in jsdom
+  - Impact: `handleAddFromLibrary` throws at runtime during tests
+  - Mitigation: `jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid')` in `beforeEach`
+
+- Risk: Issue #264 lands mid-implementation and removes the per-file jsdom docblock
+  - Impact: Merge conflict or test environment change
+  - Mitigation: Low impact — the docblock becoming redundant after #264 is harmless; no action needed
+
+## Open Questions
+
+No unresolved ambiguity exists. All decisions were made during the explore session:
+- Test pattern: RTL (`render` + `screen` + `userEvent`), not `createRoot`
+- File location: `tests/unit/components/QuickCombatantModal.test.tsx`
+- Toast auto-dismiss: not tested
+- Count spinner: not present in code, not tested
+- Coverage depth: as comprehensive as realistic (see Scope)
+
+## Non-Goals
+
+- Increasing coverage of any other component in `lib/components/`
+- Modifying the component's production behavior
+- Achieving 100% branch coverage (the dead-code duplicate AC check and the console.log-only onAddCharacter-undefined path are explicitly excluded)
+- E2E or integration-level testing of the modal within a full combat session
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/quick-combatant-modal-unit-tests/specs/custom-form.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/specs/custom-form.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Unit tests for custom combatant form
+
+The system SHALL have automated tests verifying that the Create New tab form validates input and calls `onAddMonster` with the correct payload on success.
+
+#### Scenario: Custom form renders all fields
+
+- **Given** the user switches to the "Create New" tab
+- **When** the tab panel is visible
+- **Then** fields for Name, Dexterity, AC, Max HP, Current HP, and Initiative are present, along with "Add Combatant" and "Cancel" buttons
+
+#### Scenario: Happy path — submitting valid custom monster
+
+- **Given** the Create New tab is active and the user fills: Name="Dragon", Dexterity=14, AC=15, Max HP=50, Current HP=50, Initiative (blank)
+- **When** the user clicks "Add Combatant"
+- **Then** `onAddMonster` is called with `{ name: 'Dragon', ac: 15, maxHp: 50, hp: 50, abilityScores: { dexterity: 14, ... } }` and `onClose` is called
+
+#### Scenario: Happy path — custom monster with initiative set
+
+- **Given** the user fills the form with Name="Dragon" and Initiative=18
+- **When** the user clicks "Add Combatant"
+- **Then** `onAddMonster` is called with an object containing `{ initiative: 18 }`
+
+#### Scenario: Happy path — initiative blank omits field from payload
+
+- **Given** the user fills the form with Name="Dragon" and leaves Initiative blank
+- **When** the user clicks "Add Combatant"
+- **Then** `onAddMonster` is called with an object that does NOT contain the `initiative` key
+
+#### Scenario: Dexterity modifier display
+
+- **Given** the Create New tab is active with default Dexterity=10
+- **When** the user changes Dexterity to 14
+- **Then** the modifier display shows "+2"
+
+#### Scenario: Validation — empty name
+
+- **Given** the Create New tab is active with all fields at default values (Name is empty)
+- **When** the user clicks "Add Combatant"
+- **Then** the error "Name is required" is visible and `onAddMonster` is NOT called
+
+#### Scenario: Validation — dexterity out of range (too low)
+
+- **Given** the user enters Name="Dragon" and Dexterity=0
+- **When** the user clicks "Add Combatant"
+- **Then** an error containing "Dexterity must be between 1 and 30" is visible and `onAddMonster` is NOT called
+
+#### Scenario: Validation — dexterity out of range (too high)
+
+- **Given** the user enters Name="Dragon" and Dexterity=31
+- **When** the user clicks "Add Combatant"
+- **Then** an error containing "Dexterity must be between 1 and 30" is visible and `onAddMonster` is NOT called
+
+#### Scenario: Validation — AC less than 1
+
+- **Given** the user enters Name="Dragon" and AC=0
+- **When** the user clicks "Add Combatant"
+- **Then** the error "AC must be at least 1" is visible and `onAddMonster` is NOT called
+
+#### Scenario: Validation — Max HP less than 1
+
+- **Given** the user enters Name="Dragon" and Max HP=0
+- **When** the user clicks "Add Combatant"
+- **Then** the error "Max HP must be at least 1" is visible and `onAddMonster` is NOT called
+
+#### Scenario: Validation — Current HP exceeds Max HP
+
+- **Given** the user enters Name="Dragon", Max HP=10, and Current HP=11
+- **When** the user clicks "Add Combatant"
+- **Then** the error "Current HP must be between 0 and Max HP" is visible and `onAddMonster` is NOT called
+
+#### Scenario: Validation error clears on tab switch
+
+- **Given** the user has triggered a validation error ("Name is required")
+- **When** the user switches to the Monsters tab and back to Create New
+- **Then** the error message is no longer visible
+
+#### Scenario: Cancel button calls onClose
+
+- **Given** the Create New tab is active
+- **When** the user clicks "Cancel"
+- **Then** `onClose` is called once
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (custom form happy path and all validation branches) -> Requirement: ADDED Unit tests for custom combatant form
+- Design decision: Decision 1 (RTL) -> all userEvent.type/click interactions
+- Design decision: Decision 5 (spy crypto.randomUUID) -> happy path payload assertion
+- Requirement -> Task(s): tasks.md §6 "Test: custom form"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Validation prevents invalid submissions
+
+- **Given** any combination of invalid field values
+- **When** the form is submitted
+- **Then** `onAddMonster` is never called and an error message is always displayed — no silent partial submissions

--- a/openspec/changes/quick-combatant-modal-unit-tests/specs/render-and-navigation.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/specs/render-and-navigation.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Unit tests for modal render and navigation
+
+The system SHALL have automated tests verifying that `QuickCombatantModal` renders correctly and responds to navigation interactions.
+
+#### Scenario: Modal renders with monsters tab active by default
+
+- **Given** the component is rendered with monster templates and no active tab override
+- **When** the component mounts
+- **Then** the heading "Add Combatant" is visible, the Monsters tab has `aria-selected="true"`, and the Party Members and Create New tabs have `aria-selected="false"`
+
+#### Scenario: Close button calls onClose
+
+- **Given** the component is rendered
+- **When** the user clicks the × close button
+- **Then** the `onClose` callback is called exactly once
+
+#### Scenario: Backdrop click calls onClose
+
+- **Given** the component is rendered
+- **When** the user clicks the backdrop (the outermost dialog overlay)
+- **Then** the `onClose` callback is called exactly once
+
+#### Scenario: Inner modal click does not call onClose
+
+- **Given** the component is rendered
+- **When** the user clicks inside the white modal card area
+- **Then** the `onClose` callback is NOT called
+
+#### Scenario: Switching to Party Members tab
+
+- **Given** the component is rendered with the Monsters tab active
+- **When** the user clicks the "Party Members" tab button
+- **Then** the Party Members tab has `aria-selected="true"` and the Monsters tab has `aria-selected="false"`
+
+#### Scenario: Switching to Create New tab
+
+- **Given** the component is rendered with the Monsters tab active
+- **When** the user clicks the "Create New" tab button
+- **Then** the Create New tab has `aria-selected="true"` and the custom form is visible
+
+#### Scenario: Tab switch resets search and filter
+
+- **Given** the user has typed "Goblin" in the search box and set creator filter to "My"
+- **When** the user switches to the Party Members tab
+- **Then** the search query is cleared and the creator filter resets to "All"
+
+## MODIFIED Requirements
+
+None. This is a new test file with no changes to existing requirements.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (close/backdrop behavior) -> Requirement: ADDED Unit tests for modal render and navigation
+- Design decision: Decision 6 (aria-label query strategy) -> Scenario: Close button calls onClose
+- Requirement -> Task(s): tasks.md §1 "Test: render and navigation"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Tests pass consistently
+
+- **Given** the test suite runs in jsdom via Jest
+- **When** `npx jest tests/unit/components/QuickCombatantModal.test.tsx` is executed three times in succession
+- **Then** all tests pass each time with no intermittent failures

--- a/openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md
@@ -1,0 +1,120 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Unit tests for monster search and filter
+
+The system SHALL have automated tests verifying that Fuse.js search and creator filter correctly narrow the monster list.
+
+#### Scenario: Monster list renders all templates initially
+
+- **Given** the component is rendered with 3 monster templates (Goblin/global, Orc/mine, Troll/other)
+- **When** the monsters tab is active with no search query
+- **Then** all three monster names are visible in the list
+
+#### Scenario: Typing in search filters monster list
+
+- **Given** the monsters tab is active showing all 3 monsters
+- **When** the user types "Goblin" in the search input
+- **Then** "Goblin" is visible in the list and "Orc" and "Troll" are not visible
+
+#### Scenario: Clearing search restores full list
+
+- **Given** the user has typed "Goblin" and the list shows only Goblin
+- **When** the user clears the search input
+- **Then** all three monsters are visible again
+
+#### Scenario: Search with no match shows empty state
+
+- **Given** the monsters tab is active
+- **When** the user types "zzznomatch" in the search input
+- **Then** the text "No monsters match your search and filter criteria" is visible
+
+#### Scenario: Creator filter "My" shows only user's monsters
+
+- **Given** the monsters tab is active with userId="user-test-123" and 3 monsters (Goblin/global, Orc/mine, Troll/other)
+- **When** the user clicks the "My" filter button
+- **Then** only "Orc" is visible; "Goblin" and "Troll" are not visible
+
+#### Scenario: Creator filter "Global" shows only global monsters
+
+- **Given** the monsters tab is active
+- **When** the user clicks the "Global" filter button
+- **Then** only "Goblin" is visible; "Orc" and "Troll" are not visible
+
+#### Scenario: Creator filter "Other" shows only shared monsters
+
+- **Given** the monsters tab is active
+- **When** the user clicks the "Other" filter button
+- **Then** only "Troll" is visible; "Goblin" and "Orc" are not visible
+
+#### Scenario: Creator filter "All" (default) shows everything
+
+- **Given** the user has applied the "Global" filter
+- **When** the user clicks the "All" filter button
+- **Then** all three monsters are visible
+
+#### Scenario: Loading state on monsters tab
+
+- **Given** `loadingTemplates=true`
+- **When** the monsters tab is active
+- **Then** "Loading templates..." is visible and the search input is not present
+
+#### Scenario: Empty monster templates shows prompt
+
+- **Given** `monsterTemplates=[]`
+- **When** the monsters tab is active
+- **Then** "No monster templates available" is visible with a "Create one" link
+
+### Requirement: ADDED Unit tests for character search and filter
+
+The system SHALL have automated tests verifying that search and filter correctly narrow the character list.
+
+#### Scenario: Character list renders all templates initially
+
+- **Given** the characters tab is active with 2 character templates
+- **When** no search query is entered
+- **Then** both character names are visible
+
+#### Scenario: Typing in search filters character list
+
+- **Given** the characters tab is active with "Aria" and "Bron" characters
+- **When** the user types "Aria" in the search input
+- **Then** "Aria" is visible and "Bron" is not visible
+
+#### Scenario: Loading state on characters tab
+
+- **Given** `loadingTemplates=true`
+- **When** the user switches to the Party Members tab
+- **Then** "Loading characters..." is visible
+
+#### Scenario: Empty character templates shows prompt
+
+- **Given** `characterTemplates=[]`
+- **When** the user switches to the Party Members tab
+- **Then** "No party members available" is visible with a "Create one" link
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (Fuse.js search, creator filter) -> Requirement: ADDED Unit tests for monster search and filter
+- Design decision: Decision 2 (real Fuse.js) -> Scenarios: Typing in search filters monster list, Clearing search restores full list
+- Design decision: Decision 6 (aria-label query strategy) -> all search input scenarios
+- Requirement -> Task(s): tasks.md §2 "Test: monster states", §3 "Test: monster search and filter", §5 "Test: character tab"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Fuse.js search is deterministic
+
+- **Given** the fixture monster names are "Goblin", "Orc", "Troll" (clearly distinct)
+- **When** the search term "Goblin" is entered
+- **Then** only Goblin matches — Fuse.js 0.3 threshold does not produce cross-matches for these names

--- a/openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Unit tests for monster selection
+
+The system SHALL have automated tests verifying that clicking Add on a monster row invokes `onAddMonster` with the correct payload.
+
+#### Scenario: Adding a monster calls onAddMonster with correct payload
+
+- **Given** the monsters tab is active with at least one monster template (Goblin, id="g1")
+- **When** the user clicks the "Add" button for Goblin (aria-label: "Add Goblin to encounter")
+- **Then** `onAddMonster` is called once with an object containing `{ id: 'test-uuid', templateId: 'g1', name: 'Goblin' }` and all other fields spread from the template
+
+#### Scenario: Adding a monster shows success toast
+
+- **Given** `showToast=true` (default)
+- **When** the user clicks Add for Goblin
+- **Then** a toast with the text "Goblin added successfully" is visible
+
+#### Scenario: Adding a monster with showToast=false shows no toast
+
+- **Given** `showToast=false`
+- **When** the user clicks Add for Goblin
+- **Then** no toast element is rendered
+
+#### Scenario: Modal stays open after adding a monster
+
+- **Given** the monsters tab is active
+- **When** the user clicks Add for Goblin
+- **Then** the modal is still visible (the "Add Combatant" heading is still present) and `onClose` has not been called
+
+#### Scenario: Global badge shown for global monster
+
+- **Given** a monster with `userId === GLOBAL_USER_ID`
+- **When** the monsters tab renders
+- **Then** "(Global)" badge is visible next to that monster's name
+
+#### Scenario: Mine badge shown for user's own monster
+
+- **Given** a monster with `userId === userId` prop
+- **When** the monsters tab renders
+- **Then** "(Mine)" badge is visible next to that monster's name
+
+#### Scenario: Shared badge shown for other user's monster
+
+- **Given** a monster with `userId` that is neither GLOBAL_USER_ID nor the current userId
+- **When** the monsters tab renders
+- **Then** "(Shared)" badge is visible next to that monster's name
+
+### Requirement: ADDED Unit tests for character selection
+
+The system SHALL have automated tests verifying that clicking Add on a character row invokes `onAddCharacter` with the correct payload.
+
+#### Scenario: Adding a character calls onAddCharacter with the character object
+
+- **Given** the characters tab is active with "Aria" (id="c1")
+- **When** the user clicks the "Add" button for Aria (aria-label: "Add Aria to combat")
+- **Then** `onAddCharacter` is called once with the Aria character object
+
+#### Scenario: Adding a character shows success toast
+
+- **Given** `showToast=true` and the characters tab is active
+- **When** the user clicks Add for Aria
+- **Then** a toast with the text "Aria added successfully" is visible
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element (monster selection, character selection callbacks) -> Requirement: ADDED Unit tests for monster/character selection
+- Design decision: Decision 5 (spy crypto.randomUUID) -> Scenario: Adding a monster calls onAddMonster with correct payload
+- Design decision: Decision 1 (RTL) -> all click scenarios use `userEvent.click`
+- Requirement -> Task(s): tasks.md §4 "Test: monster selection", §5 "Test: character tab"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Selection callbacks are called exactly once per click
+
+- **Given** a monster template in the list
+- **When** the Add button is clicked once
+- **Then** `onAddMonster` is called exactly once (toHaveBeenCalledTimes(1)) — no double-fire

--- a/openspec/changes/quick-combatant-modal-unit-tests/tasks.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/tasks.md
@@ -14,13 +14,13 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/render-and-naviga
 
 - [x] Create `tests/unit/components/QuickCombatantModal.test.tsx` with file header (`@jest-environment jsdom`, `IS_REACT_ACT_ENVIRONMENT`, imports, `next/link` mock, `crypto.randomUUID` spy, minimal fixtures)
 - [x] Write `describe('render and navigation')` block:
-  - [ ] Test: modal renders with monsters tab active by default (heading visible, Monsters tab `aria-selected="true"`)
-  - [ ] Test: close button calls `onClose`
-  - [ ] Test: backdrop click calls `onClose`
-  - [ ] Test: clicking inside the modal does NOT call `onClose`
-  - [ ] Test: switching to Party Members tab updates `aria-selected`
-  - [ ] Test: switching to Create New tab makes custom form visible
-  - [ ] Test: tab switch resets search query and creator filter to defaults
+  - [x] Test: modal renders with monsters tab active by default (heading visible, Monsters tab `aria-selected="true"`)
+  - [x] Test: close button calls `onClose`
+  - [x] Test: backdrop click calls `onClose`
+  - [x] Test: clicking inside the modal does NOT call `onClose`
+  - [x] Test: switching to Party Members tab updates `aria-selected`
+  - [x] Test: switching to Create New tab makes custom form visible
+  - [x] Test: tab switch resets search query and creator filter to defaults
 - [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="render and navigation"` — all pass
 
 ### §2 — Test: monster states
@@ -28,8 +28,8 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/render-and-naviga
 Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md`
 
 - [x] Write `describe('monster tab states')` block:
-  - [ ] Test: `loadingTemplates=true` shows "Loading templates..." and hides search input
-  - [ ] Test: `monsterTemplates=[]` shows "No monster templates available" with link
+  - [x] Test: `loadingTemplates=true` shows "Loading templates..." and hides search input
+  - [x] Test: `monsterTemplates=[]` shows "No monster templates available" with link
 - [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="monster tab states"` — all pass
 
 ### §3 — Test: monster search and filter
@@ -37,14 +37,14 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter
 Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md`
 
 - [x] Write `describe('monster search and filter')` block:
-  - [ ] Test: all monsters visible initially (no search, no filter)
-  - [ ] Test: typing "Goblin" filters list to Goblin only
-  - [ ] Test: clearing search restores all monsters
-  - [ ] Test: no-match search shows "No monsters match your search and filter criteria"
-  - [ ] Test: "My" filter shows only user's monster (Orc)
-  - [ ] Test: "Global" filter shows only global monster (Goblin)
-  - [ ] Test: "Other" filter shows only shared monster (Troll)
-  - [ ] Test: "All" filter (after "Global") shows all monsters
+  - [x] Test: all monsters visible initially (no search, no filter)
+  - [x] Test: typing "Goblin" filters list to Goblin only
+  - [x] Test: clearing search restores all monsters
+  - [x] Test: no-match search shows "No monsters match your search and filter criteria"
+  - [x] Test: "My" filter shows only user's monster (Orc)
+  - [x] Test: "Global" filter shows only global monster (Goblin)
+  - [x] Test: "Other" filter shows only shared monster (Troll)
+  - [x] Test: "All" filter (after "Global") shows all monsters
 - [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="monster search and filter"` — all pass
 
 ### §4 — Test: monster selection
@@ -52,13 +52,13 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter
 Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md`
 
 - [x] Write `describe('monster selection')` block:
-  - [ ] Test: clicking Add calls `onAddMonster` with `{ id: 'test-uuid', templateId: 'g1', name: 'Goblin' }` (and spread fields)
-  - [ ] Test: adding monster shows success toast ("Goblin added successfully")
-  - [ ] Test: adding monster with `showToast=false` shows no toast
-  - [ ] Test: modal stays open after adding (heading still visible, `onClose` not called)
-  - [ ] Test: "(Global)" badge rendered for global monster
-  - [ ] Test: "(Mine)" badge rendered for user's own monster
-  - [ ] Test: "(Shared)" badge rendered for other user's monster
+  - [x] Test: clicking Add calls `onAddMonster` with `{ id: 'test-uuid', templateId: 'g1', name: 'Goblin' }` (and spread fields)
+  - [x] Test: adding monster shows success toast ("Goblin added successfully")
+  - [x] Test: adding monster with `showToast=false` shows no toast
+  - [x] Test: modal stays open after adding (heading still visible, `onClose` not called)
+  - [x] Test: "(Global)" badge rendered for global monster
+  - [x] Test: "(Mine)" badge rendered for user's own monster
+  - [x] Test: "(Shared)" badge rendered for other user's monster
 - [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="monster selection"` — all pass
 
 ### §5 — Test: character tab
@@ -66,12 +66,12 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md`
 Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md`, `openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md`
 
 - [x] Write `describe('character tab')` block:
-  - [ ] Test: `loadingTemplates=true` on characters tab shows "Loading characters..."
-  - [ ] Test: `characterTemplates=[]` shows "No party members available" with link
-  - [ ] Test: characters render when present ("Aria" and "Bron" visible)
-  - [ ] Test: typing "Aria" filters to Aria only
-  - [ ] Test: clicking Add calls `onAddCharacter` with the Aria character object
-  - [ ] Test: adding character shows toast ("Aria added successfully")
+  - [x] Test: `loadingTemplates=true` on characters tab shows "Loading characters..."
+  - [x] Test: `characterTemplates=[]` shows "No party members available" with link
+  - [x] Test: characters render when present ("Aria" and "Bron" visible)
+  - [x] Test: typing "Aria" filters to Aria only
+  - [x] Test: clicking Add calls `onAddCharacter` with the Aria character object
+  - [x] Test: adding character shows toast ("Aria added successfully")
 - [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="character tab"` — all pass
 
 ### §6 — Test: custom form
@@ -79,19 +79,19 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter
 Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/custom-form.md`
 
 - [x] Write `describe('custom form')` block:
-  - [ ] Test: form fields render (Name, Dexterity, AC, Max HP, Current HP, Initiative, "Add Combatant" button, "Cancel" button)
-  - [ ] Test: happy path — valid inputs → `onAddMonster` called with correct payload, `onClose` called
-  - [ ] Test: initiative filled → payload includes `initiative: 18`
-  - [ ] Test: initiative blank → payload does NOT include `initiative` key
-  - [ ] Test: dexterity 14 → modifier displays "+2"
-  - [ ] Test: empty name → "Name is required" error, `onAddMonster` not called
-  - [ ] Test: dexterity=0 → dexterity range error, `onAddMonster` not called
-  - [ ] Test: dexterity=31 → dexterity range error, `onAddMonster` not called
-  - [ ] Test: AC=0 → "AC must be at least 1", `onAddMonster` not called
-  - [ ] Test: maxHp=0 → "Max HP must be at least 1", `onAddMonster` not called
-  - [ ] Test: hp > maxHp → "Current HP must be between 0 and Max HP", `onAddMonster` not called
-  - [ ] Test: validation error clears when switching tabs
-  - [ ] Test: Cancel button calls `onClose`
+  - [x] Test: form fields render (Name, Dexterity, AC, Max HP, Current HP, Initiative, "Add Combatant" button, "Cancel" button)
+  - [x] Test: happy path — valid inputs → `onAddMonster` called with correct payload, `onClose` called
+  - [x] Test: initiative filled → payload includes `initiative: 18`
+  - [x] Test: initiative blank → payload does NOT include `initiative` key
+  - [x] Test: dexterity 14 → modifier displays "+2"
+  - [x] Test: empty name → "Name is required" error, `onAddMonster` not called
+  - [x] Test: dexterity=0 → dexterity range error, `onAddMonster` not called
+  - [x] Test: dexterity=31 → dexterity range error, `onAddMonster` not called
+  - [x] Test: AC=0 → "AC must be at least 1", `onAddMonster` not called
+  - [x] Test: maxHp=0 → "Max HP must be at least 1", `onAddMonster` not called
+  - [x] Test: hp > maxHp → "Current HP must be between 0 and Max HP", `onAddMonster` not called
+  - [x] Test: validation error clears when switching tabs
+  - [x] Test: Cancel button calls `onClose`
 - [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="custom form"` — all pass
 
 ### §7 — Update OpenWolf anatomy
@@ -105,7 +105,7 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/custom-form.md`
 
 ## Validation
 
-- [x] Run full unit test suite: `npm test` — all tests pass (no regressions)
+- [x] Run full unit test suite: `npm run test:unit` — all tests pass (no regressions)
 - [x] Run coverage for target file: `npx jest --coverage --collectCoverageFrom='lib/components/QuickCombatantModal.tsx' tests/unit/components/QuickCombatantModal.test.tsx` — statement ≥ 70%, branch ≥ 55%
 - [x] Run type check: `npx tsc --noEmit` — no errors
 - [x] Run build: `npm run build` — succeeds
@@ -114,7 +114,7 @@ Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/custom-form.md`
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test` — all tests pass
+- **Unit tests** — `npm run test:unit` — all tests pass
 - **Integration tests** — `npm run test:integration` — all tests pass
 - **Build** — `npm run build` — no errors
 - If **ANY** of the above fail, iterate and fix before pushing
@@ -122,9 +122,9 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 ## PR and Merge
 
 - [x] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
-- [ ] Commit all changes to `test/quick-combatant-modal-unit-tests` and push to remote
-- [ ] Open PR from `test/quick-combatant-modal-unit-tests` to `main`. PR body MUST include: `Closes #258`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force)
+- [x] Commit all changes to `test/quick-combatant-modal-unit-tests` and push to remote
+- [x] Open PR from `test/quick-combatant-modal-unit-tests` to `main`. PR body MUST include: `Closes #258`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
 - [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow Remote push validation, push, wait 180 seconds, repeat until no unresolved threads remain
 - [ ] **Monitor CI checks** — poll via `gh pr checks <PR-URL> --json isRequired,state`; fix any blocking failure, commit, follow Remote push validation, push, wait 180 seconds, repeat

--- a/openspec/changes/quick-combatant-modal-unit-tests/tasks.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/tasks.md
@@ -1,0 +1,158 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b test/quick-combatant-modal-unit-tests` then immediately `git push -u origin test/quick-combatant-modal-unit-tests`
+- [x] Verify `@testing-library/user-event` is in `package.json` dependencies; install if missing (`npm install --save-dev @testing-library/user-event`)
+
+## Execution
+
+### §1 — Test: render and navigation
+
+Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/render-and-navigation.md`
+
+- [x] Create `tests/unit/components/QuickCombatantModal.test.tsx` with file header (`@jest-environment jsdom`, `IS_REACT_ACT_ENVIRONMENT`, imports, `next/link` mock, `crypto.randomUUID` spy, minimal fixtures)
+- [x] Write `describe('render and navigation')` block:
+  - [ ] Test: modal renders with monsters tab active by default (heading visible, Monsters tab `aria-selected="true"`)
+  - [ ] Test: close button calls `onClose`
+  - [ ] Test: backdrop click calls `onClose`
+  - [ ] Test: clicking inside the modal does NOT call `onClose`
+  - [ ] Test: switching to Party Members tab updates `aria-selected`
+  - [ ] Test: switching to Create New tab makes custom form visible
+  - [ ] Test: tab switch resets search query and creator filter to defaults
+- [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="render and navigation"` — all pass
+
+### §2 — Test: monster states
+
+Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md`
+
+- [x] Write `describe('monster tab states')` block:
+  - [ ] Test: `loadingTemplates=true` shows "Loading templates..." and hides search input
+  - [ ] Test: `monsterTemplates=[]` shows "No monster templates available" with link
+- [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="monster tab states"` — all pass
+
+### §3 — Test: monster search and filter
+
+Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md`
+
+- [x] Write `describe('monster search and filter')` block:
+  - [ ] Test: all monsters visible initially (no search, no filter)
+  - [ ] Test: typing "Goblin" filters list to Goblin only
+  - [ ] Test: clearing search restores all monsters
+  - [ ] Test: no-match search shows "No monsters match your search and filter criteria"
+  - [ ] Test: "My" filter shows only user's monster (Orc)
+  - [ ] Test: "Global" filter shows only global monster (Goblin)
+  - [ ] Test: "Other" filter shows only shared monster (Troll)
+  - [ ] Test: "All" filter (after "Global") shows all monsters
+- [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="monster search and filter"` — all pass
+
+### §4 — Test: monster selection
+
+Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md`
+
+- [x] Write `describe('monster selection')` block:
+  - [ ] Test: clicking Add calls `onAddMonster` with `{ id: 'test-uuid', templateId: 'g1', name: 'Goblin' }` (and spread fields)
+  - [ ] Test: adding monster shows success toast ("Goblin added successfully")
+  - [ ] Test: adding monster with `showToast=false` shows no toast
+  - [ ] Test: modal stays open after adding (heading still visible, `onClose` not called)
+  - [ ] Test: "(Global)" badge rendered for global monster
+  - [ ] Test: "(Mine)" badge rendered for user's own monster
+  - [ ] Test: "(Shared)" badge rendered for other user's monster
+- [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="monster selection"` — all pass
+
+### §5 — Test: character tab
+
+Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/search-and-filter.md`, `openspec/changes/quick-combatant-modal-unit-tests/specs/selection.md`
+
+- [x] Write `describe('character tab')` block:
+  - [ ] Test: `loadingTemplates=true` on characters tab shows "Loading characters..."
+  - [ ] Test: `characterTemplates=[]` shows "No party members available" with link
+  - [ ] Test: characters render when present ("Aria" and "Bron" visible)
+  - [ ] Test: typing "Aria" filters to Aria only
+  - [ ] Test: clicking Add calls `onAddCharacter` with the Aria character object
+  - [ ] Test: adding character shows toast ("Aria added successfully")
+- [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="character tab"` — all pass
+
+### §6 — Test: custom form
+
+Spec: `openspec/changes/quick-combatant-modal-unit-tests/specs/custom-form.md`
+
+- [x] Write `describe('custom form')` block:
+  - [ ] Test: form fields render (Name, Dexterity, AC, Max HP, Current HP, Initiative, "Add Combatant" button, "Cancel" button)
+  - [ ] Test: happy path — valid inputs → `onAddMonster` called with correct payload, `onClose` called
+  - [ ] Test: initiative filled → payload includes `initiative: 18`
+  - [ ] Test: initiative blank → payload does NOT include `initiative` key
+  - [ ] Test: dexterity 14 → modifier displays "+2"
+  - [ ] Test: empty name → "Name is required" error, `onAddMonster` not called
+  - [ ] Test: dexterity=0 → dexterity range error, `onAddMonster` not called
+  - [ ] Test: dexterity=31 → dexterity range error, `onAddMonster` not called
+  - [ ] Test: AC=0 → "AC must be at least 1", `onAddMonster` not called
+  - [ ] Test: maxHp=0 → "Max HP must be at least 1", `onAddMonster` not called
+  - [ ] Test: hp > maxHp → "Current HP must be between 0 and Max HP", `onAddMonster` not called
+  - [ ] Test: validation error clears when switching tabs
+  - [ ] Test: Cancel button calls `onClose`
+- [x] Run: `npx jest tests/unit/components/QuickCombatantModal.test.tsx --testNamePattern="custom form"` — all pass
+
+### §7 — Update OpenWolf anatomy
+
+- [x] Add entry to `.wolf/anatomy.md` for `tests/unit/components/QuickCombatantModal.test.tsx`
+- [x] Append entry to `.wolf/memory.md`
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill on the changed files. The primary agent must automatically address all findings before committing.
+
+## Validation
+
+- [x] Run full unit test suite: `npm test` — all tests pass (no regressions)
+- [x] Run coverage for target file: `npx jest --coverage --collectCoverageFrom='lib/components/QuickCombatantModal.tsx' tests/unit/components/QuickCombatantModal.test.tsx` — statement ≥ 70%, branch ≥ 55%
+- [x] Run type check: `npx tsc --noEmit` — no errors
+- [x] Run build: `npm run build` — succeeds
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test` — all tests pass
+- **Integration tests** — `npm run test:integration` — all tests pass
+- **Build** — `npm run build` — no errors
+- If **ANY** of the above fail, iterate and fix before pushing
+
+## PR and Merge
+
+- [x] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [ ] Commit all changes to `test/quick-combatant-modal-unit-tests` and push to remote
+- [ ] Open PR from `test/quick-combatant-modal-unit-tests` to `main`. PR body MUST include: `Closes #258`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow Remote push validation, push, wait 180 seconds, repeat until no unresolved threads remain
+- [ ] **Monitor CI checks** — poll via `gh pr checks <PR-URL> --json isRequired,state`; fix any blocking failure, commit, follow Remote push validation, push, wait 180 seconds, repeat
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify
+
+Ownership metadata:
+
+- Implementer: (assigned agent)
+- Reviewer(s): @dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → diagnose with `npx jest --verbose` or `npm run build` → fix → commit → validate → push → re-run checks
+- Review comment → address → commit → validate → push → confirm thread resolved
+- Security finding → N/A (test-only change, no new dependencies expected)
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all tasks complete (`- [x]`)
+- [ ] Update `.wolf/anatomy.md` if any files were renamed or moved during review
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/quick-combatant-modal-unit-tests/` to `openspec/changes/archive/YYYY-MM-DD-quick-combatant-modal-unit-tests/` **in a single atomic commit** (stage both the new location and the deletion of the old location together)
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-quick-combatant-modal-unit-tests/` exists and `openspec/changes/quick-combatant-modal-unit-tests/` is gone
+- [ ] **Create a doc branch** for the archive commit: `git checkout -b doc/archive-YYYY-MM-DD-quick-combatant-modal-unit-tests` then `git push -u origin doc/archive-YYYY-MM-DD-quick-combatant-modal-unit-tests`
+- [ ] Open a PR from the doc branch to `main` with title `docs: archive quick-combatant-modal-unit-tests (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until merged (same comment/CI loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -d test/quick-combatant-modal-unit-tests doc/archive-YYYY-MM-DD-quick-combatant-modal-unit-tests`

--- a/openspec/changes/quick-combatant-modal-unit-tests/tests.md
+++ b/openspec/changes/quick-combatant-modal-unit-tests/tests.md
@@ -1,0 +1,102 @@
+---
+name: tests
+description: Test plan for QuickCombatantModal unit test suite
+---
+
+# Tests
+
+## Overview
+
+All test cases live in `tests/unit/components/QuickCombatantModal.test.tsx`. This is a pure unit test change — no production code is modified. Because the test file IS the deliverable, the TDD cycle is: write test → run and confirm it fails (component behavior already exists) → confirm it passes with real component → verify coverage target met.
+
+Each test maps to a `tasks.md` section and a spec scenario.
+
+## Test Cases
+
+### §1 — Render and navigation (`tasks.md §1`)
+
+Spec: `specs/render-and-navigation.md`
+
+- [ ] **Modal renders with monsters tab active** — `screen.getByRole('tab', { name: 'Monsters' })` has `aria-selected="true"`; Party Members and Create New have `aria-selected="false"`; heading "Add Combatant" is visible
+- [ ] **Close button calls onClose** — `userEvent.click` the `aria-label="Close modal"` button; `onClose` called once
+- [ ] **Backdrop click calls onClose** — `userEvent.click` the `role="dialog"` element directly; `onClose` called once
+- [ ] **Inner modal click does NOT call onClose** — `userEvent.click` the inner card `div`; `onClose` not called
+- [ ] **Switch to Party Members tab** — `userEvent.click('Party Members' tab)`; Party Members has `aria-selected="true"`, Monsters has `aria-selected="false"`
+- [ ] **Switch to Create New tab** — `userEvent.click('Create New' tab)`; custom form "Add Combatant" submit button is visible
+- [ ] **Tab switch resets search and filter** — type "Goblin", click "My" filter, then click Party Members tab; switch back to Monsters tab; search input is empty and "All" filter is active
+
+### §2 — Monster tab states (`tasks.md §2`)
+
+Spec: `specs/search-and-filter.md`
+
+- [ ] **Loading state** — render with `loadingTemplates=true`; "Loading templates..." visible; search input absent
+- [ ] **Empty templates** — render with `monsterTemplates=[]`; "No monster templates available" visible; "Create one" link present
+
+### §3 — Monster search and filter (`tasks.md §3`)
+
+Spec: `specs/search-and-filter.md`
+
+- [ ] **All monsters visible initially** — Goblin, Orc, Troll all in document
+- [ ] **Search filters to matching monster** — `userEvent.type` "Goblin" → Goblin visible, Orc and Troll absent
+- [ ] **Clear search restores full list** — after searching "Goblin", `userEvent.clear` → all three visible
+- [ ] **No-match search shows empty state** — type "zzznomatch" → "No monsters match your search and filter criteria" visible
+- [ ] **"My" filter shows only user's monster** — click "My" button → Orc visible, Goblin and Troll absent
+- [ ] **"Global" filter shows only global monster** — click "Global" button → Goblin visible, Orc and Troll absent
+- [ ] **"Other" filter shows only shared monster** — click "Other" button → Troll visible, Goblin and Orc absent
+- [ ] **"All" filter restores all** — click "Global", then "All" → Goblin, Orc, Troll all visible
+
+### §4 — Monster selection (`tasks.md §4`)
+
+Spec: `specs/selection.md`
+
+- [ ] **Add calls onAddMonster with correct payload** — click `aria-label="Add Goblin to encounter"`; `onAddMonster` called with `{ id: 'test-uuid', templateId: 'g1', name: 'Goblin', ... }` (spread fields)
+- [ ] **Success toast shown (showToast=true)** — toast "Goblin added successfully" visible after add
+- [ ] **No toast when showToast=false** — render with `showToast=false`, click Add; no toast element rendered
+- [ ] **Modal stays open after add** — heading "Add Combatant" still visible; `onClose` not called
+- [ ] **(Global) badge** — Goblin row contains "(Global)" text
+- [ ] **(Mine) badge** — Orc row contains "(Mine)" text
+- [ ] **(Shared) badge** — Troll row contains "(Shared)" text
+
+### §5 — Character tab (`tasks.md §5`)
+
+Spec: `specs/search-and-filter.md`, `specs/selection.md`
+
+- [ ] **Loading state on characters tab** — render `loadingTemplates=true`, switch to Party Members tab; "Loading characters..." visible
+- [ ] **Empty characters** — render `characterTemplates=[]`, switch to Party Members tab; "No party members available" visible
+- [ ] **Characters render when present** — switch to Party Members; "Aria" and "Bron" visible
+- [ ] **Search filters characters** — type "Aria" → Aria visible, Bron absent
+- [ ] **Add character calls onAddCharacter** — click `aria-label="Add Aria to combat"`; `onAddCharacter` called with Aria character object
+- [ ] **Character add shows toast** — "Aria added successfully" visible after add
+
+### §6 — Custom form (`tasks.md §6`)
+
+Spec: `specs/custom-form.md`
+
+- [ ] **Form fields render** — Name, Dexterity, AC, Max HP, Current HP, Initiative inputs and "Add Combatant" / "Cancel" buttons present
+- [ ] **Happy path — no initiative** — fill Name="Dragon", leave Initiative blank, submit; `onAddMonster` called with payload without `initiative` key; `onClose` called
+- [ ] **Happy path — initiative set** — fill Name="Dragon", set Initiative=18, submit; `onAddMonster` payload includes `{ initiative: 18 }`
+- [ ] **Dexterity modifier display** — set Dexterity to 14; "+2" modifier text visible
+- [ ] **Validation: empty name** — submit with blank Name; "Name is required" visible; `onAddMonster` not called
+- [ ] **Validation: dexterity=0** — submit with Dexterity=0; dexterity range error visible; `onAddMonster` not called
+- [ ] **Validation: dexterity=31** — submit with Dexterity=31; dexterity range error visible; `onAddMonster` not called
+- [ ] **Validation: AC=0** — submit with AC=0; "AC must be at least 1" visible; `onAddMonster` not called
+- [ ] **Validation: maxHp=0** — submit with Max HP=0; "Max HP must be at least 1" visible; `onAddMonster` not called
+- [ ] **Validation: hp > maxHp** — submit with Max HP=10, Current HP=11; "Current HP must be between 0 and Max HP" visible; `onAddMonster` not called
+- [ ] **Validation error clears on tab switch** — trigger "Name is required", switch to Monsters tab, switch back to Create New; error no longer visible
+- [ ] **Cancel calls onClose** — click "Cancel"; `onClose` called once
+
+## Coverage Target Verification
+
+After all test cases pass, run:
+
+```bash
+npx jest --coverage \
+  --collectCoverageFrom='lib/components/QuickCombatantModal.tsx' \
+  tests/unit/components/QuickCombatantModal.test.tsx
+```
+
+Expected:
+- Statement coverage: ≥ 70%
+- Branch coverage: ≥ 55%
+
+If below target, identify uncovered branches via the coverage report and add targeted tests before opening the PR.

--- a/tests/unit/components/QuickCombatantModal.test.tsx
+++ b/tests/unit/components/QuickCombatantModal.test.tsx
@@ -253,6 +253,7 @@ describe('monster selection', () => {
     const user = userEvent.setup();
     const { onAddMonster } = renderModal();
     await user.click(screen.getByRole('button', { name: 'Add Goblin to encounter' }));
+    expect(onAddMonster).toHaveBeenCalledTimes(1);
     expect(onAddMonster).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'test-uuid', templateId: 'g1', name: 'Goblin', hp: 7, ac: 15 })
     );
@@ -333,6 +334,7 @@ describe('character tab', () => {
     const { onAddCharacter } = renderModal();
     await user.click(screen.getByRole('tab', { name: 'Party Members' }));
     await user.click(screen.getByRole('button', { name: 'Add Aria to combat' }));
+    expect(onAddCharacter).toHaveBeenCalledTimes(1);
     expect(onAddCharacter).toHaveBeenCalledWith(ARIA);
   });
 

--- a/tests/unit/components/QuickCombatantModal.test.tsx
+++ b/tests/unit/components/QuickCombatantModal.test.tsx
@@ -254,7 +254,7 @@ describe('monster selection', () => {
     const { onAddMonster } = renderModal();
     await user.click(screen.getByRole('button', { name: 'Add Goblin to encounter' }));
     expect(onAddMonster).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'test-uuid', templateId: 'g1', name: 'Goblin' })
+      expect.objectContaining({ id: 'test-uuid', templateId: 'g1', name: 'Goblin', hp: 7, ac: 15 })
     );
   });
 
@@ -380,7 +380,7 @@ describe('custom form', () => {
     // Leave Initiative blank
     await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
     expect(onAddMonster).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'Dragon', ac: 15, maxHp: 50, hp: 50 })
+      expect.objectContaining({ name: 'Dragon', ac: 15, maxHp: 50, hp: 50, abilityScores: expect.objectContaining({ dexterity: 14 }) })
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/components/QuickCombatantModal.test.tsx
+++ b/tests/unit/components/QuickCombatantModal.test.tsx
@@ -1,0 +1,518 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QuickCombatantModal } from '@/lib/components/QuickCombatantModal';
+import { MonsterTemplate, Character } from '@/lib/types';
+import { GLOBAL_USER_ID } from '@/lib/constants';
+
+// @ts-expect-error IS_REACT_ACT_ENVIRONMENT
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const USER_ID = 'user-123';
+const OTHER_USER_ID = 'other-user-456';
+
+const makeMonsterTemplate = (overrides: Partial<MonsterTemplate> = {}): MonsterTemplate => ({
+  id: 'g1',
+  userId: GLOBAL_USER_ID,
+  name: 'Goblin',
+  size: 'small',
+  type: 'humanoid',
+  speed: '30 ft.',
+  challengeRating: 0.25,
+  hp: 7,
+  maxHp: 7,
+  ac: 15,
+  abilityScores: {
+    strength: 8,
+    dexterity: 14,
+    constitution: 10,
+    intelligence: 10,
+    wisdom: 8,
+    charisma: 8,
+  },
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+  ...overrides,
+});
+
+const GOBLIN = makeMonsterTemplate({ id: 'g1', userId: GLOBAL_USER_ID, name: 'Goblin' });
+const ORC = makeMonsterTemplate({ id: 'o1', userId: USER_ID, name: 'Orc' });
+const TROLL = makeMonsterTemplate({ id: 't1', userId: OTHER_USER_ID, name: 'Troll' });
+
+const MONSTER_TEMPLATES = [GOBLIN, ORC, TROLL];
+
+const makeCharacter = (overrides: Partial<Character> = {}): Character => ({
+  id: 'c1',
+  userId: USER_ID,
+  name: 'Aria',
+  classes: [{ class: 'Rogue', level: 3 }],
+  hp: 20,
+  maxHp: 20,
+  ac: 14,
+  abilityScores: {
+    strength: 10,
+    dexterity: 16,
+    constitution: 12,
+    intelligence: 12,
+    wisdom: 10,
+    charisma: 12,
+  },
+  ...overrides,
+});
+
+const ARIA = makeCharacter({ id: 'c1', name: 'Aria' });
+const BRON = makeCharacter({ id: 'c2', name: 'Bron' });
+const CHARACTER_TEMPLATES = [ARIA, BRON];
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof QuickCombatantModal>> = {}) {
+  const onAddMonster = jest.fn();
+  const onAddCharacter = jest.fn();
+  const onClose = jest.fn();
+  render(
+    <QuickCombatantModal
+      onAddMonster={onAddMonster}
+      onAddCharacter={onAddCharacter}
+      onClose={onClose}
+      monsterTemplates={MONSTER_TEMPLATES}
+      characterTemplates={CHARACTER_TEMPLATES}
+      userId={USER_ID}
+      showToast={true}
+      {...overrides}
+    />
+  );
+  return { onAddMonster, onAddCharacter, onClose };
+}
+
+describe('render and navigation', () => {
+  beforeEach(() => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('modal renders with monsters tab active by default', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Add Combatant' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Monsters' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Party Members' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: 'Create New' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('close button calls onClose', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByRole('button', { name: 'Close modal' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('backdrop click calls onClose', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByRole('dialog'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking inside the modal does NOT call onClose', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    // Click on the heading — inside the modal card
+    await user.click(screen.getByRole('heading', { name: 'Add Combatant' }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('switching to Party Members tab updates aria-selected', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    expect(screen.getByRole('tab', { name: 'Party Members' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Monsters' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('switching to Create New tab makes custom form visible', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Create New' }));
+    expect(screen.getByRole('button', { name: 'Add Combatant' })).toBeInTheDocument();
+  });
+
+  test('tab switch resets search query and creator filter to defaults', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    // Type in search and click a filter
+    await user.type(screen.getByLabelText('Search monsters'), 'Goblin');
+    await user.click(screen.getByRole('button', { name: 'My' }));
+    // Switch to Party Members then back to Monsters
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    await user.click(screen.getByRole('tab', { name: 'Monsters' }));
+    expect(screen.getByLabelText('Search monsters')).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('monster tab states', () => {
+  test('loadingTemplates=true shows "Loading templates..." and hides search input', () => {
+    renderModal({ loadingTemplates: true });
+    expect(screen.getByText('Loading templates...')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Search monsters')).not.toBeInTheDocument();
+  });
+
+  test('monsterTemplates=[] shows "No monster templates available" with link', () => {
+    renderModal({ monsterTemplates: [] });
+    expect(screen.getByText(/No monster templates available/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Create one' })).toBeInTheDocument();
+  });
+});
+
+describe('monster search and filter', () => {
+  beforeEach(() => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('all monsters visible initially', () => {
+    renderModal();
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+    expect(screen.getByText('Orc')).toBeInTheDocument();
+    expect(screen.getByText('Troll')).toBeInTheDocument();
+  });
+
+  test('typing "Goblin" filters list to Goblin only', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.type(screen.getByLabelText('Search monsters'), 'Goblin');
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+    expect(screen.queryByText('Orc')).not.toBeInTheDocument();
+    expect(screen.queryByText('Troll')).not.toBeInTheDocument();
+  });
+
+  test('clearing search restores all monsters', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    const input = screen.getByLabelText('Search monsters');
+    await user.type(input, 'Goblin');
+    await user.clear(input);
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+    expect(screen.getByText('Orc')).toBeInTheDocument();
+    expect(screen.getByText('Troll')).toBeInTheDocument();
+  });
+
+  test('no-match search shows empty state message', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.type(screen.getByLabelText('Search monsters'), 'zzznomatch');
+    expect(screen.getByText(/No monsters match your search and filter criteria/)).toBeInTheDocument();
+  });
+
+  test('"My" filter shows only user\'s monster', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: 'My' }));
+    expect(screen.getByText('Orc')).toBeInTheDocument();
+    expect(screen.queryByText('Goblin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Troll')).not.toBeInTheDocument();
+  });
+
+  test('"Global" filter shows only global monster', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: 'Global' }));
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+    expect(screen.queryByText('Orc')).not.toBeInTheDocument();
+    expect(screen.queryByText('Troll')).not.toBeInTheDocument();
+  });
+
+  test('"Other" filter shows only shared monster', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: 'Other' }));
+    expect(screen.getByText('Troll')).toBeInTheDocument();
+    expect(screen.queryByText('Goblin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Orc')).not.toBeInTheDocument();
+  });
+
+  test('"All" filter after "Global" shows all monsters', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: 'Global' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+    expect(screen.getByText('Orc')).toBeInTheDocument();
+    expect(screen.getByText('Troll')).toBeInTheDocument();
+  });
+});
+
+describe('monster selection', () => {
+  beforeEach(() => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('clicking Add calls onAddMonster with correct payload', async () => {
+    const user = userEvent.setup();
+    const { onAddMonster } = renderModal();
+    await user.click(screen.getByRole('button', { name: 'Add Goblin to encounter' }));
+    expect(onAddMonster).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'test-uuid', templateId: 'g1', name: 'Goblin' })
+    );
+  });
+
+  test('adding monster shows success toast', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: 'Add Goblin to encounter' }));
+    expect(screen.getByText('Goblin added successfully')).toBeInTheDocument();
+  });
+
+  test('adding monster with showToast=false shows no toast', async () => {
+    const user = userEvent.setup();
+    renderModal({ showToast: false });
+    await user.click(screen.getByRole('button', { name: 'Add Goblin to encounter' }));
+    expect(screen.queryByText('Goblin added successfully')).not.toBeInTheDocument();
+  });
+
+  test('modal stays open after adding', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByRole('button', { name: 'Add Goblin to encounter' }));
+    expect(screen.getByRole('heading', { name: 'Add Combatant' })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('(Global) badge rendered for global monster', () => {
+    renderModal();
+    expect(screen.getAllByText('(Global)').length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('(Mine) badge rendered for user\'s own monster', () => {
+    renderModal();
+    expect(screen.getAllByText('(Mine)').length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('(Shared) badge rendered for other user\'s monster', () => {
+    renderModal();
+    expect(screen.getAllByText('(Shared)').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('character tab', () => {
+  beforeEach(() => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('loadingTemplates=true on characters tab shows "Loading characters..."', async () => {
+    const user = userEvent.setup();
+    renderModal({ loadingTemplates: true });
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    expect(screen.getByText('Loading characters...')).toBeInTheDocument();
+  });
+
+  test('characterTemplates=[] shows "No party members available" with link', async () => {
+    const user = userEvent.setup();
+    renderModal({ characterTemplates: [] });
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    expect(screen.getByText(/No party members available/)).toBeInTheDocument();
+  });
+
+  test('characters render when present', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    expect(screen.getByText('Aria')).toBeInTheDocument();
+    expect(screen.getByText('Bron')).toBeInTheDocument();
+  });
+
+  test('typing "Aria" filters to Aria only', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    await user.type(screen.getByLabelText('Search characters'), 'Aria');
+    expect(screen.getByText('Aria')).toBeInTheDocument();
+    expect(screen.queryByText('Bron')).not.toBeInTheDocument();
+  });
+
+  test('clicking Add calls onAddCharacter with the character object', async () => {
+    const user = userEvent.setup();
+    const { onAddCharacter } = renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    await user.click(screen.getByRole('button', { name: 'Add Aria to combat' }));
+    expect(onAddCharacter).toHaveBeenCalledWith(ARIA);
+  });
+
+  test('adding character shows toast', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Party Members' }));
+    await user.click(screen.getByRole('button', { name: 'Add Aria to combat' }));
+    expect(screen.getByText('Aria added successfully')).toBeInTheDocument();
+  });
+});
+
+describe('custom form', () => {
+  beforeEach(() => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function openCustomTab() {
+    const user = userEvent.setup();
+    const mocks = renderModal();
+    await user.click(screen.getByRole('tab', { name: 'Create New' }));
+    return { user, ...mocks };
+  }
+
+  test('form fields render', async () => {
+    await openCustomTab();
+    expect(screen.getByLabelText(/Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Dexterity/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^AC/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max HP/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Current HP/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Initiative/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add Combatant' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  test('happy path — valid inputs → onAddMonster called with correct payload, onClose called', async () => {
+    const { user, onAddMonster, onClose } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    // Clear dexterity default and set to 14
+    await user.clear(screen.getByLabelText(/Dexterity/));
+    await user.type(screen.getByLabelText(/Dexterity/), '14');
+    await user.clear(screen.getByLabelText(/^AC/));
+    await user.type(screen.getByLabelText(/^AC/), '15');
+    await user.clear(screen.getByLabelText(/Max HP/));
+    await user.type(screen.getByLabelText(/Max HP/), '50');
+    await user.clear(screen.getByLabelText(/Current HP/));
+    await user.type(screen.getByLabelText(/Current HP/), '50');
+    // Leave Initiative blank
+    await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
+    expect(onAddMonster).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Dragon', ac: 15, maxHp: 50, hp: 50 })
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('initiative filled → payload includes initiative: 18', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    await user.type(screen.getByLabelText(/Initiative/), '18');
+    await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
+    expect(onAddMonster).toHaveBeenCalledWith(
+      expect.objectContaining({ initiative: 18 })
+    );
+  });
+
+  test('initiative blank → payload does NOT include initiative key', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
+    const call = onAddMonster.mock.calls[0][0];
+    expect(call).not.toHaveProperty('initiative');
+  });
+
+  test('dexterity 14 → modifier displays "+2"', async () => {
+    const { user } = await openCustomTab();
+    await user.clear(screen.getByLabelText(/Dexterity/));
+    await user.type(screen.getByLabelText(/Dexterity/), '14');
+    expect(screen.getByText(/\+2/)).toBeInTheDocument();
+  });
+
+  test('empty name → "Name is required" error, onAddMonster not called', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(onAddMonster).not.toHaveBeenCalled();
+  });
+
+  test('dexterity=0 → dexterity range error, onAddMonster not called', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    // fireEvent.input bypasses jsdom's number input constraint validation;
+    // fireEvent.submit bypasses browser constraint validation that would block onSubmit
+    fireEvent.input(screen.getByLabelText(/Dexterity/), { target: { value: '0' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
+    expect(screen.getByText(/Dexterity must be between 1 and 30/)).toBeInTheDocument();
+    expect(onAddMonster).not.toHaveBeenCalled();
+  });
+
+  test('dexterity=31 → dexterity range error, onAddMonster not called', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    fireEvent.input(screen.getByLabelText(/Dexterity/), { target: { value: '31' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
+    expect(screen.getByText(/Dexterity must be between 1 and 30/)).toBeInTheDocument();
+    expect(onAddMonster).not.toHaveBeenCalled();
+  });
+
+  test('AC=0 → "AC must be at least 1", onAddMonster not called', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    fireEvent.input(screen.getByLabelText(/^AC/), { target: { value: '0' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
+    expect(screen.getByText('AC must be at least 1')).toBeInTheDocument();
+    expect(onAddMonster).not.toHaveBeenCalled();
+  });
+
+  test('maxHp=0 → "Max HP must be at least 1", onAddMonster not called', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    fireEvent.input(screen.getByLabelText(/Max HP/), { target: { value: '0' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
+    expect(screen.getByText('Max HP must be at least 1')).toBeInTheDocument();
+    expect(onAddMonster).not.toHaveBeenCalled();
+  });
+
+  test('hp > maxHp → "Current HP must be between 0 and Max HP", onAddMonster not called', async () => {
+    const { user, onAddMonster } = await openCustomTab();
+    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    await user.clear(screen.getByLabelText(/Max HP/));
+    await user.type(screen.getByLabelText(/Max HP/), '10');
+    await user.clear(screen.getByLabelText(/Current HP/));
+    await user.type(screen.getByLabelText(/Current HP/), '11');
+    await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
+    expect(screen.getByText('Current HP must be between 0 and Max HP')).toBeInTheDocument();
+    expect(onAddMonster).not.toHaveBeenCalled();
+  });
+
+  test('validation error clears when switching tabs', async () => {
+    const { user } = await openCustomTab();
+    // Trigger error
+    await user.click(screen.getByRole('button', { name: 'Add Combatant' }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    // Switch to monsters and back
+    await user.click(screen.getByRole('tab', { name: 'Monsters' }));
+    await user.click(screen.getByRole('tab', { name: 'Create New' }));
+    expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+  });
+
+  test('Cancel button calls onClose', async () => {
+    const { user, onClose } = await openCustomTab();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/QuickCombatantModal.test.tsx
+++ b/tests/unit/components/QuickCombatantModal.test.tsx
@@ -74,6 +74,14 @@ const ARIA = makeCharacter({ id: 'c1', name: 'Aria' });
 const BRON = makeCharacter({ id: 'c2', name: 'Bron' });
 const CHARACTER_TEMPLATES = [ARIA, BRON];
 
+beforeEach(() => {
+  jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 function renderModal(overrides: Partial<React.ComponentProps<typeof QuickCombatantModal>> = {}) {
   const onAddMonster = jest.fn();
   const onAddCharacter = jest.fn();
@@ -94,14 +102,6 @@ function renderModal(overrides: Partial<React.ComponentProps<typeof QuickCombata
 }
 
 describe('render and navigation', () => {
-  beforeEach(() => {
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   test('modal renders with monsters tab active by default', () => {
     renderModal();
     expect(screen.getByRole('heading', { name: 'Add Combatant' })).toBeInTheDocument();
@@ -176,14 +176,6 @@ describe('monster tab states', () => {
 });
 
 describe('monster search and filter', () => {
-  beforeEach(() => {
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   test('all monsters visible initially', () => {
     renderModal();
     expect(screen.getByText('Goblin')).toBeInTheDocument();
@@ -257,14 +249,6 @@ describe('monster search and filter', () => {
 });
 
 describe('monster selection', () => {
-  beforeEach(() => {
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   test('clicking Add calls onAddMonster with correct payload', async () => {
     const user = userEvent.setup();
     const { onAddMonster } = renderModal();
@@ -313,14 +297,6 @@ describe('monster selection', () => {
 });
 
 describe('character tab', () => {
-  beforeEach(() => {
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   test('loadingTemplates=true on characters tab shows "Loading characters..."', async () => {
     const user = userEvent.setup();
     renderModal({ loadingTemplates: true });
@@ -370,14 +346,6 @@ describe('character tab', () => {
 });
 
 describe('custom form', () => {
-  beforeEach(() => {
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid' as `${string}-${string}-${string}-${string}-${string}`);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   async function openCustomTab() {
     const user = userEvent.setup();
     const mocks = renderModal();
@@ -450,8 +418,8 @@ describe('custom form', () => {
   });
 
   test('dexterity=0 → dexterity range error, onAddMonster not called', async () => {
-    const { user, onAddMonster } = await openCustomTab();
-    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    const { onAddMonster } = await openCustomTab();
+    fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'Dragon' } });
     // fireEvent.input bypasses jsdom's number input constraint validation;
     // fireEvent.submit bypasses browser constraint validation that would block onSubmit
     fireEvent.input(screen.getByLabelText(/Dexterity/), { target: { value: '0' } });
@@ -461,8 +429,8 @@ describe('custom form', () => {
   });
 
   test('dexterity=31 → dexterity range error, onAddMonster not called', async () => {
-    const { user, onAddMonster } = await openCustomTab();
-    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    const { onAddMonster } = await openCustomTab();
+    fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'Dragon' } });
     fireEvent.input(screen.getByLabelText(/Dexterity/), { target: { value: '31' } });
     fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
     expect(screen.getByText(/Dexterity must be between 1 and 30/)).toBeInTheDocument();
@@ -470,8 +438,8 @@ describe('custom form', () => {
   });
 
   test('AC=0 → "AC must be at least 1", onAddMonster not called', async () => {
-    const { user, onAddMonster } = await openCustomTab();
-    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    const { onAddMonster } = await openCustomTab();
+    fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'Dragon' } });
     fireEvent.input(screen.getByLabelText(/^AC/), { target: { value: '0' } });
     fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
     expect(screen.getByText('AC must be at least 1')).toBeInTheDocument();
@@ -479,8 +447,8 @@ describe('custom form', () => {
   });
 
   test('maxHp=0 → "Max HP must be at least 1", onAddMonster not called', async () => {
-    const { user, onAddMonster } = await openCustomTab();
-    await user.type(screen.getByLabelText(/Name/), 'Dragon');
+    const { onAddMonster } = await openCustomTab();
+    fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'Dragon' } });
     fireEvent.input(screen.getByLabelText(/Max HP/), { target: { value: '0' } });
     fireEvent.submit(screen.getByRole('button', { name: 'Add Combatant' }).closest('form')!);
     expect(screen.getByText('Max HP must be at least 1')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Adds a comprehensive RTL unit test suite for `lib/components/QuickCombatantModal.tsx`.

Closes #258

## Coverage Results

| Metric | Result | Target |
|--------|--------|--------|
| Statements | 90.69% | ≥ 70% |
| Branches | 88.49% | ≥ 55% |

## Test Breakdown (43 tests)

- **render and navigation** (7) — default tab state, close button, backdrop click, inner-click no-close, tab switching, reset on switch
- **monster tab states** (2) — loading state, empty state
- **monster search and filter** (8) — initial display, search filtering, clear, no-match, My/Global/Other/All filters
- **monster selection** (7) — payload shape, toast shown/hidden, modal stays open, badge rendering
- **character tab** (6) — loading, empty, render, search filter, add callback, toast
- **custom form** (13) — field render, happy path (with/without initiative), modifier display, all validation branches (name/dex/AC/maxHp/hp), error clear on tab switch, cancel

## Notable Implementation Details

- Uses `fireEvent.input` + `fireEvent.submit` for number inputs with `min`/`max` constraints — jsdom enforces HTML5 constraint validation during button-triggered form submit, blocking React's `onSubmit` when values are outside range
- Uses `getAllByText` for badge assertions (hidden tab panels remain in DOM simultaneously)
- Real Fuse.js (not mocked) with clearly distinct fixture names (Goblin/Orc/Troll)
- Deterministic `crypto.randomUUID` spy for payload assertions