### PR TITLE
docs: archive active-and-setup-view-integration-tests (2026-05-29)

### DIFF
--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/design.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/design.md
@@ -1,0 +1,119 @@
+## Context
+
+- Relevant architecture: `ActiveCombatView` and `CombatSetupView` are the two top-level orchestrator components in the combat feature. Both receive the full `UseCombatReturn` interface (50 members) as props, spread from the `useCombat` hook called in `app/combat/page.tsx`. Child components (`CombatantCard`, `InitiativeEntry`, `LairActionsSlot`, `LegendaryActionsPanel`, `CombatInfoIcon`, `Modal`, `QuickCombatantModal`) render inside them.
+- Dependencies: `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event` (all installed via #254). `jest.setup.ts` already imports `@testing-library/jest-dom`. `jest.config.js` uses `testEnvironment: jsdom`.
+- Interfaces/contracts touched: `UseCombatReturn` (lib/hooks/useCombat.ts), `makeUseCombat` factory (tests/unit/fixtures/useCombat.ts).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Achieve ≥ 60% statement coverage for both `ActiveCombatView.tsx` and `CombatSetupView.tsx`
+- Exercise key user flows via RTL: render, turn advance, modal triggers, combatant removal
+- Reuse the existing `makeUseCombat` fixture without duplication
+
+### Non-Goals
+
+- Testing `useCombat` hook logic (covered elsewhere)
+- 100% coverage — only major orchestration paths are required
+- E2E or API-layer testing
+
+## Decisions
+
+### Decision 1: Test placement in tests/unit/components/
+
+- Chosen: `tests/unit/components/ActiveCombatView.test.tsx` and `tests/unit/components/CombatSetupView.test.tsx`
+- Alternatives considered: `tests/integration/components/` (as suggested in the GitHub issue)
+- Rationale: These tests mock `useCombat` at the module boundary and render child components for real — no real persistence layer, no server, no database. That is a unit test by the project's definition. The `integration` label in the issue referred to the testing strategy (one mock, real children), not the test tier.
+- Trade-offs: Runs under `npm test` only, not `npm run test:integration`. This is correct — the integration suite is for API/server tests with a real database.
+
+### Decision 2: Reuse makeUseCombat from tests/unit/fixtures/useCombat.ts
+
+- Chosen: Import `makeUseCombat` directly from `@/tests/unit/fixtures/useCombat`
+- Alternatives considered: Creating a new `tests/integration/helpers/makeCombatReturn.ts` (as specified in the issue)
+- Rationale: The fixture already exists, is complete (all 50 members), and is already used by `tests/unit/combat/combatPage.test.tsx`. Duplicating it adds maintenance burden with no benefit.
+- Trade-offs: None — the existing factory is a direct fit.
+
+### Decision 3: Mock useCombat at module boundary, render children for real
+
+- Chosen: `jest.mock('@/lib/hooks/useCombat', () => ({ useCombat: jest.fn() }))` with `(useCombat as jest.Mock).mockReturnValue(makeUseCombat(overrides))` per test
+- Alternatives considered: Mocking all child components; full shallow rendering
+- Rationale: One mock at the hook boundary tests the wiring between the hook contract and the rendered UI in a realistic way. Child components are already tested in their own files.
+- Trade-offs: If a child component has a rendering bug it could cause false failures. Mitigated by having child component tests pass in CI before this work begins.
+
+### Decision 4: Mock next/link
+
+- Chosen: `jest.mock('next/link', () => ({ default: ({ children }: any) => children }))`
+- Rationale: Next.js router is not available in jsdom. This is a standard pattern already present in the test suite.
+- Trade-offs: None.
+
+## Proposal to Design Mapping
+
+- Proposal element: Tests in `tests/unit/components/` using unit jest config
+  - Design decision: Decision 1
+  - Validation approach: Files picked up by `jest.config.js` glob `**/tests/**/*.test.(ts|tsx)`
+- Proposal element: Reuse `makeUseCombat` fixture, no new helper
+  - Design decision: Decision 2
+  - Validation approach: Import resolves; TypeScript compilation succeeds
+- Proposal element: Mock hook at module boundary, render children for real
+  - Design decision: Decision 3
+  - Validation approach: RTL `render`, `screen` queries, `userEvent` interactions
+
+## Functional Requirements Mapping
+
+- Requirement: ActiveCombatView renders combatant list in initiative order
+  - Design element: `makeUseCombat({ combatState: mockState })` + `getDisplayCombatants` mock
+  - Acceptance criteria reference: specs/active-combat-view.md
+  - Testability notes: RTL `screen.getByText` on combatant names
+- Requirement: Next turn button calls `nextTurn()`
+  - Design element: `userEvent.click` on "Next Turn" button; assert `nextTurn` mock called
+  - Acceptance criteria reference: specs/active-combat-view.md
+  - Testability notes: Button accessible by role
+- Requirement: Encounter description modal opens/closes
+  - Design element: `setShowEncounterDescription` mock; re-render with `showEncounterDescription: true`
+  - Acceptance criteria reference: specs/active-combat-view.md
+  - Testability notes: Modal content visible/hidden based on prop
+- Requirement: CombatSetupView renders setup combatant list
+  - Design element: `makeUseCombat({ setupCombatants: [...] })`
+  - Acceptance criteria reference: specs/combat-setup-view.md
+  - Testability notes: RTL `screen.getByText` on combatant names
+- Requirement: Start combat button calls `startCombatWithSetupCombatants()`
+  - Design element: `userEvent.click` on "Start Combat"; assert mock called
+  - Acceptance criteria reference: specs/combat-setup-view.md
+  - Testability notes: Button accessible by role
+- Requirement: Add combatant button calls `setShowCombatantModal(true)`
+  - Design element: `userEvent.click` on add button; assert mock called with `true`
+  - Acceptance criteria reference: specs/combat-setup-view.md
+  - Testability notes: Button accessible by role or text
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Tests must pass consistently in CI without flakiness
+  - Design element: No timers, no real async I/O; all mocks return synchronous values
+  - Acceptance criteria reference: All tests green in CI
+  - Testability notes: `userEvent` setup/cleanup per test via `beforeEach`
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Child component rendering may surface unexpected dependency requirements
+  - Impact: Additional mocks needed (e.g., CSS modules, SVG imports)
+  - Mitigation: `jest.config.js` already has moduleNameMapper and transform configured for the project; same patterns used in existing component tests
+
+## Rollback / Mitigation
+
+- Rollback trigger: New test files cause existing tests to fail or CI to break
+- Rollback steps: Delete the two new test files; no production code is touched
+- Data migration considerations: None
+- Verification after rollback: `npm test` green
+
+## Operational Blocking Policy
+
+- If CI checks fail: Investigate and fix before merging; do not use `--no-verify` or admin merge
+- If security checks fail: Same — fix the root cause
+- If required reviews are blocked/stale: Ping reviewers; do not self-merge without review
+- Escalation path and timeout: If blocked for >2 business days, raise in the project channel
+
+## Open Questions
+
+No open questions. All decisions confirmed during explore session.

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/proposal.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/proposal.md
@@ -1,0 +1,61 @@
+## GitHub Issues
+
+- #259
+
+## Why
+
+- Problem statement: `ActiveCombatView.tsx` (403 lines) and `CombatSetupView.tsx` (193 lines) have 0% coverage. These are the two top-level orchestrator components that wire all combat UI together — bugs in their prop threading, modal triggers, and callback dispatch are currently undetectable.
+- Why now: All four blocker issues (#254 RTL infra, #256 CombatantCard, #257 standalone components, #258 QuickCombatantModal) are now closed. This is Wave 3 of the Testing Quality Initiative (#242).
+- Business/user impact: The combat flow is the primary user interaction surface. Regressions in turn advancement, combatant removal, or modal triggers would be high-visibility and currently undetected by CI.
+
+## Problem Space
+
+- Current behavior: Both components have 0% statement coverage. No tests exist for the orchestration layer.
+- Desired behavior: Both components reach ≥ 60% statement coverage. Key user flows (render, turn advance, modal open/close, remove combatant) are exercised by automated tests.
+- Constraints: `UseCombatReturn` has 50 members. Unit testing at full isolation would require mocking all 50. Instead, mock the `useCombat` hook at the module boundary and render child components for real — one mock, realistic rendering.
+- Assumptions: The `makeUseCombat` factory at `tests/unit/fixtures/useCombat.ts` is complete and covers all 50 members of `UseCombatReturn`. Child components (`CombatantCard`, `InitiativeEntry`, `LairActionsSlot`, etc.) are already covered by their own tests.
+- Edge cases considered: Components that depend on `combatState` being null vs. populated; `setupCombatants` being empty vs. non-empty; modal open/close state toggling via boolean flags in the hook return.
+
+## Scope
+
+### In Scope
+
+- `tests/unit/components/ActiveCombatView.test.tsx` — new test file
+- `tests/unit/components/CombatSetupView.test.tsx` — new test file
+- Reuse of `tests/unit/fixtures/useCombat.ts` (`makeUseCombat`) as the mock factory
+
+### Out of Scope
+
+- No new shared helper file (the existing fixture already serves this purpose)
+- No changes to `jest.config.js` or `jest.integration.config.js`
+- No migration of existing tests
+- No tests for child components (covered separately)
+
+## What Changes
+
+- New file: `tests/unit/components/ActiveCombatView.test.tsx`
+- New file: `tests/unit/components/CombatSetupView.test.tsx`
+
+## Risks
+
+- Risk: Child components render for real and may themselves require additional mocking (e.g., `next/link`, Next.js router).
+  - Impact: Test setup complexity could be higher than expected.
+  - Mitigation: `next/link` mock is a one-liner already used elsewhere in the test suite. Other child components were explicitly tested first (#256, #257, #258) to ensure they render cleanly in isolation.
+- Risk: Coverage target of ≥ 60% may not be reachable with the scenarios listed if conditional branches are numerous.
+  - Impact: Acceptance criteria not met.
+  - Mitigation: The issue analysis shows the listed scenarios map to the major uncovered code paths. If 60% is not reachable, add scenarios for remaining branches before closing.
+
+## Open Questions
+
+No unresolved ambiguity. The approach, file locations, fixture reuse, and test scope were all confirmed during the explore session preceding this proposal.
+
+## Non-Goals
+
+- End-to-end tests for the combat flow
+- Testing the `useCombat` hook itself (covered by `tests/unit/combat/combatPage.test.tsx`)
+- Migrating existing combat tests to RTL
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/specs/active-combat-view.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/specs/active-combat-view.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED ActiveCombatView renders combatant list
+
+The system SHALL render the list of combatants returned by `getDisplayCombatants()` when `combatState` is populated.
+
+#### Scenario: Combatant names appear in the rendered output
+
+- **Given** `useCombat` is mocked to return a `combatState` with two combatants and `getDisplayCombatants` returns those combatants
+- **When** `ActiveCombatView` is rendered
+- **Then** both combatant names are visible in the document
+
+#### Scenario: No combatants renders an empty list
+
+- **Given** `useCombat` is mocked with `combatState: null` and `getDisplayCombatants` returning `[]`
+- **When** `ActiveCombatView` is rendered
+- **Then** no combatant name elements are present
+
+---
+
+### Requirement: ADDED Next turn button dispatches nextTurn callback
+
+The system SHALL call `nextTurn()` when the user clicks the "Next Turn" button.
+
+#### Scenario: Clicking next turn invokes the callback
+
+- **Given** `ActiveCombatView` is rendered with a mocked `nextTurn` jest.fn()
+- **When** the user clicks the "Next Turn" button
+- **Then** the `nextTurn` mock is called exactly once
+
+---
+
+### Requirement: ADDED Active combatant is visually distinguished
+
+The system SHALL render the active combatant with a visual indicator distinguishing it from inactive combatants.
+
+#### Scenario: Active combatant has a distinguishing marker
+
+- **Given** `combatState` has `currentTurnIndex` pointing to combatant at index 0
+- **When** `ActiveCombatView` is rendered
+- **Then** the first combatant element has a CSS class or attribute indicating it is active
+
+---
+
+### Requirement: ADDED Encounter description modal is controlled by showEncounterDescription
+
+The system SHALL render the encounter description modal when `showEncounterDescription` is `true` and hide it when `false`.
+
+#### Scenario: Modal is visible when showEncounterDescription is true
+
+- **Given** `useCombat` is mocked with `showEncounterDescription: true`
+- **When** `ActiveCombatView` is rendered
+- **Then** the encounter description modal content is visible in the document
+
+#### Scenario: Modal is not visible when showEncounterDescription is false
+
+- **Given** `useCombat` is mocked with `showEncounterDescription: false`
+- **When** `ActiveCombatView` is rendered
+- **Then** the encounter description modal content is not present or hidden
+
+---
+
+### Requirement: ADDED Remove combatant confirm flow triggers removeCombatant
+
+The system SHALL call `removeCombatant()` when the user confirms the remove action.
+
+#### Scenario: Confirming removal calls the callback
+
+- **Given** `ActiveCombatView` is rendered with `removeConfirmId` set to a combatant ID and a mocked `removeCombatant`
+- **When** the user clicks the confirm remove button
+- **Then** `removeCombatant` is called with the expected combatant ID
+
+## MODIFIED Requirements
+
+None. This is a new test file — no existing requirements are modified.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element: ActiveCombatView 0% coverage → Requirements: render, nextTurn, active highlight, modal, remove
+- Design decision 1 (tests/unit/components/) → all requirements in this file
+- Design decision 3 (mock at module boundary) → all scenario Given clauses
+- Requirements → Task: "Create tests/unit/components/ActiveCombatView.test.tsx" in tasks.md
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Tests pass consistently in CI
+
+- **Given** the test suite runs in a clean jsdom environment with no real network or timer dependencies
+- **When** `npm test` executes `ActiveCombatView.test.tsx`
+- **Then** all tests pass on every run without flakiness

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/specs/combat-setup-view.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/specs/combat-setup-view.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED CombatSetupView renders setup combatant list
+
+The system SHALL render the list of combatants in `setupCombatants` when the array is non-empty.
+
+#### Scenario: Setup combatant names appear in the rendered output
+
+- **Given** `useCombat` is mocked to return `setupCombatants` with two entries
+- **When** `CombatSetupView` is rendered
+- **Then** both combatant names are visible in the document
+
+#### Scenario: Empty setupCombatants renders an empty list
+
+- **Given** `useCombat` is mocked with `setupCombatants: []`
+- **When** `CombatSetupView` is rendered
+- **Then** no combatant name elements are present in the setup list
+
+---
+
+### Requirement: ADDED Start combat button dispatches startCombatWithSetupCombatants callback
+
+The system SHALL call `startCombatWithSetupCombatants()` when the user clicks the "Start Combat" button.
+
+#### Scenario: Clicking start combat invokes the callback
+
+- **Given** `CombatSetupView` is rendered with a mocked `startCombatWithSetupCombatants` jest.fn()
+- **When** the user clicks the "Start Combat" button
+- **Then** the `startCombatWithSetupCombatants` mock is called exactly once
+
+---
+
+### Requirement: ADDED Add combatant button opens QuickCombatantModal
+
+The system SHALL call `setShowCombatantModal(true)` when the user clicks the "Add Combatant" button.
+
+#### Scenario: Clicking add combatant calls setShowCombatantModal with true
+
+- **Given** `CombatSetupView` is rendered with a mocked `setShowCombatantModal` jest.fn()
+- **When** the user clicks the "Add Combatant" button
+- **Then** `setShowCombatantModal` is called with `true`
+
+#### Scenario: QuickCombatantModal is visible when showCombatantModal is true
+
+- **Given** `useCombat` is mocked with `showCombatantModal: true`
+- **When** `CombatSetupView` is rendered
+- **Then** the `QuickCombatantModal` is present in the document
+
+---
+
+### Requirement: ADDED Remove from setup calls removeCombatantFromSetup
+
+The system SHALL call `removeCombatantFromSetup()` with the correct ID when the user removes a combatant from the setup list.
+
+#### Scenario: Remove button calls the callback with the combatant ID
+
+- **Given** `CombatSetupView` is rendered with one setup combatant and a mocked `removeCombatantFromSetup` jest.fn()
+- **When** the user clicks the remove button for that combatant
+- **Then** `removeCombatantFromSetup` is called with the combatant's ID
+
+## MODIFIED Requirements
+
+None. This is a new test file — no existing requirements are modified.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element: CombatSetupView 0% coverage → Requirements: render, start combat, add modal, remove from setup
+- Design decision 1 (tests/unit/components/) → all requirements in this file
+- Design decision 3 (mock at module boundary) → all scenario Given clauses
+- Requirements → Task: "Create tests/unit/components/CombatSetupView.test.tsx" in tasks.md
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Tests pass consistently in CI
+
+- **Given** the test suite runs in a clean jsdom environment with no real network or timer dependencies
+- **When** `npm test` executes `CombatSetupView.test.tsx`
+- **Then** all tests pass on every run without flakiness

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tasks.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tasks.md
@@ -68,10 +68,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 - [x] Commit all changes to `test/active-and-setup-view-integration-tests` and push to remote
 - [x] Open PR from `test/active-and-setup-view-integration-tests` to `main`. PR body must include `Closes #259`.
 - [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
-- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
-- [ ] **Monitor CI checks** — poll using `gh pr checks <PR-URL> --json name,state`; when any required check fails, diagnose and fix, commit, follow all steps in [Remote push validation], push, wait 180 seconds then repeat until all required checks pass
-- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [x] **Monitor CI checks** — poll using `gh pr checks <PR-URL> --json name,state`; when any required check fails, diagnose and fix, commit, follow all steps in [Remote push validation], push, wait 180 seconds then repeat until all required checks pass
+- [x] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
 
 Ownership metadata:
 
@@ -87,14 +87,14 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify new test files appear on `main`
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync approved spec deltas into `openspec/specs/` (global spec): copy `specs/active-combat-view.md` and `specs/combat-setup-view.md` to `openspec/specs/active-and-setup-view-integration-tests/`
-- [ ] Archive the change: move `openspec/changes/active-and-setup-view-integration-tests/` to `openspec/changes/archive/YYYY-MM-DD-active-and-setup-view-integration-tests/` **in a single atomic commit** — stage both the new location and the deletion of the original
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-active-and-setup-view-integration-tests/` exists and `openspec/changes/active-and-setup-view-integration-tests/` is gone
-- [ ] **Create a doc branch**: `git checkout -b doc/archive-YYYY-MM-DD-active-and-setup-view-integration-tests` then `git push -u origin doc/archive-YYYY-MM-DD-active-and-setup-view-integration-tests`
-- [ ] Open a PR from the doc branch to `main` with title `docs: archive active-and-setup-view-integration-tests (YYYY-MM-DD)`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
-- [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d test/active-and-setup-view-integration-tests doc/archive-YYYY-MM-DD-active-and-setup-view-integration-tests`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify new test files appear on `main`
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Sync approved spec deltas into `openspec/specs/` (global spec): copy `specs/active-combat-view.md` and `specs/combat-setup-view.md` to `openspec/specs/active-and-setup-view-integration-tests/`
+- [x] Archive the change: move `openspec/changes/active-and-setup-view-integration-tests/` to `openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/` **in a single atomic commit** — stage both the new location and the deletion of the original
+- [x] Confirm `openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/` exists and `openspec/changes/active-and-setup-view-integration-tests/` is gone
+- [x] **Create a doc branch**: `git checkout -b doc/archive-2026-05-29-active-and-setup-view-integration-tests` then `git push -u origin doc/archive-2026-05-29-active-and-setup-view-integration-tests`
+- [x] Open a PR from the doc branch to `main` with title `docs: archive active-and-setup-view-integration-tests (2026-05-29)`
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [x] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d test/active-and-setup-view-integration-tests doc/archive-2026-05-29-active-and-setup-view-integration-tests`

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tests.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tests.md
@@ -25,38 +25,38 @@ For each test case below:
 
 Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/active-combat-view.md`
 
-- [ ] **ACT-1** Renders combatant names from `getDisplayCombatants`
+- [x] **ACT-1** Renders combatant names from `getDisplayCombatants`
   - Scenario: "Combatant names appear in the rendered output"
   - Mock: `getDisplayCombatants` returns `[{ name: 'Goblin', ... }, { name: 'Orc', ... }]`
   - Assert: `screen.getByText('Goblin')` and `screen.getByText('Orc')` present
 
-- [ ] **ACT-2** Empty combatant list renders no combatant elements
+- [x] **ACT-2** Empty combatant list renders no combatant elements
   - Scenario: "No combatants renders an empty list"
   - Mock: `getDisplayCombatants` returns `[]`, `combatState: null`
   - Assert: no combatant name elements in document
 
-- [ ] **ACT-3** Clicking "Next Turn" calls `nextTurn()` exactly once
+- [x] **ACT-3** Clicking "Next Turn" calls `nextTurn()` exactly once
   - Scenario: "Clicking next turn invokes the callback"
   - Mock: `nextTurn: jest.fn()`
   - Interact: `await userEvent.click(screen.getByRole('button', { name: /next turn/i }))`
   - Assert: `expect(nextTurn).toHaveBeenCalledTimes(1)`
 
-- [ ] **ACT-4** Active combatant has a visual indicator
+- [x] **ACT-4** Active combatant has a visual indicator
   - Scenario: "Active combatant has a distinguishing marker"
   - Mock: `combatState.currentTurnIndex = 0`, `getDisplayCombatants` returns one combatant
   - Assert: active combatant element has expected class or `aria-current` attribute
 
-- [ ] **ACT-5** Encounter description modal visible when `showEncounterDescription: true`
+- [x] **ACT-5** Encounter description modal visible when `showEncounterDescription: true`
   - Scenario: "Modal is visible when showEncounterDescription is true"
   - Mock: `makeUseCombat({ showEncounterDescription: true })`
   - Assert: modal content element is in the document
 
-- [ ] **ACT-6** Encounter description modal absent when `showEncounterDescription: false`
+- [x] **ACT-6** Encounter description modal absent when `showEncounterDescription: false`
   - Scenario: "Modal is not visible when showEncounterDescription is false"
   - Mock: `makeUseCombat({ showEncounterDescription: false })`
   - Assert: modal content element is not present or has `hidden` attribute
 
-- [ ] **ACT-7** Confirming remove calls `removeCombatant` with correct ID
+- [x] **ACT-7** Confirming remove calls `removeCombatant` with correct ID
   - Scenario: "Confirming removal calls the callback"
   - Mock: `removeConfirmId: 'c1'`, `removeCombatant: jest.fn()`
   - Interact: `await userEvent.click(screen.getByRole('button', { name: /confirm/i }))`
@@ -68,34 +68,34 @@ Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/
 
 Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/combat-setup-view.md`
 
-- [ ] **CSV-1** Renders setup combatant names from `setupCombatants`
+- [x] **CSV-1** Renders setup combatant names from `setupCombatants`
   - Scenario: "Setup combatant names appear in the rendered output"
   - Mock: `setupCombatants: [{ name: 'Fighter', ... }, { name: 'Rogue', ... }]`
   - Assert: `screen.getByText('Fighter')` and `screen.getByText('Rogue')` present
 
-- [ ] **CSV-2** Empty `setupCombatants` renders no combatant elements
+- [x] **CSV-2** Empty `setupCombatants` renders no combatant elements
   - Scenario: "Empty setupCombatants renders an empty list"
   - Mock: `setupCombatants: []`
   - Assert: no combatant name elements in setup list
 
-- [ ] **CSV-3** Clicking "Start Combat" calls `startCombatWithSetupCombatants()` exactly once
+- [x] **CSV-3** Clicking "Start Combat" calls `startCombatWithSetupCombatants()` exactly once
   - Scenario: "Clicking start combat invokes the callback"
   - Mock: `startCombatWithSetupCombatants: jest.fn()`
   - Interact: `await userEvent.click(screen.getByRole('button', { name: /start combat/i }))`
   - Assert: `expect(startCombatWithSetupCombatants).toHaveBeenCalledTimes(1)`
 
-- [ ] **CSV-4** Clicking "Add Combatant" calls `setShowCombatantModal(true)`
+- [x] **CSV-4** Clicking "Add Combatant" calls `setShowCombatantModal(true)`
   - Scenario: "Clicking add combatant calls setShowCombatantModal with true"
   - Mock: `setShowCombatantModal: jest.fn()`
   - Interact: click the add combatant button
   - Assert: `expect(setShowCombatantModal).toHaveBeenCalledWith(true)`
 
-- [ ] **CSV-5** `QuickCombatantModal` visible when `showCombatantModal: true`
+- [x] **CSV-5** `QuickCombatantModal` visible when `showCombatantModal: true`
   - Scenario: "QuickCombatantModal is visible when showCombatantModal is true"
   - Mock: `makeUseCombat({ showCombatantModal: true })`
   - Assert: modal element or its title is present in the document
 
-- [ ] **CSV-6** Remove button calls `removeCombatantFromSetup` with correct ID
+- [x] **CSV-6** Remove button calls `removeCombatantFromSetup` with correct ID
   - Scenario: "Remove button calls the callback with the combatant ID"
   - Mock: `setupCombatants: [{ id: 's1', name: 'Fighter', ... }]`, `removeCombatantFromSetup: jest.fn()`
   - Interact: click the remove button for 'Fighter'
@@ -105,5 +105,5 @@ Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/
 
 ### Task 3 — Coverage verification (no new test code)
 
-- [ ] **COV-1** `ActiveCombatView.tsx` statement coverage ≥ 60% after ACT-1 through ACT-7 pass
-- [ ] **COV-2** `CombatSetupView.tsx` statement coverage ≥ 60% after CSV-1 through CSV-6 pass
+- [x] **COV-1** `ActiveCombatView.tsx` statement coverage ≥ 60% after ACT-1 through ACT-7 pass
+- [x] **COV-2** `CombatSetupView.tsx` statement coverage ≥ 60% after CSV-1 through CSV-6 pass

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tests.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tests.md
@@ -1,0 +1,109 @@
+---
+name: tests
+description: Tests for the active-and-setup-view-integration-tests change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the test cases for the `active-and-setup-view-integration-tests` change. All work follows a strict TDD process: write a failing test, write the minimum code to pass it, then refactor.
+
+Since this change *is* the tests (no production code changes), the TDD cycle applies to the test file structure itself: write the test shell with a failing assertion, fill in the render/interaction, confirm green.
+
+## Testing Steps
+
+For each test case below:
+
+1. **Write a failing test** — add the `it(...)` block with the assertion before wiring up mocks/interactions. Run; expect failure.
+2. **Wire up the mock/interaction** — configure `makeUseCombat` override and RTL interaction. Run; expect pass.
+3. **Refactor** — extract repeated setup into `beforeEach` or helpers as patterns emerge.
+
+## Test Cases
+
+### Task 1 — `tests/unit/components/ActiveCombatView.test.tsx`
+
+Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/active-combat-view.md`
+
+- [ ] **ACT-1** Renders combatant names from `getDisplayCombatants`
+  - Scenario: "Combatant names appear in the rendered output"
+  - Mock: `getDisplayCombatants` returns `[{ name: 'Goblin', ... }, { name: 'Orc', ... }]`
+  - Assert: `screen.getByText('Goblin')` and `screen.getByText('Orc')` present
+
+- [ ] **ACT-2** Empty combatant list renders no combatant elements
+  - Scenario: "No combatants renders an empty list"
+  - Mock: `getDisplayCombatants` returns `[]`, `combatState: null`
+  - Assert: no combatant name elements in document
+
+- [ ] **ACT-3** Clicking "Next Turn" calls `nextTurn()` exactly once
+  - Scenario: "Clicking next turn invokes the callback"
+  - Mock: `nextTurn: jest.fn()`
+  - Interact: `await userEvent.click(screen.getByRole('button', { name: /next turn/i }))`
+  - Assert: `expect(nextTurn).toHaveBeenCalledTimes(1)`
+
+- [ ] **ACT-4** Active combatant has a visual indicator
+  - Scenario: "Active combatant has a distinguishing marker"
+  - Mock: `combatState.currentTurnIndex = 0`, `getDisplayCombatants` returns one combatant
+  - Assert: active combatant element has expected class or `aria-current` attribute
+
+- [ ] **ACT-5** Encounter description modal visible when `showEncounterDescription: true`
+  - Scenario: "Modal is visible when showEncounterDescription is true"
+  - Mock: `makeUseCombat({ showEncounterDescription: true })`
+  - Assert: modal content element is in the document
+
+- [ ] **ACT-6** Encounter description modal absent when `showEncounterDescription: false`
+  - Scenario: "Modal is not visible when showEncounterDescription is false"
+  - Mock: `makeUseCombat({ showEncounterDescription: false })`
+  - Assert: modal content element is not present or has `hidden` attribute
+
+- [ ] **ACT-7** Confirming remove calls `removeCombatant` with correct ID
+  - Scenario: "Confirming removal calls the callback"
+  - Mock: `removeConfirmId: 'c1'`, `removeCombatant: jest.fn()`
+  - Interact: `await userEvent.click(screen.getByRole('button', { name: /confirm/i }))`
+  - Assert: `expect(removeCombatant).toHaveBeenCalledWith('c1')`
+
+---
+
+### Task 2 — `tests/unit/components/CombatSetupView.test.tsx`
+
+Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/combat-setup-view.md`
+
+- [ ] **CSV-1** Renders setup combatant names from `setupCombatants`
+  - Scenario: "Setup combatant names appear in the rendered output"
+  - Mock: `setupCombatants: [{ name: 'Fighter', ... }, { name: 'Rogue', ... }]`
+  - Assert: `screen.getByText('Fighter')` and `screen.getByText('Rogue')` present
+
+- [ ] **CSV-2** Empty `setupCombatants` renders no combatant elements
+  - Scenario: "Empty setupCombatants renders an empty list"
+  - Mock: `setupCombatants: []`
+  - Assert: no combatant name elements in setup list
+
+- [ ] **CSV-3** Clicking "Start Combat" calls `startCombatWithSetupCombatants()` exactly once
+  - Scenario: "Clicking start combat invokes the callback"
+  - Mock: `startCombatWithSetupCombatants: jest.fn()`
+  - Interact: `await userEvent.click(screen.getByRole('button', { name: /start combat/i }))`
+  - Assert: `expect(startCombatWithSetupCombatants).toHaveBeenCalledTimes(1)`
+
+- [ ] **CSV-4** Clicking "Add Combatant" calls `setShowCombatantModal(true)`
+  - Scenario: "Clicking add combatant calls setShowCombatantModal with true"
+  - Mock: `setShowCombatantModal: jest.fn()`
+  - Interact: click the add combatant button
+  - Assert: `expect(setShowCombatantModal).toHaveBeenCalledWith(true)`
+
+- [ ] **CSV-5** `QuickCombatantModal` visible when `showCombatantModal: true`
+  - Scenario: "QuickCombatantModal is visible when showCombatantModal is true"
+  - Mock: `makeUseCombat({ showCombatantModal: true })`
+  - Assert: modal element or its title is present in the document
+
+- [ ] **CSV-6** Remove button calls `removeCombatantFromSetup` with correct ID
+  - Scenario: "Remove button calls the callback with the combatant ID"
+  - Mock: `setupCombatants: [{ id: 's1', name: 'Fighter', ... }]`, `removeCombatantFromSetup: jest.fn()`
+  - Interact: click the remove button for 'Fighter'
+  - Assert: `expect(removeCombatantFromSetup).toHaveBeenCalledWith('s1')`
+
+---
+
+### Task 3 — Coverage verification (no new test code)
+
+- [ ] **COV-1** `ActiveCombatView.tsx` statement coverage ≥ 60% after ACT-1 through ACT-7 pass
+- [ ] **COV-2** `CombatSetupView.tsx` statement coverage ≥ 60% after CSV-1 through CSV-6 pass

--- a/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tests.md
+++ b/openspec/changes/archive/2026-05-29-active-and-setup-view-integration-tests/tests.md
@@ -23,7 +23,7 @@ For each test case below:
 
 ### Task 1 — `tests/unit/components/ActiveCombatView.test.tsx`
 
-Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/active-combat-view.md`
+Spec reference: `openspec/specs/active-and-setup-view-integration-tests/active-combat-view.md`
 
 - [x] **ACT-1** Renders combatant names from `getDisplayCombatants`
   - Scenario: "Combatant names appear in the rendered output"
@@ -66,7 +66,7 @@ Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/
 
 ### Task 2 — `tests/unit/components/CombatSetupView.test.tsx`
 
-Spec reference: `openspec/changes/active-and-setup-view-integration-tests/specs/combat-setup-view.md`
+Spec reference: `openspec/specs/active-and-setup-view-integration-tests/combat-setup-view.md`
 
 - [x] **CSV-1** Renders setup combatant names from `setupCombatants`
   - Scenario: "Setup combatant names appear in the rendered output"

--- a/openspec/specs/active-and-setup-view-integration-tests/active-combat-view.md
+++ b/openspec/specs/active-and-setup-view-integration-tests/active-combat-view.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED ActiveCombatView renders combatant list
+
+The system SHALL render the list of combatants returned by `getDisplayCombatants()` when `combatState` is populated.
+
+#### Scenario: Combatant names appear in the rendered output
+
+- **Given** `useCombat` is mocked to return a `combatState` with two combatants and `getDisplayCombatants` returns those combatants
+- **When** `ActiveCombatView` is rendered
+- **Then** both combatant names are visible in the document
+
+#### Scenario: No combatants renders an empty list
+
+- **Given** `useCombat` is mocked with `combatState: null` and `getDisplayCombatants` returning `[]`
+- **When** `ActiveCombatView` is rendered
+- **Then** no combatant name elements are present
+
+---
+
+### Requirement: ADDED Next turn button dispatches nextTurn callback
+
+The system SHALL call `nextTurn()` when the user clicks the "Next Turn" button.
+
+#### Scenario: Clicking next turn invokes the callback
+
+- **Given** `ActiveCombatView` is rendered with a mocked `nextTurn` jest.fn()
+- **When** the user clicks the "Next Turn" button
+- **Then** the `nextTurn` mock is called exactly once
+
+---
+
+### Requirement: ADDED Active combatant is visually distinguished
+
+The system SHALL render the active combatant with a visual indicator distinguishing it from inactive combatants.
+
+#### Scenario: Active combatant has a distinguishing marker
+
+- **Given** `combatState` has `currentTurnIndex` pointing to combatant at index 0
+- **When** `ActiveCombatView` is rendered
+- **Then** the first combatant element has a CSS class or attribute indicating it is active
+
+---
+
+### Requirement: ADDED Encounter description modal is controlled by showEncounterDescription
+
+The system SHALL render the encounter description modal when `showEncounterDescription` is `true` and hide it when `false`.
+
+#### Scenario: Modal is visible when showEncounterDescription is true
+
+- **Given** `useCombat` is mocked with `showEncounterDescription: true`
+- **When** `ActiveCombatView` is rendered
+- **Then** the encounter description modal content is visible in the document
+
+#### Scenario: Modal is not visible when showEncounterDescription is false
+
+- **Given** `useCombat` is mocked with `showEncounterDescription: false`
+- **When** `ActiveCombatView` is rendered
+- **Then** the encounter description modal content is not present or hidden
+
+---
+
+### Requirement: ADDED Remove combatant confirm flow triggers removeCombatant
+
+The system SHALL call `removeCombatant()` when the user confirms the remove action.
+
+#### Scenario: Confirming removal calls the callback
+
+- **Given** `ActiveCombatView` is rendered with `removeConfirmId` set to a combatant ID and a mocked `removeCombatant`
+- **When** the user clicks the confirm remove button
+- **Then** `removeCombatant` is called with the expected combatant ID
+
+## MODIFIED Requirements
+
+None. This is a new test file — no existing requirements are modified.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element: ActiveCombatView 0% coverage → Requirements: render, nextTurn, active highlight, modal, remove
+- Design decision 1 (tests/unit/components/) → all requirements in this file
+- Design decision 3 (mock at module boundary) → all scenario Given clauses
+- Requirements → Task: "Create tests/unit/components/ActiveCombatView.test.tsx" in tasks.md
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Tests pass consistently in CI
+
+- **Given** the test suite runs in a clean jsdom environment with no real network or timer dependencies
+- **When** `npm test` executes `ActiveCombatView.test.tsx`
+- **Then** all tests pass on every run without flakiness

--- a/openspec/specs/active-and-setup-view-integration-tests/combat-setup-view.md
+++ b/openspec/specs/active-and-setup-view-integration-tests/combat-setup-view.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED CombatSetupView renders setup combatant list
+
+The system SHALL render the list of combatants in `setupCombatants` when the array is non-empty.
+
+#### Scenario: Setup combatant names appear in the rendered output
+
+- **Given** `useCombat` is mocked to return `setupCombatants` with two entries
+- **When** `CombatSetupView` is rendered
+- **Then** both combatant names are visible in the document
+
+#### Scenario: Empty setupCombatants renders an empty list
+
+- **Given** `useCombat` is mocked with `setupCombatants: []`
+- **When** `CombatSetupView` is rendered
+- **Then** no combatant name elements are present in the setup list
+
+---
+
+### Requirement: ADDED Start combat button dispatches startCombatWithSetupCombatants callback
+
+The system SHALL call `startCombatWithSetupCombatants()` when the user clicks the "Start Combat" button.
+
+#### Scenario: Clicking start combat invokes the callback
+
+- **Given** `CombatSetupView` is rendered with a mocked `startCombatWithSetupCombatants` jest.fn()
+- **When** the user clicks the "Start Combat" button
+- **Then** the `startCombatWithSetupCombatants` mock is called exactly once
+
+---
+
+### Requirement: ADDED Add combatant button opens QuickCombatantModal
+
+The system SHALL call `setShowCombatantModal(true)` when the user clicks the "Add Combatant" button.
+
+#### Scenario: Clicking add combatant calls setShowCombatantModal with true
+
+- **Given** `CombatSetupView` is rendered with a mocked `setShowCombatantModal` jest.fn()
+- **When** the user clicks the "Add Combatant" button
+- **Then** `setShowCombatantModal` is called with `true`
+
+#### Scenario: QuickCombatantModal is visible when showCombatantModal is true
+
+- **Given** `useCombat` is mocked with `showCombatantModal: true`
+- **When** `CombatSetupView` is rendered
+- **Then** the `QuickCombatantModal` is present in the document
+
+---
+
+### Requirement: ADDED Remove from setup calls removeCombatantFromSetup
+
+The system SHALL call `removeCombatantFromSetup()` with the correct ID when the user removes a combatant from the setup list.
+
+#### Scenario: Remove button calls the callback with the combatant ID
+
+- **Given** `CombatSetupView` is rendered with one setup combatant and a mocked `removeCombatantFromSetup` jest.fn()
+- **When** the user clicks the remove button for that combatant
+- **Then** `removeCombatantFromSetup` is called with the combatant's ID
+
+## MODIFIED Requirements
+
+None. This is a new test file — no existing requirements are modified.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element: CombatSetupView 0% coverage → Requirements: render, start combat, add modal, remove from setup
+- Design decision 1 (tests/unit/components/) → all requirements in this file
+- Design decision 3 (mock at module boundary) → all scenario Given clauses
+- Requirements → Task: "Create tests/unit/components/CombatSetupView.test.tsx" in tasks.md
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Tests pass consistently in CI
+
+- **Given** the test suite runs in a clean jsdom environment with no real network or timer dependencies
+- **When** `npm test` executes `CombatSetupView.test.tsx`
+- **Then** all tests pass on every run without flakiness


### PR DESCRIPTION
Archives the completed `active-and-setup-view-integration-tests` OpenSpec change and syncs approved specs to the global spec store.