### PR TITLE
refactor: migrate ui, TargetActionModal, CreatureStatsForm tests to RTL

### DIFF
--- a/tests/unit/components/CreatureStatsForm.test.tsx
+++ b/tests/unit/components/CreatureStatsForm.test.tsx
@@ -1,12 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 import React from 'react';
-import { createRoot, Root } from 'react-dom/client';
-import { act } from 'react';
-import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, test, expect, jest } from '@jest/globals';
 import { CreatureStatsForm } from '@/lib/components/CreatureStatsForm';
 import type { CreatureStats } from '@/lib/types';
 
@@ -20,36 +19,18 @@ const BASE_STATS: CreatureStats = {
   },
 };
 
-let container: HTMLDivElement;
-let root: Root;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  act(() => { root?.unmount(); });
-  container.remove();
-});
-
-function render(stats: CreatureStats, onChange: (s: CreatureStats) => void) {
-  act(() => {
-    root = createRoot(container);
-    root.render(<CreatureStatsForm stats={stats} onChange={onChange} />);
-  });
+function renderForm(stats: CreatureStats, onChange: (s: CreatureStats) => void) {
+  render(<CreatureStatsForm stats={stats} onChange={onChange} />);
+  return { user: userEvent.setup() };
 }
 
-function clickResistancesHeader() {
-  const resistancesBtn = Array.from(container.querySelectorAll('button')).find(
-    b => b.textContent?.includes('Resistances'),
-  );
-  act(() => { (resistancesBtn as HTMLButtonElement).click(); });
+async function expandResistances(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /resistances/i }));
 }
 
