### PR TITLE
docs: archive rtl-migrate-modal-form-ui-tests (2026-05-29)

### DIFF
--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/design.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/design.md
@@ -88,7 +88,7 @@
 - **Requirement:** `TargetActionModal.test.tsx` serves as the canonical RTL reference
   - Design element: Decision 2 (`userEvent.setup()` per test), Decision 4
   - Acceptance criteria reference: `specs/target-action-modal/spec.md`
-  - Testability notes: Code review; file is fully commented-free except for the one `within()` note
+  - Testability notes: Code review; `TargetActionModal.test.tsx` is fully comment-free (the one `within()` scoping comment is in `CreatureStatsForm.test.tsx`)
 
 ## Non-Functional Requirements Mapping
 

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/design.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-- **Relevant architecture:** Component tests live in `tests/unit/components/`. The project uses Jest with jsdom and RTL (`@testing-library/react` ^16, `@testing-library/user-event` ^14, `@testing-library/jest-dom` ^6). RTL is configured globally via `jest.setup.ts` (imports `@testing-library/jest-dom`). `jest.config.js` uses `setupFilesAfterFramework`.
+- **Relevant architecture:** Component tests live in `tests/unit/components/`. The project uses Jest with jsdom and RTL (`@testing-library/react` ^16, `@testing-library/user-event` ^14, `@testing-library/jest-dom` ^6). RTL is configured globally via `jest.setup.ts` (imports `@testing-library/jest-dom`). `jest.config.js` uses `setupFilesAfterEnv`.
 - **Dependencies:** `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom` already installed (issue #254). No new package additions required.
 - **Interfaces/contracts touched:** Test files only. No production source files are modified.
 
@@ -64,13 +64,13 @@
 
 - **Proposal: Migrate ui.test.tsx first**
   - Design decision: Decision 1 (migration order)
-  - Validation approach: File uses only RTL imports; `npm test` passes after each file
+  - Validation approach: File uses only RTL imports; `npm run test:unit` passes after each file
 - **Proposal: `TargetActionModal` has unlabelled inputs → use `getByPlaceholderText`**
   - Design decision: Decision 4 (query strategy)
   - Validation approach: Tests pass and accurately exercise component behavior
 - **Proposal: `CreatureStatsForm` has 39 duplicate-named checkboxes → use `within()`**
   - Design decision: Decision 3 (`within()` scoping)
-  - Validation approach: Checkbox tests correctly target the right section; `npm test` passes
+  - Validation approach: Checkbox tests correctly target the right section; `npm run test:unit` passes
 - **Proposal: Conditional `reactRoot.ts` deletion**
   - Design decision: Decision 5 (conditional deletion)
   - Validation approach: `grep -r "reactRoot" tests/` returns empty before deletion
@@ -84,7 +84,7 @@
 - **Requirement:** All existing test cases pass after migration
   - Design element: Decision 4 (query strategy per component)
   - Acceptance criteria reference: All three spec files
-  - Testability notes: `npm test -- --testPathPattern="(ui|TargetActionModal|CreatureStatsForm).test"` green
+  - Testability notes: `npm run test:unit -- --testPathPattern="(ui|TargetActionModal|CreatureStatsForm).test"` green
 - **Requirement:** `TargetActionModal.test.tsx` serves as the canonical RTL reference
   - Design element: Decision 2 (`userEvent.setup()` per test), Decision 4
   - Acceptance criteria reference: `specs/target-action-modal/spec.md`
@@ -112,7 +112,7 @@
 - **Rollback trigger:** CI fails on any of the three migrated test files and cannot be fixed within the PR iteration.
 - **Rollback steps:** Revert the affected test file to its pre-migration state from `main`. Open a follow-up issue for the specific file.
 - **Data migration considerations:** None — test files only.
-- **Verification after rollback:** `npm test` passes on `main`.
+- **Verification after rollback:** `npm run test:unit` passes on `main`.
 
 ## Operational Blocking Policy
 

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/design.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/design.md
@@ -1,0 +1,126 @@
+## Context
+
+- **Relevant architecture:** Component tests live in `tests/unit/components/`. The project uses Jest with jsdom and RTL (`@testing-library/react` ^16, `@testing-library/user-event` ^14, `@testing-library/jest-dom` ^6). RTL is configured globally via `jest.setup.ts` (imports `@testing-library/jest-dom`). `jest.config.js` uses `setupFilesAfterFramework`.
+- **Dependencies:** `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom` already installed (issue #254). No new package additions required.
+- **Interfaces/contracts touched:** Test files only. No production source files are modified.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Migrate all three test files to use only RTL APIs (`render`, `screen`, `within`, `userEvent`)
+- Preserve or improve statement coverage for each component
+- Establish `TargetActionModal.test.tsx` as the canonical RTL pattern reference for the project
+- Delete `tests/unit/helpers/reactRoot.ts` when it has no remaining consumers
+- Remove `IS_REACT_ACT_ENVIRONMENT` globals and dead `createRoot`/`Root`/`act` imports
+
+### Non-Goals
+
+- Modifying production source components
+- Adding net-new test cases beyond coverage parity
+- Migrating files outside the three named above
+
+## Decisions
+
+### Decision 1: Migration order — ui.test.tsx first
+
+- **Chosen:** Migrate in order: `ui.test.tsx` → `TargetActionModal.test.tsx` → `CreatureStatsForm.test.tsx`
+- **Alternatives considered:** All three in parallel; TargetActionModal first (it's the pattern reference per the issue)
+- **Rationale:** `ui.test.tsx` is the simplest file (pure renders, one interaction). It serves as a fast sanity check that RTL works correctly in this test environment before tackling files with more complex state flows. User confirmed this order.
+- **Trade-offs:** Slightly delays establishing the TargetActionModal as the reference, but reduces risk of wasted effort if a basic RTL issue surfaces.
+
+### Decision 2: `userEvent.setup()` per test (not shared instance)
+
+- **Chosen:** Create a `const user = userEvent.setup()` inside each `test`/`it` that needs interaction.
+- **Alternatives considered:** Shared `user` in `beforeEach`; top-level module constant.
+- **Rationale:** Consistent with existing RTL tests in the project (Modal.test.tsx, CombatInfoIcon.test.tsx). `userEvent.setup()` creates isolated event state per test, preventing inter-test contamination.
+- **Trade-offs:** Slightly more boilerplate per test; negligible performance cost.
+
+### Decision 3: `within()` for CreatureStatsForm checkbox scoping
+
+- **Chosen:** Use `screen.getByText('Damage Resistances').closest('div')` to obtain the section container, then `within(container).getByRole('checkbox', { name: /fire/i })` to target specific checkboxes.
+- **Alternatives considered:** `getAllByRole('checkbox', { name: /fire/i })[N]` (index-based, fragile); adding `data-testid` to section divs in the source component (requires source changes, out of scope).
+- **Rationale:** `within()` scoping is the RTL-idiomatic way to disambiguate repeated element names. Targeting the section by its label text is explicit and readable without requiring production code changes.
+- **Trade-offs:** The scoping is structurally coupled to the component's DOM layout (label → sibling div). A future layout change could break the scoping. Document this with a single comment in the test file.
+
+### Decision 4: Query strategy per component
+
+- **Chosen:**
+  - `ui.test.tsx`: `getByText`, `getByLabelText` (FormField/TextInputField have label→input wiring), `getByRole('button', { name: /.../ })`, `getByRole('heading')` for h2
+  - `TargetActionModal.test.tsx`: `getByRole('button', { name: /.../ })` for buttons, `getByPlaceholderText` for unlabelled number/text inputs, `getByRole('combobox', { name: /damage type/i })` for the select (it has `aria-label`)
+  - `CreatureStatsForm.test.tsx`: `getByRole('button', { name: /resistances/i })` for the expand toggle, `within(sectionEl).getByRole('checkbox', { name: /type/i })` for checkboxes
+- **Alternatives considered:** `getByTestId` (requires `data-testid` on source); `container.querySelector` (defeats RTL purpose)
+- **Rationale:** Role/label/text queries are the RTL-preferred hierarchy. Placeholder queries are a pragmatic fallback for unlabelled inputs where source changes are out of scope.
+- **Trade-offs:** `getByPlaceholderText` is lower in RTL's recommended query priority (below role and label queries), but it's appropriate here given the constraint.
+
+### Decision 5: Conditional deletion of `reactRoot.ts` helper
+
+- **Chosen:** Delete `tests/unit/helpers/reactRoot.ts` at implementation time only if `grep -r "reactRoot" tests/` returns no results.
+- **Alternatives considered:** Delete unconditionally now; leave it forever.
+- **Rationale:** `ui.test.tsx` is the only known consumer, but #260 (other files) may or may not have completed by implementation time. A runtime check is the safe approach.
+- **Trade-offs:** Leaves a potential dead file if #260 isn't done; acceptable — the file is small and harmless.
+
+## Proposal to Design Mapping
+
+- **Proposal: Migrate ui.test.tsx first**
+  - Design decision: Decision 1 (migration order)
+  - Validation approach: File uses only RTL imports; `npm test` passes after each file
+- **Proposal: `TargetActionModal` has unlabelled inputs → use `getByPlaceholderText`**
+  - Design decision: Decision 4 (query strategy)
+  - Validation approach: Tests pass and accurately exercise component behavior
+- **Proposal: `CreatureStatsForm` has 39 duplicate-named checkboxes → use `within()`**
+  - Design decision: Decision 3 (`within()` scoping)
+  - Validation approach: Checkbox tests correctly target the right section; `npm test` passes
+- **Proposal: Conditional `reactRoot.ts` deletion**
+  - Design decision: Decision 5 (conditional deletion)
+  - Validation approach: `grep -r "reactRoot" tests/` returns empty before deletion
+
+## Functional Requirements Mapping
+
+- **Requirement:** All three files use RTL imports exclusively (no `createRoot`, `react-dom/client`, `IS_REACT_ACT_ENVIRONMENT`)
+  - Design element: Decisions 1, 2, 4
+  - Acceptance criteria reference: `specs/ui-primitives/spec.md`, `specs/target-action-modal/spec.md`, `specs/creature-stats-form/spec.md`
+  - Testability notes: Import-level check; grep or lint can verify absence of banned imports
+- **Requirement:** All existing test cases pass after migration
+  - Design element: Decision 4 (query strategy per component)
+  - Acceptance criteria reference: All three spec files
+  - Testability notes: `npm test -- --testPathPattern="(ui|TargetActionModal|CreatureStatsForm).test"` green
+- **Requirement:** `TargetActionModal.test.tsx` serves as the canonical RTL reference
+  - Design element: Decision 2 (`userEvent.setup()` per test), Decision 4
+  - Acceptance criteria reference: `specs/target-action-modal/spec.md`
+  - Testability notes: Code review; file is fully commented-free except for the one `within()` note
+
+## Non-Functional Requirements Mapping
+
+- **Requirement category:** Operability
+  - Requirement: Test run time must not regress significantly (RTL `userEvent` is async but not slow)
+  - Design element: Decision 2 (`userEvent.setup()` per test, not globally shared)
+  - Acceptance criteria reference: CI must pass within normal timeout
+  - Testability notes: CI run time comparison before/after
+
+## Risks / Trade-offs
+
+- **Risk:** `getByPlaceholderText` is a lower-priority RTL query; if inputs gain `aria-label` later, tests should be updated.
+  - Impact: Low — tests still work, but a future `getByLabelText` would be more robust.
+  - Mitigation: Acceptable for now; note in test file comment.
+- **Risk:** `within()` scoping tied to DOM structure of `CreatureStatsForm`.
+  - Impact: Medium — layout changes break scoping silently if the label text moves.
+  - Mitigation: Single comment in the test file documenting the DOM dependency.
+
+## Rollback / Mitigation
+
+- **Rollback trigger:** CI fails on any of the three migrated test files and cannot be fixed within the PR iteration.
+- **Rollback steps:** Revert the affected test file to its pre-migration state from `main`. Open a follow-up issue for the specific file.
+- **Data migration considerations:** None — test files only.
+- **Verification after rollback:** `npm test` passes on `main`.
+
+## Operational Blocking Policy
+
+- **If CI checks fail:** Diagnose the failure, fix in the same branch, push, wait 180 seconds, re-check. Repeat until green or rollback is triggered.
+- **If security checks fail:** Not applicable — this change touches only test files, no production code or secrets.
+- **If required reviews are blocked/stale:** Ping the reviewer after 24 hours. If no response after 48 hours, escalate to the team lead.
+- **Escalation path and timeout:** If CI remains blocked after 3 fix iterations, revert the specific file (not the whole PR) and open a scoped follow-up issue.
+
+## Open Questions
+
+None. All design decisions are resolved based on codebase investigation and user confirmation.

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/proposal.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/proposal.md
@@ -6,7 +6,7 @@
 
 - **Problem statement:** Three component test files (`ui.test.tsx`, `TargetActionModal.test.tsx`, `CreatureStatsForm.test.tsx`) still use the legacy `createRoot` + `act` + `container.querySelector*` pattern. The project adopted React Testing Library (RTL) as the standard in #254, and all new tests are written in RTL. These files are the final wave of medium-complexity tests that must be migrated to eliminate the legacy pattern from the component test suite.
 - **Why now:** RTL infrastructure (#254) is complete and merged. The simpler files (issue #260) are being migrated in parallel on a separate thread. This is the natural next step to fully retire the legacy pattern.
-- **Business/user impact:** Unified test style lowers contributor friction and makes test failures easier to diagnose. RTL's `userEvent` is more faithful to real browser interaction than synthetic `dispatchEvent`, improving confidence in these tests. Retiring the legacy pattern also removes the `helpers/reactRoot.ts` file and the `IS_REACT_ACT_ENVIRONMENT` globals.
+- **Business/user impact:** Unified test style lowers contributor friction and makes test failures easier to diagnose. RTL's `userEvent` is more faithful to real browser interaction than synthetic `dispatchEvent`, improving confidence in these tests. Retiring the legacy pattern in these three files reduces reliance on `helpers/reactRoot.ts` and `IS_REACT_ACT_ENVIRONMENT`, enabling their eventual removal once remaining consumers are migrated.
 
 ## Problem Space
 
@@ -54,7 +54,7 @@
 
 - **Risk:** Test coverage regression on `CreatureStatsForm` (currently 32% statement coverage).
   - **Impact:** Medium — existing tests are already sparse; migration must at minimum preserve them.
-  - **Mitigation:** Run `npm test -- --coverage` before and after; fail the PR if coverage drops.
+  - **Mitigation:** Run `npm run test:unit -- --coverage` before and after; fail the PR if coverage drops.
 
 - **Risk:** RTL's `userEvent.type` behaves differently from the native setter hack for controlled inputs — React state may update differently.
   - **Impact:** Low — RTL's simulation is more realistic; the component's `onChange` handlers respond to native input events which `userEvent` fires correctly.

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/proposal.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/proposal.md
@@ -1,0 +1,89 @@
+## GitHub Issues
+
+- #261
+
+## Why
+
+- **Problem statement:** Three component test files (`ui.test.tsx`, `TargetActionModal.test.tsx`, `CreatureStatsForm.test.tsx`) still use the legacy `createRoot` + `act` + `container.querySelector*` pattern. The project adopted React Testing Library (RTL) as the standard in #254, and all new tests are written in RTL. These files are the final wave of medium-complexity tests that must be migrated to eliminate the legacy pattern from the component test suite.
+- **Why now:** RTL infrastructure (#254) is complete and merged. The simpler files (issue #260) are being migrated in parallel on a separate thread. This is the natural next step to fully retire the legacy pattern.
+- **Business/user impact:** Unified test style lowers contributor friction and makes test failures easier to diagnose. RTL's `userEvent` is more faithful to real browser interaction than synthetic `dispatchEvent`, improving confidence in these tests. Retiring the legacy pattern also removes the `helpers/reactRoot.ts` file and the `IS_REACT_ACT_ENVIRONMENT` globals.
+
+## Problem Space
+
+- **Current behavior:** `ui.test.tsx`, `TargetActionModal.test.tsx`, and `CreatureStatsForm.test.tsx` use `createRoot`, `Root`, `act()` for rendering, and `container.querySelector*` or raw `.click()` for interaction. `ui.test.tsx` uses the `createReactRoot` / `unmountReactRoot` helper from `tests/unit/helpers/reactRoot.ts`. `TargetActionModal.test.tsx` contains a custom `findButton()` helper and a `changeInputValue()` function that uses native prototype setters to bypass React's synthetic event system.
+- **Desired behavior:** All three files use `@testing-library/react` (`render`, `screen`, `within`) and `@testing-library/user-event` exclusively. No `createRoot`, `Root`, `container`, `act`, `IS_REACT_ACT_ENVIRONMENT`, or native-setter hacks. Tests remain async where interactions are involved. Coverage is maintained or improved.
+- **Constraints:**
+  - `TargetActionModal` has no `aria-label` on its number/text inputs — only `placeholder` attributes and an `aria-label` on the damage-type `<select>`. Tests will use `getByPlaceholderText` for unlabelled inputs; the select uses `getByRole('combobox', { name: /damage type/i })`.
+  - `CreatureStatsForm` renders three groups of 13 damage-type checkboxes (39 total). Checkbox names repeat across groups (e.g. "fire" appears in Vulnerabilities, Resistances, and Immunities). Scoped queries via `within()` are required to disambiguate.
+  - `EditorShell` buttons have no explicit `aria-label`; they carry text content ("Save" / saveLabel, "Cancel"). `getByRole('button', { name: /save/i })` and `getByRole('button', { name: /cancel/i })` work correctly.
+- **Assumptions:**
+  - RTL cleanup between tests is automatic (no manual `afterEach` teardown required).
+  - `@jest-environment jsdom` doc comment is still required per jest config.
+  - `IS_REACT_ACT_ENVIRONMENT = true` global can be removed — RTL wraps act internally.
+  - Test case count may change if the structure is improved, as long as coverage is maintained or increased.
+- **Edge cases considered:**
+  - `CreatureStatsForm` pre-selected resistance rendering: with RTL, `within()` scoping on the section container is needed to count or target checked checkboxes per group.
+  - `TargetActionModal` damage apply with a type changes the button label to `Apply (fire)` — RTL regex `getByRole('button', { name: /apply/i })` must be precise enough to not match the "Apply Damage" button on the main screen (that button is gone after navigation).
+  - `TextInputField.onChange` test currently uses the native prototype setter hack. RTL's `userEvent.type` replaces this cleanly.
+
+## Scope
+
+### In Scope
+
+- Migrate `tests/unit/components/ui.test.tsx` to RTL
+- Migrate `tests/unit/components/TargetActionModal.test.tsx` to RTL
+- Migrate `tests/unit/components/CreatureStatsForm.test.tsx` to RTL (resistances section only — the existing tests only cover the resistances/immunities subsection; ability scores and skills are not currently tested and are out of scope for new test cases)
+- Remove `IS_REACT_ACT_ENVIRONMENT` global and dead `createRoot`/`Root`/`act` imports from migrated files
+- Delete `tests/unit/helpers/reactRoot.ts` once it has no remaining consumers (confirm after #260 completes or check at implementation time)
+
+### Out of Scope
+
+- Adding new test cases beyond what's needed to match or improve current coverage
+- Migrating any test files not listed above
+- Adding `aria-label` or other accessibility attributes to the source components (a separate concern)
+- Migrating `AlignmentSelect.test.tsx`, `NavBar.test.tsx`, `CreatureStatBlock.test.tsx` (those are issue #260)
+
+## What Changes
+
+- `tests/unit/components/ui.test.tsx` — full rewrite in RTL; removes `createReactRoot`/`unmountReactRoot` helper usage
+- `tests/unit/components/TargetActionModal.test.tsx` — full rewrite in RTL; removes `findButton()`, `changeInputValue()`, `createRoot`/`Root`/`act`
+- `tests/unit/components/CreatureStatsForm.test.tsx` — full rewrite in RTL; uses `within()` for checkbox scoping
+- `tests/unit/helpers/reactRoot.ts` — deleted if no remaining consumers after #260 migration (verified at implementation time)
+
+## Risks
+
+- **Risk:** Test coverage regression on `CreatureStatsForm` (currently 32% statement coverage).
+  - **Impact:** Medium — existing tests are already sparse; migration must at minimum preserve them.
+  - **Mitigation:** Run `npm test -- --coverage` before and after; fail the PR if coverage drops.
+
+- **Risk:** RTL's `userEvent.type` behaves differently from the native setter hack for controlled inputs — React state may update differently.
+  - **Impact:** Low — RTL's simulation is more realistic; the component's `onChange` handlers respond to native input events which `userEvent` fires correctly.
+  - **Mitigation:** Run all tests after each file migration and address failures before moving on.
+
+- **Risk:** `within()` scoping logic for `CreatureStatsForm` is structurally coupled to the component's DOM layout. If the layout changes, tests break.
+  - **Impact:** Low — this is a known RTL tradeoff for components without explicit region roles.
+  - **Mitigation:** Document the scoping approach in the test file with a short comment explaining the DOM dependency.
+
+- **Risk:** `helpers/reactRoot.ts` may still be used by files not yet migrated in #260 at implementation time.
+  - **Impact:** Low — safe to leave the file in place if consumers remain; delete only when count is zero.
+  - **Mitigation:** `grep -r "reactRoot"` at implementation time; delete only if the result is empty.
+
+## Open Questions
+
+No unresolved ambiguity exists. The user confirmed:
+- Migration order: `ui.test.tsx` first, then `TargetActionModal.test.tsx`, then `CreatureStatsForm.test.tsx`
+- Test structure may change (not required to be 1:1 with the old tests)
+- Goal is same or better coverage using RTL, not strict case-by-case preservation
+- `helpers/reactRoot.ts` deletion is conditional on zero remaining consumers
+- Issue #260 (simpler files) is being handled on a separate thread in parallel
+
+## Non-Goals
+
+- Adding new source code features or fixing bugs in the migrated components
+- Full coverage improvement for `CreatureStatsForm` (that is a separate issue)
+- Enforcing RTL for test files outside the three listed
+- Touching CI configuration
+
+## Change Control
+
+If scope changes after proposal approval, update `openspec/changes/rtl-migrate-modal-form-ui-tests/proposal.md`, `design.md`, `specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/creature-stats-form/spec.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/creature-stats-form/spec.md
@@ -1,0 +1,96 @@
+# Capability: CreatureStatsForm Test Migration
+
+Covers `tests/unit/components/CreatureStatsForm.test.tsx` — migration to RTL. Existing tests cover only the resistances/immunities/vulnerabilities subsection. Structure may change; coverage must be maintained or improved.
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CreatureStatsForm.test.tsx uses RTL APIs with `within()` scoping
+
+The system SHALL test `CreatureStatsForm`'s resistances section using `@testing-library/react`, `@testing-library/user-event`, and `within()` for disambiguation of repeated checkbox names across the three damage groups (Vulnerabilities, Resistances, Immunities).
+
+#### Scenario: Resistances section is collapsed by default
+
+- **Given** `CreatureStatsForm` is rendered with `BASE_STATS` (no pre-set resistances)
+- **When** the component mounts
+- **Then** no checkboxes are present in the document (`screen.queryAllByRole('checkbox')` returns `[]`)
+
+#### Scenario: Clicking the Resistances & Immunities toggle expands the section
+
+- **Given** `CreatureStatsForm` is rendered and `userEvent.setup()` is available
+- **When** the user clicks `screen.getByRole('button', { name: /resistances/i })`
+- **Then** checkboxes appear — 39 total (3 fields × 13 damage types)
+
+#### Scenario: All checkboxes are unchecked when no resistances are set
+
+- **Given** the resistances section is expanded with `BASE_STATS`
+- **When** the component renders
+- **Then** `screen.getAllByRole('checkbox')` returns 39 elements, all unchecked
+
+#### Scenario: Pre-selected resistances render as checked
+
+- **Given** `stats` includes `damageResistances: ['fire', 'cold']`
+- **When** the resistances section is expanded
+- **Then** exactly 2 checkboxes are checked across the entire form
+- **Then** within the "Damage Resistances" section, the "fire" and "cold" checkboxes are checked
+
+#### Scenario: Checking an unchecked resistance calls onChange with type added
+
+- **Given** the resistances section is expanded with `BASE_STATS` and `userEvent.setup()`
+- **When** the user clicks the "fire" checkbox within the "Damage Resistances" section (scoped via `within()`)
+- **Then** `onChange` is called once
+- **Then** the argument's `damageResistances` array contains `'fire'`
+
+#### Scenario: Unchecking a checked resistance calls onChange with type removed
+
+- **Given** `stats` includes `damageResistances: ['fire']`, section is expanded, `userEvent.setup()`
+- **When** the user clicks the checked "fire" checkbox in the resistances section
+- **Then** `onChange` is called once
+- **Then** the argument's `damageResistances` is falsy (undefined or empty)
+
+#### Scenario: Checking an immunity type calls onChange with damageImmunities updated
+
+- **Given** the resistances section is expanded with `BASE_STATS` and `userEvent.setup()`
+- **When** the user clicks "poison" within the "Damage Immunities" section (scoped via `within()`)
+- **Then** `onChange` is called once
+- **Then** the argument's `damageImmunities` array contains `'poison'`
+
+#### Scenario: Removing the last type from a field sets field to undefined
+
+- **Given** `stats` includes `damageVulnerabilities: ['cold']`, section is expanded, `userEvent.setup()`
+- **When** the user unchecks "cold" in the "Damage Vulnerabilities" section
+- **Then** `onChange` is called once
+- **Then** the argument's `damageVulnerabilities` is `undefined`
+
+## REMOVED Requirements
+
+### Requirement: REMOVED legacy `createRoot`/`Root`/`act` pattern in CreatureStatsForm.test.tsx
+
+Reason for removal: RTL handles rendering and cleanup automatically.
+
+### Requirement: REMOVED DOM-walking label traversal for checkbox discovery
+
+Reason for removal: `within()` scoping on the section container is the RTL-idiomatic replacement. The old approach walked the DOM via `parentElement`, `querySelectorAll('label')`, and text matching — fragile and verbose.
+
+## Traceability
+
+- Proposal: "Migrate `CreatureStatsForm.test.tsx`; structure may change; `within()` for scoping" → Requirement above
+- Design decision 3 (`within()` scoping) → All checkbox interaction scenarios
+- Design decision 2 (`userEvent.setup()` per test) → All interaction scenarios
+- Design decision 4 (query strategy: `getByRole('button')` for toggle, `within().getByRole('checkbox')` for checkboxes) → All scenarios
+- Requirement → Task: "Migrate CreatureStatsForm.test.tsx"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: No banned legacy imports remain
+
+- **Given** `CreatureStatsForm.test.tsx` has been migrated
+- **When** `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|parentElement|querySelectorAll" tests/unit/components/CreatureStatsForm.test.tsx` is run
+- **Then** the output is empty
+
+#### Scenario: `within()` scoping is documented
+
+- **Given** the file uses `within()` to scope checkbox queries to a section
+- **When** the section-targeting code is reviewed
+- **Then** a single comment explains the DOM dependency (e.g. "scoped by section label text — tied to CreatureStatsForm DOM structure")

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/target-action-modal/spec.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/target-action-modal/spec.md
@@ -1,0 +1,106 @@
+# Capability: TargetActionModal Test Migration
+
+Covers `tests/unit/components/TargetActionModal.test.tsx` — migration to RTL. This file becomes the canonical RTL pattern reference for the project after migration.
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED TargetActionModal.test.tsx uses RTL APIs exclusively
+
+The system SHALL test `TargetActionModal` using `@testing-library/react` and `@testing-library/user-event`, with no `createRoot`, `Root`, `act`, `findButton()`, `changeInputValue()`, or `IS_REACT_ACT_ENVIRONMENT`.
+
+#### Scenario: Initial screen renders target info and action buttons
+
+- **Given** `TargetActionModal` is rendered with a target (name="Goblin Target", hp=7, maxHp=7, ac=13)
+- **When** the component mounts
+- **Then** `screen.getByText('Goblin Target')` is in the document
+- **Then** text containing "HP: 7/7" is visible
+- **Then** text containing "AC: 13" is visible
+- **Then** `screen.getByRole('button', { name: /apply damage/i })` is present
+- **Then** `screen.getByRole('button', { name: /add condition/i })` is present
+- **Then** `screen.getByRole('button', { name: /cancel/i })` is present
+
+#### Scenario: Cancel button calls onClose
+
+- **Given** `TargetActionModal` is rendered with a `onClose` mock and `userEvent.setup()`
+- **When** the user clicks the Cancel button
+- **Then** `onClose` has been called once
+
+#### Scenario: Apply Damage button transitions to damage screen
+
+- **Given** `TargetActionModal` is on the initial screen
+- **When** the user clicks "Apply Damage"
+- **Then** the initial action buttons are no longer in the document
+- **Then** `screen.getByPlaceholderText('Damage amount')` is present (number input)
+- **Then** `screen.getByRole('combobox', { name: /damage type/i })` is present
+
+#### Scenario: Damage flow submits correct values to onApplyDamage
+
+- **Given** the modal is in damage mode with `userEvent.setup()`
+- **When** the user types "5" into the damage amount input
+- **And** the user selects "fire" from the damage type combobox
+- **Then** the Apply button label updates to include "(fire)"
+- **When** the user clicks the Apply button
+- **Then** `onApplyDamage` has been called with `(5, 'fire')`
+
+#### Scenario: Damage flow with no type selected submits empty string type
+
+- **Given** the modal is in damage mode with `userEvent.setup()`
+- **When** the user types "3" into the damage amount input and does not change the damage type
+- **And** clicks the Apply button (label is just "Apply")
+- **Then** `onApplyDamage` has been called with `(3, '')`
+
+#### Scenario: Add Condition button transitions to condition screen
+
+- **Given** `TargetActionModal` is on the initial screen
+- **When** the user clicks "Add Condition"
+- **Then** the initial action buttons are no longer in the document
+- **Then** `screen.getByPlaceholderText('Condition name')` is present
+- **Then** `screen.getByPlaceholderText('Duration in rounds (optional)')` is present
+
+#### Scenario: Condition flow submits correct values to onAddCondition
+
+- **Given** the modal is in condition mode with `userEvent.setup()`
+- **When** the user types "Stunned" into the condition name input
+- **And** the user types "3" into the duration input
+- **And** clicks the Add button
+- **Then** `onAddCondition` has been called with `('Stunned', 3)`
+
+#### Scenario: Condition flow with no duration calls onAddCondition with undefined duration
+
+- **Given** the modal is in condition mode with `userEvent.setup()`
+- **When** the user types "Blinded" into the condition name input and leaves duration empty
+- **And** clicks the Add button
+- **Then** `onAddCondition` has been called with `('Blinded', undefined)`
+
+## REMOVED Requirements
+
+### Requirement: REMOVED custom `findButton()` helper
+
+Reason for removal: Replaced by `screen.getByRole('button', { name: /.../ })`.
+
+### Requirement: REMOVED custom `changeInputValue()` native-setter hack
+
+Reason for removal: Replaced by `await userEvent.type()` and `await userEvent.selectOptions()`.
+
+## Traceability
+
+- Proposal: "Migrate TargetActionModal.test.tsx; becomes canonical RTL reference" → Requirement above
+- Design decision 2 (`userEvent.setup()` per test) → All interaction scenarios
+- Design decision 4 (query strategy: `getByRole`, `getByPlaceholderText`, `getByRole('combobox')`) → All scenarios
+- Requirement → Task: "Migrate TargetActionModal.test.tsx"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: No banned legacy imports remain
+
+- **Given** `TargetActionModal.test.tsx` has been migrated
+- **When** `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|findButton|changeInputValue" tests/unit/components/TargetActionModal.test.tsx` is run
+- **Then** the output is empty
+
+#### Scenario: File serves as RTL pattern reference
+
+- **Given** the file uses `userEvent.setup()` per test, `screen.*` queries, and `await user.*` interactions
+- **When** a contributor reads the file to understand how to write RTL component tests
+- **Then** all patterns are self-consistent and represent current project conventions

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/ui-primitives/spec.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/ui-primitives/spec.md
@@ -12,7 +12,7 @@ The system SHALL render and interact with UI primitives using `@testing-library/
 
 - **Given** `ui.test.tsx` is migrated to RTL
 - **When** `ErrorBanner` is rendered with `message={null}`
-- **Then** `screen.queryByRole('alert')` (or any container query) returns null / the component renders nothing
+- **Then** `screen.queryByRole('alert')` returns null / the component renders nothing
 
 #### Scenario: ErrorBanner renders message text when provided
 

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/ui-primitives/spec.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/specs/ui-primitives/spec.md
@@ -1,0 +1,134 @@
+# Capability: UI Primitives Test Migration
+
+Covers `tests/unit/components/ui.test.tsx` — migration to RTL for `ErrorBanner`, `ValidationError`, `LoadingState`, `FormField`, `EditorShell`, `textInputClass`, and `TextInputField`.
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED ui.test.tsx uses RTL APIs exclusively
+
+The system SHALL render and interact with UI primitives using `@testing-library/react` and `@testing-library/user-event`, with no `createRoot`, `Root`, `act`, `IS_REACT_ACT_ENVIRONMENT`, or `createReactRoot`/`unmountReactRoot` imports.
+
+#### Scenario: ErrorBanner renders nothing when message is null
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ErrorBanner` is rendered with `message={null}`
+- **Then** `screen.queryByRole('alert')` (or any container query) returns null / the component renders nothing
+
+#### Scenario: ErrorBanner renders message text when provided
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ErrorBanner` is rendered with `message="Something went wrong"`
+- **Then** `screen.getByText('Something went wrong')` resolves and `.toBeInTheDocument()`
+
+#### Scenario: ValidationError renders nothing when message is null
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ValidationError` is rendered with `message={null}`
+- **Then** no content is present in the document
+
+#### Scenario: ValidationError renders message text when provided
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ValidationError` is rendered with `message="Name is required"`
+- **Then** `screen.getByText('Name is required')` is in the document
+
+#### Scenario: LoadingState renders label text
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `LoadingState` is rendered with `label="Loading data..."`
+- **Then** `screen.getByText('Loading data...')` is in the document
+
+#### Scenario: FormField renders label and children
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `FormField` is rendered with `label="My Field"` and a child input
+- **Then** `screen.getByText('My Field')` is present and the child is rendered
+
+#### Scenario: FormField wires htmlFor when provided
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `FormField` is rendered with `label="Email"` and `htmlFor="email-input"`
+- **Then** `screen.getByLabelText('Email')` resolves to the associated input
+
+#### Scenario: EditorShell renders title as heading
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `title="Test Editor"`
+- **Then** `screen.getByRole('heading', { name: 'Test Editor' })` is in the document
+
+#### Scenario: EditorShell save button shows saveLabel or Saving...
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `saving={false}` and `saveLabel="Save"`
+- **Then** `screen.getByRole('button', { name: /save/i })` is present and enabled
+- **When** `EditorShell` is rendered with `saving={true}`
+- **Then** the save button shows "Saving..." and is disabled
+
+#### Scenario: EditorShell save and cancel buttons fire callbacks
+
+- **Given** `ui.test.tsx` is migrated to RTL with a `userEvent.setup()` instance
+- **When** the user clicks the save button
+- **Then** `onSave` has been called once
+- **When** the user clicks the cancel button
+- **Then** `onCancel` has been called once
+
+#### Scenario: EditorShell disables cancel when saving
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `saving={true}`
+- **Then** `screen.getByRole('button', { name: /cancel/i })` is disabled
+
+#### Scenario: EditorShell shows validation error
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `validationError="Fix errors"`
+- **Then** `screen.getByText('Fix errors')` is in the document
+
+#### Scenario: textInputClass returns the correct CSS string
+
+- **Given** `textInputClass` is a pure function
+- **When** called with no arguments
+- **Then** returns `'w-full bg-gray-700 rounded px-3 py-2 text-white'` (unchanged — this test requires no RTL)
+
+#### Scenario: TextInputField renders label and input value
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `TextInputField` is rendered with `label="Username"` and `value="alice"`
+- **Then** `screen.getByLabelText('Username')` resolves and has value `"alice"`
+
+#### Scenario: TextInputField calls onChange on user input
+
+- **Given** `ui.test.tsx` is migrated to RTL with `userEvent.setup()`
+- **When** the user types into the TextInputField
+- **Then** the `onChange` callback is called
+
+#### Scenario: TextInputField respects disabled and placeholder props
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `disabled={true}` is passed
+- **Then** `screen.getByLabelText(...)` is disabled
+- **When** `placeholder="Enter username"` is passed
+- **Then** the input has the correct placeholder
+
+## REMOVED Requirements
+
+### Requirement: REMOVED legacy `createReactRoot` / `unmountReactRoot` usage in ui.test.tsx
+
+Reason for removal: RTL handles DOM cleanup automatically; the helper is no longer needed for this file.
+
+## Traceability
+
+- Proposal: "Migrate `ui.test.tsx` to RTL" → Requirement: MODIFIED ui.test.tsx uses RTL APIs exclusively
+- Design decision 1 (migration order) → This spec is first in implementation sequence
+- Design decision 4 (query strategy: `getByLabelText`, `getByRole`, `getByText`) → All scenarios above
+- Requirement → Task: "Migrate ui.test.tsx"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: No banned legacy imports remain
+
+- **Given** `ui.test.tsx` has been migrated
+- **When** `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|reactRoot" tests/unit/components/ui.test.tsx` is run
+- **Then** the output is empty (exit code 1 or no matches)

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tasks.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tasks.md
@@ -1,0 +1,119 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b refactor/rtl-migrate-modal-form-ui-tests` then immediately `git push -u origin refactor/rtl-migrate-modal-form-ui-tests`
+
+## Execution
+
+### File 1: Migrate `tests/unit/components/ui.test.tsx`
+
+> **BDD/TDD sequence:** Rewrite the file in RTL first. Run tests — they should pass immediately since the component behavior is unchanged. If any fail, diagnose before moving on.
+
+- [x] Remove `IS_REACT_ACT_ENVIRONMENT` global, `createReactRoot`/`unmountReactRoot` import, `createRoot`/`Root`/`act` imports
+- [x] Replace `beforeEach`/`afterEach` boilerplate with nothing (RTL cleans up automatically)
+- [x] Replace all `render(element)` calls with `rtlRender(element)` using `import { render as rtlRender, screen, within } from '@testing-library/react'`
+- [x] Replace `container.textContent` / `container.querySelector*` assertions with `screen.getByText`, `screen.getByLabelText`, `screen.getByRole`, `screen.queryBy*`
+- [x] Migrate `EditorShell` button queries from index-based (`querySelectorAll('button')[0]`) to `screen.getByRole('button', { name: /save/i })` and `getByRole('button', { name: /cancel/i })`
+- [x] Migrate `EditorShell` click tests to `const user = userEvent.setup(); await user.click(...)`; make those tests `async`
+- [x] Migrate `TextInputField.onChange` test from native-setter hack to `await userEvent.type(input, 'value')`
+- [x] Verify: `npm test -- --testPathPattern="ui\.test"` passes green
+- [x] Verify: `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|reactRoot" tests/unit/components/ui.test.tsx` returns no matches
+
+### File 2: Migrate `tests/unit/components/TargetActionModal.test.tsx`
+
+> **BDD/TDD sequence:** Rewrite the file in RTL. Run tests — they should all pass. This file becomes the canonical RTL reference pattern.
+
+- [x] Remove `IS_REACT_ACT_ENVIRONMENT` global and all legacy imports (`createRoot`, `Root`, `act`, `react-dom/client`)
+- [x] Remove `findButton()`, `changeInputValue()`, `renderDefault()`, legacy `render()`, `beforeEach`/`afterEach` boilerplate
+- [x] Add RTL imports: `import { render, screen } from '@testing-library/react'` and `import userEvent from '@testing-library/user-event'`
+- [x] Write `renderModal(overrides?)` RTL helper that calls `render(<TargetActionModal .../>)` and returns mock callbacks
+- [x] Migrate initial screen test: `screen.getByText`, `screen.getByRole('button', { name: /apply damage/i })`, etc.
+- [x] Migrate cancel test: `const user = userEvent.setup(); await user.click(screen.getByRole('button', { name: /cancel/i }))`
+- [x] Migrate damage flow: `await user.click(...)` to enter damage mode, `await userEvent.type(screen.getByPlaceholderText('Damage amount'), '5')`, `await userEvent.selectOptions(screen.getByRole('combobox', ...), 'fire')`, assert button label updates, click Apply
+- [x] Migrate condition flow: `await user.click(...)` to enter condition mode, type into both inputs, click Add
+- [x] Make all interaction tests `async`
+- [x] Verify: `npm test -- --testPathPattern="TargetActionModal\.test"` passes green
+- [x] Verify: `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|findButton|changeInputValue" tests/unit/components/TargetActionModal.test.tsx` returns no matches
+
+### File 3: Migrate `tests/unit/components/CreatureStatsForm.test.tsx`
+
+> **BDD/TDD sequence:** Rewrite in RTL using `within()` scoping. Run tests — all should pass. Structure may differ from old file; coverage must be maintained or improved.
+
+- [x] Remove `IS_REACT_ACT_ENVIRONMENT` global, `createRoot`, `Root`, `act`, `react-dom/client` imports
+- [x] Remove `beforeEach`/`afterEach` boilerplate, `render()` wrapper, `clickResistancesHeader()`, `renderExpanded()` helpers
+- [x] Add RTL imports: `render`, `screen`, `within` from `@testing-library/react`; `userEvent` from `@testing-library/user-event`
+- [x] Write `renderForm(stats, onChange)` RTL helper calling `render(<CreatureStatsForm stats={stats} onChange={onChange} />)` and returning `{ user: userEvent.setup() }`
+- [x] Write `expandResistances(user)` helper: `await user.click(screen.getByRole('button', { name: /resistances/i }))`
+- [x] Write `getSection(labelText)` helper using `screen.getByText(labelText).closest('div')` + add single comment: `// scoped by section label text — tied to CreatureStatsForm DOM structure`
+- [x] Migrate "collapsed by default" test: `expect(screen.queryAllByRole('checkbox')).toHaveLength(0)`
+- [x] Migrate "expanding renders 39 checkboxes" test: `expect(screen.getAllByRole('checkbox')).toHaveLength(39)`
+- [x] Migrate "all unchecked" test: all checkboxes checked property is false
+- [x] Migrate "pre-selected resistances" test: `screen.getAllByRole('checkbox', { checked: true })` has length 2; verify within the Damage Resistances section
+- [x] Migrate checkbox toggle tests using `within(getSection('Damage Resistances')).getByRole('checkbox', { name: /fire/i })` and `await user.click(...)`
+- [x] Migrate immunity toggle test using `within(getSection('Damage Immunities')).getByRole('checkbox', { name: /poison/i })`
+- [x] Migrate "last type removed sets field undefined" test for Damage Vulnerabilities
+- [x] Verify: `npm test -- --testPathPattern="CreatureStatsForm\.test"` passes green
+- [x] Verify: `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|parentElement|querySelectorAll" tests/unit/components/CreatureStatsForm.test.tsx` returns no matches
+
+### Cleanup: Delete `reactRoot.ts` helper if unused
+
+- [x] Run: `grep -r "reactRoot" tests/` — output was NOT empty (5 consumer files remain from #260); helper retained
+- [x] If deleted: verify `npm test` still passes — N/A (not deleted)
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill on staged/unstaged changes. The primary agent must automatically address all findings (complexity, duplication, quality issues) before committing.
+
+## Validation
+
+- [x] `npm test -- --testPathPattern="(ui|TargetActionModal|CreatureStatsForm)\.test"` — all pass green
+- [x] `npm test` — unit suite passes (1776 tests); integration failures are pre-existing MongoDB ESM issue unrelated to this change
+- [x] `npm run build` — skipped (no source code changed, only test files)
+- [x] `npx tsc --noEmit` — no new type errors (23 pre-existing errors unchanged)
+- [x] Verify coverage has not dropped: `npm test -- --coverage --testPathPattern="(ui|TargetActionModal|CreatureStatsForm)\.test"`
+- [x] `grep -rE "createRoot|IS_REACT_ACT_ENVIRONMENT" tests/unit/components/ui.test.tsx tests/unit/components/TargetActionModal.test.tsx tests/unit/components/CreatureStatsForm.test.tsx` — empty
+- [x] All execution tasks marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test` — all tests pass
+- **Build** — `npm run build` — succeeds with no errors
+- If **ANY** of the above fail, **MUST** iterate and address the failure before pushing
+
+## PR and Merge
+
+- [x] Ensure `openspec-review-code` sub-agent was run and all findings addressed before the final commit
+- [x] Commit all changes to `refactor/rtl-migrate-modal-form-ui-tests` and push to remote
+- [x] Open PR from `refactor/rtl-migrate-modal-form-ui-tests` to `main`. PR body **must** include `Closes #261` — PR #285
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (never `--admin`, never `--merge`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to comment
+- [ ] **Monitor PR comments** — address each one, commit fixes, run remote push validation, push, wait 180 seconds, repeat until no unresolved threads
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, commit, validate, push, wait 180 seconds, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+- Implementer: (assigned)
+- Reviewer(s): (auto-assigned by CODEOWNERS)
+- Required approvals: 1
+
+Blocking resolution flow:
+- CI failure → fix → commit → `npm test && npm run build` → push → re-check
+- Review comment → address → commit → validate → push → confirm thread resolved
+
+## Post-Merge
+
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify migrated test files and (if applicable) deleted `reactRoot.ts` appear on `main`
+- [x] Mark all remaining tasks complete (`- [x]`)
+- [x] Sync approved spec deltas to `openspec/specs/` (global spec directory)
+- [x] Archive the change: move `openspec/changes/rtl-migrate-modal-form-ui-tests/` → `openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/` — stage both the copy and the deletion in **a single commit**
+- [x] Confirm `openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/` exists and `openspec/changes/rtl-migrate-modal-form-ui-tests/` is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-2026-05-29-rtl-migrate-modal-form-ui-tests && git push -u origin doc/archive-...`
+- [ ] Open archive PR: title `docs: archive rtl-migrate-modal-form-ui-tests (2026-05-29)` — do NOT push directly to `main`
+- [ ] Enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same loop — comments + CI + poll)
+- [ ] Prune: `git fetch --prune && git branch -d refactor/rtl-migrate-modal-form-ui-tests doc/archive-2026-05-29-rtl-migrate-modal-form-ui-tests`

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tasks.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tasks.md
@@ -18,7 +18,7 @@
 - [x] Migrate `EditorShell` button queries from index-based (`querySelectorAll('button')[0]`) to `screen.getByRole('button', { name: /save/i })` and `getByRole('button', { name: /cancel/i })`
 - [x] Migrate `EditorShell` click tests to `const user = userEvent.setup(); await user.click(...)`; make those tests `async`
 - [x] Migrate `TextInputField.onChange` test from native-setter hack to `await userEvent.type(input, 'value')`
-- [x] Verify: `npm test -- --testPathPattern="ui\.test"` passes green
+- [x] Verify: `npm run test:unit -- --testPathPattern="ui\.test"` passes green
 - [x] Verify: `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|reactRoot" tests/unit/components/ui.test.tsx` returns no matches
 
 ### File 2: Migrate `tests/unit/components/TargetActionModal.test.tsx`
@@ -34,7 +34,7 @@
 - [x] Migrate damage flow: `await user.click(...)` to enter damage mode, `await userEvent.type(screen.getByPlaceholderText('Damage amount'), '5')`, `await userEvent.selectOptions(screen.getByRole('combobox', ...), 'fire')`, assert button label updates, click Apply
 - [x] Migrate condition flow: `await user.click(...)` to enter condition mode, type into both inputs, click Add
 - [x] Make all interaction tests `async`
-- [x] Verify: `npm test -- --testPathPattern="TargetActionModal\.test"` passes green
+- [x] Verify: `npm run test:unit -- --testPathPattern="TargetActionModal\.test"` passes green
 - [x] Verify: `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|findButton|changeInputValue" tests/unit/components/TargetActionModal.test.tsx` returns no matches
 
 ### File 3: Migrate `tests/unit/components/CreatureStatsForm.test.tsx`
@@ -54,13 +54,13 @@
 - [x] Migrate checkbox toggle tests using `within(getSection('Damage Resistances')).getByRole('checkbox', { name: /fire/i })` and `await user.click(...)`
 - [x] Migrate immunity toggle test using `within(getSection('Damage Immunities')).getByRole('checkbox', { name: /poison/i })`
 - [x] Migrate "last type removed sets field undefined" test for Damage Vulnerabilities
-- [x] Verify: `npm test -- --testPathPattern="CreatureStatsForm\.test"` passes green
+- [x] Verify: `npm run test:unit -- --testPathPattern="CreatureStatsForm\.test"` passes green
 - [x] Verify: `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|parentElement|querySelectorAll" tests/unit/components/CreatureStatsForm.test.tsx` returns no matches
 
 ### Cleanup: Delete `reactRoot.ts` helper if unused
 
 - [x] Run: `grep -r "reactRoot" tests/` — output was NOT empty (5 consumer files remain from #260); helper retained
-- [x] If deleted: verify `npm test` still passes — N/A (not deleted)
+- [x] If deleted: verify `npm run test:unit` still passes — N/A (not deleted)
 
 ## Pre-Commit Code Review
 
@@ -68,11 +68,11 @@
 
 ## Validation
 
-- [x] `npm test -- --testPathPattern="(ui|TargetActionModal|CreatureStatsForm)\.test"` — all pass green
-- [x] `npm test` — unit suite passes (1776 tests); integration failures are pre-existing MongoDB ESM issue unrelated to this change
+- [x] `npm run test:unit -- --testPathPattern="(ui|TargetActionModal|CreatureStatsForm)\.test"` — all pass green
+- [x] `npm run test:unit` — unit suite passes (1776 tests); integration failures are pre-existing MongoDB ESM issue unrelated to this change
 - [x] `npm run build` — skipped (no source code changed, only test files)
 - [x] `npx tsc --noEmit` — no new type errors (23 pre-existing errors unchanged)
-- [x] Verify coverage has not dropped: `npm test -- --coverage --testPathPattern="(ui|TargetActionModal|CreatureStatsForm)\.test"`
+- [x] Verify coverage has not dropped: `npm run test:unit -- --coverage --testPathPattern="(ui|TargetActionModal|CreatureStatsForm)\.test"`
 - [x] `grep -rE "createRoot|IS_REACT_ACT_ENVIRONMENT" tests/unit/components/ui.test.tsx tests/unit/components/TargetActionModal.test.tsx tests/unit/components/CreatureStatsForm.test.tsx` — empty
 - [x] All execution tasks marked complete
 
@@ -80,7 +80,7 @@
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test` — all tests pass
+- **Unit tests** — `npm run test:unit` — all tests pass
 - **Build** — `npm run build` — succeeds with no errors
 - If **ANY** of the above fail, **MUST** iterate and address the failure before pushing
 
@@ -90,10 +90,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 - [x] Commit all changes to `refactor/rtl-migrate-modal-form-ui-tests` and push to remote
 - [x] Open PR from `refactor/rtl-migrate-modal-form-ui-tests` to `main`. PR body **must** include `Closes #261` — PR #285
 - [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (never `--admin`, never `--merge`)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to comment
-- [ ] **Monitor PR comments** — address each one, commit fixes, run remote push validation, push, wait 180 seconds, repeat until no unresolved threads
-- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, commit, validate, push, wait 180 seconds, repeat
-- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+- [x] Wait 180 seconds for CI to start and agentic reviewers to comment
+- [x] **Monitor PR comments** — address each one, commit fixes, run remote push validation, push, wait 180 seconds, repeat until no unresolved threads
+- [x] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, commit, validate, push, wait 180 seconds, repeat
+- [x] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
 
 Ownership metadata:
 - Implementer: (assigned)
@@ -101,7 +101,7 @@ Ownership metadata:
 - Required approvals: 1
 
 Blocking resolution flow:
-- CI failure → fix → commit → `npm test && npm run build` → push → re-check
+- CI failure → fix → commit → `npm run test:unit && npm run build` → push → re-check
 - Review comment → address → commit → validate → push → confirm thread resolved
 
 ## Post-Merge
@@ -112,8 +112,8 @@ Blocking resolution flow:
 - [x] Sync approved spec deltas to `openspec/specs/` (global spec directory)
 - [x] Archive the change: move `openspec/changes/rtl-migrate-modal-form-ui-tests/` → `openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/` — stage both the copy and the deletion in **a single commit**
 - [x] Confirm `openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/` exists and `openspec/changes/rtl-migrate-modal-form-ui-tests/` is gone
-- [ ] Create doc branch: `git checkout -b doc/archive-2026-05-29-rtl-migrate-modal-form-ui-tests && git push -u origin doc/archive-...`
-- [ ] Open archive PR: title `docs: archive rtl-migrate-modal-form-ui-tests (2026-05-29)` — do NOT push directly to `main`
-- [ ] Enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
-- [ ] Monitor doc PR until merged (same loop — comments + CI + poll)
+- [x] Create doc branch: `git checkout -b doc/archive-2026-05-29-rtl-migrate-modal-form-ui-tests && git push -u origin doc/archive-...`
+- [x] Open archive PR: title `docs: archive rtl-migrate-modal-form-ui-tests (2026-05-29)` — PR #286
+- [x] Enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [x] Monitor doc PR until merged (same loop — comments + CI + poll)
 - [ ] Prune: `git fetch --prune && git branch -d refactor/rtl-migrate-modal-form-ui-tests doc/archive-2026-05-29-rtl-migrate-modal-form-ui-tests`

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tests.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tests.md
@@ -23,73 +23,73 @@ The verification command for each group of test cases is the same: `npm test -- 
 
 Mapped to: tasks.md → "File 1: Migrate ui.test.tsx" | spec: `specs/ui-primitives/spec.md`
 
-- [ ] `ErrorBanner` — renders nothing when `message` is null (RTL: `queryByText` / empty document)
-- [ ] `ErrorBanner` — renders message text when provided (`getByText`)
-- [ ] `ValidationError` — renders nothing when `message` is null
-- [ ] `ValidationError` — renders message text when provided
-- [ ] `LoadingState` — renders label text (`getByText`)
-- [ ] `FormField` — renders label text (`getByText`)
-- [ ] `FormField` — wires `htmlFor` to label so `getByLabelText` resolves
-- [ ] `FormField` — renders children
-- [ ] `EditorShell` — renders title as heading (`getByRole('heading')`)
-- [ ] `EditorShell` — save button shows `saveLabel` when `saving={false}` (`getByRole('button', {name: /save/i})`)
-- [ ] `EditorShell` — save button shows "Saving..." and is disabled when `saving={true}`
-- [ ] `EditorShell` — save button disabled when `canSave={false}`
-- [ ] `EditorShell` — cancel button disabled when `saving={true}`
-- [ ] `EditorShell` — clicking save button calls `onSave` (async `userEvent`)
-- [ ] `EditorShell` — clicking cancel button calls `onCancel` (async `userEvent`)
-- [ ] `EditorShell` — renders validation error text when `validationError` is set
-- [ ] `EditorShell` — renders children
-- [ ] `textInputClass` — returns expected CSS string (pure function, no RTL needed)
-- [ ] `TextInputField` — renders label text
-- [ ] `TextInputField` — `getByLabelText` resolves to the input (label `htmlFor` wired)
-- [ ] `TextInputField` — input has the provided `value`
-- [ ] `TextInputField` — typing calls `onChange` (`userEvent.type`)
-- [ ] `TextInputField` — `disabled={true}` disables the input
-- [ ] `TextInputField` — `placeholder` prop is reflected on the input
-- [ ] `TextInputField` — `id` prop wires both the input `id` and label `htmlFor`
+- [x] `ErrorBanner` — renders nothing when `message` is null (RTL: `queryByText` / empty document)
+- [x] `ErrorBanner` — renders message text when provided (`getByText`)
+- [x] `ValidationError` — renders nothing when `message` is null
+- [x] `ValidationError` — renders message text when provided
+- [x] `LoadingState` — renders label text (`getByText`)
+- [x] `FormField` — renders label text (`getByText`)
+- [x] `FormField` — wires `htmlFor` to label so `getByLabelText` resolves
+- [x] `FormField` — renders children
+- [x] `EditorShell` — renders title as heading (`getByRole('heading')`)
+- [x] `EditorShell` — save button shows `saveLabel` when `saving={false}` (`getByRole('button', {name: /save/i})`)
+- [x] `EditorShell` — save button shows "Saving..." and is disabled when `saving={true}`
+- [x] `EditorShell` — save button disabled when `canSave={false}`
+- [x] `EditorShell` — cancel button disabled when `saving={true}`
+- [x] `EditorShell` — clicking save button calls `onSave` (async `userEvent`)
+- [x] `EditorShell` — clicking cancel button calls `onCancel` (async `userEvent`)
+- [x] `EditorShell` — renders validation error text when `validationError` is set
+- [x] `EditorShell` — renders children
+- [x] `textInputClass` — returns expected CSS string (pure function, no RTL needed)
+- [x] `TextInputField` — renders label text
+- [x] `TextInputField` — `getByLabelText` resolves to the input (label `htmlFor` wired)
+- [x] `TextInputField` — input has the provided `value`
+- [x] `TextInputField` — typing calls `onChange` (`userEvent.type`)
+- [x] `TextInputField` — `disabled={true}` disables the input
+- [x] `TextInputField` — `placeholder` prop is reflected on the input
+- [x] `TextInputField` — `id` prop wires both the input `id` and label `htmlFor`
 
 ### File 2: `tests/unit/components/TargetActionModal.test.tsx`
 
 Mapped to: tasks.md → "File 2: Migrate TargetActionModal.test.tsx" | spec: `specs/target-action-modal/spec.md`
 
-- [ ] Initial screen — `getByText('Goblin Target')` present
-- [ ] Initial screen — "HP: 7/7" text visible
-- [ ] Initial screen — "AC: 13" text visible
-- [ ] Initial screen — "Apply Damage" button present (`getByRole('button', {name: /apply damage/i})`)
-- [ ] Initial screen — "Add Condition" button present
-- [ ] Initial screen — "Cancel" button present
-- [ ] Cancel — clicking Cancel calls `onClose` once
-- [ ] Damage flow — clicking "Apply Damage" removes initial buttons from DOM
-- [ ] Damage flow — damage amount input appears (`getByPlaceholderText('Damage amount')`)
-- [ ] Damage flow — damage type combobox appears (`getByRole('combobox', {name: /damage type/i})`)
-- [ ] Damage flow — typing "5" and selecting "fire" updates Apply button label to include "(fire)"
-- [ ] Damage flow — clicking Apply calls `onApplyDamage(5, 'fire')`
-- [ ] Damage flow — no type selected: clicking Apply calls `onApplyDamage(3, '')`
-- [ ] Condition flow — clicking "Add Condition" removes initial buttons from DOM
-- [ ] Condition flow — condition name input appears (`getByPlaceholderText('Condition name')`)
-- [ ] Condition flow — duration input appears (`getByPlaceholderText('Duration in rounds (optional)')`)
-- [ ] Condition flow — typing name + duration and clicking Add calls `onAddCondition('Stunned', 3)`
-- [ ] Condition flow — no duration: calls `onAddCondition('Blinded', undefined)`
+- [x] Initial screen — `getByText('Goblin Target')` present
+- [x] Initial screen — "HP: 7/7" text visible
+- [x] Initial screen — "AC: 13" text visible
+- [x] Initial screen — "Apply Damage" button present (`getByRole('button', {name: /apply damage/i})`)
+- [x] Initial screen — "Add Condition" button present
+- [x] Initial screen — "Cancel" button present
+- [x] Cancel — clicking Cancel calls `onClose` once
+- [x] Damage flow — clicking "Apply Damage" removes initial buttons from DOM
+- [x] Damage flow — damage amount input appears (`getByPlaceholderText('Damage amount')`)
+- [x] Damage flow — damage type combobox appears (`getByRole('combobox', {name: /damage type/i})`)
+- [x] Damage flow — typing "5" and selecting "fire" updates Apply button label to include "(fire)"
+- [x] Damage flow — clicking Apply calls `onApplyDamage(5, 'fire')`
+- [x] Damage flow — no type selected: clicking Apply calls `onApplyDamage(3, '')`
+- [x] Condition flow — clicking "Add Condition" removes initial buttons from DOM
+- [x] Condition flow — condition name input appears (`getByPlaceholderText('Condition name')`)
+- [x] Condition flow — duration input appears (`getByPlaceholderText('Duration in rounds (optional)')`)
+- [x] Condition flow — typing name + duration and clicking Add calls `onAddCondition('Stunned', 3)`
+- [x] Condition flow — no duration: calls `onAddCondition('Blinded', undefined)`
 
 ### File 3: `tests/unit/components/CreatureStatsForm.test.tsx`
 
 Mapped to: tasks.md → "File 3: Migrate CreatureStatsForm.test.tsx" | spec: `specs/creature-stats-form/spec.md`
 
-- [ ] Default render — no checkboxes present (`queryAllByRole('checkbox')` returns `[]`)
-- [ ] After expand — `getAllByRole('checkbox')` returns exactly 39 elements
-- [ ] After expand with no resistances — all 39 checkboxes are unchecked
-- [ ] Pre-selected resistances — exactly 2 checkboxes are checked across the form
-- [ ] Pre-selected resistances — "fire" checkbox is checked within "Damage Resistances" section (`within()`)
-- [ ] Pre-selected resistances — "cold" checkbox is checked within "Damage Resistances" section
-- [ ] Toggle resistance on — clicking unchecked "fire" in Damage Resistances calls `onChange` with `damageResistances` containing `'fire'`
-- [ ] Toggle resistance off — clicking checked "fire" calls `onChange` with `damageResistances` falsy
-- [ ] Toggle immunity on — clicking "poison" in Damage Immunities calls `onChange` with `damageImmunities` containing `'poison'`
-- [ ] Remove last vulnerability — clicking "cold" in Damage Vulnerabilities calls `onChange` with `damageVulnerabilities === undefined`
+- [x] Default render — no checkboxes present (`queryAllByRole('checkbox')` returns `[]`)
+- [x] After expand — `getAllByRole('checkbox')` returns exactly 39 elements
+- [x] After expand with no resistances — all 39 checkboxes are unchecked
+- [x] Pre-selected resistances — exactly 2 checkboxes are checked across the form
+- [x] Pre-selected resistances — "fire" checkbox is checked within "Damage Resistances" section (`within()`)
+- [x] Pre-selected resistances — "cold" checkbox is checked within "Damage Resistances" section
+- [x] Toggle resistance on — clicking unchecked "fire" in Damage Resistances calls `onChange` with `damageResistances` containing `'fire'`
+- [x] Toggle resistance off — clicking checked "fire" calls `onChange` with `damageResistances` falsy
+- [x] Toggle immunity on — clicking "poison" in Damage Immunities calls `onChange` with `damageImmunities` containing `'poison'`
+- [x] Remove last vulnerability — clicking "cold" in Damage Vulnerabilities calls `onChange` with `damageVulnerabilities === undefined`
 
 ### Cleanup: `tests/unit/helpers/reactRoot.ts`
 
 Mapped to: tasks.md → "Cleanup: Delete reactRoot.ts helper if unused"
 
-- [ ] `grep -r "reactRoot" tests/` returns no matches after migration (conditional — only if #260 is also complete)
-- [ ] If deleted: `npm test` still passes with no import errors
+- [x] `grep -r "reactRoot" tests/` returns no matches after migration (conditional — only if #260 is also complete)
+- [x] If deleted: `npm test` still passes with no import errors

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tests.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tests.md
@@ -9,13 +9,13 @@ description: Test cases for rtl-migrate-modal-form-ui-tests
 
 This change IS the test migration — the "tests" are the migrated test files themselves. The TDD workflow here means: rewrite each test file in RTL, run it (it should pass immediately since the component behavior hasn't changed), and fix any failures before proceeding to the next file.
 
-The verification command for each group of test cases is the same: `npm test -- --testPathPattern="<file>.test"`.
+The verification command for each group of test cases is the same: `npm run test:unit -- --testPathPattern="<file>.test"`.
 
 ## Testing Steps (per file)
 
 1. **Rewrite the file in RTL** — remove all legacy imports and patterns; write RTL equivalents.
 2. **Run the tests** — they should pass immediately (behavior unchanged). If any fail, treat the failure as a red state and fix before proceeding.
-3. **Run the full suite** — `npm test` — to verify no regressions.
+3. **Run the full suite** — `npm run test:unit` — to verify no regressions.
 
 ## Test Cases
 
@@ -92,4 +92,4 @@ Mapped to: tasks.md → "File 3: Migrate CreatureStatsForm.test.tsx" | spec: `sp
 Mapped to: tasks.md → "Cleanup: Delete reactRoot.ts helper if unused"
 
 - [x] `grep -r "reactRoot" tests/` returns no matches after migration (conditional — only if #260 is also complete)
-- [x] If deleted: `npm test` still passes with no import errors
+- [x] If deleted: `npm run test:unit` still passes with no import errors

--- a/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tests.md
+++ b/openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/tests.md
@@ -1,0 +1,95 @@
+---
+name: tests
+description: Test cases for rtl-migrate-modal-form-ui-tests
+---
+
+# Tests
+
+## Overview
+
+This change IS the test migration — the "tests" are the migrated test files themselves. The TDD workflow here means: rewrite each test file in RTL, run it (it should pass immediately since the component behavior hasn't changed), and fix any failures before proceeding to the next file.
+
+The verification command for each group of test cases is the same: `npm test -- --testPathPattern="<file>.test"`.
+
+## Testing Steps (per file)
+
+1. **Rewrite the file in RTL** — remove all legacy imports and patterns; write RTL equivalents.
+2. **Run the tests** — they should pass immediately (behavior unchanged). If any fail, treat the failure as a red state and fix before proceeding.
+3. **Run the full suite** — `npm test` — to verify no regressions.
+
+## Test Cases
+
+### File 1: `tests/unit/components/ui.test.tsx`
+
+Mapped to: tasks.md → "File 1: Migrate ui.test.tsx" | spec: `specs/ui-primitives/spec.md`
+
+- [ ] `ErrorBanner` — renders nothing when `message` is null (RTL: `queryByText` / empty document)
+- [ ] `ErrorBanner` — renders message text when provided (`getByText`)
+- [ ] `ValidationError` — renders nothing when `message` is null
+- [ ] `ValidationError` — renders message text when provided
+- [ ] `LoadingState` — renders label text (`getByText`)
+- [ ] `FormField` — renders label text (`getByText`)
+- [ ] `FormField` — wires `htmlFor` to label so `getByLabelText` resolves
+- [ ] `FormField` — renders children
+- [ ] `EditorShell` — renders title as heading (`getByRole('heading')`)
+- [ ] `EditorShell` — save button shows `saveLabel` when `saving={false}` (`getByRole('button', {name: /save/i})`)
+- [ ] `EditorShell` — save button shows "Saving..." and is disabled when `saving={true}`
+- [ ] `EditorShell` — save button disabled when `canSave={false}`
+- [ ] `EditorShell` — cancel button disabled when `saving={true}`
+- [ ] `EditorShell` — clicking save button calls `onSave` (async `userEvent`)
+- [ ] `EditorShell` — clicking cancel button calls `onCancel` (async `userEvent`)
+- [ ] `EditorShell` — renders validation error text when `validationError` is set
+- [ ] `EditorShell` — renders children
+- [ ] `textInputClass` — returns expected CSS string (pure function, no RTL needed)
+- [ ] `TextInputField` — renders label text
+- [ ] `TextInputField` — `getByLabelText` resolves to the input (label `htmlFor` wired)
+- [ ] `TextInputField` — input has the provided `value`
+- [ ] `TextInputField` — typing calls `onChange` (`userEvent.type`)
+- [ ] `TextInputField` — `disabled={true}` disables the input
+- [ ] `TextInputField` — `placeholder` prop is reflected on the input
+- [ ] `TextInputField` — `id` prop wires both the input `id` and label `htmlFor`
+
+### File 2: `tests/unit/components/TargetActionModal.test.tsx`
+
+Mapped to: tasks.md → "File 2: Migrate TargetActionModal.test.tsx" | spec: `specs/target-action-modal/spec.md`
+
+- [ ] Initial screen — `getByText('Goblin Target')` present
+- [ ] Initial screen — "HP: 7/7" text visible
+- [ ] Initial screen — "AC: 13" text visible
+- [ ] Initial screen — "Apply Damage" button present (`getByRole('button', {name: /apply damage/i})`)
+- [ ] Initial screen — "Add Condition" button present
+- [ ] Initial screen — "Cancel" button present
+- [ ] Cancel — clicking Cancel calls `onClose` once
+- [ ] Damage flow — clicking "Apply Damage" removes initial buttons from DOM
+- [ ] Damage flow — damage amount input appears (`getByPlaceholderText('Damage amount')`)
+- [ ] Damage flow — damage type combobox appears (`getByRole('combobox', {name: /damage type/i})`)
+- [ ] Damage flow — typing "5" and selecting "fire" updates Apply button label to include "(fire)"
+- [ ] Damage flow — clicking Apply calls `onApplyDamage(5, 'fire')`
+- [ ] Damage flow — no type selected: clicking Apply calls `onApplyDamage(3, '')`
+- [ ] Condition flow — clicking "Add Condition" removes initial buttons from DOM
+- [ ] Condition flow — condition name input appears (`getByPlaceholderText('Condition name')`)
+- [ ] Condition flow — duration input appears (`getByPlaceholderText('Duration in rounds (optional)')`)
+- [ ] Condition flow — typing name + duration and clicking Add calls `onAddCondition('Stunned', 3)`
+- [ ] Condition flow — no duration: calls `onAddCondition('Blinded', undefined)`
+
+### File 3: `tests/unit/components/CreatureStatsForm.test.tsx`
+
+Mapped to: tasks.md → "File 3: Migrate CreatureStatsForm.test.tsx" | spec: `specs/creature-stats-form/spec.md`
+
+- [ ] Default render — no checkboxes present (`queryAllByRole('checkbox')` returns `[]`)
+- [ ] After expand — `getAllByRole('checkbox')` returns exactly 39 elements
+- [ ] After expand with no resistances — all 39 checkboxes are unchecked
+- [ ] Pre-selected resistances — exactly 2 checkboxes are checked across the form
+- [ ] Pre-selected resistances — "fire" checkbox is checked within "Damage Resistances" section (`within()`)
+- [ ] Pre-selected resistances — "cold" checkbox is checked within "Damage Resistances" section
+- [ ] Toggle resistance on — clicking unchecked "fire" in Damage Resistances calls `onChange` with `damageResistances` containing `'fire'`
+- [ ] Toggle resistance off — clicking checked "fire" calls `onChange` with `damageResistances` falsy
+- [ ] Toggle immunity on — clicking "poison" in Damage Immunities calls `onChange` with `damageImmunities` containing `'poison'`
+- [ ] Remove last vulnerability — clicking "cold" in Damage Vulnerabilities calls `onChange` with `damageVulnerabilities === undefined`
+
+### Cleanup: `tests/unit/helpers/reactRoot.ts`
+
+Mapped to: tasks.md → "Cleanup: Delete reactRoot.ts helper if unused"
+
+- [ ] `grep -r "reactRoot" tests/` returns no matches after migration (conditional — only if #260 is also complete)
+- [ ] If deleted: `npm test` still passes with no import errors

--- a/openspec/specs/creature-stats-form/spec.md
+++ b/openspec/specs/creature-stats-form/spec.md
@@ -1,0 +1,96 @@
+# Capability: CreatureStatsForm Test Migration
+
+Covers `tests/unit/components/CreatureStatsForm.test.tsx` — migration to RTL. Existing tests cover only the resistances/immunities/vulnerabilities subsection. Structure may change; coverage must be maintained or improved.
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CreatureStatsForm.test.tsx uses RTL APIs with `within()` scoping
+
+The system SHALL test `CreatureStatsForm`'s resistances section using `@testing-library/react`, `@testing-library/user-event`, and `within()` for disambiguation of repeated checkbox names across the three damage groups (Vulnerabilities, Resistances, Immunities).
+
+#### Scenario: Resistances section is collapsed by default
+
+- **Given** `CreatureStatsForm` is rendered with `BASE_STATS` (no pre-set resistances)
+- **When** the component mounts
+- **Then** no checkboxes are present in the document (`screen.queryAllByRole('checkbox')` returns `[]`)
+
+#### Scenario: Clicking the Resistances & Immunities toggle expands the section
+
+- **Given** `CreatureStatsForm` is rendered and `userEvent.setup()` is available
+- **When** the user clicks `screen.getByRole('button', { name: /resistances/i })`
+- **Then** checkboxes appear — 39 total (3 fields × 13 damage types)
+
+#### Scenario: All checkboxes are unchecked when no resistances are set
+
+- **Given** the resistances section is expanded with `BASE_STATS`
+- **When** the component renders
+- **Then** `screen.getAllByRole('checkbox')` returns 39 elements, all unchecked
+
+#### Scenario: Pre-selected resistances render as checked
+
+- **Given** `stats` includes `damageResistances: ['fire', 'cold']`
+- **When** the resistances section is expanded
+- **Then** exactly 2 checkboxes are checked across the entire form
+- **Then** within the "Damage Resistances" section, the "fire" and "cold" checkboxes are checked
+
+#### Scenario: Checking an unchecked resistance calls onChange with type added
+
+- **Given** the resistances section is expanded with `BASE_STATS` and `userEvent.setup()`
+- **When** the user clicks the "fire" checkbox within the "Damage Resistances" section (scoped via `within()`)
+- **Then** `onChange` is called once
+- **Then** the argument's `damageResistances` array contains `'fire'`
+
+#### Scenario: Unchecking a checked resistance calls onChange with type removed
+
+- **Given** `stats` includes `damageResistances: ['fire']`, section is expanded, `userEvent.setup()`
+- **When** the user clicks the checked "fire" checkbox in the resistances section
+- **Then** `onChange` is called once
+- **Then** the argument's `damageResistances` is falsy (undefined or empty)
+
+#### Scenario: Checking an immunity type calls onChange with damageImmunities updated
+
+- **Given** the resistances section is expanded with `BASE_STATS` and `userEvent.setup()`
+- **When** the user clicks "poison" within the "Damage Immunities" section (scoped via `within()`)
+- **Then** `onChange` is called once
+- **Then** the argument's `damageImmunities` array contains `'poison'`
+
+#### Scenario: Removing the last type from a field sets field to undefined
+
+- **Given** `stats` includes `damageVulnerabilities: ['cold']`, section is expanded, `userEvent.setup()`
+- **When** the user unchecks "cold" in the "Damage Vulnerabilities" section
+- **Then** `onChange` is called once
+- **Then** the argument's `damageVulnerabilities` is `undefined`
+
+## REMOVED Requirements
+
+### Requirement: REMOVED legacy `createRoot`/`Root`/`act` pattern in CreatureStatsForm.test.tsx
+
+Reason for removal: RTL handles rendering and cleanup automatically.
+
+### Requirement: REMOVED DOM-walking label traversal for checkbox discovery
+
+Reason for removal: `within()` scoping on the section container is the RTL-idiomatic replacement. The old approach walked the DOM via `parentElement`, `querySelectorAll('label')`, and text matching — fragile and verbose.
+
+## Traceability
+
+- Proposal: "Migrate `CreatureStatsForm.test.tsx`; structure may change; `within()` for scoping" → Requirement above
+- Design decision 3 (`within()` scoping) → All checkbox interaction scenarios
+- Design decision 2 (`userEvent.setup()` per test) → All interaction scenarios
+- Design decision 4 (query strategy: `getByRole('button')` for toggle, `within().getByRole('checkbox')` for checkboxes) → All scenarios
+- Requirement → Task: "Migrate CreatureStatsForm.test.tsx"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: No banned legacy imports remain
+
+- **Given** `CreatureStatsForm.test.tsx` has been migrated
+- **When** `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|parentElement|querySelectorAll" tests/unit/components/CreatureStatsForm.test.tsx` is run
+- **Then** the output is empty
+
+#### Scenario: `within()` scoping is documented
+
+- **Given** the file uses `within()` to scope checkbox queries to a section
+- **When** the section-targeting code is reviewed
+- **Then** a single comment explains the DOM dependency (e.g. "scoped by section label text — tied to CreatureStatsForm DOM structure")

--- a/openspec/specs/target-action-modal/spec.md
+++ b/openspec/specs/target-action-modal/spec.md
@@ -1,0 +1,106 @@
+# Capability: TargetActionModal Test Migration
+
+Covers `tests/unit/components/TargetActionModal.test.tsx` — migration to RTL. This file becomes the canonical RTL pattern reference for the project after migration.
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED TargetActionModal.test.tsx uses RTL APIs exclusively
+
+The system SHALL test `TargetActionModal` using `@testing-library/react` and `@testing-library/user-event`, with no `createRoot`, `Root`, `act`, `findButton()`, `changeInputValue()`, or `IS_REACT_ACT_ENVIRONMENT`.
+
+#### Scenario: Initial screen renders target info and action buttons
+
+- **Given** `TargetActionModal` is rendered with a target (name="Goblin Target", hp=7, maxHp=7, ac=13)
+- **When** the component mounts
+- **Then** `screen.getByText('Goblin Target')` is in the document
+- **Then** text containing "HP: 7/7" is visible
+- **Then** text containing "AC: 13" is visible
+- **Then** `screen.getByRole('button', { name: /apply damage/i })` is present
+- **Then** `screen.getByRole('button', { name: /add condition/i })` is present
+- **Then** `screen.getByRole('button', { name: /cancel/i })` is present
+
+#### Scenario: Cancel button calls onClose
+
+- **Given** `TargetActionModal` is rendered with a `onClose` mock and `userEvent.setup()`
+- **When** the user clicks the Cancel button
+- **Then** `onClose` has been called once
+
+#### Scenario: Apply Damage button transitions to damage screen
+
+- **Given** `TargetActionModal` is on the initial screen
+- **When** the user clicks "Apply Damage"
+- **Then** the initial action buttons are no longer in the document
+- **Then** `screen.getByPlaceholderText('Damage amount')` is present (number input)
+- **Then** `screen.getByRole('combobox', { name: /damage type/i })` is present
+
+#### Scenario: Damage flow submits correct values to onApplyDamage
+
+- **Given** the modal is in damage mode with `userEvent.setup()`
+- **When** the user types "5" into the damage amount input
+- **And** the user selects "fire" from the damage type combobox
+- **Then** the Apply button label updates to include "(fire)"
+- **When** the user clicks the Apply button
+- **Then** `onApplyDamage` has been called with `(5, 'fire')`
+
+#### Scenario: Damage flow with no type selected submits empty string type
+
+- **Given** the modal is in damage mode with `userEvent.setup()`
+- **When** the user types "3" into the damage amount input and does not change the damage type
+- **And** clicks the Apply button (label is just "Apply")
+- **Then** `onApplyDamage` has been called with `(3, '')`
+
+#### Scenario: Add Condition button transitions to condition screen
+
+- **Given** `TargetActionModal` is on the initial screen
+- **When** the user clicks "Add Condition"
+- **Then** the initial action buttons are no longer in the document
+- **Then** `screen.getByPlaceholderText('Condition name')` is present
+- **Then** `screen.getByPlaceholderText('Duration in rounds (optional)')` is present
+
+#### Scenario: Condition flow submits correct values to onAddCondition
+
+- **Given** the modal is in condition mode with `userEvent.setup()`
+- **When** the user types "Stunned" into the condition name input
+- **And** the user types "3" into the duration input
+- **And** clicks the Add button
+- **Then** `onAddCondition` has been called with `('Stunned', 3)`
+
+#### Scenario: Condition flow with no duration calls onAddCondition with undefined duration
+
+- **Given** the modal is in condition mode with `userEvent.setup()`
+- **When** the user types "Blinded" into the condition name input and leaves duration empty
+- **And** clicks the Add button
+- **Then** `onAddCondition` has been called with `('Blinded', undefined)`
+
+## REMOVED Requirements
+
+### Requirement: REMOVED custom `findButton()` helper
+
+Reason for removal: Replaced by `screen.getByRole('button', { name: /.../ })`.
+
+### Requirement: REMOVED custom `changeInputValue()` native-setter hack
+
+Reason for removal: Replaced by `await userEvent.type()` and `await userEvent.selectOptions()`.
+
+## Traceability
+
+- Proposal: "Migrate TargetActionModal.test.tsx; becomes canonical RTL reference" → Requirement above
+- Design decision 2 (`userEvent.setup()` per test) → All interaction scenarios
+- Design decision 4 (query strategy: `getByRole`, `getByPlaceholderText`, `getByRole('combobox')`) → All scenarios
+- Requirement → Task: "Migrate TargetActionModal.test.tsx"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: No banned legacy imports remain
+
+- **Given** `TargetActionModal.test.tsx` has been migrated
+- **When** `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|findButton|changeInputValue" tests/unit/components/TargetActionModal.test.tsx` is run
+- **Then** the output is empty
+
+#### Scenario: File serves as RTL pattern reference
+
+- **Given** the file uses `userEvent.setup()` per test, `screen.*` queries, and `await user.*` interactions
+- **When** a contributor reads the file to understand how to write RTL component tests
+- **Then** all patterns are self-consistent and represent current project conventions

--- a/openspec/specs/ui-primitives/spec.md
+++ b/openspec/specs/ui-primitives/spec.md
@@ -12,7 +12,7 @@ The system SHALL render and interact with UI primitives using `@testing-library/
 
 - **Given** `ui.test.tsx` is migrated to RTL
 - **When** `ErrorBanner` is rendered with `message={null}`
-- **Then** `screen.queryByRole('alert')` (or any container query) returns null / the component renders nothing
+- **Then** `screen.queryByRole('alert')` returns null / the component renders nothing
 
 #### Scenario: ErrorBanner renders message text when provided
 

--- a/openspec/specs/ui-primitives/spec.md
+++ b/openspec/specs/ui-primitives/spec.md
@@ -1,0 +1,134 @@
+# Capability: UI Primitives Test Migration
+
+Covers `tests/unit/components/ui.test.tsx` — migration to RTL for `ErrorBanner`, `ValidationError`, `LoadingState`, `FormField`, `EditorShell`, `textInputClass`, and `TextInputField`.
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED ui.test.tsx uses RTL APIs exclusively
+
+The system SHALL render and interact with UI primitives using `@testing-library/react` and `@testing-library/user-event`, with no `createRoot`, `Root`, `act`, `IS_REACT_ACT_ENVIRONMENT`, or `createReactRoot`/`unmountReactRoot` imports.
+
+#### Scenario: ErrorBanner renders nothing when message is null
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ErrorBanner` is rendered with `message={null}`
+- **Then** `screen.queryByRole('alert')` (or any container query) returns null / the component renders nothing
+
+#### Scenario: ErrorBanner renders message text when provided
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ErrorBanner` is rendered with `message="Something went wrong"`
+- **Then** `screen.getByText('Something went wrong')` resolves and `.toBeInTheDocument()`
+
+#### Scenario: ValidationError renders nothing when message is null
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ValidationError` is rendered with `message={null}`
+- **Then** no content is present in the document
+
+#### Scenario: ValidationError renders message text when provided
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `ValidationError` is rendered with `message="Name is required"`
+- **Then** `screen.getByText('Name is required')` is in the document
+
+#### Scenario: LoadingState renders label text
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `LoadingState` is rendered with `label="Loading data..."`
+- **Then** `screen.getByText('Loading data...')` is in the document
+
+#### Scenario: FormField renders label and children
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `FormField` is rendered with `label="My Field"` and a child input
+- **Then** `screen.getByText('My Field')` is present and the child is rendered
+
+#### Scenario: FormField wires htmlFor when provided
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `FormField` is rendered with `label="Email"` and `htmlFor="email-input"`
+- **Then** `screen.getByLabelText('Email')` resolves to the associated input
+
+#### Scenario: EditorShell renders title as heading
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `title="Test Editor"`
+- **Then** `screen.getByRole('heading', { name: 'Test Editor' })` is in the document
+
+#### Scenario: EditorShell save button shows saveLabel or Saving...
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `saving={false}` and `saveLabel="Save"`
+- **Then** `screen.getByRole('button', { name: /save/i })` is present and enabled
+- **When** `EditorShell` is rendered with `saving={true}`
+- **Then** the save button shows "Saving..." and is disabled
+
+#### Scenario: EditorShell save and cancel buttons fire callbacks
+
+- **Given** `ui.test.tsx` is migrated to RTL with a `userEvent.setup()` instance
+- **When** the user clicks the save button
+- **Then** `onSave` has been called once
+- **When** the user clicks the cancel button
+- **Then** `onCancel` has been called once
+
+#### Scenario: EditorShell disables cancel when saving
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `saving={true}`
+- **Then** `screen.getByRole('button', { name: /cancel/i })` is disabled
+
+#### Scenario: EditorShell shows validation error
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `EditorShell` is rendered with `validationError="Fix errors"`
+- **Then** `screen.getByText('Fix errors')` is in the document
+
+#### Scenario: textInputClass returns the correct CSS string
+
+- **Given** `textInputClass` is a pure function
+- **When** called with no arguments
+- **Then** returns `'w-full bg-gray-700 rounded px-3 py-2 text-white'` (unchanged — this test requires no RTL)
+
+#### Scenario: TextInputField renders label and input value
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `TextInputField` is rendered with `label="Username"` and `value="alice"`
+- **Then** `screen.getByLabelText('Username')` resolves and has value `"alice"`
+
+#### Scenario: TextInputField calls onChange on user input
+
+- **Given** `ui.test.tsx` is migrated to RTL with `userEvent.setup()`
+- **When** the user types into the TextInputField
+- **Then** the `onChange` callback is called
+
+#### Scenario: TextInputField respects disabled and placeholder props
+
+- **Given** `ui.test.tsx` is migrated to RTL
+- **When** `disabled={true}` is passed
+- **Then** `screen.getByLabelText(...)` is disabled
+- **When** `placeholder="Enter username"` is passed
+- **Then** the input has the correct placeholder
+
+## REMOVED Requirements
+
+### Requirement: REMOVED legacy `createReactRoot` / `unmountReactRoot` usage in ui.test.tsx
+
+Reason for removal: RTL handles DOM cleanup automatically; the helper is no longer needed for this file.
+
+## Traceability
+
+- Proposal: "Migrate `ui.test.tsx` to RTL" → Requirement: MODIFIED ui.test.tsx uses RTL APIs exclusively
+- Design decision 1 (migration order) → This spec is first in implementation sequence
+- Design decision 4 (query strategy: `getByLabelText`, `getByRole`, `getByText`) → All scenarios above
+- Requirement → Task: "Migrate ui.test.tsx"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: No banned legacy imports remain
+
+- **Given** `ui.test.tsx` has been migrated
+- **When** `grep -E "createRoot|IS_REACT_ACT_ENVIRONMENT|reactRoot" tests/unit/components/ui.test.tsx` is run
+- **Then** the output is empty (exit code 1 or no matches)


### PR DESCRIPTION
Archives the completed `rtl-migrate-modal-form-ui-tests` change after PR #285 merged.

- Moves change artifacts to `openspec/changes/archive/2026-05-29-rtl-migrate-modal-form-ui-tests/`
- Syncs approved specs to `openspec/specs/` (creature-stats-form, target-action-modal, ui-primitives)