### PR TITLE
test: migrate AlignmentSelect, NavBar, CreatureStatBlock tests to RTL

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom';
 import { webcrypto } from 'crypto';
 
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
 if (typeof globalThis.crypto?.randomUUID !== 'function') {
   Object.defineProperty(globalThis.crypto ?? globalThis, 'randomUUID', {
     value: webcrypto.randomUUID.bind(webcrypto),

--- a/tests/unit/components/AlignmentSelect.test.tsx
+++ b/tests/unit/components/AlignmentSelect.test.tsx
@@ -1,117 +1,74 @@
 /**
  * @jest-environment jsdom
  */
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 import React from 'react';
-import { createRoot, Root } from 'react-dom/client';
-import { act } from 'react';
-import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, test, expect, jest } from '@jest/globals';
 import { AlignmentSelect } from '@/lib/components/AlignmentSelect';
 import { VALID_ALIGNMENTS } from '@/lib/types';
 
-let container: HTMLDivElement;
-let root: Root;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-  root = createRoot(container);
-});
-
-afterEach(() => {
-  act(() => { root.unmount(); });
-  container.remove();
-});
-
-function renderSelect(
-  value: string,
-  onChange: (v: string) => void,
-  disabled = false,
-) {
-  act(() => {
-    root.render(
-      <AlignmentSelect value={value} onChange={onChange} disabled={disabled} />,
-    );
-  });
+function renderSelect(props: Partial<Parameters<typeof AlignmentSelect>[0]> = {}) {
+  return render(
+    <AlignmentSelect value="" onChange={jest.fn() as (v: string) => void} {...props} />,
+  );
 }
 
 describe('AlignmentSelect', () => {
-  test('renders a <label> with text "Alignment"', () => {
-    renderSelect('', jest.fn() as (v: string) => void);
-    const label = container.querySelector('label');
-    expect(label).not.toBeNull();
-    expect(label!.textContent).toBe('Alignment');
+  test('renders a label with text "Alignment"', () => {
+    renderSelect();
+    expect(screen.getByText('Alignment')).toBeInTheDocument();
   });
 
-  test('renders a <select> with aria-label="Alignment"', () => {
-    renderSelect('', jest.fn() as (v: string) => void);
-    const select = container.querySelector('select');
-    expect(select).not.toBeNull();
-    expect(select!.getAttribute('aria-label')).toBe('Alignment');
+  test('renders a select with aria-label "Alignment"', () => {
+    renderSelect();
+    expect(screen.getByRole('combobox', { name: 'Alignment' })).toBeInTheDocument();
   });
 
   test('renders exactly 10 options (1 placeholder + 9 standard alignments) by default', () => {
-    renderSelect('', jest.fn() as (v: string) => void);
-    const options = container.querySelectorAll('option');
-    // 9 standard alignments (first 9 of VALID_ALIGNMENTS) + 1 placeholder
-    expect(options.length).toBe(10);
+    renderSelect();
+    expect(screen.getAllByRole('option')).toHaveLength(10);
   });
 
   test('renders all VALID_ALIGNMENTS + placeholder when showExtendedAlignments is true', () => {
-    act(() => {
-      root.render(
-        <AlignmentSelect value="" onChange={jest.fn() as (v: string) => void} showExtendedAlignments />,
-      );
-    });
-    const options = container.querySelectorAll('option');
-    // All VALID_ALIGNMENTS + 1 placeholder
-    expect(options.length).toBe(VALID_ALIGNMENTS.length + 1);
+    renderSelect({ showExtendedAlignments: true });
+    expect(screen.getAllByRole('option')).toHaveLength(VALID_ALIGNMENTS.length + 1);
   });
 
-  test('placeholder option has value="" and text "Select Alignment"', () => {
-    renderSelect('', jest.fn() as (v: string) => void);
-    const firstOption = container.querySelector('option') as HTMLOptionElement;
-    expect(firstOption.value).toBe('');
-    expect(firstOption.textContent).toBe('Select Alignment');
+  test('placeholder option has value "" and text "Select Alignment"', () => {
+    renderSelect();
+    const placeholder = screen.getByRole('option', { name: 'Select Alignment' }) as HTMLOptionElement;
+    expect(placeholder.value).toBe('');
   });
 
   test('each of the 9 standard alignment options has the correct value', () => {
-    renderSelect('', jest.fn() as (v: string) => void);
-    const options = Array.from(container.querySelectorAll('option')) as HTMLOptionElement[];
-    // Skip the placeholder (index 0)
-    const standardAlignments = VALID_ALIGNMENTS.slice(0, 9);
-    standardAlignments.forEach((alignment, i) => {
-      expect(options[i + 1].value).toBe(alignment);
+    renderSelect();
+    VALID_ALIGNMENTS.slice(0, 9).forEach((alignment) => {
+      expect(screen.getByRole('option', { name: alignment })).toBeInTheDocument();
     });
   });
 
   test('controlled value: select shows the provided value as selected', () => {
-    renderSelect('Lawful Good', jest.fn() as (v: string) => void);
-    const select = container.querySelector('select') as HTMLSelectElement;
+    renderSelect({ value: 'Lawful Good' });
+    const select = screen.getByRole('combobox', { name: 'Alignment' }) as HTMLSelectElement;
     expect(select.value).toBe('Lawful Good');
   });
 
-  test('calls onChange with the selected value when user changes the select', () => {
+  test('calls onChange with the selected value when user changes the select', async () => {
     const onChange = jest.fn() as jest.MockedFunction<(v: string) => void>;
-    renderSelect('', onChange);
-    const select = container.querySelector('select') as HTMLSelectElement;
-    act(() => {
-      select.value = 'Chaotic Evil';
-      select.dispatchEvent(new Event('change', { bubbles: true }));
-    });
+    renderSelect({ onChange });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Alignment' }), 'Chaotic Evil');
     expect(onChange).toHaveBeenCalledWith('Chaotic Evil');
   });
 
   test('select is disabled when disabled prop is true', () => {
-    renderSelect('', jest.fn() as (v: string) => void, true);
-    const select = container.querySelector('select') as HTMLSelectElement;
-    expect(select.disabled).toBe(true);
+    renderSelect({ disabled: true });
+    expect(screen.getByRole('combobox', { name: 'Alignment' })).toBeDisabled();
   });
 
   test('select is not disabled when disabled prop is false', () => {
-    renderSelect('', jest.fn() as (v: string) => void, false);
-    const select = container.querySelector('select') as HTMLSelectElement;
-    expect(select.disabled).toBe(false);
+    renderSelect({ disabled: false });
+    expect(screen.getByRole('combobox', { name: 'Alignment' })).not.toBeDisabled();
   });
 });

--- a/tests/unit/components/AlignmentSelect.test.tsx
+++ b/tests/unit/components/AlignmentSelect.test.tsx
@@ -45,7 +45,8 @@ describe('AlignmentSelect', () => {
   test('each of the 9 standard alignment options has the correct value', () => {
     renderSelect();
     VALID_ALIGNMENTS.slice(0, 9).forEach((alignment) => {
-      expect(screen.getByRole('option', { name: alignment })).toBeInTheDocument();
+      const option = screen.getByRole('option', { name: alignment }) as HTMLOptionElement;
+      expect(option.value).toBe(alignment);
     });
   });
 

--- a/tests/unit/components/CreatureStatBlock.test.tsx
+++ b/tests/unit/components/CreatureStatBlock.test.tsx
@@ -44,7 +44,7 @@ describe('CreatureStatBlock — CombatStatsRow integration', () => {
 
   test('renders without acNote when omitted', () => {
     renderBlock({ ac: 10 });
-    expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^\(.*\)$/)).not.toBeInTheDocument();
   });
 
   test('renders ability scores in full mode', () => {

--- a/tests/unit/components/CreatureStatBlock.test.tsx
+++ b/tests/unit/components/CreatureStatBlock.test.tsx
@@ -39,7 +39,7 @@ describe('CreatureStatBlock — CombatStatsRow integration', () => {
 
   test('renders acNote when provided', () => {
     renderBlock({ ac: 14, acNote: 'chain mail' });
-    expect(screen.getByText(/chain mail/)).toBeInTheDocument();
+    expect(screen.getByText('(chain mail)')).toBeInTheDocument();
   });
 
   test('renders without acNote when omitted', () => {

--- a/tests/unit/components/CreatureStatBlock.test.tsx
+++ b/tests/unit/components/CreatureStatBlock.test.tsx
@@ -1,73 +1,61 @@
 /**
  * @jest-environment jsdom
  */
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 import React from 'react';
-import { act } from 'react';
-import { describe, test, expect, afterEach } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect } from '@jest/globals';
 import { CreatureStatBlock } from '@/lib/components/CreatureStatBlock';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
-import type { Root } from 'react-dom/client';
 
 const BASE_ABILITY_SCORES = {
   strength: 10, dexterity: 10, constitution: 10,
   intelligence: 10, wisdom: 10, charisma: 10,
 };
 
-let container: HTMLDivElement;
-let root: Root;
-
-afterEach(() => {
-  unmountReactRoot(container, root);
-});
-
-function renderBlock(props: Partial<Parameters<typeof CreatureStatBlock>[0]> = {}): HTMLDivElement {
-  ({ container, root } = createReactRoot());
-  act(() => {
-    root.render(React.createElement(CreatureStatBlock, {
-      abilityScores: BASE_ABILITY_SCORES,
-      ac: 16,
-      hp: 30,
-      maxHp: 30,
-      ...props,
-    }));
-  });
-  return container;
+function renderBlock(props: Partial<Parameters<typeof CreatureStatBlock>[0]> = {}) {
+  return render(
+    <CreatureStatBlock
+      abilityScores={BASE_ABILITY_SCORES}
+      ac={16}
+      hp={30}
+      maxHp={30}
+      {...props}
+    />,
+  );
 }
 
 describe('CreatureStatBlock — CombatStatsRow integration', () => {
   test('renders AC value under AC label', () => {
     renderBlock({ ac: 16 });
-    expect(container.textContent).toContain('AC');
-    expect(container.textContent).toContain('16');
+    expect(screen.getByText('AC')).toBeInTheDocument();
+    expect(screen.getByText('16')).toBeInTheDocument();
   });
 
   test('renders HP/maxHp values under HP label', () => {
     renderBlock({ hp: 30, maxHp: 30 });
-    expect(container.textContent).toContain('HP');
-    expect(container.textContent).toContain('30/30');
+    expect(screen.getByText('HP')).toBeInTheDocument();
+    expect(screen.getByText('30/30')).toBeInTheDocument();
   });
 
   test('renders acNote when provided', () => {
     renderBlock({ ac: 14, acNote: 'chain mail' });
-    expect(container.textContent).toContain('(chain mail)');
+    expect(screen.getByText(/chain mail/)).toBeInTheDocument();
   });
 
   test('renders without acNote when omitted', () => {
     renderBlock({ ac: 10 });
-    expect(container.textContent).not.toContain('(');
+    expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
   });
 
   test('renders ability scores in full mode', () => {
     renderBlock({ isCompact: false });
-    expect(container.textContent).toContain('STR');
-    expect(container.textContent).toContain('DEX');
+    expect(screen.getByText('STR')).toBeInTheDocument();
+    expect(screen.getByText('DEX')).toBeInTheDocument();
   });
 
   test('hides ability scores in compact mode', () => {
     renderBlock({ isCompact: true });
-    expect(container.textContent).not.toContain('STR');
-    expect(container.textContent).not.toContain('DEX');
+    expect(screen.queryByText('STR')).not.toBeInTheDocument();
+    expect(screen.queryByText('DEX')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/components/NavBar.test.tsx
+++ b/tests/unit/components/NavBar.test.tsx
@@ -1,9 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { jest, describe, it, expect } from '@jest/globals';
 
 jest.mock('next/link', () => ({
   __esModule: true,
@@ -16,24 +15,12 @@ jest.mock('@/lib/hooks/useAuth', () => ({
 }));
 
 import React from 'react';
-import { Root } from 'react-dom/client';
-import { act } from 'react';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { NavBar } from '@/lib/components/NavBar';
 import { useAuth } from '@/lib/hooks/useAuth';
 
 const mockedUseAuth = jest.mocked(useAuth);
-
-let container: HTMLDivElement;
-let root: Root;
-
-beforeEach(() => {
-  ({ container, root } = createReactRoot());
-});
-
-afterEach(() => {
-  unmountReactRoot(container, root);
-});
 
 function mockAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
   mockedUseAuth.mockReturnValue({
@@ -44,39 +31,40 @@ function mockAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
 }
 
 describe('NavBar', () => {
-  it('renders navigation links', () => {
+  it('renders all navigation links', () => {
     mockAuth({});
-    act(() => { root.render(<NavBar />); });
-    const hrefs = Array.from(container.querySelectorAll('a')).map(a => a.getAttribute('href'));
-    expect(hrefs).toContain('/campaigns');
-    expect(hrefs).toContain('/encounters');
-    expect(hrefs).toContain('/parties');
-    expect(hrefs).toContain('/characters');
+    render(<NavBar />);
+    expect(screen.getByRole('link', { name: 'Campaigns' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Encounters' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Characters' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Monsters' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Combat' })).toBeInTheDocument();
   });
 
   it('does not show logout button when not authenticated', () => {
     mockAuth({});
-    act(() => { root.render(<NavBar />); });
-    expect(container.querySelector('[data-testid="logout-button"]')).toBeNull();
+    render(<NavBar />);
+    expect(screen.queryByTestId('logout-button')).not.toBeInTheDocument();
   });
 
   it('does not show logout button while loading', () => {
     mockAuth({ isAuthenticated: true, loading: true });
-    act(() => { root.render(<NavBar />); });
-    expect(container.querySelector('[data-testid="logout-button"]')).toBeNull();
+    render(<NavBar />);
+    expect(screen.queryByTestId('logout-button')).not.toBeInTheDocument();
   });
 
   it('shows logout button when authenticated and not loading', () => {
     mockAuth({ isAuthenticated: true, user: { userId: 'u1', email: 'u@test.com' } });
-    act(() => { root.render(<NavBar />); });
-    expect(container.querySelector('[data-testid="logout-button"]')).not.toBeNull();
+    render(<NavBar />);
+    expect(screen.getByTestId('logout-button')).toBeInTheDocument();
   });
 
-  it('calls logout when logout button clicked', () => {
+  it('calls logout when logout button clicked', async () => {
     const logout = jest.fn() as any;
     mockAuth({ isAuthenticated: true, user: { userId: 'u1', email: 'u@test.com' }, logout });
-    act(() => { root.render(<NavBar />); });
-    act(() => { (container.querySelector('[data-testid="logout-button"]') as HTMLButtonElement).click(); });
+    render(<NavBar />);
+    await userEvent.click(screen.getByTestId('logout-button'));
     expect(logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/components/NavBar.test.tsx
+++ b/tests/unit/components/NavBar.test.tsx
@@ -31,15 +31,15 @@ function mockAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
 }
 
 describe('NavBar', () => {
-  it('renders all navigation links', () => {
+  it('renders all navigation links with correct hrefs', () => {
     mockAuth({});
     render(<NavBar />);
-    expect(screen.getByRole('link', { name: 'Campaigns' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Encounters' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Characters' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Monsters' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Combat' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Campaigns' })).toHaveAttribute('href', '/campaigns');
+    expect(screen.getByRole('link', { name: 'Encounters' })).toHaveAttribute('href', '/encounters');
+    expect(screen.getByRole('link', { name: 'Parties' })).toHaveAttribute('href', '/parties');
+    expect(screen.getByRole('link', { name: 'Characters' })).toHaveAttribute('href', '/characters');
+    expect(screen.getByRole('link', { name: 'Monsters' })).toHaveAttribute('href', '/monsters');
+    expect(screen.getByRole('link', { name: 'Combat' })).toHaveAttribute('href', '/combat');
   });
 
   it('does not show logout button when not authenticated', () => {


### PR DESCRIPTION
Migrates three component test files from the manual `createRoot`/`act`/`container.querySelectorAll` pattern to React Testing Library (RTL).

## Changes
- `tests/unit/components/AlignmentSelect.test.tsx` — RTL migration with `renderSelect` helper
- `tests/unit/components/NavBar.test.tsx` — RTL migration; jest.mock order preserved; covers all 6 nav links
- `tests/unit/components/CreatureStatBlock.test.tsx` — RTL migration with `renderBlock` helper

## Verification
- All three files pass their individual test runs (10, 5, 6 tests respectively)
- Full unit suite: 1747 tests, 133 suites — all pass
- Integration suite: 180 tests, 20 suites — all pass
- Build: succeeds with no errors

Closes #260