-function renderExpanded(stats: CreatureStats, onChange: (s: CreatureStats) => void) {
-  render(stats, onChange);
-  clickResistancesHeader();
+function getSection(labelText: string) {
+  // scoped by section label text — tied to CreatureStatsForm DOM structure
+  return screen.getByText(labelText).closest('div')!;
 }
 
 // ---------------------------------------------------------------------------
@@ -58,40 +39,32 @@ function renderExpanded(stats: CreatureStats, onChange: (s: CreatureStats) => vo
 
 describe('CreatureStatsForm – resistances section', () => {
   test('resistances section is collapsed by default', () => {
-    const onChange = jest.fn();
-    render(BASE_STATS, onChange as any);
-    // When collapsed, checkboxes for damage types should not be present
-    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
-    expect(checkboxes.length).toBe(0);
+    renderForm(BASE_STATS, jest.fn() as any);
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
   });
 
-  test('expanding section renders checkboxes for all 13 damage types per field (39 total)', () => {
-    renderExpanded(BASE_STATS, jest.fn() as any);
-    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
-    // 3 fields × 13 types = 39 checkboxes
-    expect(checkboxes.length).toBe(39);
+  test('expanding section renders checkboxes for all 13 damage types per field (39 total)', async () => {
+    const { user } = renderForm(BASE_STATS, jest.fn() as any);
+    await expandResistances(user);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(39);
   });
 
-  test('checkboxes are unchecked when no resistances set', () => {
-    renderExpanded(BASE_STATS, jest.fn() as any);
-    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
-    checkboxes.forEach(cb => expect((cb as HTMLInputElement).checked).toBe(false));
-  });
-
-  test('pre-selected resistances render as checked', () => {
-    const stats = { ...BASE_STATS, damageResistances: ['fire' as const, 'cold' as const] };
-    renderExpanded(stats, jest.fn() as any);
-    // Find the fire resistance checkbox (first field group = vulnerabilities, second = resistances)
-    const labels = container.querySelectorAll('label');
-    const fireLabel = Array.from(labels).find(l => {
-      const span = l.querySelector('span');
-      return span?.textContent === 'fire' && l.closest('div[data-field]') === null;
+  test('checkboxes are unchecked when no resistances set', async () => {
+    const { user } = renderForm(BASE_STATS, jest.fn() as any);
+    await expandResistances(user);
+    screen.getAllByRole('checkbox').forEach(cb => {
+      expect((cb as HTMLInputElement).checked).toBe(false);
     });
-    // Simpler: check that exactly 2 checkboxes in the form are checked (one for fire, one for cold in the resistance section)
-    const checked = Array.from(container.querySelectorAll('input[type="checkbox"]')).filter(
-      cb => (cb as HTMLInputElement).checked
-    );
-    expect(checked.length).toBe(2);
+  });
+
+  test('pre-selected resistances render as checked', async () => {
+    const stats = { ...BASE_STATS, damageResistances: ['fire' as const, 'cold' as const] };
+    const { user } = renderForm(stats, jest.fn() as any);
+    await expandResistances(user);
+    const checked = screen.getAllByRole('checkbox').filter(cb => (cb as HTMLInputElement).checked);
+    expect(checked).toHaveLength(2);
+    const resistancesSection = getSection('Damage Resistances');
+    expect(within(resistancesSection).getAllByRole('checkbox', { checked: true })).toHaveLength(2);
   });
 });
 
@@ -100,88 +73,56 @@ describe('CreatureStatsForm – resistances section', () => {
 // ---------------------------------------------------------------------------
 
 describe('CreatureStatsForm – checkbox toggle calls onChange', () => {
-  test('checking an unchecked resistance calls onChange with the type added', () => {
+  test('checking an unchecked resistance calls onChange with the type added', async () => {
     const onChange = jest.fn();
-    renderExpanded(BASE_STATS, onChange as any);
+    const { user } = renderForm(BASE_STATS, onChange as any);
+    await expandResistances(user);
 
-    // Find the "Damage Resistances" section label, then the "fire" checkbox within it
-    const sectionLabel = Array.from(container.querySelectorAll('label')).find(
-      l => l.textContent?.includes('Damage Resistances'),
-    )!;
-    const sectionDiv = sectionLabel.parentElement!;
-    const fireLabel = Array.from(sectionDiv.querySelectorAll('label')).find(
-      l => l.querySelector('span')?.textContent?.trim() === 'fire',
-    )!;
-    const fireResistanceCheckbox = fireLabel.querySelector('input[type="checkbox"]') as HTMLInputElement;
-    expect(fireResistanceCheckbox).not.toBeNull();
-
-    act(() => {
-      fireResistanceCheckbox.click();
-    });
+    const fireCheckbox = within(getSection('Damage Resistances')).getByRole('checkbox', { name: /fire/i });
+    await user.click(fireCheckbox);
 
     expect(onChange).toHaveBeenCalled();
     const callArg = (onChange as jest.Mock).mock.calls[0][0] as CreatureStats;
     expect(callArg.damageResistances).toContain('fire');
   });
 
-  test('unchecking a checked resistance calls onChange with the type removed', () => {
+  test('unchecking a checked resistance calls onChange with the type removed', async () => {
     const stats = { ...BASE_STATS, damageResistances: ['fire' as const] };
     const onChange = jest.fn();
-    renderExpanded(stats, onChange as any);
+    const { user } = renderForm(stats, onChange as any);
+    await expandResistances(user);
 
-    // Find the checked fire checkbox in the resistance group
-    const checkedBoxes = Array.from(container.querySelectorAll('input[type="checkbox"]')).filter(
-      cb => (cb as HTMLInputElement).checked
-    );
-    expect(checkedBoxes.length).toBe(1);
-
-    act(() => {
-      (checkedBoxes[0] as HTMLInputElement).click();
-    });
+    const fireCheckbox = within(getSection('Damage Resistances')).getByRole('checkbox', { name: /fire/i });
+    expect((fireCheckbox as HTMLInputElement).checked).toBe(true);
+    await user.click(fireCheckbox);
 
     expect(onChange).toHaveBeenCalled();
     const callArg = (onChange as jest.Mock).mock.calls[0][0] as CreatureStats;
-    // When last type is removed, field should be undefined (falsy)
     expect(callArg.damageResistances).toBeFalsy();
   });
 
-  test('checking immunity type calls onChange with damageImmunities containing the type', () => {
+  test('checking immunity type calls onChange with damageImmunities containing the type', async () => {
     const onChange = jest.fn();
-    renderExpanded(BASE_STATS, onChange as any);
+    const { user } = renderForm(BASE_STATS, onChange as any);
+    await expandResistances(user);
 
-    // Find the "Damage Immunities" section label, then the "poison" checkbox within it
-    const sectionLabel = Array.from(container.querySelectorAll('label')).find(
-      l => l.textContent?.includes('Damage Immunities'),
-    )!;
-    const sectionDiv = sectionLabel.parentElement!;
-    const poisonLabel = Array.from(sectionDiv.querySelectorAll('label')).find(
-      l => l.querySelector('span')?.textContent?.trim() === 'poison',
-    )!;
-    const poisonImmunityCheckbox = poisonLabel.querySelector('input[type="checkbox"]') as HTMLInputElement;
-    expect(poisonImmunityCheckbox).not.toBeNull();
-
-    act(() => {
-      poisonImmunityCheckbox.click();
-    });
+    const poisonCheckbox = within(getSection('Damage Immunities')).getByRole('checkbox', { name: /poison/i });
+    await user.click(poisonCheckbox);
 
     expect(onChange).toHaveBeenCalled();
     const callArg = (onChange as jest.Mock).mock.calls[0][0] as CreatureStats;
     expect(callArg.damageImmunities).toContain('poison');
   });
 
-  test('removing last type from a field sets field to undefined', () => {
+  test('removing last type from a field sets field to undefined', async () => {
     const stats = { ...BASE_STATS, damageVulnerabilities: ['cold' as const] };
     const onChange = jest.fn();
-    renderExpanded(stats, onChange as any);
+    const { user } = renderForm(stats, onChange as any);
+    await expandResistances(user);
 
-    const checkedBoxes = Array.from(container.querySelectorAll('input[type="checkbox"]')).filter(
-      cb => (cb as HTMLInputElement).checked
-    );
-    expect(checkedBoxes.length).toBe(1);
-
-    act(() => {
-      (checkedBoxes[0] as HTMLInputElement).click();
-    });
+    const coldCheckbox = within(getSection('Damage Vulnerabilities')).getByRole('checkbox', { name: /cold/i });
+    expect((coldCheckbox as HTMLInputElement).checked).toBe(true);
+    await user.click(coldCheckbox);
 
     const callArg = (onChange as jest.Mock).mock.calls[0][0] as CreatureStats;
     expect(callArg.damageVulnerabilities).toBeUndefined();

--- a/tests/unit/components/CreatureStatsForm.test.tsx
+++ b/tests/unit/components/CreatureStatsForm.test.tsx
@@ -98,7 +98,7 @@ describe('CreatureStatsForm – checkbox toggle calls onChange', () => {
 
     expect(onChange).toHaveBeenCalled();
     const callArg = (onChange as jest.Mock).mock.calls[0][0] as CreatureStats;
-    expect(callArg.damageResistances).toBeFalsy();
+    expect(callArg.damageResistances).toBeUndefined();
   });
 
   test('checking immunity type calls onChange with damageImmunities containing the type', async () => {

--- a/tests/unit/components/CreatureStatsForm.test.tsx
+++ b/tests/unit/components/CreatureStatsForm.test.tsx
@@ -20,8 +20,9 @@ const BASE_STATS: CreatureStats = {
 };
 
 function renderForm(stats: CreatureStats, onChange: (s: CreatureStats) => void) {
+  const user = userEvent.setup();
   render(<CreatureStatsForm stats={stats} onChange={onChange} />);
-  return { user: userEvent.setup() };
+  return { user };
 }
 
 async function expandResistances(user: ReturnType<typeof userEvent.setup>) {
@@ -61,7 +62,7 @@ describe('CreatureStatsForm – resistances section', () => {
     const stats = { ...BASE_STATS, damageResistances: ['fire' as const, 'cold' as const] };
     const { user } = renderForm(stats, jest.fn() as any);
     await expandResistances(user);
-    const checked = screen.getAllByRole('checkbox').filter(cb => (cb as HTMLInputElement).checked);
+    const checked = screen.getAllByRole('checkbox', { checked: true });
     expect(checked).toHaveLength(2);
     const resistancesSection = getSection('Damage Resistances');
     expect(within(resistancesSection).getAllByRole('checkbox', { checked: true })).toHaveLength(2);

--- a/tests/unit/components/TargetActionModal.test.tsx
+++ b/tests/unit/components/TargetActionModal.test.tsx
@@ -63,7 +63,7 @@ describe('TargetActionModal', () => {
     const user = userEvent.setup();
 
     await user.click(screen.getByRole('button', { name: /apply damage/i }));
-    expect(screen.queryByRole('button', { name: /apply damage/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /apply damage/i })).not.toBeInTheDocument();
 
     await user.type(screen.getByPlaceholderText('Damage amount'), '5');
     await user.selectOptions(screen.getByRole('combobox', { name: /damage type/i }), 'fire');
@@ -77,7 +77,7 @@ describe('TargetActionModal', () => {
     const user = userEvent.setup();
 
     await user.click(screen.getByRole('button', { name: /add condition/i }));
-    expect(screen.queryByRole('button', { name: /add condition/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /add condition/i })).not.toBeInTheDocument();
 
     await user.type(screen.getByPlaceholderText('Condition name'), 'Stunned');
     await user.type(screen.getByPlaceholderText('Duration in rounds (optional)'), '3');

--- a/tests/unit/components/TargetActionModal.test.tsx
+++ b/tests/unit/components/TargetActionModal.test.tsx
@@ -1,12 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { jest, describe, test, expect } from '@jest/globals';
 import React from 'react';
-import { createRoot, Root } from 'react-dom/client';
-import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TargetActionModal } from '@/lib/components/TargetActionModal';
 import type { CombatantState } from '@/lib/types';
 
@@ -22,136 +21,68 @@ const TARGET: CombatantState = {
   abilityScores: { strength: 8, dexterity: 14, constitution: 10, intelligence: 10, wisdom: 8, charisma: 8 },
 };
 
-let container: HTMLDivElement;
-let root: Root;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-  jest.spyOn(window, 'alert').mockImplementation(() => {});
-});
-
-afterEach(() => {
-  act(() => { root?.unmount(); });
-  container.remove();
-  jest.restoreAllMocks();
-});
-
-function render(
-  target: CombatantState,
-  onClose: ReturnType<typeof jest.fn>,
-  onApplyDamage: ReturnType<typeof jest.fn>,
-  onAddCondition: ReturnType<typeof jest.fn>
-) {
-  act(() => {
-    root = createRoot(container);
-    root.render(
-      <TargetActionModal
-        target={target}
-        onClose={onClose as any}
-        onApplyDamage={onApplyDamage as any}
-        onAddCondition={onAddCondition as any}
-      />
-    );
-  });
-}
-
-function findButton(text: string): HTMLButtonElement {
-  const buttons = Array.from(container.querySelectorAll('button'));
-  const found = buttons.find(b => b.textContent?.trim() === text);
-  if (!found) throw new Error(`Could not find button with text: ${text}`);
-  return found;
-}
-
-function renderDefault() {
-  const onClose = jest.fn();
-  const onApplyDamage = jest.fn();
-  const onAddCondition = jest.fn();
-  render(TARGET, onClose, onApplyDamage, onAddCondition);
+function renderModal(overrides: Partial<{
+  onClose: jest.Mock;
+  onApplyDamage: jest.Mock;
+  onAddCondition: jest.Mock;
+}> = {}) {
+  const onClose = overrides.onClose ?? jest.fn();
+  const onApplyDamage = overrides.onApplyDamage ?? jest.fn();
+  const onAddCondition = overrides.onAddCondition ?? jest.fn();
+  render(
+    <TargetActionModal
+      target={TARGET}
+      onClose={onClose as any}
+      onApplyDamage={onApplyDamage as any}
+      onAddCondition={onAddCondition as any}
+    />
+  );
   return { onClose, onApplyDamage, onAddCondition };
-}
-
-function changeInputValue(element: HTMLInputElement | HTMLSelectElement, value: string) {
-  act(() => {
-    const proto = element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLSelectElement.prototype;
-    const nativeSetter = Object.getOwnPropertyDescriptor(proto, 'value')!.set!;
-    nativeSetter.call(element, value);
-    const eventType = element instanceof HTMLInputElement ? 'input' : 'change';
-    element.dispatchEvent(new Event(eventType, { bubbles: true }));
-  });
 }
 
 describe('TargetActionModal', () => {
   test('renders target info and buttons', () => {
-    renderDefault();
-
-    expect(container.textContent).toContain('Goblin Target');
-    expect(container.textContent).toContain('HP: 7/7');
-    expect(container.textContent).toContain('AC: 13');
-    expect(findButton('Apply Damage')).not.toBeNull();
-    expect(findButton('Add Condition')).not.toBeNull();
-    expect(findButton('Cancel')).not.toBeNull();
+    renderModal();
+    screen.getByText('Goblin Target');
+    screen.getByText(/HP: 7\/7/);
+    screen.getByText(/AC: 13/);
+    screen.getByRole('button', { name: /apply damage/i });
+    screen.getByRole('button', { name: /add condition/i });
+    screen.getByRole('button', { name: /cancel/i });
   });
 
-  test('calls onClose when Cancel is clicked', () => {
-    const { onClose } = renderDefault();
-
-    act(() => {
-      findButton('Cancel').click();
-    });
-
+  test('calls onClose when Cancel is clicked', async () => {
+    const { onClose } = renderModal();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onClose).toHaveBeenCalled();
   });
 
-  test('transitions to damage screen and fires onApplyDamage', () => {
-    const { onApplyDamage } = renderDefault();
+  test('transitions to damage screen and fires onApplyDamage', async () => {
+    const { onApplyDamage } = renderModal();
+    const user = userEvent.setup();
 
-    act(() => {
-      findButton('Apply Damage').click();
-    });
+    await user.click(screen.getByRole('button', { name: /apply damage/i }));
+    expect(screen.queryByRole('button', { name: /apply damage/i })).toBeNull();
 
-    expect(container.textContent).not.toContain('Apply Damage');
-    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
-    expect(input).not.toBeNull();
+    await user.type(screen.getByPlaceholderText('Damage amount'), '5');
+    await user.selectOptions(screen.getByRole('combobox', { name: /damage type/i }), 'fire');
 
-    // Fill damage input
-    changeInputValue(input, '5');
-
-    // Select damage type
-    const select = container.querySelector('select') as HTMLSelectElement;
-    expect(select).not.toBeNull();
-    changeInputValue(select, 'fire');
-
-    // Click Apply
-    act(() => {
-      findButton('Apply (fire)').click();
-    });
-
+    await user.click(screen.getByRole('button', { name: /apply \(fire\)/i }));
     expect(onApplyDamage).toHaveBeenCalledWith(5, 'fire');
   });
 
-  test('transitions to condition screen and fires onAddCondition', () => {
-    const { onAddCondition } = renderDefault();
+  test('transitions to condition screen and fires onAddCondition', async () => {
+    const { onAddCondition } = renderModal();
+    const user = userEvent.setup();
 
-    act(() => {
-      findButton('Add Condition').click();
-    });
+    await user.click(screen.getByRole('button', { name: /add condition/i }));
+    expect(screen.queryByRole('button', { name: /add condition/i })).toBeNull();
 
-    expect(container.textContent).not.toContain('Add Condition');
-    const nameInput = container.querySelector('input[placeholder="Condition name"]') as HTMLInputElement;
-    const durationInput = container.querySelector('input[placeholder="Duration in rounds (optional)"]') as HTMLInputElement;
-    expect(nameInput).not.toBeNull();
-    expect(durationInput).not.toBeNull();
+    await user.type(screen.getByPlaceholderText('Condition name'), 'Stunned');
+    await user.type(screen.getByPlaceholderText('Duration in rounds (optional)'), '3');
 
-    // Fill inputs
-    changeInputValue(nameInput, 'Stunned');
-    changeInputValue(durationInput, '3');
-
-    // Click Add
-    act(() => {
-      findButton('Add').click();
-    });
-
+    await user.click(screen.getByRole('button', { name: /^add$/i }));
     expect(onAddCondition).toHaveBeenCalledWith('Stunned', 3);
   });
 });

--- a/tests/unit/components/ui.test.tsx
+++ b/tests/unit/components/ui.test.tsx
@@ -94,17 +94,17 @@ describe('EditorShell', () => {
 
   it('disables save button when saving', () => {
     rtlRender(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
-    expect((screen.getByRole('button', { name: /saving/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
   });
 
   it('disables save button when canSave is false', () => {
     rtlRender(<EditorShell {...defaultProps} canSave={false}><div /></EditorShell>);
-    expect((screen.getByRole('button', { name: /save/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
   });
 
   it('disables cancel button when saving', () => {
     rtlRender(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
-    expect((screen.getByRole('button', { name: /cancel/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
   });
 
   it('renders validation error when provided', () => {
@@ -153,14 +153,15 @@ describe('TextInputField', () => {
 
   it('calls onChange when input changes', async () => {
     const onChange = jest.fn();
+    const user = userEvent.setup();
     rtlRender(<TextInputField label="Username" value="" onChange={onChange} />);
-    await userEvent.type(screen.getByRole('textbox'), 'bob');
+    await user.type(screen.getByRole('textbox'), 'bob');
     expect(onChange).toHaveBeenCalled();
   });
 
   it('disables input when disabled is true', () => {
     rtlRender(<TextInputField label="Username" value="" onChange={jest.fn()} disabled={true} />);
-    expect((screen.getByRole('textbox') as HTMLInputElement).disabled).toBe(true);
+    expect(screen.getByRole('textbox')).toBeDisabled();
   });
 
   it('renders placeholder text', () => {

--- a/tests/unit/components/ui.test.tsx
+++ b/tests/unit/components/ui.test.tsx
@@ -1,14 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-
+import { jest, describe, it, expect } from '@jest/globals';
 import React from 'react';
-import { Root } from 'react-dom/client';
-import { act } from 'react';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
+import { render as rtlRender, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   ErrorBanner,
   ValidationError,
@@ -19,68 +16,53 @@ import {
   TextInputField,
 } from '@/lib/components/ui';
 
-let container: HTMLDivElement;
-let root: Root;
-
-beforeEach(() => {
-  ({ container, root } = createReactRoot());
-});
-
-afterEach(() => {
-  unmountReactRoot(container, root);
-});
-
-function render(element: React.ReactElement) {
-  act(() => { root.render(element); });
-}
-
 // ---------------------------------------------------------------------------
 
 describe('ErrorBanner', () => {
   it('renders nothing when message is null', () => {
-    render(<ErrorBanner message={null} />);
+    const { container } = rtlRender(<ErrorBanner message={null} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders message text when provided', () => {
-    render(<ErrorBanner message="Something went wrong" />);
-    expect(container.textContent).toContain('Something went wrong');
+    rtlRender(<ErrorBanner message="Something went wrong" />);
+    screen.getByText('Something went wrong');
   });
 });
 
 describe('ValidationError', () => {
   it('renders nothing when message is null', () => {
-    render(<ValidationError message={null} />);
+    const { container } = rtlRender(<ValidationError message={null} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders message text when provided', () => {
-    render(<ValidationError message="Name is required" />);
-    expect(container.textContent).toContain('Name is required');
+    rtlRender(<ValidationError message="Name is required" />);
+    screen.getByText('Name is required');
   });
 });
 
 describe('LoadingState', () => {
   it('renders the label text', () => {
-    render(<LoadingState label="Loading data..." />);
-    expect(container.textContent).toContain('Loading data...');
+    rtlRender(<LoadingState label="Loading data..." />);
+    screen.getByText('Loading data...');
   });
 });
 
 describe('FormField', () => {
   it('renders label text', () => {
-    render(<FormField label="My Field"><input /></FormField>);
-    expect(container.querySelector('label')?.textContent).toBe('My Field');
+    rtlRender(<FormField label="My Field"><input /></FormField>);
+    screen.getByText('My Field');
   });
 
   it('sets htmlFor on label when provided', () => {
-    render(<FormField label="Email" htmlFor="email-input"><input id="email-input" /></FormField>);
-    expect(container.querySelector('label')?.htmlFor).toBe('email-input');
+    rtlRender(<FormField label="Email" htmlFor="email-input"><input id="email-input" /></FormField>);
+    screen.getByLabelText('Email');
   });
 
   it('renders children', () => {
-    render(<FormField label="Name"><input data-testid="child-input" /></FormField>);
-    expect(container.querySelector('[data-testid="child-input"]')).not.toBeNull();
+    rtlRender(<FormField label="Name"><input data-testid="child-input" /></FormField>);
+    screen.getByTestId('child-input');
   });
 });
 
@@ -96,57 +78,59 @@ describe('EditorShell', () => {
   };
 
   it('renders title', () => {
-    render(<EditorShell {...defaultProps}><div /></EditorShell>);
-    expect(container.querySelector('h2')?.textContent).toBe('Test Editor');
+    rtlRender(<EditorShell {...defaultProps}><div /></EditorShell>);
+    screen.getByRole('heading', { name: 'Test Editor' });
   });
 
   it('renders save button with saveLabel', () => {
-    render(<EditorShell {...defaultProps}><div /></EditorShell>);
-    expect(container.querySelectorAll('button')[0].textContent).toBe('Save');
+    rtlRender(<EditorShell {...defaultProps}><div /></EditorShell>);
+    screen.getByRole('button', { name: /save/i });
   });
 
   it('shows Saving... text when saving is true', () => {
-    render(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
-    expect(container.querySelectorAll('button')[0].textContent).toBe('Saving...');
+    rtlRender(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
+    screen.getByRole('button', { name: /saving/i });
   });
 
   it('disables save button when saving', () => {
-    render(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
-    expect((container.querySelectorAll('button')[0] as HTMLButtonElement).disabled).toBe(true);
+    rtlRender(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
+    expect((screen.getByRole('button', { name: /saving/i }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('disables save button when canSave is false', () => {
-    render(<EditorShell {...defaultProps} canSave={false}><div /></EditorShell>);
-    expect((container.querySelectorAll('button')[0] as HTMLButtonElement).disabled).toBe(true);
+    rtlRender(<EditorShell {...defaultProps} canSave={false}><div /></EditorShell>);
+    expect((screen.getByRole('button', { name: /save/i }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('disables cancel button when saving', () => {
-    render(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
-    expect((container.querySelectorAll('button')[1] as HTMLButtonElement).disabled).toBe(true);
+    rtlRender(<EditorShell {...defaultProps} saving={true}><div /></EditorShell>);
+    expect((screen.getByRole('button', { name: /cancel/i }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('renders validation error when provided', () => {
-    render(<EditorShell {...defaultProps} validationError="Fix errors"><div /></EditorShell>);
-    expect(container.textContent).toContain('Fix errors');
+    rtlRender(<EditorShell {...defaultProps} validationError="Fix errors"><div /></EditorShell>);
+    screen.getByText('Fix errors');
   });
 
-  it('calls onSave when save button clicked', () => {
+  it('calls onSave when save button clicked', async () => {
     const onSave = jest.fn();
-    render(<EditorShell {...defaultProps} onSave={onSave}><div /></EditorShell>);
-    act(() => { (container.querySelectorAll('button')[0] as HTMLButtonElement).click(); });
+    const user = userEvent.setup();
+    rtlRender(<EditorShell {...defaultProps} onSave={onSave}><div /></EditorShell>);
+    await user.click(screen.getByRole('button', { name: /save/i }));
     expect(onSave).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onCancel when cancel button clicked', () => {
+  it('calls onCancel when cancel button clicked', async () => {
     const onCancel = jest.fn();
-    render(<EditorShell {...defaultProps} onCancel={onCancel}><div /></EditorShell>);
-    act(() => { (container.querySelectorAll('button')[1] as HTMLButtonElement).click(); });
+    const user = userEvent.setup();
+    rtlRender(<EditorShell {...defaultProps} onCancel={onCancel}><div /></EditorShell>);
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it('renders children', () => {
-    render(<EditorShell {...defaultProps}><span data-testid="child">content</span></EditorShell>);
-    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
+    rtlRender(<EditorShell {...defaultProps}><span data-testid="child">content</span></EditorShell>);
+    screen.getByTestId('child');
   });
 });
 
@@ -158,40 +142,34 @@ describe('textInputClass', () => {
 
 describe('TextInputField', () => {
   it('renders label text', () => {
-    render(<TextInputField label="Username" value="" onChange={jest.fn()} />);
-    expect(container.querySelector('label')?.textContent).toBe('Username');
+    rtlRender(<TextInputField label="Username" value="" onChange={jest.fn()} />);
+    screen.getByText('Username');
   });
 
   it('renders input with provided value', () => {
-    render(<TextInputField label="Username" value="alice" onChange={jest.fn()} />);
-    expect((container.querySelector('input') as HTMLInputElement)?.value).toBe('alice');
+    rtlRender(<TextInputField label="Username" value="alice" onChange={jest.fn()} />);
+    screen.getByDisplayValue('alice');
   });
 
-  it('calls onChange when input changes', () => {
+  it('calls onChange when input changes', async () => {
     const onChange = jest.fn();
-    render(<TextInputField label="Username" value="" onChange={onChange} />);
-    const input = container.querySelector('input') as HTMLInputElement;
-    act(() => {
-      const nativeSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
-      nativeSetter.call(input, 'bob');
-      input.dispatchEvent(new Event('input', { bubbles: true }));
-    });
+    rtlRender(<TextInputField label="Username" value="" onChange={onChange} />);
+    await userEvent.type(screen.getByRole('textbox'), 'bob');
     expect(onChange).toHaveBeenCalled();
   });
 
   it('disables input when disabled is true', () => {
-    render(<TextInputField label="Username" value="" onChange={jest.fn()} disabled={true} />);
-    expect((container.querySelector('input') as HTMLInputElement)?.disabled).toBe(true);
+    rtlRender(<TextInputField label="Username" value="" onChange={jest.fn()} disabled={true} />);
+    expect((screen.getByRole('textbox') as HTMLInputElement).disabled).toBe(true);
   });
 
   it('renders placeholder text', () => {
-    render(<TextInputField label="Username" value="" onChange={jest.fn()} placeholder="Enter username" />);
-    expect((container.querySelector('input') as HTMLInputElement)?.placeholder).toBe('Enter username');
+    rtlRender(<TextInputField label="Username" value="" onChange={jest.fn()} placeholder="Enter username" />);
+    screen.getByPlaceholderText('Enter username');
   });
 
   it('wires id to input and label htmlFor when provided', () => {
-    render(<TextInputField id="my-field" label="My Field" value="" onChange={jest.fn()} />);
-    expect((container.querySelector('input') as HTMLInputElement)?.id).toBe('my-field');
-    expect(container.querySelector('label')?.htmlFor).toBe('my-field');
+    rtlRender(<TextInputField id="my-field" label="My Field" value="" onChange={jest.fn()} />);
+    screen.getByLabelText('My Field');
   });
 });


### PR DESCRIPTION
## Summary

Migrates the final wave of medium-complexity component tests from the legacy `createRoot` + `act` + `container.querySelector*` pattern to React Testing Library.

Closes #261

## Changes

- `tests/unit/components/ui.test.tsx` — full RTL rewrite; removes `createReactRoot`/`unmountReactRoot` helper usage
- `tests/unit/components/TargetActionModal.test.tsx` — full RTL rewrite; removes `findButton()`, `changeInputValue()`, `createRoot`/`Root`/`act`
- `tests/unit/components/CreatureStatsForm.test.tsx` — full RTL rewrite; uses `within()` for checkbox scoping across damage type groups
- `tests/unit/helpers/reactRoot.ts` — retained (still consumed by other test files pending #260)

## Approach

- All tests use `render`, `screen`, `within` from `@testing-library/react` and `userEvent.setup()` from `@testing-library/user-event`
- Role-based queries (`getByRole`, `getByPlaceholderText`, `getByText`) replace all `container.querySelector*` calls
- Async `user.click()` / `user.type()` / `user.selectOptions()` replace `act(() => { el.click() })` and native-setter hacks
- `IS_REACT_ACT_ENVIRONMENT` global removed from all three files
- RTL handles cleanup automatically — no `beforeEach`/`afterEach` boilerplate needed

## Validation

- All 1776 unit tests pass
- No new TypeScript errors introduced (baseline: 23 pre-existing errors in unrelated files)
- No legacy patterns remain in migrated files