### PR TITLE
fix: restore globalThis.fetch after each test in logout-clears-storage

### DIFF
--- a/tests/integration/offline/logout-clears-storage.test.ts
+++ b/tests/integration/offline/logout-clears-storage.test.ts
@@ -33,6 +33,7 @@ describe("logout clears storage integration", () => {
   let container: HTMLDivElement;
   let root: Root;
   let logoutFn: (() => Promise<void>) | null = null;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     (
@@ -40,20 +41,15 @@ describe("logout clears storage integration", () => {
     ).IS_REACT_ACT_ENVIRONMENT = true;
     localStorage.clear();
     replaceMock.mockReset();
+    logoutFn = null;
 
-    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.endsWith("/api/auth/logout")) {
-        return {
-          ok: true,
-          json: async () => ({}),
-        } as Response;
+        return { ok: true, json: async () => ({}) } as Response;
       }
-
-      return {
-        ok: false,
-        json: async () => ({}),
-      } as Response;
+      return { ok: false, json: async () => ({}) } as Response;
     }) as typeof fetch;
 
     container = document.createElement("div");
@@ -61,11 +57,12 @@ describe("logout clears storage integration", () => {
     root = createRoot(container);
   });
 
-  afterEach(() => {
-    act(() => {
+  afterEach(async () => {
+    await act(async () => {
       root.unmount();
     });
     container.remove();
+    globalThis.fetch = originalFetch;
     jest.restoreAllMocks();
   });
 
@@ -123,7 +120,7 @@ describe("logout clears storage integration", () => {
       return null;
     }
 
-    global.fetch = jest.fn(async () => {
+    globalThis.fetch = jest.fn(async () => {
       throw new Error("network down");
     }) as typeof fetch;
 

--- a/tests/integration/offline/logout-clears-storage.test.ts
+++ b/tests/integration/offline/logout-clears-storage.test.ts
@@ -58,12 +58,15 @@ describe("logout clears storage integration", () => {
   });
 
   afterEach(async () => {
-    await act(async () => {
-      root.unmount();
-    });
-    container.remove();
-    globalThis.fetch = originalFetch;
-    jest.restoreAllMocks();
+    try {
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      container.remove();
+      globalThis.fetch = originalFetch;
+      jest.restoreAllMocks();
+    }
   });
 
   test("logout removes sessionCombat:v1:* keys and sessionData but keeps unrelated keys", async () => {


### PR DESCRIPTION
## Summary

Improves the `logout-clears-storage` integration test suite to properly clean up `globalThis.fetch` after each test, preventing mock state from leaking between suites.

## Problem

`jest.restoreAllMocks()` only restores mocks created via `jest.spyOn()`. Direct assignments like `globalThis.fetch = jest.fn(...)` are invisible to Jest's restore mechanism, so the mock fetch was leaking into subsequent test suites — a potential source of flakiness.

Note: `jest.spyOn(globalThis, 'fetch')` is not viable here because jsdom does not define `globalThis.fetch`, so there is nothing to spy on.

## Changes

- Save `globalThis.fetch` before each test in `beforeEach` and restore it in `afterEach`
- Use `globalThis` consistently (was `global` in test 2 — same object, but consistent naming avoids confusion)
- Make `afterEach` async to properly `await act(async () => root.unmount())`

## Verification

- `npm run test:ci` passes locally
- No new lint errors

Closes #(none — follow-up from #292)