### PR TITLE
docs: Multi-User Campaigns design & phased plan

### DIFF
--- a/docs/multi-user-campaigns/01-identity-and-membership.md
+++ b/docs/multi-user-campaigns/01-identity-and-membership.md
@@ -6,9 +6,11 @@ This is the spine the rest of the initiative builds on.
 
 **Depends on:** nothing.
 
+> **Tracking:** epic [#293](https://github.com/dougis-org/session-combat/issues/293).
+
 ## Deliverables (sub-issues)
 
-### 1a. Add `username` to the User model
+### 1a. Add `username` to the User model · [#300](https://github.com/dougis-org/session-combat/issues/300)
 - Add `username?: string` to `User` in `lib/types.ts`.
 - Add a **sparse unique index** on `users.username` in `lib/db.ts` (mirror the
   existing unique `email` index).
@@ -17,7 +19,7 @@ This is the spine the rest of the initiative builds on.
 - **Acceptance:** existing users keep working; index rejects duplicates; backfill
   is safe to re-run.
 
-### 1b. Username validation + set/edit
+### 1b. Username validation + set/edit · [#301](https://github.com/dougis-org/session-combat/issues/301)
 - Validation rules in `lib/validation/` (length, allowed charset, reserved words,
   case-insensitive uniqueness).
 - Allow setting a username at registration and editing it on a profile/account
@@ -25,7 +27,7 @@ This is the spine the rest of the initiative builds on.
 - **Acceptance:** invalid/duplicate usernames rejected with clear errors; a user
   can set and change their handle.
 
-### 1c. User search endpoint
+### 1c. User search endpoint · [#302](https://github.com/dougis-org/session-combat/issues/302)
 - `GET /api/users/search?q=` returning minimal public profiles (`{ id, username }`)
   for member-add. Backed by `fuse.js` (already a dependency) or a prefix query.
 - Rate-limited (reuse `lib/rate-limit.ts`); never leaks email/password fields;
@@ -34,7 +36,7 @@ This is the spine the rest of the initiative builds on.
 - **Acceptance:** searching a partial username returns matching handles only;
   no PII leakage; rate limit enforced.
 
-### 1d. `campaignMembers` collection + storage
+### 1d. `campaignMembers` collection + storage · [#303](https://github.com/dougis-org/session-combat/issues/303)
 - Add `CampaignMember` type; create `campaignMembers` collection with a unique
   `{campaignId, userId}` index.
 - `storage` methods: add member, update status/role, list members for a campaign,
@@ -43,7 +45,7 @@ This is the spine the rest of the initiative builds on.
 - **Acceptance:** the owner is always an active DM member; duplicate memberships
   rejected; storage methods covered by unit/integration tests.
 
-### 1e. Member-aware campaign access (refactor)
+### 1e. Member-aware campaign access (refactor) · [#304](https://github.com/dougis-org/session-combat/issues/304)
 - Add `assertCampaignAccess(campaignId, userId)` to `lib/utils/campaign.ts`
   returning the caller's role (`dm` | `player`) or denying access.
 - Refactor campaign read routes (`app/api/campaigns/[id]/**`) from `{ userId, id }`

--- a/docs/multi-user-campaigns/01-identity-and-membership.md
+++ b/docs/multi-user-campaigns/01-identity-and-membership.md
@@ -52,3 +52,18 @@ This is the spine the rest of the initiative builds on.
 - **Depends on:** 1d.
 - **Acceptance:** a player member can GET a campaign; a non-member gets 404/403;
   mutations stay DM-gated; existing owner behavior unchanged.
+
+The access check every campaign-scoped route funnels through (today's
+`{ userId, id }` owner check is the leftmost path only):
+
+```mermaid
+flowchart TD
+    req["request { campaignId, userId, op }"] --> m{"active CampaignMember<br/>for (campaignId, userId)?"}
+    m -->|no| deny["404 / 403"]
+    m -->|"yes · role = dm"| any["allow read + write"]
+    m -->|"yes · role = player"| rw{"write op?"}
+    rw -->|no| readok["allow read"]
+    rw -->|yes| feat{"feature opts player in?<br/>(e.g. send message, share roll)"}
+    feat -->|yes| allow["allow scoped write"]
+    feat -->|no| deny
+```

--- a/docs/multi-user-campaigns/01-identity-and-membership.md
+++ b/docs/multi-user-campaigns/01-identity-and-membership.md
@@ -1,0 +1,54 @@
+# Phase 1 — Identity & membership foundations
+
+**Goal:** Give users a unique, searchable handle and give campaigns a membership
+layer (owner = DM, plus invited players), then make campaign access member-aware.
+This is the spine the rest of the initiative builds on.
+
+**Depends on:** nothing.
+
+## Deliverables (sub-issues)
+
+### 1a. Add `username` to the User model
+- Add `username?: string` to `User` in `lib/types.ts`.
+- Add a **sparse unique index** on `users.username` in `lib/db.ts` (mirror the
+  existing unique `email` index).
+- Backfill migration script (`scripts/`) to assign usernames to existing accounts
+  (e.g. derived from email local-part, de-duplicated). Idempotent.
+- **Acceptance:** existing users keep working; index rejects duplicates; backfill
+  is safe to re-run.
+
+### 1b. Username validation + set/edit
+- Validation rules in `lib/validation/` (length, allowed charset, reserved words,
+  case-insensitive uniqueness).
+- Allow setting a username at registration and editing it on a profile/account
+  screen. `PATCH /api/auth/me` (or equivalent) to update.
+- **Acceptance:** invalid/duplicate usernames rejected with clear errors; a user
+  can set and change their handle.
+
+### 1c. User search endpoint
+- `GET /api/users/search?q=` returning minimal public profiles (`{ id, username }`)
+  for member-add. Backed by `fuse.js` (already a dependency) or a prefix query.
+- Rate-limited (reuse `lib/rate-limit.ts`); never leaks email/password fields;
+  intended for use inside the invite flow.
+- **Depends on:** 1a.
+- **Acceptance:** searching a partial username returns matching handles only;
+  no PII leakage; rate limit enforced.
+
+### 1d. `campaignMembers` collection + storage
+- Add `CampaignMember` type; create `campaignMembers` collection with a unique
+  `{campaignId, userId}` index.
+- `storage` methods: add member, update status/role, list members for a campaign,
+  list campaigns for a member.
+- On campaign creation, seed an `active` `dm` membership for the owner.
+- **Acceptance:** the owner is always an active DM member; duplicate memberships
+  rejected; storage methods covered by unit/integration tests.
+
+### 1e. Member-aware campaign access (refactor)
+- Add `assertCampaignAccess(campaignId, userId)` to `lib/utils/campaign.ts`
+  returning the caller's role (`dm` | `player`) or denying access.
+- Refactor campaign read routes (`app/api/campaigns/[id]/**`) from `{ userId, id }`
+  to use the helper, so active members can read campaigns they don't own. Write
+  operations remain DM-only unless a feature specifies otherwise.
+- **Depends on:** 1d.
+- **Acceptance:** a player member can GET a campaign; a non-member gets 404/403;
+  mutations stay DM-gated; existing owner behavior unchanged.

--- a/docs/multi-user-campaigns/02-invite-and-accept.md
+++ b/docs/multi-user-campaigns/02-invite-and-accept.md
@@ -5,6 +5,53 @@ or decline. Membership only becomes `active` on acceptance.
 
 **Depends on:** Phase 1 (1c search, 1d members, 1e access).
 
+## Membership lifecycle
+
+A `CampaignMember.status` moves through these states. The owner is seeded directly
+as `active` with role `dm` (Phase 1d) and never goes through the invite flow.
+
+```mermaid
+stateDiagram-v2
+    [*] --> invited: DM invites by username (2a)
+    invited --> active: invitee accepts (2b)
+    invited --> declined: invitee declines (2b)
+    active --> removed: DM removes member (2c)
+    declined --> invited: DM re-invites (2a)
+    removed --> invited: DM re-invites (2a)
+    active --> [*]
+    declined --> [*]
+    removed --> [*]
+
+    note right of active
+        owner is seeded here as
+        role = dm (Phase 1d)
+    end note
+```
+
+## Invite → accept sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant DM
+    participant Search as GET /users/search (1c)
+    participant Inv as POST /campaigns/:id/members (2a)
+    participant DB as MongoDB
+    participant P as Player
+    participant Inbox as GET /me/invitations (2b)
+
+    DM->>Search: q="ali"
+    Search-->>DM: [{ id, username }]
+    DM->>Inv: invite { userId }
+    Inv->>Inv: assert caller is DM; no dup / self
+    Inv->>DB: insert member { status: invited }
+    P->>Inbox: list my pending invites
+    Inbox-->>P: [{ campaign, invitedBy }]
+    P->>Inv: respond { accept } (2b)
+    Inv->>DB: status = active, respondedAt
+    Note over P: campaign now appears<br/>in the player's list
+```
+
 ## Deliverables (sub-issues)
 
 ### 2a. Invite API

--- a/docs/multi-user-campaigns/02-invite-and-accept.md
+++ b/docs/multi-user-campaigns/02-invite-and-accept.md
@@ -5,6 +5,8 @@ or decline. Membership only becomes `active` on acceptance.
 
 **Depends on:** Phase 1 (1c search, 1d members, 1e access).
 
+> **Tracking:** epic [#294](https://github.com/dougis-org/session-combat/issues/294).
+
 ## Membership lifecycle
 
 A `CampaignMember.status` moves through these states. The owner is seeded directly
@@ -54,16 +56,23 @@ sequenceDiagram
 
 ## Deliverables (sub-issues)
 
-### 2a. Invite API
+### 2a. Invite API · [#305](https://github.com/dougis-org/session-combat/issues/305)
 - `POST /api/campaigns/[id]/members` — DM-only — creates a `CampaignMember` with
   status `invited` for a given `userId` (resolved from username search).
 - Guards: caller must be the campaign DM; cannot invite an existing
   active/invited member; cannot invite self.
+- **Re-invite (upsert, not insert):** because `{campaignId, userId}` is unique (1d),
+  the invite must **upsert**. If a prior membership exists in `declined` or
+  `removed`, transition it back to `invited` (reset `invitedBy`/`invitedAt`, clear
+  `respondedAt`) instead of `insertOne`, which would hit the unique index. Only
+  existing `active`/`invited` members are rejected. (This is the
+  `declined → invited` / `removed → invited` path in the lifecycle diagram above.)
 - **Depends on:** 1c, 1d, 1e.
-- **Acceptance:** DM can invite a user by username; duplicates and self-invites
-  rejected; non-DM cannot invite.
+- **Acceptance:** DM can invite a user by username; re-inviting a previously
+  declined/removed user succeeds and resets status to `invited`; active/invited
+  duplicates and self-invites rejected; non-DM cannot invite.
 
-### 2b. Accept / decline API + invitations inbox
+### 2b. Accept / decline API + invitations inbox · [#306](https://github.com/dougis-org/session-combat/issues/306)
 - `POST /api/campaigns/[id]/members/respond` (or `PATCH .../members/me`) for the
   invited user to set status `active` or `declined`; stamps `respondedAt`.
 - `GET /api/me/invitations` listing the caller's pending invites.
@@ -71,7 +80,7 @@ sequenceDiagram
 - **Acceptance:** invited user can accept (→ active member) or decline; inbox lists
   only the caller's pending invites; others cannot respond on their behalf.
 
-### 2c. Campaign member-management UI
+### 2c. Campaign member-management UI · [#307](https://github.com/dougis-org/session-combat/issues/307)
 - On the campaign page: member list with roles/status, a username search box, and
   an invite action; pending-invite badges; DM can remove a member
   (status `removed`).
@@ -79,7 +88,7 @@ sequenceDiagram
 - **Acceptance:** DM can search, invite, see pending/active members, and remove a
   member; follows existing `lib/components` + Tailwind semantic-token conventions.
 
-### 2d. Player invitations inbox UI
+### 2d. Player invitations inbox UI · [#308](https://github.com/dougis-org/session-combat/issues/308)
 - A surface (nav badge + page/panel) where a player sees pending campaign invites
   and accepts/declines.
 - **Depends on:** 2b.

--- a/docs/multi-user-campaigns/02-invite-and-accept.md
+++ b/docs/multi-user-campaigns/02-invite-and-accept.md
@@ -1,0 +1,40 @@
+# Phase 2 — Invite & accept flow
+
+**Goal:** Let a DM find users by username and invite them; let invited users accept
+or decline. Membership only becomes `active` on acceptance.
+
+**Depends on:** Phase 1 (1c search, 1d members, 1e access).
+
+## Deliverables (sub-issues)
+
+### 2a. Invite API
+- `POST /api/campaigns/[id]/members` — DM-only — creates a `CampaignMember` with
+  status `invited` for a given `userId` (resolved from username search).
+- Guards: caller must be the campaign DM; cannot invite an existing
+  active/invited member; cannot invite self.
+- **Depends on:** 1c, 1d, 1e.
+- **Acceptance:** DM can invite a user by username; duplicates and self-invites
+  rejected; non-DM cannot invite.
+
+### 2b. Accept / decline API + invitations inbox
+- `POST /api/campaigns/[id]/members/respond` (or `PATCH .../members/me`) for the
+  invited user to set status `active` or `declined`; stamps `respondedAt`.
+- `GET /api/me/invitations` listing the caller's pending invites.
+- **Depends on:** 1d.
+- **Acceptance:** invited user can accept (→ active member) or decline; inbox lists
+  only the caller's pending invites; others cannot respond on their behalf.
+
+### 2c. Campaign member-management UI
+- On the campaign page: member list with roles/status, a username search box, and
+  an invite action; pending-invite badges; DM can remove a member
+  (status `removed`).
+- **Depends on:** 2a.
+- **Acceptance:** DM can search, invite, see pending/active members, and remove a
+  member; follows existing `lib/components` + Tailwind semantic-token conventions.
+
+### 2d. Player invitations inbox UI
+- A surface (nav badge + page/panel) where a player sees pending campaign invites
+  and accepts/declines.
+- **Depends on:** 2b.
+- **Acceptance:** player sees invites, can accept/decline, and the campaign appears
+  in their campaign list once accepted.

--- a/docs/multi-user-campaigns/03-cross-user-characters.md
+++ b/docs/multi-user-campaigns/03-cross-user-characters.md
@@ -7,6 +7,8 @@ own them.
 **Depends on:** Phase 1 (1e access). Benefits from Phase 2 (active members exist),
 but the data layer can be built against memberships directly.
 
+> **Tracking:** epic [#295](https://github.com/dougis-org/session-combat/issues/295).
+
 ## How a player's character reaches a DM's party
 
 The character record stays owned by the player; the DM only references it once the
@@ -24,7 +26,7 @@ flowchart LR
 
 ## Deliverables (sub-issues)
 
-### 3a. Character sharing (opt-in) — data + player UI
+### 3a. Character sharing (opt-in) — data + player UI · [#309](https://github.com/dougis-org/session-combat/issues/309)
 - Add `CampaignCharacterShare` type; create `campaignCharacterShares` collection
   with unique `{campaignId, characterId}`.
 - API for a player to share/unshare one of **their** characters into a campaign
@@ -35,13 +37,20 @@ flowchart LR
 - **Acceptance:** a player can share/unshare only their own characters into
   campaigns they belong to; sharing a character they don't own is rejected.
 
-### 3b. Party builder uses shared characters
+### 3b. Party builder uses shared characters · [#310](https://github.com/dougis-org/session-combat/issues/310)
 - Update the party access rule: the DM may add a `characterId` to a party in a
   campaign if that character is shared into the campaign by an active member (in
   addition to characters the DM owns).
 - Party builder UI: surface shared members' characters as selectable, grouped by
   owner; respect soft-delete (`characters_active`).
+- **Cleanup on unshare / member removal (proactive + reactive):** prefer
+  **proactive** cleanup — when a character is unshared or a member is removed, set
+  `leftAt` on the affected `Party.members[]` entries (reusing the existing leave
+  semantics) so stale references aren't persisted. Keep a **reactive** guard in the
+  party / campaign-context loader that filters any character no longer shared, as
+  defense-in-depth.
 - **Depends on:** 3a.
 - **Acceptance:** DM can add a player's shared character to a campaign party;
-  unsharing/removing a member or character handles party membership gracefully;
-  DM cannot add an unshared character.
+  unsharing a character or removing a member proactively sets `leftAt` on its party
+  entries and it stops appearing in party/campaign context; DM cannot add an
+  unshared character.

--- a/docs/multi-user-campaigns/03-cross-user-characters.md
+++ b/docs/multi-user-campaigns/03-cross-user-characters.md
@@ -7,6 +7,21 @@ own them.
 **Depends on:** Phase 1 (1e access). Benefits from Phase 2 (active members exist),
 but the data layer can be built against memberships directly.
 
+## How a player's character reaches a DM's party
+
+The character record stays owned by the player; the DM only references it once the
+player has shared it and the DM-side party rule confirms the share.
+
+```mermaid
+flowchart LR
+    C["Character<br/>(owned by Player)"] -->|player shares · 3a| S["CampaignCharacterShare<br/>{campaignId, characterId, userId}"]
+    M["CampaignMember<br/>(player, active)"] -. guards .-> S
+    S -->|DM picks in builder · 3b| PB{"Party add rule"}
+    DMC["DM-owned character"] --> PB
+    PB -->|"shared by active member<br/>OR owned by DM"| P["Party.members[]"]
+    PB -.->|otherwise| X["rejected"]
+```
+
 ## Deliverables (sub-issues)
 
 ### 3a. Character sharing (opt-in) — data + player UI

--- a/docs/multi-user-campaigns/03-cross-user-characters.md
+++ b/docs/multi-user-campaigns/03-cross-user-characters.md
@@ -1,0 +1,32 @@
+# Phase 3 — Cross-user characters into parties
+
+**Goal:** Let players opt their own characters into a campaign, and let the DM pull
+those shared characters into the parties they build — even though the DM doesn't
+own them.
+
+**Depends on:** Phase 1 (1e access). Benefits from Phase 2 (active members exist),
+but the data layer can be built against memberships directly.
+
+## Deliverables (sub-issues)
+
+### 3a. Character sharing (opt-in) — data + player UI
+- Add `CampaignCharacterShare` type; create `campaignCharacterShares` collection
+  with unique `{campaignId, characterId}`.
+- API for a player to share/unshare one of **their** characters into a campaign
+  they're an active member of, plus a list endpoint of characters a member has
+  shared.
+- Player UI: on the campaign (or character) view, choose which characters to share.
+- **Depends on:** 1e.
+- **Acceptance:** a player can share/unshare only their own characters into
+  campaigns they belong to; sharing a character they don't own is rejected.
+
+### 3b. Party builder uses shared characters
+- Update the party access rule: the DM may add a `characterId` to a party in a
+  campaign if that character is shared into the campaign by an active member (in
+  addition to characters the DM owns).
+- Party builder UI: surface shared members' characters as selectable, grouped by
+  owner; respect soft-delete (`characters_active`).
+- **Depends on:** 3a.
+- **Acceptance:** DM can add a player's shared character to a campaign party;
+  unsharing/removing a member or character handles party membership gracefully;
+  DM cannot add an unshared character.

--- a/docs/multi-user-campaigns/04-realtime-transport.md
+++ b/docs/multi-user-campaigns/04-realtime-transport.md
@@ -19,20 +19,23 @@ flowchart TB
         ES["EventSource"]
         Dock --> Hook --> ES
     end
-    subgraph Server["Next.js (Fly.io)"]
+    subgraph Server["Next.js instance (Fly.io)"]
         SSE["GET /campaigns/:id/stream (4a)"]
         AUTH["assertCampaignAccess (1e)"]
+        REG["Subscriber registry<br/>(demux by campaignId)"]
         TA["Transport abstraction<br/>subscribe(campaignId, onEvent)"]
         SSE --> AUTH
         SSE --> TA
+        TA --> REG
     end
     subgraph Mongo["MongoDB"]
-        CS["Change Streams (Atlas)"]
+        CS["ONE shared change stream<br/>per instance (Atlas)"]
         POLL["since-timestamp poll (local dev)"]
     end
     ES -- "HTTP text/event-stream" --> SSE
-    TA -->|prod| CS
-    TA -->|fallback| POLL
+    REG -->|prod · single cursor| CS
+    REG -->|fallback| POLL
+    CS -. "events demux'd to all<br/>campaigns + connections" .-> REG
 ```
 
 ## Transport selection (4a)
@@ -42,7 +45,7 @@ The same `subscribe()` interface picks its source at runtime so clients never ch
 ```mermaid
 flowchart TD
     start(["subscribe(campaignId)"]) --> q{"Mongo is a<br/>replica set?"}
-    q -->|yes · Atlas| cs["watch() change stream<br/>filtered to campaignId"]
+    q -->|yes · Atlas| cs["one shared watch() per instance<br/>(unfiltered) → demux by campaignId"]
     q -->|no · standalone dev| poll["poll collections since<br/>last-seen timestamp"]
     cs --> emit["emit typed campaign events"]
     poll --> emit
@@ -60,21 +63,22 @@ flowchart TD
 - Transport abstraction in `lib/server/` (or `lib/api/`): a `subscribe(campaignId,
   onEvent)` that uses **MongoDB Change Streams** when available (Atlas) and a
   **`since`-timestamp DB poll** otherwise. Emits typed events scoped to the campaign.
-- **Multiplex one stream per campaign (not per connection):** keep an in-process
-  subscriber registry so each server instance opens **one** change stream per active
-  campaign (or a single collection-wide stream) and fans events out to all that
-  campaign's SSE connections. Opening a cursor per connection scales linearly with
-  connected users and exhausts Atlas connection / change-stream limits.
-  Reference-count subscribers and close the stream when a campaign's last connection
-  drops.
+- **One shared change stream per process (multiplex across campaigns *and*
+  connections):** each server instance opens a **single** change stream over the
+  relevant collections — **not** filtered by campaign — and demultiplexes events to
+  per-campaign subscriber sets in-process via a registry keyed by `campaignId`.
+  Never one cursor per connection *or* per campaign; both scale with load and
+  exhaust Atlas connection / change-stream limits. Keep the count of streams to
+  Mongo as low as possible (ideally one per instance). The shared stream opens lazily
+  on the first SSE connection and closes when the instance's last connection drops.
 - Heartbeat/keepalive comments; clean teardown on disconnect; respects Fly's
   request lifecycle.
 - **Depends on:** 1e.
 - **Acceptance:** an authorized member receives events for their campaign and
-  nothing for campaigns they're not in; multiple connections to one campaign share a
-  single change stream; works against Atlas (change streams) and a standalone Mongo
-  (polling); connections close cleanly and the shared stream closes when the last
-  one drops.
+  nothing for campaigns they're not in; connections across **multiple** campaigns on
+  one instance share a **single** change stream (verified by cursor count); works
+  against Atlas (change streams) and a standalone Mongo (polling); connections close
+  cleanly and the shared stream closes when the instance's last connection drops.
 
 ### 4b. Client `useCampaignStream` hook · [#312](https://github.com/dougis-org/session-combat/issues/312)
 - React hook in `lib/hooks/` wrapping `EventSource` with auto-reconnect/backoff,

--- a/docs/multi-user-campaigns/04-realtime-transport.md
+++ b/docs/multi-user-campaigns/04-realtime-transport.md
@@ -7,6 +7,49 @@ plumbing everything else plugs into.
 
 **Depends on:** Phase 1 (1e access). Items 4a/4b/4c can largely proceed in parallel.
 
+## Component layout
+
+```mermaid
+flowchart TB
+    subgraph Browser
+        Dock["CampaignChat dock (4c)"]
+        Hook["useCampaignStream (4b)"]
+        ES["EventSource"]
+        Dock --> Hook --> ES
+    end
+    subgraph Server["Next.js (Fly.io)"]
+        SSE["GET /campaigns/:id/stream (4a)"]
+        AUTH["assertCampaignAccess (1e)"]
+        TA["Transport abstraction<br/>subscribe(campaignId, onEvent)"]
+        SSE --> AUTH
+        SSE --> TA
+    end
+    subgraph Mongo["MongoDB"]
+        CS["Change Streams (Atlas)"]
+        POLL["since-timestamp poll (local dev)"]
+    end
+    ES -- "HTTP text/event-stream" --> SSE
+    TA -->|prod| CS
+    TA -->|fallback| POLL
+```
+
+## Transport selection (4a)
+
+The same `subscribe()` interface picks its source at runtime so clients never change:
+
+```mermaid
+flowchart TD
+    start(["subscribe(campaignId)"]) --> q{"Mongo is a<br/>replica set?"}
+    q -->|yes · Atlas| cs["watch() change stream<br/>filtered to campaignId"]
+    q -->|no · standalone dev| poll["poll collections since<br/>last-seen timestamp"]
+    cs --> emit["emit typed campaign events"]
+    poll --> emit
+    emit --> sse["write SSE frames + heartbeat"]
+    sse --> close{"client<br/>disconnected?"}
+    close -->|no| emit
+    close -->|yes| teardown["close cursor / stop poll"]
+```
+
 ## Deliverables (sub-issues)
 
 ### 4a. SSE stream endpoint + transport abstraction

--- a/docs/multi-user-campaigns/04-realtime-transport.md
+++ b/docs/multi-user-campaigns/04-realtime-transport.md
@@ -1,0 +1,38 @@
+# Phase 4 — Real-time transport
+
+**Goal:** Stand up the real-time pipe — a per-campaign SSE stream backed by MongoDB
+Change Streams (prod/Atlas) with a polling fallback (local dev) — plus the client
+hook and the collapsible chat dock shell. **No product features yet**, just the
+plumbing everything else plugs into.
+
+**Depends on:** Phase 1 (1e access). Items 4a/4b/4c can largely proceed in parallel.
+
+## Deliverables (sub-issues)
+
+### 4a. SSE stream endpoint + transport abstraction
+- `GET /api/campaigns/[id]/stream` returning a `text/event-stream` `ReadableStream`;
+  caller must pass `assertCampaignAccess`.
+- Transport abstraction in `lib/server/` (or `lib/api/`): a `subscribe(campaignId,
+  onEvent)` that uses **MongoDB Change Streams** when available (Atlas) and a
+  **`since`-timestamp DB poll** otherwise. Emits typed events scoped to the campaign.
+- Heartbeat/keepalive comments; clean teardown on disconnect; respects Fly's
+  request lifecycle.
+- **Depends on:** 1e.
+- **Acceptance:** an authorized member receives events for their campaign and
+  nothing for campaigns they're not in; works against Atlas (change streams) and a
+  standalone Mongo (polling); connections close cleanly.
+
+### 4b. Client `useCampaignStream` hook
+- React hook in `lib/hooks/` wrapping `EventSource` with auto-reconnect/backoff,
+  connection state, and typed event dispatch.
+- **Acceptance:** components can subscribe to a campaign and receive typed events;
+  reconnects after transient drops; tears down on unmount.
+
+### 4c. Collapsible / pinnable chat dock shell
+- `CampaignChat` component in `lib/components/`: fixed dock that toggles
+  collapsed pill ↔ expanded drawer, with a **pin-open** control persisted to
+  `localStorage`. No data wiring yet — layout, states, and a11y only.
+- Follows Tailwind semantic tokens (`--color-party`, etc.) and existing component
+  patterns.
+- **Acceptance:** dock collapses/expands, pin state survives reload, doesn't
+  obstruct the page when collapsed, keyboard-accessible.

--- a/docs/multi-user-campaigns/04-realtime-transport.md
+++ b/docs/multi-user-campaigns/04-realtime-transport.md
@@ -7,6 +7,8 @@ plumbing everything else plugs into.
 
 **Depends on:** Phase 1 (1e access). Items 4a/4b/4c can largely proceed in parallel.
 
+> **Tracking:** epic [#296](https://github.com/dougis-org/session-combat/issues/296).
+
 ## Component layout
 
 ```mermaid
@@ -52,26 +54,35 @@ flowchart TD
 
 ## Deliverables (sub-issues)
 
-### 4a. SSE stream endpoint + transport abstraction
+### 4a. SSE stream endpoint + transport abstraction · [#311](https://github.com/dougis-org/session-combat/issues/311)
 - `GET /api/campaigns/[id]/stream` returning a `text/event-stream` `ReadableStream`;
   caller must pass `assertCampaignAccess`.
 - Transport abstraction in `lib/server/` (or `lib/api/`): a `subscribe(campaignId,
   onEvent)` that uses **MongoDB Change Streams** when available (Atlas) and a
   **`since`-timestamp DB poll** otherwise. Emits typed events scoped to the campaign.
+- **Multiplex one stream per campaign (not per connection):** keep an in-process
+  subscriber registry so each server instance opens **one** change stream per active
+  campaign (or a single collection-wide stream) and fans events out to all that
+  campaign's SSE connections. Opening a cursor per connection scales linearly with
+  connected users and exhausts Atlas connection / change-stream limits.
+  Reference-count subscribers and close the stream when a campaign's last connection
+  drops.
 - Heartbeat/keepalive comments; clean teardown on disconnect; respects Fly's
   request lifecycle.
 - **Depends on:** 1e.
 - **Acceptance:** an authorized member receives events for their campaign and
-  nothing for campaigns they're not in; works against Atlas (change streams) and a
-  standalone Mongo (polling); connections close cleanly.
+  nothing for campaigns they're not in; multiple connections to one campaign share a
+  single change stream; works against Atlas (change streams) and a standalone Mongo
+  (polling); connections close cleanly and the shared stream closes when the last
+  one drops.
 
-### 4b. Client `useCampaignStream` hook
+### 4b. Client `useCampaignStream` hook · [#312](https://github.com/dougis-org/session-combat/issues/312)
 - React hook in `lib/hooks/` wrapping `EventSource` with auto-reconnect/backoff,
   connection state, and typed event dispatch.
 - **Acceptance:** components can subscribe to a campaign and receive typed events;
   reconnects after transient drops; tears down on unmount.
 
-### 4c. Collapsible / pinnable chat dock shell
+### 4c. Collapsible / pinnable chat dock shell · [#313](https://github.com/dougis-org/session-combat/issues/313)
 - `CampaignChat` component in `lib/components/`: fixed dock that toggles
   collapsed pill ↔ expanded drawer, with a **pin-open** control persisted to
   `localStorage`. No data wiring yet — layout, states, and a11y only.

--- a/docs/multi-user-campaigns/05-messaging.md
+++ b/docs/multi-user-campaigns/05-messaging.md
@@ -5,6 +5,25 @@ visibility, delivered live over the Phase 4 stream and rendered in the chat dock
 
 **Depends on:** Phase 1 (1e), Phase 4 (4a/4b transport + 4c dock).
 
+## Visibility model
+
+Server-side, every message carries a `visibility.scope`. The stream filter decides
+who a stored message is pushed to (and `GET` history applies the same predicate):
+
+```mermaid
+flowchart TD
+    msg["message { senderId, visibility }"] --> scope{"scope?"}
+    scope -->|group| grp["all active members"]
+    scope -->|dm-only| dmo["DM + sender"]
+    scope -->|direct| dir["sender + toUserId"]
+    grp --> push["push via SSE / return in history"]
+    dmo --> push
+    dir --> push
+```
+
+> The same `{ scope, toUserId? }` envelope is reused by shared rolls (Phase 6),
+> so a new scope added here is automatically available to rolls.
+
 ## Deliverables (sub-issues)
 
 ### 5a. `campaignMessages` collection + API

--- a/docs/multi-user-campaigns/05-messaging.md
+++ b/docs/multi-user-campaigns/05-messaging.md
@@ -1,0 +1,30 @@
+# Phase 5 — Messaging
+
+**Goal:** Persistent, campaign-scoped messaging with group / direct / DM-only
+visibility, delivered live over the Phase 4 stream and rendered in the chat dock.
+
+**Depends on:** Phase 1 (1e), Phase 4 (4a/4b transport + 4c dock).
+
+## Deliverables (sub-issues)
+
+### 5a. `campaignMessages` collection + API
+- Add `CampaignMessage` type; create collection with index `{campaignId, createdAt}`.
+- `POST /api/campaigns/[id]/messages` — send a `text` message with a `visibility`
+  (`group` | `direct`+`toUserId` | `dm-only`); `GET` for paginated history filtered
+  by what the caller is allowed to see.
+- Visibility enforcement server-side: `dm-only` reaches only the DM + sender;
+  `direct` reaches only sender + recipient; `group` reaches all active members.
+- **Depends on:** 1e.
+- **Acceptance:** messages persist; history pagination works; a player cannot read
+  a direct/dm-only message not addressed to them; writes emit a stream event.
+
+### 5b. Wire chat dock to stream + send
+- Connect `CampaignChat` to `useCampaignStream` for live message events and to the
+  send API; composer includes a **visibility selector** (Group / DM / whisper to a
+  member).
+- Render the message feed with sender handle, timestamp, and a visibility marker;
+  unread indicator when collapsed.
+- **Depends on:** 4b, 4c, 5a.
+- **Acceptance:** a member sends a group/direct/DM message and connected members
+  see it live; history loads on open; whisper targets resolve by username;
+  visibility markers are clear.

--- a/docs/multi-user-campaigns/05-messaging.md
+++ b/docs/multi-user-campaigns/05-messaging.md
@@ -5,6 +5,8 @@ visibility, delivered live over the Phase 4 stream and rendered in the chat dock
 
 **Depends on:** Phase 1 (1e), Phase 4 (4a/4b transport + 4c dock).
 
+> **Tracking:** epic [#297](https://github.com/dougis-org/session-combat/issues/297).
+
 ## Visibility model
 
 Server-side, every message carries a `visibility.scope`. The stream filter decides
@@ -26,7 +28,7 @@ flowchart TD
 
 ## Deliverables (sub-issues)
 
-### 5a. `campaignMessages` collection + API
+### 5a. `campaignMessages` collection + API · [#314](https://github.com/dougis-org/session-combat/issues/314)
 - Add `CampaignMessage` type; create collection with index `{campaignId, createdAt}`.
 - `POST /api/campaigns/[id]/messages` — send a `text` message with a `visibility`
   (`group` | `direct`+`toUserId` | `dm-only`); `GET` for paginated history filtered
@@ -37,7 +39,7 @@ flowchart TD
 - **Acceptance:** messages persist; history pagination works; a player cannot read
   a direct/dm-only message not addressed to them; writes emit a stream event.
 
-### 5b. Wire chat dock to stream + send
+### 5b. Wire chat dock to stream + send · [#315](https://github.com/dougis-org/session-combat/issues/315)
 - Connect `CampaignChat` to `useCampaignStream` for live message events and to the
   send API; composer includes a **visibility selector** (Group / DM / whisper to a
   member).

--- a/docs/multi-user-campaigns/06-shared-rolls.md
+++ b/docs/multi-user-campaigns/06-shared-rolls.md
@@ -6,21 +6,31 @@ are tied to the active session log.
 
 **Depends on:** Phase 5 (5b dock + feed). Reuses the existing `sessionLogs` model.
 
+> **Tracking:** epic [#298](https://github.com/dougis-org/session-combat/issues/298).
+
 ## Deliverables (sub-issues)
 
-### 6a. `campaignRolls` collection + roll API
+### 6a. `campaignRolls` collection + roll API · [#316](https://github.com/dougis-org/session-combat/issues/316)
 - Add `CampaignRoll` type; create collection with index
   `{campaignId, sessionId, createdAt}`.
+- **Active-session tracking:** the current `Campaign` model has no concept of an
+  *open* session (`sessionLogs` are recorded post-session). Add
+  `activeSessionId?: string` to `Campaign`, set when the DM starts/opens a session
+  and cleared when it ends; rolls are stamped with it. With **no** active session the
+  API rejects the roll (or requires the DM to start one first) — it must not silently
+  drop `sessionId`. (This `Campaign` field change may ship as a small prerequisite or
+  as part of this issue.)
 - `POST /api/campaigns/[id]/rolls` — record a roll (`formula`, computed `rolls[]`,
-  `total`, optional `label`) against the campaign's active `sessionId`, with a
+  `total`, optional `label`) against the campaign's `activeSessionId`, with a
   `visibility` (`group` | `dm-only` | `direct`+`toUserId`); `GET` filtered by
   visibility + session.
 - Server-side visibility enforcement mirrors messaging; emits a stream event.
-- **Depends on:** 1e (and a notion of the campaign's current/active session).
-- **Acceptance:** a roll persists against the right session; a `dm-only` roll is
-  invisible to other players; rolls list scoped to the session.
+- **Depends on:** 1e, plus the `activeSessionId` addition above.
+- **Acceptance:** a roll persists against the active session; rolling with no active
+  session is rejected (not silently dropped); a `dm-only` roll is invisible to other
+  players; rolls list scoped to the session.
 
-### 6b. Roll-share UI in the chat dock
+### 6b. Roll-share UI in the chat dock · [#317](https://github.com/dougis-org/session-combat/issues/317)
 - Roll entry control in `CampaignChat` (formula or quick buttons) with a visibility
   selector (DM-only vs Group); render rolls as a distinct feed item (formula,
   breakdown, total, roller handle, visibility marker).

--- a/docs/multi-user-campaigns/06-shared-rolls.md
+++ b/docs/multi-user-campaigns/06-shared-rolls.md
@@ -1,0 +1,29 @@
+# Phase 6 — Shared dice rolls (session-scoped)
+
+**Goal:** Let players share dice rolls into a session, with visibility control so a
+roll (e.g. a saving throw) can be sent to the DM only or to the whole group. Rolls
+are tied to the active session log.
+
+**Depends on:** Phase 5 (5b dock + feed). Reuses the existing `sessionLogs` model.
+
+## Deliverables (sub-issues)
+
+### 6a. `campaignRolls` collection + roll API
+- Add `CampaignRoll` type; create collection with index
+  `{campaignId, sessionId, createdAt}`.
+- `POST /api/campaigns/[id]/rolls` — record a roll (`formula`, computed `rolls[]`,
+  `total`, optional `label`) against the campaign's active `sessionId`, with a
+  `visibility` (`group` | `dm-only` | `direct`+`toUserId`); `GET` filtered by
+  visibility + session.
+- Server-side visibility enforcement mirrors messaging; emits a stream event.
+- **Depends on:** 1e (and a notion of the campaign's current/active session).
+- **Acceptance:** a roll persists against the right session; a `dm-only` roll is
+  invisible to other players; rolls list scoped to the session.
+
+### 6b. Roll-share UI in the chat dock
+- Roll entry control in `CampaignChat` (formula or quick buttons) with a visibility
+  selector (DM-only vs Group); render rolls as a distinct feed item (formula,
+  breakdown, total, roller handle, visibility marker).
+- **Depends on:** 5b, 6a.
+- **Acceptance:** a player rolls and shares to DM-only or group and the right
+  audience sees it live in the feed; roll breakdown is legible.

--- a/docs/multi-user-campaigns/07-scene-content.md
+++ b/docs/multi-user-campaigns/07-scene-content.md
@@ -1,0 +1,33 @@
+# Phase 7 — Scene content (maps / images)
+
+**Goal:** Let the DM push scene-setting content — maps, images, text — to the
+group during a session. Scene content is modeled as a message (campaign-persistent)
+with an optional image attachment stored in GridFS.
+
+**Depends on:** Phase 5 (5b dock + feed). Scene messages reuse the `CampaignMessage`
+model (`kind: 'scene'`).
+
+## Deliverables (sub-issues)
+
+### 7a. GridFS attachment upload/serve
+- Endpoints to upload a scene image to **MongoDB GridFS** and stream it back by id,
+  with access gated by `assertCampaignAccess`.
+- Constraints: allowed image types, max size, basic validation; returns an
+  `attachmentId` usable as `CampaignMessage.attachmentId`.
+- **Acceptance:** an authorized DM can upload an image and any active member can
+  fetch it; non-members cannot; oversized/invalid files rejected; bytes survive a
+  Fly machine restart (persisted in Mongo, not local disk).
+
+### 7b. DM "push scene" + render
+- DM action in `CampaignChat` (or campaign view) to push a `scene` message
+  (text and/or image) to the group; renders inline in the feed with an enlargeable
+  image.
+- **Depends on:** 5b, 7a.
+- **Acceptance:** DM pushes a map/image/text and connected members see it live;
+  scene content remains in campaign history; image renders and can be enlarged.
+
+## Future (out of scope, design stays open for)
+- Additional message kinds (handouts, links, audio cues).
+- Additional shared-item types beyond rolls.
+- Per-scene visibility (reveal to a subset of players).
+- Read receipts / typing indicators.

--- a/docs/multi-user-campaigns/07-scene-content.md
+++ b/docs/multi-user-campaigns/07-scene-content.md
@@ -7,18 +7,26 @@ with an optional image attachment stored in GridFS.
 **Depends on:** Phase 5 (5b dock + feed). Scene messages reuse the `CampaignMessage`
 model (`kind: 'scene'`).
 
+> **Tracking:** epic [#299](https://github.com/dougis-org/session-combat/issues/299).
+
 ## Deliverables (sub-issues)
 
-### 7a. GridFS attachment upload/serve
+### 7a. GridFS attachment upload/serve · [#318](https://github.com/dougis-org/session-combat/issues/318)
 - Endpoints to upload a scene image to **MongoDB GridFS** and stream it back by id,
   with access gated by `assertCampaignAccess`.
 - Constraints: allowed image types, max size, basic validation; returns an
   `attachmentId` usable as `CampaignMessage.attachmentId`.
+- **Orphan avoidance:** prefer a **single atomic endpoint** that stores the image and
+  creates the `scene` `CampaignMessage` together, so a file is never persisted
+  without a referencing message. If a two-step upload is kept, mark fresh uploads
+  `pending` and run a periodic sweep that purges GridFS files unreferenced by any
+  `CampaignMessage` past a threshold (e.g. 24h).
 - **Acceptance:** an authorized DM can upload an image and any active member can
-  fetch it; non-members cannot; oversized/invalid files rejected; bytes survive a
-  Fly machine restart (persisted in Mongo, not local disk).
+  fetch it; non-members cannot; oversized/invalid files rejected; an abandoned upload
+  never leaves a permanently orphaned file; bytes survive a Fly machine restart
+  (persisted in Mongo, not local disk).
 
-### 7b. DM "push scene" + render
+### 7b. DM "push scene" + render · [#319](https://github.com/dougis-org/session-combat/issues/319)
 - DM action in `CampaignChat` (or campaign view) to push a `scene` message
   (text and/or image) to the group; renders inline in the feed with an enlargeable
   image.

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -92,6 +92,7 @@ existing `lib/db.ts` pattern):
 - `CampaignCharacterShare` — `{ campaignId, userId, characterId, sharedAt }`. Unique `{campaignId,characterId}`. Player opt-in of a character into a campaign.
 - `CampaignMessage` — `{ campaignId, senderId, kind: 'text'|'scene', visibility: {scope:'group'|'direct'|'dm-only', toUserId?}, body?, attachmentId? }`. Index `{campaignId,createdAt}`. Persistent.
 - `CampaignRoll` — `{ campaignId, sessionId, rollerId, label?, formula, rolls[], total, visibility: {scope:'group'|'dm-only'|'direct', toUserId?} }`. Index `{campaignId,sessionId,createdAt}`. Session-scoped.
+- `Campaign.activeSessionId?: string` — **NEW**: the session currently open for live play (set when the DM starts a session, cleared when it ends). Phase 6 rolls are scoped to it; with no active session, roll submission is rejected rather than silently dropped.
 
 The relationships between the existing entities (grey-ish: `User`, `Campaign`,
 `Character`, `Party`, `SessionLog`) and the new ones introduced by this initiative:
@@ -122,6 +123,7 @@ erDiagram
     Campaign {
         string id
         string userId "owner = DM"
+        string activeSessionId "NEW: open session, scopes rolls"
     }
     CampaignMember {
         string campaignId
@@ -160,7 +162,8 @@ Campaign reads are currently `{ userId, id }` (single owner). This becomes
 `assertCampaignAccess(campaignId, userId)` helper in `lib/utils/campaign.ts` that
 returns the member's role. Party building gains a rule: the DM may add a
 `characterId` to a party only if that character is shared into the campaign by an
-active member. Phase 1e delivers this refactor; most later phases depend on it.
+active member. Phase 1e ([#304](https://github.com/dougis-org/session-combat/issues/304))
+delivers this refactor; most later phases depend on it.
 
 ## Phase roadmap
 
@@ -169,13 +172,13 @@ on its own. `→` marks hard dependencies; everything else can run in parallel.
 
 | Phase | Theme | Epic | Sub-issues | Depends on |
 |-------|-------|------|------------|------------|
-| 1 | Identity & membership foundations | #293 | 1a #300 · 1b #301 · 1c #302 · 1d #303 · 1e #304 | — |
-| 2 | Invite & accept flow | #294 | 2a #305 · 2b #306 · 2c #307 · 2d #308 | Phase 1 |
-| 3 | Cross-user characters into parties | #295 | 3a #309 · 3b #310 | Phase 1 |
-| 4 | Real-time transport | #296 | 4a #311 · 4b #312 · 4c #313 | Phase 1 |
-| 5 | Messaging | #297 | 5a #314 · 5b #315 | Phase 4 |
-| 6 | Shared dice rolls (session-scoped) | #298 | 6a #316 · 6b #317 | Phase 5 |
-| 7 | Scene content (maps/images) | #299 | 7a #318 · 7b #319 | Phase 5 |
+| 1 | Identity & membership foundations | [#293](https://github.com/dougis-org/session-combat/issues/293) | [1a #300](https://github.com/dougis-org/session-combat/issues/300) · [1b #301](https://github.com/dougis-org/session-combat/issues/301) · [1c #302](https://github.com/dougis-org/session-combat/issues/302) · [1d #303](https://github.com/dougis-org/session-combat/issues/303) · [1e #304](https://github.com/dougis-org/session-combat/issues/304) | — |
+| 2 | Invite & accept flow | [#294](https://github.com/dougis-org/session-combat/issues/294) | [2a #305](https://github.com/dougis-org/session-combat/issues/305) · [2b #306](https://github.com/dougis-org/session-combat/issues/306) · [2c #307](https://github.com/dougis-org/session-combat/issues/307) · [2d #308](https://github.com/dougis-org/session-combat/issues/308) | Phase 1 |
+| 3 | Cross-user characters into parties | [#295](https://github.com/dougis-org/session-combat/issues/295) | [3a #309](https://github.com/dougis-org/session-combat/issues/309) · [3b #310](https://github.com/dougis-org/session-combat/issues/310) | Phase 1 |
+| 4 | Real-time transport | [#296](https://github.com/dougis-org/session-combat/issues/296) | [4a #311](https://github.com/dougis-org/session-combat/issues/311) · [4b #312](https://github.com/dougis-org/session-combat/issues/312) · [4c #313](https://github.com/dougis-org/session-combat/issues/313) | Phase 1 |
+| 5 | Messaging | [#297](https://github.com/dougis-org/session-combat/issues/297) | [5a #314](https://github.com/dougis-org/session-combat/issues/314) · [5b #315](https://github.com/dougis-org/session-combat/issues/315) | Phase 4 |
+| 6 | Shared dice rolls (session-scoped) | [#298](https://github.com/dougis-org/session-combat/issues/298) | [6a #316](https://github.com/dougis-org/session-combat/issues/316) · [6b #317](https://github.com/dougis-org/session-combat/issues/317) | Phase 5 |
+| 7 | Scene content (maps/images) | [#299](https://github.com/dougis-org/session-combat/issues/299) | [7a #318](https://github.com/dougis-org/session-combat/issues/318) · [7b #319](https://github.com/dougis-org/session-combat/issues/319) | Phase 5 |
 
 ### Dependency graph
 
@@ -245,6 +248,63 @@ flowchart LR
     n5b --> n7b
     n7a --> n7b
 ```
+
+### Build order & parallelism (waves)
+
+The dependency graph above shows *what blocks what*; this view shows *when each
+sub-issue can start* and *what runs concurrently*. A "wave" is the earliest point a
+sub-issue can begin assuming unlimited parallel hands (each bar ≈ one deliverable;
+bars in the same column run in parallel). Exact edges remain authoritative in the
+dependency graph — the waves are the schedule those edges imply.
+
+```mermaid
+gantt
+    title Earliest-start schedule (overlap = can be built in parallel)
+    dateFormat YYYY-MM-DD
+    axisFormat W%d
+
+    section Phase 1 · Identity & membership
+    1a username model          :done1a, 2026-01-01, 1d
+    1d campaignMembers         :done1d, 2026-01-01, 1d
+    1b username set/edit       :after done1a, 1d
+    1c user search             :done1c, after done1a, 1d
+    1e assertCampaignAccess    :done1e, after done1d, 1d
+
+    section Phase 2 · Invite & accept
+    2b accept/decline + inbox  :done2b, after done1d, 1d
+    2a invite API              :done2a, after done1c done1e, 1d
+    2c member mgmt UI          :after done2a, 1d
+    2d invitations inbox UI    :after done2b, 1d
+
+    section Phase 3 · Cross-user characters
+    3a character sharing       :done3a, after done1e, 1d
+    3b party builder           :after done3a, 1d
+
+    section Phase 4 · Real-time transport
+    4b useCampaignStream       :done4b, 2026-01-01, 1d
+    4c chat dock shell         :done4c, 2026-01-01, 1d
+    4a SSE + transport         :done4a, after done1e, 1d
+
+    section Phase 5 · Messaging
+    5a messages API            :done5a, after done1e, 1d
+    5b wire dock               :done5b, after done4b done4c done5a, 1d
+
+    section Phase 6 · Shared rolls
+    6a rolls API               :done6a, after done1e, 1d
+    6b roll UI                 :after done5b done6a, 1d
+
+    section Phase 7 · Scene content
+    7a GridFS upload/serve     :done7a, 2026-01-01, 1d
+    7b push scene              :after done5b done7a, 1d
+```
+
+| Wave | Can start | Notes |
+|------|-----------|-------|
+| 1 | **1a, 1d, 4b, 4c, 7a** | All dependency-free — the UI shell (4c), stream hook (4b), and GridFS (7a) need nothing upstream, so they parallelize the Phase 1 foundations |
+| 2 | **1b, 1c, 1e, 2b** | `1e` (access spine) unlocks most of the rest; `2b` only needs `1d` |
+| 3 | **2a, 2d, 3a, 4a, 5a, 6a** | Widest fan-out — six independent tracks once `1e` lands |
+| 4 | **2c, 3b, 5b** | `5b` is the integration point (needs `4b` + `4c` + `5a`) |
+| 5 | **6b, 7b** | Feature UIs that sit on top of messaging (`5b`) |
 
 See the per-phase docs for deliverables, acceptance criteria, and affected files:
 

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -1,0 +1,101 @@
+# Multi-User Campaigns
+
+> Status: **Planning** · Owner: DM (campaign owner) · Last updated: 2026-05-30
+
+This initiative turns campaigns from a single-owner artifact into a shared space
+where a DM (the campaign owner) invites a group of players who participate during
+sessions. It is intentionally built foundations-first as small, independently
+deliverable pieces so work can proceed in parallel and the design can keep growing
+over time.
+
+## Goals
+
+The group of users attached to a campaign serves these purposes:
+
+1. **Parties from real players** — the DM can pull players' characters into the
+   parties they build.
+2. **Scene-setting** — the DM can push information to the group during a session
+   (maps, images, text) to set the scene.
+3. **Shared rolls** — players can share dice rolls (and similar) with either the
+   DM directly or the whole group (e.g. a saving throw that only the DM sees).
+4. **Group & direct messaging** — members can message each other or the entire
+   group.
+5. **Always-available chat UI** — a collapsible messaging panel that can be pinned
+   open, so it doesn't permanently consume screen space.
+
+This is **not** a complete requirements set. The data model and APIs are designed
+to expand (new message kinds, new visibility scopes, new shared item types) without
+reshaping the foundations.
+
+## Architecture decisions
+
+| Area | Decision | Rationale |
+|------|----------|-----------|
+| Real-time transport | **Server-Sent Events (SSE)** from a per-campaign stream endpoint; client→server stays plain `POST` | Next.js App Router supports streaming responses with no custom server; broadcast-shaped feature set; works behind Fly's HTTPS proxy; zero new infra/cost |
+| Real-time backplane | **MongoDB Change Streams** with a **DB-polling fallback** behind a transport abstraction | We already run MongoDB; change streams cost nothing and work across machines. Polling fallback keeps standalone/dev Mongo and non-replica-set deploys working |
+| Fly scale-to-zero | No special handling | Open SSE connections keep the machine warm during a session; idle = nobody connected = nothing to deliver |
+| Scene/image storage | **MongoDB GridFS** | No binary store exists today; GridFS needs no S3/bucket, survives Fly's ephemeral disk, stays zero-cost |
+| Membership | **Invite + accept**; players own their own characters and **opt them in** per campaign | Consent-based; players maintain their own sheets |
+| Owner role | The existing `campaign.userId` owner is treated as the **DM** | No migration of ownership; layer membership on top |
+| Message persistence | **Persistent, campaign-scoped** (scene content/images are messages, so also campaign-scoped) | History / recap; scene assets stay available across sessions |
+| Roll persistence | **Session-scoped** (tied to existing `sessionLogs`) | Rolls belong to the session they happened in |
+
+## Resolved decisions
+
+- **Production MongoDB is Atlas** (a replica set), so **Change Streams are
+  available at no extra cost** — the SSE backplane uses them directly in prod. The
+  DB-polling fallback is retained only for standalone/local-dev Mongo (which is not
+  a replica set), kept behind the Phase 4 transport abstraction so it stays a config
+  detail.
+
+## Data model (target shapes)
+
+New/changed types in `lib/types.ts` and new MongoDB collections (indexes follow the
+existing `lib/db.ts` pattern):
+
+- `User.username?: string` — unique, searchable handle (sparse unique index; backfilled).
+- `CampaignMember` — `{ campaignId, userId, role: 'dm'|'player', status: 'invited'|'active'|'declined'|'removed', invitedBy, invitedAt, respondedAt? }`. Unique `{campaignId,userId}`.
+- `CampaignCharacterShare` — `{ campaignId, userId, characterId, sharedAt }`. Unique `{campaignId,characterId}`. Player opt-in of a character into a campaign.
+- `CampaignMessage` — `{ campaignId, senderId, kind: 'text'|'scene', visibility: {scope:'group'|'direct'|'dm-only', toUserId?}, body?, attachmentId? }`. Index `{campaignId,createdAt}`. Persistent.
+- `CampaignRoll` — `{ campaignId, sessionId, rollerId, label?, formula, rolls[], total, visibility: {scope:'group'|'dm-only'|'direct', toUserId?} }`. Index `{campaignId,sessionId,createdAt}`. Session-scoped.
+
+## Access-control change (the spine)
+
+Campaign reads are currently `{ userId, id }` (single owner). This becomes
+**"requester is the DM *or* an active member"** via a new
+`assertCampaignAccess(campaignId, userId)` helper in `lib/utils/campaign.ts` that
+returns the member's role. Party building gains a rule: the DM may add a
+`characterId` to a party only if that character is shared into the campaign by an
+active member. Phase 1e delivers this refactor; most later phases depend on it.
+
+## Phase roadmap
+
+Each phase is an epic (parent issue). Each deliverable is a sub-issue that can ship
+on its own. `→` marks hard dependencies; everything else can run in parallel.
+
+| Phase | Theme | Epic | Sub-issues | Depends on |
+|-------|-------|------|------------|------------|
+| 1 | Identity & membership foundations | #293 | 1a #300 · 1b #301 · 1c #302 · 1d #303 · 1e #304 | — |
+| 2 | Invite & accept flow | #294 | 2a #305 · 2b #306 · 2c #307 · 2d #308 | Phase 1 |
+| 3 | Cross-user characters into parties | #295 | 3a #309 · 3b #310 | Phase 1 |
+| 4 | Real-time transport | #296 | 4a #311 · 4b #312 · 4c #313 | Phase 1 |
+| 5 | Messaging | #297 | 5a #314 · 5b #315 | Phase 4 |
+| 6 | Shared dice rolls (session-scoped) | #298 | 6a #316 · 6b #317 | Phase 5 |
+| 7 | Scene content (maps/images) | #299 | 7a #318 · 7b #319 | Phase 5 |
+
+See the per-phase docs for deliverables, acceptance criteria, and affected files:
+
+- [Phase 1 — Identity & membership](./01-identity-and-membership.md)
+- [Phase 2 — Invite & accept](./02-invite-and-accept.md)
+- [Phase 3 — Cross-user characters](./03-cross-user-characters.md)
+- [Phase 4 — Real-time transport](./04-realtime-transport.md)
+- [Phase 5 — Messaging](./05-messaging.md)
+- [Phase 6 — Shared dice rolls](./06-shared-rolls.md)
+- [Phase 7 — Scene content](./07-scene-content.md)
+
+## How we work
+
+- This folder is the human-readable source of truth for approach and progress.
+- GitHub issues track delivery: 7 phase epics, each with fine-grained sub-issues.
+- An **OpenSpec change** (`openspec/changes/…`) is opened **per issue, as we pick it
+  up**, following the existing proposal → tasks → specs convention.

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -1,6 +1,6 @@
 # Multi-User Campaigns
 
-> Status: **Planning** · Owner: DM (campaign owner) · Last updated: 2026-05-30
+> Status: **Planning** · Owner: DM (campaign owner) · Last updated: 2026-05-31
 
 This initiative turns campaigns from a single-owner artifact into a shared space
 where a DM (the campaign owner) invites a group of players who participate during
@@ -48,6 +48,40 @@ reshaping the foundations.
   a replica set), kept behind the Phase 4 transport abstraction so it stays a config
   detail.
 
+## Real-time data flow
+
+How a live update reaches members, end to end. Client→server is a normal `POST`;
+server→clients is the SSE push driven by the MongoDB change stream (Atlas) or the
+polling fallback (local dev).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P as Player (browser)
+    participant DM as DM (browser)
+    participant API as Next.js route<br/>POST /messages
+    participant DB as MongoDB (Atlas)
+    participant ST as SSE stream<br/>GET /campaigns/:id/stream
+
+    Note over DM,ST: On campaign open, each member's<br/>EventSource connects (after assertCampaignAccess)
+    DM->>ST: open EventSource
+    P->>ST: open EventSource
+
+    P->>API: POST message { body, visibility }
+    API->>API: assertCampaignAccess(campaignId, userId)
+    API->>DB: insert campaignMessages doc
+    API-->>P: 201 Created
+    DB-->>ST: change stream event (insert)
+    ST->>ST: filter by campaignId + visibility
+    ST-->>DM: SSE: message event
+    ST-->>P: SSE: message event (echo)
+    Note right of ST: dm-only / direct messages are<br/>only pushed to the allowed recipients
+```
+
+> Local dev (standalone Mongo, no replica set) swaps the change-stream feed for a
+> `since`-timestamp DB poll behind the same transport interface — clients are
+> unaffected. See [Phase 4](./04-realtime-transport.md).
+
 ## Data model (target shapes)
 
 New/changed types in `lib/types.ts` and new MongoDB collections (indexes follow the
@@ -58,6 +92,66 @@ existing `lib/db.ts` pattern):
 - `CampaignCharacterShare` — `{ campaignId, userId, characterId, sharedAt }`. Unique `{campaignId,characterId}`. Player opt-in of a character into a campaign.
 - `CampaignMessage` — `{ campaignId, senderId, kind: 'text'|'scene', visibility: {scope:'group'|'direct'|'dm-only', toUserId?}, body?, attachmentId? }`. Index `{campaignId,createdAt}`. Persistent.
 - `CampaignRoll` — `{ campaignId, sessionId, rollerId, label?, formula, rolls[], total, visibility: {scope:'group'|'dm-only'|'direct', toUserId?} }`. Index `{campaignId,sessionId,createdAt}`. Session-scoped.
+
+The relationships between the existing entities (grey-ish: `User`, `Campaign`,
+`Character`, `Party`, `SessionLog`) and the new ones introduced by this initiative:
+
+```mermaid
+erDiagram
+    User ||--o{ Campaign : "owns (DM)"
+    User ||--o{ Character : owns
+    User ||--o{ CampaignMember : "is"
+    Campaign ||--o{ CampaignMember : has
+    Campaign ||--o{ Party : has
+    Campaign ||--o{ SessionLog : has
+    Campaign ||--o{ CampaignCharacterShare : has
+    Character ||--o{ CampaignCharacterShare : "shared via"
+    Party }o--o{ Character : includes
+    Campaign ||--o{ CampaignMessage : has
+    User ||--o{ CampaignMessage : sends
+    CampaignMessage |o--o| SceneAttachment : "may attach (GridFS)"
+    Campaign ||--o{ CampaignRoll : has
+    SessionLog ||--o{ CampaignRoll : scopes
+    User ||--o{ CampaignRoll : rolls
+
+    User {
+        string id
+        string email
+        string username "NEW: unique, searchable"
+    }
+    Campaign {
+        string id
+        string userId "owner = DM"
+    }
+    CampaignMember {
+        string campaignId
+        string userId
+        enum role "dm | player"
+        enum status "invited|active|declined|removed"
+    }
+    CampaignCharacterShare {
+        string campaignId
+        string characterId
+        string userId "owner who opted in"
+    }
+    CampaignMessage {
+        string campaignId
+        string senderId
+        enum kind "text | scene"
+        json visibility "group|direct|dm-only"
+        string attachmentId "GridFS id, scene only"
+    }
+    CampaignRoll {
+        string campaignId
+        string sessionId "session-scoped"
+        string rollerId
+        json visibility "group|dm-only|direct"
+    }
+    SceneAttachment {
+        string id "GridFS file id"
+        string contentType
+    }
+```
 
 ## Access-control change (the spine)
 
@@ -82,6 +176,75 @@ on its own. `→` marks hard dependencies; everything else can run in parallel.
 | 5 | Messaging | #297 | 5a #314 · 5b #315 | Phase 4 |
 | 6 | Shared dice rolls (session-scoped) | #298 | 6a #316 · 6b #317 | Phase 5 |
 | 7 | Scene content (maps/images) | #299 | 7a #318 · 7b #319 | Phase 5 |
+
+### Dependency graph
+
+Arrows are hard dependencies (a node can't start until its predecessors merge).
+Nodes with no inbound arrow at the same level can be built in parallel — e.g. the
+Phase 1 identity track (1a→1b, 1a→1c) runs alongside the membership track
+(1d→1e), and the Phase 4 dock shell (4c) and hook (4b) need nothing upstream.
+
+```mermaid
+flowchart LR
+    subgraph P1["Phase 1 · Identity & membership"]
+        direction TB
+        n1a["1a username model"]
+        n1b["1b username set/edit"]
+        n1c["1c user search"]
+        n1d["1d campaignMembers"]
+        n1e["1e assertCampaignAccess"]
+        n1a --> n1b
+        n1a --> n1c
+        n1d --> n1e
+    end
+    subgraph P2["Phase 2 · Invite & accept"]
+        n2a["2a invite API"]
+        n2b["2b accept/decline + inbox"]
+        n2c["2c member mgmt UI"]
+        n2d["2d invitations inbox UI"]
+        n2a --> n2c
+        n2b --> n2d
+    end
+    subgraph P3["Phase 3 · Cross-user characters"]
+        n3a["3a character sharing"]
+        n3b["3b party builder"]
+        n3a --> n3b
+    end
+    subgraph P4["Phase 4 · Real-time transport"]
+        n4a["4a SSE + transport"]
+        n4b["4b useCampaignStream"]
+        n4c["4c chat dock shell"]
+    end
+    subgraph P5["Phase 5 · Messaging"]
+        n5a["5a messages API"]
+        n5b["5b wire dock"]
+    end
+    subgraph P6["Phase 6 · Shared rolls"]
+        n6a["6a rolls API"]
+        n6b["6b roll UI"]
+    end
+    subgraph P7["Phase 7 · Scene content"]
+        n7a["7a GridFS"]
+        n7b["7b push scene"]
+    end
+
+    n1c --> n2a
+    n1d --> n2a
+    n1e --> n2a
+    n1d --> n2b
+    n1e --> n3a
+    n1e --> n4a
+    n3a --> n3b
+    n1e --> n5a
+    n4b --> n5b
+    n4c --> n5b
+    n5a --> n5b
+    n1e --> n6a
+    n5b --> n6b
+    n6a --> n6b
+    n5b --> n7b
+    n7a --> n7b
+```
 
 See the per-phase docs for deliverables, acceptance criteria, and affected files:
 

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -32,7 +32,7 @@ reshaping the foundations.
 | Area | Decision | Rationale |
 |------|----------|-----------|
 | Real-time transport | **Server-Sent Events (SSE)** from a per-campaign stream endpoint; client→server stays plain `POST` | Next.js App Router supports streaming responses with no custom server; broadcast-shaped feature set; works behind Fly's HTTPS proxy; zero new infra/cost |
-| Real-time backplane | **MongoDB Change Streams** with a **DB-polling fallback** behind a transport abstraction | We already run MongoDB; change streams cost nothing and work across machines. Polling fallback keeps standalone/dev Mongo and non-replica-set deploys working |
+| Real-time backplane | **MongoDB Change Streams** with a **DB-polling fallback** behind a transport abstraction. **One shared change stream per server instance**, multiplexed across all campaigns and connections (demuxed in-process by `campaignId`) | We already run MongoDB; change streams cost nothing and work across machines. A single cursor per instance keeps Mongo/Atlas connection & change-stream usage flat regardless of how many campaigns or members are live. Polling fallback keeps standalone/dev Mongo and non-replica-set deploys working |
 | Fly scale-to-zero | No special handling | Open SSE connections keep the machine warm during a session; idle = nobody connected = nothing to deliver |
 | Scene/image storage | **MongoDB GridFS** | No binary store exists today; GridFS needs no S3/bucket, survives Fly's ephemeral disk, stays zero-cost |
 | Membership | **Invite + accept**; players own their own characters and **opt them in** per campaign | Consent-based; players maintain their own sheets |
@@ -78,8 +78,10 @@ sequenceDiagram
     Note right of ST: dm-only / direct messages are<br/>only pushed to the allowed recipients
 ```
 
-> Local dev (standalone Mongo, no replica set) swaps the change-stream feed for a
-> `since`-timestamp DB poll behind the same transport interface — clients are
+> In prod the change-stream feed is a **single shared stream per server instance**,
+> demultiplexed in-process to the right campaign's connections (never one cursor per
+> campaign or per connection). Local dev (standalone Mongo, no replica set) swaps it
+> for a `since`-timestamp DB poll behind the same transport interface — clients are
 > unaffected. See [Phase 4](./04-realtime-transport.md).
 
 ## Data model (target shapes)


### PR DESCRIPTION
## Summary

Adds a review-friendly design & implementation plan for turning campaigns from a single-owner artifact into a shared, multi-user space (DM + invited players). **Docs only — no application code changes.**

The plan covers the requested capabilities:
1. Pulling players' characters into DM-built parties
2. DM scene-setting (maps, images, text) to the group
3. Shared dice rolls with visibility (DM-only vs group)
4. Group & direct messaging
5. A collapsible, pinnable chat dock

## What's included

- `docs/multi-user-campaigns/README.md` — overview, architecture decisions, target data model, the access-control "spine", and a roadmap linking every epic/sub-issue.
- `docs/multi-user-campaigns/01-…07-*.md` — one doc per phase with deliverables, acceptance criteria, dependencies, and affected files.
- **Mermaid diagrams**: real-time SSE sequence, data-model ER, phase-dependency graph, `assertCampaignAccess` decision flow, membership state machine + invite sequence, character-share flow, transport selection (change streams vs polling), and the message visibility model.

## Key decisions baked in

- **Real-time:** per-campaign **SSE** endpoint backed by **MongoDB Change Streams** (free on the existing Atlas deployment), with a `since`-timestamp polling fallback for local dev behind a transport abstraction — no new infra/cost, no custom server.
- **Membership:** invite + accept; owner = DM; players own their characters and opt them into a campaign.
- **Persistence:** messages campaign-scoped (scene images = scene messages); rolls session-scoped via existing `sessionLogs`.
- **Scene assets:** stored in MongoDB GridFS (survives Fly's ephemeral disk, zero-cost).

## Tracking

Delivery is tracked by 7 phase epics (#293–#299) with fine-grained sub-issues (#300–#319) linked underneath. OpenSpec changes will be opened per-issue as work begins.

https://claude.ai/code/session_0172pf7SzMdUEbNDssUayaPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0172pf7SzMdUEbNDssUayaPX)_