### PR TITLE
feat: add campaignMembers collection with storage methods and DM seeding

### DIFF
--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -58,7 +58,11 @@ export const POST = withAuth(async (request, auth) => {
         invitedAt: new Date(),
       });
     } catch (memberError) {
-      await storage.deleteCampaign(campaign.id, auth.userId);
+      try {
+        await storage.deleteCampaign(campaign.id, auth.userId);
+      } catch (rollbackError) {
+        console.error('Failed to rollback campaign creation:', rollbackError);
+      }
       throw memberError;
     }
 

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
-import { Campaign, CAMPAIGN_STATUSES } from '@/lib/types';
+import { Campaign, CAMPAIGN_STATUSES, CampaignMember } from '@/lib/types';
 import { sanitizeChapters, sanitizeCurrentChapterId } from '@/lib/utils/campaign';
 
 export const GET = withAuth(async (_request, auth) => {
@@ -46,6 +46,21 @@ export const POST = withAuth(async (request, auth) => {
     };
 
     await storage.saveCampaign(campaign);
+
+    try {
+      await storage.addMember({
+        id: crypto.randomUUID(),
+        campaignId: campaign.id,
+        userId: auth.userId,
+        role: 'dm',
+        status: 'active',
+        invitedBy: auth.userId,
+        invitedAt: new Date(),
+      });
+    } catch (memberError) {
+      await storage.deleteCampaign(campaign.id, auth.userId);
+      throw memberError;
+    }
 
     return NextResponse.json(campaign, { status: 201 });
   } catch (error) {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -76,6 +76,54 @@ import type { Mock } from '@jest/globals';
 
 This should be rare. The `jest.Mock` global type from `@types/jest` covers the common cases. Prefer that first.
 
+## Integration Test Data Isolation
+
+Integration tests share a single MongoDB instance. Each test file is responsible for cleaning up exactly the records it creates — no more, no less.
+
+**Rules:**
+
+1. **`beforeEach` cleans only the collection(s) your test file writes to.** Never delete all documents from a collection that other test files also write to (e.g. `campaigns`), since tests run in parallel.
+
+2. **Tests that insert into shared collections must clean up those exact records.** Use a nested `describe` with an `afterEach` that deletes by the specific IDs your test inserted:
+
+   ```ts
+   describe("my feature", () => {
+     const TEST_IDS = ["id-1", "id-2"];
+
+     afterEach(async () => {
+       const db = await getDatabase();
+       await db.collection("shared_collection").deleteMany({ id: { $in: TEST_IDS } });
+     });
+
+     test("...", async () => {
+       // insert with ids from TEST_IDS
+     });
+   });
+   ```
+
+3. **Tests that create records via the API must capture the created ID and delete it in `afterEach`:**
+
+   ```ts
+   let createdId: string | null = null;
+
+   afterEach(async () => {
+     if (createdId) {
+       const db = await getDatabase();
+       await db.collection("items").deleteMany({ id: createdId });
+       createdId = null;
+     }
+   });
+
+   test("POST creates item", async () => {
+     const res = await fetch(...);
+     const body = await res.json();
+     createdId = body.id; // capture for cleanup
+     // assertions
+   });
+   ```
+
+4. **Do not use `deleteMany({})` on shared collections** — it will race with parallel test files and cause intermittent failures.
+
 ## Running Tests
 
 ```sh

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -53,6 +53,17 @@ async function initializeDatabase(db: Db): Promise<void> {
       .createIndex({ userId: 1 }, { unique: true });
     console.log("Created indexes on password_reset_tokens.tokenHash and userId");
 
+    try {
+      await db
+        .collection("campaignMembers")
+        .createIndex({ campaignId: 1, userId: 1 }, { unique: true });
+      console.log("Created index on campaignMembers.{campaignId, userId}");
+    } catch (indexError) {
+      if (indexError instanceof Error && !indexError.message.includes("already exists")) {
+        console.warn("Warning creating campaignMembers.{campaignId, userId} index:", indexError.message);
+      }
+    }
+
     // Check if characters_active already exists as a view; only drop views,
     // never a real collection, to avoid accidental data loss during re-initialization.
     const existing = await db

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -64,6 +64,15 @@ async function initializeDatabase(db: Db): Promise<void> {
       }
     }
 
+    try {
+      await db.collection("campaignMembers").createIndex({ userId: 1 });
+      console.log("Created index on campaignMembers.userId");
+    } catch (indexError) {
+      if (indexError instanceof Error && !indexError.message.includes("already exists")) {
+        console.warn("Warning creating campaignMembers.userId index:", indexError.message);
+      }
+    }
+
     // Check if characters_active already exists as a view; only drop views,
     // never a real collection, to avoid accidental data loss during re-initialization.
     const existing = await db

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,10 @@
+export class DuplicateMemberError extends Error {
+  constructor(campaignId: string, userId: string) {
+    super(`User "${userId}" is already a member of campaign "${campaignId}".`);
+    this.name = "DuplicateMemberError";
+    // Maintain proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DuplicateMemberError);
+    }
+  }
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -924,6 +924,7 @@ export const storage = {
         db.collection<Party>("parties").deleteMany({ userId }),
         db.collection<CombatState>("combatStates").deleteMany({ userId }),
         db.collection<SavedContent>("savedContent").deleteMany({ userId }),
+        db.collection("campaignMembers").deleteMany({ userId }),
       ]);
     } catch (error) {
       console.error("Error clearing data:", error);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,7 +14,12 @@ import {
   SessionLog,
   SessionLogInput,
   SavedContent,
+  CampaignMember,
+  CampaignMemberSummary,
+  MemberRole,
+  MemberStatus,
 } from "./types";
+import { DuplicateMemberError } from "./errors";
 import { GLOBAL_USER_ID } from "./constants";
 import { ObjectId, Filter, Document } from "mongodb";
 
@@ -825,6 +830,88 @@ export const storage = {
         throw error;
       }
     },
+  },
+
+  async addMember(member: CampaignMember): Promise<void> {
+    try {
+      const db = await getDatabase();
+      const { _id, ...insertData } = member;
+      await db
+        .collection<CampaignMember>("campaignMembers")
+        .insertOne(insertData as CampaignMember);
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === 11000) {
+        throw new DuplicateMemberError(member.campaignId, member.userId);
+      }
+      console.error("Error adding campaign member:", error);
+      throw error;
+    }
+  },
+
+  async updateMember(
+    campaignId: string,
+    userId: string,
+    role?: MemberRole,
+    status?: MemberStatus,
+  ): Promise<void> {
+    try {
+      const db = await getDatabase();
+      const patch: Record<string, unknown> = {};
+      if (role !== undefined) patch.role = role;
+      if (status !== undefined) patch.status = status;
+      if (Object.keys(patch).length === 0) {
+        return;
+      }
+      await db
+        .collection<CampaignMember>("campaignMembers")
+        .updateOne({ campaignId, userId }, { $set: patch });
+    } catch (error) {
+      console.error("Error updating campaign member:", error);
+      throw error;
+    }
+  },
+
+  async listMembersForCampaign(campaignId: string): Promise<CampaignMember[]> {
+    try {
+      const db = await getDatabase();
+      const members = await db
+        .collection<CampaignMember>("campaignMembers")
+        .find({ campaignId })
+        .toArray();
+      return members.map((m) => {
+        const normalized = normalizeStoredEntityId(m);
+        const { _id, ...rest } = normalized;
+        return rest as CampaignMember;
+      });
+    } catch (error) {
+      console.error("Error listing campaign members:", error);
+      return [];
+    }
+  },
+
+  async listCampaignsForMember(userId: string): Promise<CampaignMemberSummary[]> {
+    try {
+      const db = await getDatabase();
+      const memberships = await db
+        .collection<{ campaignId: string }>("campaignMembers")
+        .find({ userId })
+        .toArray();
+      if (memberships.length === 0) {
+        return [];
+      }
+      const campaignIds = memberships.map((m) => m.campaignId);
+      const campaigns = await db
+        .collection<Campaign>("campaigns")
+        .find({ id: { $in: campaignIds } }, { projection: { id: 1, name: 1 } })
+        .toArray();
+      return campaigns.map((c) => ({
+        id: c.id,
+        name: c.name,
+      }));
+    } catch (error) {
+      console.error("Error listing campaigns for member:", error);
+      return [];
+    }
   },
 
   // Clear all data for a user

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -706,3 +706,25 @@ export interface SpellTemplate {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export const MEMBER_ROLES = ["dm", "player"] as const;
+export type MemberRole = (typeof MEMBER_ROLES)[number];
+export type MemberStatus = "active" | "pending" | "declined";
+
+export interface CampaignMember {
+  _id?: string;
+  id: string;
+  campaignId: string;
+  userId: string;
+  role: MemberRole;
+  status: MemberStatus;
+  invitedBy: string;
+  invitedAt: Date;
+  respondedAt?: Date;
+}
+
+export interface CampaignMemberSummary {
+  id: string;
+  name: string;
+}
+

--- a/openspec/changes/campaign-members-collection/.openspec.yaml
+++ b/openspec/changes/campaign-members-collection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-31

--- a/openspec/changes/campaign-members-collection/design.md
+++ b/openspec/changes/campaign-members-collection/design.md
@@ -1,0 +1,154 @@
+## Context
+
+- Relevant architecture: MongoDB-backed Next.js app. All persistence goes through the `storage` object in `lib/storage.ts`. DB indexes and views are initialized in `lib/db.ts` `initializeDatabase()`. Auth middleware (`lib/middleware.ts`) provides `userId` at route boundaries.
+- Dependencies: No external dependencies beyond existing `mongodb` driver. No dependency on issues 1a–1c.
+- Interfaces/contracts touched:
+  - `lib/types.ts` — adds new exported types
+  - `lib/errors.ts` — new file, new exported error class
+  - `lib/db.ts` — `initializeDatabase()` extended with a new index block
+  - `lib/storage.ts` — four new methods on the `storage` object
+  - `app/api/campaigns/route.ts` — POST handler seeds DM member after campaign save
+
+## Goals / Non-Goals
+
+### Goals
+
+- Define the `CampaignMember` shape and enumerate roles as a const tuple (matching project pattern)
+- Enforce `{campaignId, userId}` uniqueness at the DB layer
+- Provide typed errors for duplicate membership
+- Expose four focused storage methods with clear single responsibilities
+- Seed DM membership atomically with campaign creation at the route boundary
+
+### Non-Goals
+
+- Member-aware access gating (issue 1e)
+- Backfilling existing campaigns
+- Invite/accept/decline API endpoints
+
+## Decisions
+
+### Decision 1: `MemberRole` as a const tuple (not a TypeScript `enum`)
+
+- Chosen: `export const MEMBER_ROLES = ['dm', 'player'] as const; export type MemberRole = (typeof MEMBER_ROLES)[number];`
+- Alternatives considered: Native TS `enum MemberRole { Dm = 'dm', Player = 'player' }`, plain string union `'dm' | 'player'`
+- Rationale: Matches the existing `CAMPAIGN_STATUSES` pattern in `lib/types.ts`. Const tuples are serializable, runtime-iterable, and play nicely with MongoDB documents. Native enums add indirection and don't serialize cleanly.
+- Trade-offs: Slightly less IDE autocomplete discoverability than a named enum, but consistent with codebase convention.
+
+### Decision 2: `DuplicateMemberError` in a new `lib/errors.ts`
+
+- Chosen: New `lib/errors.ts` exporting `DuplicateMemberError extends Error`
+- Alternatives considered: Inline class in `lib/storage.ts`, adding to `lib/types.ts`
+- Rationale: Storage is a persistence concern; a standalone errors module is reusable by routes, middleware, and future storage methods without creating circular imports.
+- Trade-offs: One more file. Worth it for separation and future error types (e.g. `MemberNotFoundError` for 1e).
+
+### Decision 3: Seeding DM membership at the route boundary (not inside `saveCampaign`)
+
+- Chosen: `app/api/campaigns/route.ts` POST calls `storage.addMember(...)` after `storage.saveCampaign(...)`
+- Alternatives considered: Wrapping both inside a new `storage.createCampaign()` method; seeding inside `saveCampaign` on insert detection
+- Rationale: `saveCampaign` is a pure upsert — embedding side-effects breaks that contract. The route already holds `auth.userId` so it's the natural seeding boundary. Easier to test independently.
+- Trade-offs: Two-write non-atomicity. Mitigated by deleting the campaign on `addMember` failure in the route handler.
+
+### Decision 4: `listCampaignsForMember` returns `CampaignMemberSummary[]` (`{ id, name }`)
+
+- Chosen: Cross-collection join: fetch campaignIds from `campaignMembers`, then lookup `{ id, name }` from `campaigns`
+- Alternatives considered: Return only `campaignId[]`; return full `Campaign[]`
+- Rationale: Callers (dashboard list, 1e access check) need at minimum the name for display. Returning full Campaign objects over-fetches. Returning only IDs pushes join logic to callers.
+- Trade-offs: Two DB round-trips. Acceptable for a list that's bounded by the number of campaigns a user belongs to.
+
+### Decision 5: `updateMember` uses named params, not a patch object
+
+- Chosen: `updateMember(campaignId: string, userId: string, role?: MemberRole, status?: MemberStatus): Promise<void>`
+- Alternatives considered: `updateMember(campaignId, userId, patch: Partial<CampaignMember>)`
+- Rationale: Only two fields are mutable (role, status). Named optional params prevent callers from accidentally patching `campaignId`, `userId`, or `invitedBy`. Follows REST parameter-naming guidance.
+- Trade-offs: Less flexible if new mutable fields are added — update the signature then.
+
+## Proposal to Design Mapping
+
+- Proposal element: `CampaignMember` type with role enum
+  - Design decision: Decision 1 (const tuple)
+  - Validation approach: TypeScript compilation; unit test asserts valid roles accepted, invalid rejected at type level
+
+- Proposal element: Unique `{campaignId, userId}` index
+  - Design decision: New index block in `initializeDatabase()` mirroring `password_reset_tokens` pattern
+  - Validation approach: Integration test inserts duplicate and asserts `DuplicateMemberError`
+
+- Proposal element: `DuplicateMemberError`
+  - Design decision: Decision 2 (`lib/errors.ts`)
+  - Validation approach: Integration test; unit test mocking mongo 11000 error
+
+- Proposal element: DM seeding on campaign creation
+  - Design decision: Decision 3 (route boundary)
+  - Validation approach: Integration test POSTs a campaign and asserts `listMembersForCampaign` returns one active DM
+
+- Proposal element: `listCampaignsForMember` returns `{ id, name }`
+  - Design decision: Decision 4
+  - Validation approach: Integration test creates two campaigns, adds member to both, asserts both appear with correct names
+
+## Functional Requirements Mapping
+
+- Requirement: Owner is always an active DM member after campaign creation
+  - Design element: POST route seeds `addMember({ role: 'dm', status: 'active', ... })`; rollback deletes campaign on failure
+  - Acceptance criteria reference: Issue 303 acceptance criterion 1
+  - Testability notes: Integration test: POST `/api/campaigns` → `listMembersForCampaign` → assert DM record
+
+- Requirement: Duplicate memberships rejected
+  - Design element: MongoDB unique index + `DuplicateMemberError` wrapping error code 11000
+  - Acceptance criteria reference: Issue 303 acceptance criterion 2
+  - Testability notes: Integration test: `addMember` twice same pair → assert `DuplicateMemberError` thrown
+
+- Requirement: Storage methods covered by tests
+  - Design element: `campaigns.members.test.ts` (unit) + `campaigns.members.integration.test.ts`
+  - Acceptance criteria reference: Issue 303 acceptance criterion 3
+  - Testability notes: All four methods tested; both happy path and error paths
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Two-write campaign creation must not leave orphaned campaigns without DM members
+  - Design element: Route handler catches `addMember` failure and deletes campaign
+  - Acceptance criteria reference: Risk mitigation in proposal
+  - Testability notes: Unit test: mock `addMember` to throw, assert `deleteCampaign` called
+
+- Requirement category: security
+  - Requirement: `listMembersForCampaign` and `listCampaignsForMember` must not leak cross-user data
+  - Design element: `listMembersForCampaign` queries by `campaignId` only (access gating deferred to 1e); `listCampaignsForMember` queries by `userId`
+  - Acceptance criteria reference: Out of scope for this issue; access gating is 1e
+  - Testability notes: Note in test: access control is not enforced here, tested in 1e
+
+- Requirement category: performance
+  - Requirement: `listCampaignsForMember` join is bounded
+  - Design element: Two sequential queries; no unbounded scans; `userId` indexed via membership query
+  - Acceptance criteria reference: N/A — no explicit perf requirement at this scale
+  - Testability notes: No perf test required at this stage
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Non-atomic campaign + member creation
+  - Impact: Orphaned campaign without DM member if second write fails
+  - Mitigation: Route handler deletes campaign on `addMember` error
+
+- Risk/trade-off: Mongo error code 11000 detection
+  - Impact: `DuplicateMemberError` not thrown if driver changes error shape
+  - Mitigation: Integration test verifies against real MongoDB
+
+## Rollback / Mitigation
+
+- Rollback trigger: `addMember` throws unexpectedly during campaign creation; or index creation breaks existing tests
+- Rollback steps:
+  1. Remove the four storage methods from `lib/storage.ts`
+  2. Remove the index block from `lib/db.ts`
+  3. Revert `app/api/campaigns/route.ts` to pre-seeding state
+  4. Remove `lib/errors.ts` and type additions from `lib/types.ts`
+- Data migration considerations: Index drop is safe; no data is written to `campaignMembers` until `addMember` is called
+- Verification after rollback: Run `npm run test:unit` and `npm run test:integration`; confirm campaign POST still returns 201
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check before proceeding.
+- If security checks fail: Do not merge. Escalate to repo owner.
+- If required reviews are blocked/stale: Ping reviewer after 24h; escalate to repo owner after 48h.
+- Escalation path and timeout: Repo owner (dougis) is the single approver; no external escalation path.
+
+## Open Questions
+
+No open questions. All design decisions confirmed during exploration session.

--- a/openspec/changes/campaign-members-collection/proposal.md
+++ b/openspec/changes/campaign-members-collection/proposal.md
@@ -1,0 +1,87 @@
+## GitHub Issues
+
+- dougis-org/session-combat#303
+- dougis-org/session-combat#293 (parent epic — Phase 1: Identity & membership foundations)
+
+## Why
+
+- Problem statement: Campaigns currently model ownership via a single `userId` field. There is no way to express that a campaign has multiple participants (DM + players), which is a prerequisite for the multi-user campaign feature.
+- Why now: Issue 303 is the dependency-free leaf of Phase 1. Issues 1e (`assertCampaignAccess`) and all Phase 2+ work block on this collection existing.
+- Business/user impact: Unblocks the entire multi-user campaign initiative. Without membership records, players cannot be invited, access cannot be scoped, and collaborative play cannot ship.
+
+## Problem Space
+
+- Current behavior: A `Campaign` document has a single `userId` (the owner). Campaign reads and writes are gated solely on `{ id, userId }` ownership.
+- Desired behavior: A `campaignMembers` collection records every participant with a role (`dm` | `player`) and status (`active` | `pending` | `declined`). On campaign creation the owner is automatically seeded as an `active` `dm` member.
+- Constraints:
+  - Must not break existing campaign CRUD (owner-only access stays intact for now; 1e handles access refactor).
+  - Index must enforce uniqueness of `{campaignId, userId}` at the DB layer.
+  - Duplicate membership attempts must surface a typed `DuplicateMemberError` (not a raw Mongo error).
+- Assumptions:
+  - The `users` sparse unique index on `username` (issue 1a) is not required here — member lookup is by `userId`.
+  - `invitedBy` is always a valid userId; referential integrity is application-enforced, not DB-enforced.
+- Edge cases considered:
+  - Campaign creation failure after `saveCampaign` but before `addMember` — member seeding must be idempotent or wrapped in error handling at the call-site.
+  - Calling `addMember` twice for the same `{campaignId, userId}` pair must throw `DuplicateMemberError`.
+  - `updateMember` on a non-existent member should be a no-op (or throw — chosen: no-op, caller is responsible for validating membership first).
+
+## Scope
+
+### In Scope
+
+- `CampaignMember` type, `MemberRole` enum (`MEMBER_ROLES` const tuple), `MemberStatus` type, `CampaignMemberSummary` type in `lib/types.ts`
+- `DuplicateMemberError` in `lib/errors.ts` (new file)
+- `campaignMembers` collection unique index `{campaignId, userId}` in `lib/db.ts`
+- Four storage methods on the `storage` object in `lib/storage.ts`: `addMember`, `updateMember`, `listMembersForCampaign`, `listCampaignsForMember`
+- DM membership seeding in `app/api/campaigns/route.ts` POST handler
+- Unit tests in `tests/unit/storage/campaigns.members.test.ts`
+- Integration tests in `tests/integration/campaigns.members.integration.test.ts`
+
+### Out of Scope
+
+- Member-aware access control (`assertCampaignAccess`) — that is issue 1e / #304
+- Invite flow, accept/decline endpoints — Phase 2
+- Removing a member / leaving a campaign
+- UI changes
+- Backfilling `campaignMembers` records for existing campaigns (deferred; 1e will handle via migration or access-check fallback)
+
+## What Changes
+
+- `lib/types.ts`: add `MEMBER_ROLES`, `MemberRole`, `MemberStatus`, `CampaignMember`, `CampaignMemberSummary`
+- `lib/errors.ts`: new file, exports `DuplicateMemberError`
+- `lib/db.ts`: create unique compound index on `campaignMembers.{campaignId, userId}` inside `initializeDatabase`
+- `lib/storage.ts`: four new methods (`addMember`, `updateMember`, `listMembersForCampaign`, `listCampaignsForMember`)
+- `app/api/campaigns/route.ts`: seed DM membership after `saveCampaign` in POST handler
+- Two new test files (unit + integration)
+
+## Risks
+
+- Risk: Campaign creation becomes a two-write operation; if `addMember` throws unexpectedly, the campaign exists without a DM member record.
+  - Impact: Medium — 1e's access check will deny the owner access to their own campaign.
+  - Mitigation: Wrap both writes in the route handler's try/catch and consider deleting the campaign on `addMember` failure, or use idempotent retry logic.
+
+- Risk: `DuplicateMemberError` detection depends on MongoDB error code 11000 (duplicate key); driver version changes could affect this.
+  - Impact: Low — mongo driver is locked in package-lock.json.
+  - Mitigation: Test the duplicate rejection path in integration tests against the real DB.
+
+## Open Questions
+
+No unresolved ambiguity exists. All design decisions were resolved during exploration:
+- `MemberRole` as a `const` tuple enum (matching `CAMPAIGN_STATUSES` pattern) — confirmed.
+- `listCampaignsForMember` returns `CampaignMemberSummary[]` (`{ id, name }`) — confirmed.
+- Typed `DuplicateMemberError` — confirmed.
+- `updateMember` uses named params (not a patch object) — confirmed.
+- Seeding at the API route call-site (Option B) — confirmed.
+- Test files scoped to `campaigns.members.*`, not merged into existing campaign test files — confirmed.
+
+## Non-Goals
+
+- Full multi-user RBAC system
+- Campaign ownership transfer
+- Member permissions beyond `dm` / `player` role distinction
+- Real-time membership updates (WebSocket / polling)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/campaign-members-collection/specs/campaign-members.md
+++ b/openspec/changes/campaign-members-collection/specs/campaign-members.md
@@ -1,0 +1,180 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED CampaignMember type and role enum
+
+The system SHALL define a `CampaignMember` type with fields `id`, `campaignId`, `userId`, `role` (constrained to `MEMBER_ROLES`), `status`, `invitedBy`, `invitedAt`, and optional `respondedAt`. The system SHALL export `MEMBER_ROLES = ['dm', 'player'] as const` and derive `MemberRole` from it.
+
+#### Scenario: Valid role values
+
+- **Given** the `MEMBER_ROLES` const tuple
+- **When** a value is tested against `MemberRole`
+- **Then** only `'dm'` and `'player'` are valid; any other string is a TypeScript type error
+
+### Requirement: ADDED `campaignMembers` unique compound index
+
+The system SHALL create a unique index on `{ campaignId: 1, userId: 1 }` in the `campaignMembers` MongoDB collection during `initializeDatabase()`.
+
+#### Scenario: Index enforces uniqueness
+
+- **Given** a `campaignMembers` record exists for `(campaignId=C, userId=U)`
+- **When** a second insert is attempted with the same `(campaignId=C, userId=U)`
+- **Then** MongoDB rejects the insert with a duplicate key error (code 11000)
+
+#### Scenario: Index allows same user in different campaigns
+
+- **Given** a member record for `(campaignId=C1, userId=U)`
+- **When** a record is inserted for `(campaignId=C2, userId=U)`
+- **Then** the insert succeeds
+
+### Requirement: ADDED `DuplicateMemberError`
+
+The system SHALL throw a `DuplicateMemberError` (extending `Error`, `name = 'DuplicateMemberError'`) when `addMember` is called with a `{campaignId, userId}` pair that already exists. The error message SHALL include both the `campaignId` and `userId`.
+
+#### Scenario: Typed error on duplicate
+
+- **Given** user U is already a member of campaign C
+- **When** `storage.addMember({ campaignId: C, userId: U, ... })` is called
+- **Then** a `DuplicateMemberError` is thrown (not a raw MongoError)
+
+### Requirement: ADDED `storage.addMember`
+
+The system SHALL provide `addMember(member: CampaignMember): Promise<void>` that inserts a new membership record into `campaignMembers`.
+
+#### Scenario: Successful add
+
+- **Given** no membership exists for `(campaignId, userId)`
+- **When** `addMember` is called with a valid `CampaignMember`
+- **Then** the record is persisted and `listMembersForCampaign(campaignId)` includes it
+
+#### Scenario: Duplicate rejected
+
+- **Given** a membership already exists for `(campaignId, userId)`
+- **When** `addMember` is called with the same pair
+- **Then** `DuplicateMemberError` is thrown
+
+### Requirement: ADDED `storage.updateMember`
+
+The system SHALL provide `updateMember(campaignId: string, userId: string, role?: MemberRole, status?: MemberStatus): Promise<void>` that patches the `role` and/or `status` of an existing membership. If no matching record exists, the call is a no-op.
+
+#### Scenario: Update status
+
+- **Given** user U is a `pending` `player` in campaign C
+- **When** `updateMember(C, U, undefined, 'active')` is called
+- **Then** `listMembersForCampaign(C)` returns U with `status: 'active'` and `role: 'player'` unchanged
+
+#### Scenario: Update role
+
+- **Given** user U is a `active` `player` in campaign C
+- **When** `updateMember(C, U, 'dm', undefined)` is called
+- **Then** the member record shows `role: 'dm'`
+
+#### Scenario: Non-existent member is a no-op
+
+- **Given** user U is not a member of campaign C
+- **When** `updateMember(C, U, 'player', 'active')` is called
+- **Then** no error is thrown and no record is created
+
+### Requirement: ADDED `storage.listMembersForCampaign`
+
+The system SHALL provide `listMembersForCampaign(campaignId: string): Promise<CampaignMember[]>` that returns all membership records for a given campaign.
+
+#### Scenario: Returns all members
+
+- **Given** campaign C has members U1 (dm) and U2 (player)
+- **When** `listMembersForCampaign(C)` is called
+- **Then** both records are returned with correct fields
+
+#### Scenario: Returns empty array for unknown campaign
+
+- **Given** no members exist for campaign C
+- **When** `listMembersForCampaign(C)` is called
+- **Then** an empty array is returned
+
+### Requirement: ADDED `storage.listCampaignsForMember`
+
+The system SHALL provide `listCampaignsForMember(userId: string): Promise<CampaignMemberSummary[]>` that returns `{ id, name }` for every campaign the user is a member of, regardless of status or role.
+
+#### Scenario: Returns campaigns for member
+
+- **Given** user U is a member of campaigns C1 (name: "Alpha") and C2 (name: "Beta")
+- **When** `listCampaignsForMember(U)` is called
+- **Then** returns `[{ id: C1, name: 'Alpha' }, { id: C2, name: 'Beta' }]` (order not specified)
+
+#### Scenario: Returns empty array for non-member
+
+- **Given** user U has no membership records
+- **When** `listCampaignsForMember(U)` is called
+- **Then** an empty array is returned
+
+### Requirement: ADDED DM membership seeding on campaign creation
+
+The system SHALL automatically create an `active` `dm` membership record for the campaign owner immediately after a campaign is successfully saved, using the authenticated user's `userId` as both `userId` and `invitedBy`.
+
+#### Scenario: Owner seeded as active DM
+
+- **Given** an authenticated user U
+- **When** `POST /api/campaigns` succeeds
+- **Then** `listMembersForCampaign(newCampaignId)` returns exactly one record: `{ userId: U, role: 'dm', status: 'active' }`
+
+#### Scenario: Campaign rolled back on seed failure
+
+- **Given** `addMember` throws unexpectedly after `saveCampaign` succeeds
+- **When** the POST handler catches the error
+- **Then** the campaign is deleted and a 500 response is returned (no orphaned campaign without a DM)
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Campaign creation route
+
+The system SHALL, after saving a new campaign, also persist a DM membership for the creating user. Failure to persist the membership SHALL result in campaign deletion and a 500 error response.
+
+#### Scenario: Creation still returns 201 with campaign body
+
+- **Given** a valid campaign POST body
+- **When** both `saveCampaign` and `addMember` succeed
+- **Then** the response is `201` with the campaign JSON (unchanged from current behavior)
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal: `CampaignMember` type with role enum → Requirement: ADDED CampaignMember type and role enum
+- Proposal: Unique `{campaignId, userId}` index → Requirement: ADDED `campaignMembers` unique compound index
+- Proposal: `DuplicateMemberError` → Requirement: ADDED `DuplicateMemberError`
+- Proposal: Four storage methods → Requirements: ADDED `addMember`, `updateMember`, `listMembersForCampaign`, `listCampaignsForMember`
+- Proposal: DM seeding at route call-site → Requirements: ADDED DM membership seeding, MODIFIED Campaign creation route
+- Design Decision 1 (const tuple) → Requirement: ADDED CampaignMember type and role enum
+- Design Decision 2 (`lib/errors.ts`) → Requirement: ADDED `DuplicateMemberError`
+- Design Decision 3 (route boundary seeding) → Requirement: ADDED DM membership seeding
+- Design Decision 4 (`CampaignMemberSummary`) → Requirement: ADDED `listCampaignsForMember`
+- Design Decision 5 (named params) → Requirement: ADDED `updateMember`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No orphaned campaigns without DM members
+
+- **Given** `saveCampaign` succeeds but `addMember` throws
+- **When** the POST route handler catches the error
+- **Then** `deleteCampaign` is called with the new campaign's id and a 500 response is returned
+
+### Requirement: Security
+
+#### Scenario: No PII leakage in `listCampaignsForMember`
+
+- **Given** `listCampaignsForMember` is called
+- **When** results are returned
+- **Then** only `{ id, name }` fields are present — no `userId`, `email`, or other user fields
+
+### Requirement: Performance
+
+#### Scenario: Bounded queries
+
+- **Given** a user with N campaign memberships (N < 1000)
+- **When** `listCampaignsForMember` is called
+- **Then** exactly two sequential DB queries are issued (no N+1 pattern)

--- a/openspec/changes/campaign-members-collection/tasks.md
+++ b/openspec/changes/campaign-members-collection/tasks.md
@@ -1,0 +1,141 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/campaign-members-collection` then immediately `git push -u origin feat/campaign-members-collection`
+
+## Execution
+
+### 1. Types — `lib/types.ts`
+
+- [x] Add `export const MEMBER_ROLES = ['dm', 'player'] as const`
+- [x] Add `export type MemberRole = (typeof MEMBER_ROLES)[number]`
+- [x] Add `export type MemberStatus = 'active' | 'pending' | 'declined'`
+- [x] Add `export interface CampaignMember` with fields: `_id?`, `id`, `campaignId`, `userId`, `role: MemberRole`, `status: MemberStatus`, `invitedBy`, `invitedAt: Date`, `respondedAt?: Date`
+- [x] Add `export interface CampaignMemberSummary` with fields: `id`, `name`
+
+### 2. Errors — `lib/errors.ts` (new file)
+
+- [x] Create `lib/errors.ts` exporting `DuplicateMemberError extends Error` with `name = 'DuplicateMemberError'` and a message including both `campaignId` and `userId`
+
+### 3. DB index — `lib/db.ts`
+
+- [x] Inside `initializeDatabase()`, add a try/catch block (mirroring the `users.username` pattern) that creates a unique compound index on `campaignMembers.{ campaignId: 1, userId: 1 }`
+- [x] Log `"Created index on campaignMembers.{campaignId, userId}"` on success
+
+### 4. Storage methods — `lib/storage.ts`
+
+- [x] Import `CampaignMember`, `CampaignMemberSummary`, `MemberRole`, `MemberStatus` from `./types`
+- [x] Import `DuplicateMemberError` from `./errors`
+- [x] Implement `addMember(member: CampaignMember): Promise<void>`
+  - Insert into `campaignMembers` collection
+  - Catch MongoDB error code 11000 and throw `DuplicateMemberError`
+- [x] Implement `updateMember(campaignId: string, userId: string, role?: MemberRole, status?: MemberStatus): Promise<void>`
+  - Build `$set` patch from non-undefined params only
+  - `updateOne({ campaignId, userId }, { $set: patch })` — no-op if no match
+- [x] Implement `listMembersForCampaign(campaignId: string): Promise<CampaignMember[]>`
+  - `find({ campaignId }).toArray()` with `normalizeStoredEntityId` mapping
+- [x] Implement `listCampaignsForMember(userId: string): Promise<CampaignMemberSummary[]>`
+  - Query `campaignMembers` for all records with `userId`
+  - Extract `campaignId[]`; early-return `[]` if empty
+  - Query `campaigns` for `{ id: { $in: campaignIds } }`, project `{ id: 1, name: 1 }`
+  - Return `{ id, name }[]`
+
+### 5. Route seeding — `app/api/campaigns/route.ts`
+
+- [x] Import `storage` (already imported), `CampaignMember` from `@/lib/types`
+- [x] After `await storage.saveCampaign(campaign)` in the POST handler, call `await storage.addMember({ id: crypto.randomUUID(), campaignId: campaign.id, userId: auth.userId, role: 'dm', status: 'active', invitedBy: auth.userId, invitedAt: new Date() })`
+- [x] Wrap both writes in a try/catch: if `addMember` throws, call `await storage.deleteCampaign(campaign.id, auth.userId)` and rethrow (let outer handler return 500)
+
+### 6. Unit tests — `tests/unit/storage/campaigns.members.test.ts` (new file)
+
+Tests must use mocked DB (existing pattern in `tests/unit/storage/`).
+
+- [x] `addMember` — happy path: mock insert resolves, no error thrown
+- [x] `addMember` — duplicate: mock insert rejects with `{ code: 11000 }`, assert `DuplicateMemberError` thrown
+- [x] `updateMember` — status only: assert `$set` contains only `status`, not `role`
+- [x] `updateMember` — role only: assert `$set` contains only `role`, not `status`
+- [x] `updateMember` — both: assert `$set` contains both
+- [x] `updateMember` — no match: mock `updateOne` returns `matchedCount: 0`, assert no error
+- [x] `listMembersForCampaign` — returns normalized results
+- [x] `listMembersForCampaign` — empty: returns `[]`
+- [x] `listCampaignsForMember` — happy path: two campaigns returned as `CampaignMemberSummary[]`
+- [x] `listCampaignsForMember` — no memberships: returns `[]` without querying campaigns
+- [x] Route POST seeding — mock `saveCampaign` + `addMember` succeed, assert 201 returned
+- [x] Route POST seeding — mock `addMember` throws, assert `deleteCampaign` called and 500 returned
+
+### 7. Integration tests — `tests/integration/campaigns.members.integration.test.ts` (new file)
+
+Tests run against real MongoDB (existing pattern in `tests/integration/`). Use a dedicated test DB / cleanup in `afterEach`.
+
+- [x] `addMember` — inserts and `listMembersForCampaign` returns it
+- [x] `addMember` — duplicate throws `DuplicateMemberError`
+- [x] `addMember` — same user, different campaign: both succeed
+- [x] `updateMember` — status update persisted
+- [x] `updateMember` — role update persisted
+- [x] `updateMember` — non-existent member: no error, no record created
+- [x] `listMembersForCampaign` — returns correct members for campaign
+- [x] `listMembersForCampaign` — returns empty for unknown campaign
+- [x] `listCampaignsForMember` — returns correct `{ id, name }` for each campaign
+- [x] `listCampaignsForMember` — returns empty for user with no memberships
+- [x] POST `/api/campaigns` — response is 201 and `listMembersForCampaign` shows one active DM record
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run test:integration` — all tests pass
+- [x] `npm run build` — build succeeds with no errors
+- [x] TypeScript type check passes (no `tsc` errors)
+- [x] All completed tasks marked as complete
+- [ ] All steps in Remote push validation complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all must pass
+- **Integration tests** — `npm run test:integration`; all must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and fix before pushing
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/campaign-members-collection` and push to remote
+- [ ] Open PR from `feat/campaign-members-collection` to `main`. PR body MUST include `Closes #303` and `Closes #293` (partial — epic remains open until all sub-issues close, but note contribution).
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, run remote push validation, push to `feat/campaign-members-collection`, wait 180 seconds, repeat until no unresolved threads remain
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, run remote push validation, push, wait 180 seconds, repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration: `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: claude (AI agent)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → `npm run test:unit && npm run test:integration && npm run build` → push → re-run checks
+- Security finding → remediate → commit → validate → push → re-scan
+- Review comment → address → commit → validate → push → confirm thread resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete
+- [ ] Update `openspec/specs/` with campaign-members capability spec (sync from `specs/campaign-members.md`)
+- [ ] Archive the change: move `openspec/changes/campaign-members-collection/` to `openspec/changes/archive/YYYY-MM-DD-campaign-members-collection/` in a single commit (copy + delete staged together)
+- [ ] Confirm archive path exists and `openspec/changes/campaign-members-collection/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-members-collection` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-members-collection`
+- [ ] Open PR from doc branch to `main` with title `docs: archive campaign-members-collection (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same loop — address comments, fix CI, push to doc branch, repeat)
+- [ ] Prune merged branches: `git fetch --prune` and `git branch -d feat/campaign-members-collection doc/archive-YYYY-MM-DD-campaign-members-collection`

--- a/openspec/changes/campaign-members-collection/tests.md
+++ b/openspec/changes/campaign-members-collection/tests.md
@@ -1,0 +1,188 @@
+---
+name: tests
+description: Tests for the campaign-members-collection change
+---
+
+# Tests
+
+## Overview
+
+All work follows strict TDD: write a failing test, write the minimum code to pass it, then refactor. Test files are scoped to `campaigns.members.*` and must not modify existing campaign test files.
+
+- Unit tests: `tests/unit/storage/campaigns.members.test.ts`
+- Integration tests: `tests/integration/campaigns.members.integration.test.ts`
+
+## Testing Steps
+
+For each test case below:
+
+1. **Write the failing test** in the appropriate file. Run the suite and confirm it fails.
+2. **Write implementation code** — minimum to make it pass.
+3. **Refactor** — clean up without breaking the test.
+
+---
+
+## Test Cases
+
+### Types and errors (tasks 1–2)
+
+- [ ] **[types] `MEMBER_ROLES` contains exactly `['dm', 'player']`** — import and assert length and values
+  - Spec: ADDED CampaignMember type and role enum
+  - Task: Execution §1
+
+- [ ] **[types] `CampaignMember` has all required fields** — construct a valid object and assert TypeScript compiles (type-level test via `satisfies`)
+  - Spec: ADDED CampaignMember type and role enum
+  - Task: Execution §1
+
+- [ ] **[errors] `DuplicateMemberError` has `name === 'DuplicateMemberError'`** — construct and assert
+  - Spec: ADDED `DuplicateMemberError`
+  - Task: Execution §2
+
+- [ ] **[errors] `DuplicateMemberError` message includes campaignId and userId** — construct with known values and assert `message` contains both
+  - Spec: ADDED `DuplicateMemberError`
+  - Task: Execution §2
+
+- [ ] **[errors] `DuplicateMemberError` is instanceof `Error`** — assert inheritance
+  - Spec: ADDED `DuplicateMemberError`
+  - Task: Execution §2
+
+---
+
+### `addMember` — unit (task 4, mocked DB)
+
+- [ ] **[unit] `addMember` happy path — no error thrown when insert resolves**
+  - Mock: `campaignMembers.insertOne` resolves
+  - Assert: resolves without throwing
+  - Spec: ADDED `storage.addMember` / Scenario: Successful add
+  - Task: Execution §6
+
+- [ ] **[unit] `addMember` duplicate — throws `DuplicateMemberError` on mongo code 11000**
+  - Mock: `campaignMembers.insertOne` rejects with `{ code: 11000 }`
+  - Assert: thrown error is `instanceof DuplicateMemberError`
+  - Spec: ADDED `storage.addMember` / Scenario: Duplicate rejected
+  - Task: Execution §6
+
+---
+
+### `updateMember` — unit (task 4, mocked DB)
+
+- [ ] **[unit] `updateMember` status only — `$set` contains `status` but not `role`**
+  - Mock: `updateOne` resolves
+  - Call: `updateMember(C, U, undefined, 'active')`
+  - Assert: `$set` arg equals `{ status: 'active' }`
+  - Spec: ADDED `storage.updateMember` / Scenario: Update status
+  - Task: Execution §6
+
+- [ ] **[unit] `updateMember` role only — `$set` contains `role` but not `status`**
+  - Call: `updateMember(C, U, 'dm', undefined)`
+  - Assert: `$set` arg equals `{ role: 'dm' }`
+  - Spec: ADDED `storage.updateMember` / Scenario: Update role
+  - Task: Execution §6
+
+- [ ] **[unit] `updateMember` both fields — `$set` contains both**
+  - Call: `updateMember(C, U, 'player', 'pending')`
+  - Assert: `$set` arg equals `{ role: 'player', status: 'pending' }`
+  - Spec: ADDED `storage.updateMember`
+  - Task: Execution §6
+
+- [ ] **[unit] `updateMember` no match — no error when `matchedCount === 0`**
+  - Mock: `updateOne` returns `{ matchedCount: 0 }`
+  - Assert: resolves without throwing
+  - Spec: ADDED `storage.updateMember` / Scenario: Non-existent member is a no-op
+  - Task: Execution §6
+
+---
+
+### `listMembersForCampaign` — unit (task 4, mocked DB)
+
+- [ ] **[unit] returns normalized members for a campaign**
+  - Mock: `find().toArray()` returns two raw member docs
+  - Assert: both returned with `id` normalized
+  - Spec: ADDED `storage.listMembersForCampaign` / Scenario: Returns all members
+  - Task: Execution §6
+
+- [ ] **[unit] returns empty array when no members**
+  - Mock: `find().toArray()` returns `[]`
+  - Assert: return value is `[]`
+  - Spec: ADDED `storage.listMembersForCampaign` / Scenario: Returns empty array
+  - Task: Execution §6
+
+---
+
+### `listCampaignsForMember` — unit (task 4, mocked DB)
+
+- [ ] **[unit] returns `CampaignMemberSummary[]` when user has memberships**
+  - Mock: `campaignMembers.find` returns two docs with campaignIds; `campaigns.find` returns matching `{ id, name }` docs
+  - Assert: two `CampaignMemberSummary` objects returned
+  - Spec: ADDED `storage.listCampaignsForMember` / Scenario: Returns campaigns for member
+  - Task: Execution §6
+
+- [ ] **[unit] returns `[]` without querying campaigns when user has no memberships**
+  - Mock: `campaignMembers.find` returns `[]`
+  - Assert: campaigns collection is never queried; return value is `[]`
+  - Spec: ADDED `storage.listCampaignsForMember` / Scenario: Returns empty array
+  - Task: Execution §6
+
+---
+
+### Route seeding — unit (task 5, mocked storage)
+
+- [ ] **[unit] POST campaign — 201 returned and `addMember` called with correct DM payload**
+  - Mock: `saveCampaign` resolves, `addMember` resolves
+  - Assert: response status 201; `addMember` called with `{ role: 'dm', status: 'active', userId: auth.userId, invitedBy: auth.userId }`
+  - Spec: ADDED DM membership seeding / Scenario: Owner seeded as active DM; MODIFIED Campaign creation route
+  - Task: Execution §5 + §6
+
+- [ ] **[unit] POST campaign — `deleteCampaign` called and 500 returned when `addMember` throws**
+  - Mock: `saveCampaign` resolves, `addMember` throws
+  - Assert: `deleteCampaign` called with new campaign id; response status 500
+  - Spec: ADDED DM membership seeding / Scenario: Campaign rolled back on seed failure
+  - Task: Execution §5 + §6
+
+---
+
+### Integration tests — real MongoDB (task 7)
+
+- [ ] **[integration] `addMember` — inserted record returned by `listMembersForCampaign`**
+  - Spec: ADDED `storage.addMember` / Scenario: Successful add
+  - Task: Execution §7
+
+- [ ] **[integration] `addMember` duplicate — throws `DuplicateMemberError`**
+  - Spec: ADDED `storage.addMember` / Scenario: Duplicate rejected
+  - Task: Execution §7
+
+- [ ] **[integration] `addMember` — same user, different campaigns: both succeed**
+  - Spec: ADDED `campaignMembers` unique compound index / Scenario: Index allows same user in different campaigns
+  - Task: Execution §7
+
+- [ ] **[integration] `updateMember` status — persisted and readable**
+  - Spec: ADDED `storage.updateMember` / Scenario: Update status
+  - Task: Execution §7
+
+- [ ] **[integration] `updateMember` role — persisted and readable**
+  - Spec: ADDED `storage.updateMember` / Scenario: Update role
+  - Task: Execution §7
+
+- [ ] **[integration] `updateMember` non-existent — no error, no record created**
+  - Spec: ADDED `storage.updateMember` / Scenario: Non-existent member is a no-op
+  - Task: Execution §7
+
+- [ ] **[integration] `listMembersForCampaign` — returns correct members**
+  - Spec: ADDED `storage.listMembersForCampaign` / Scenario: Returns all members
+  - Task: Execution §7
+
+- [ ] **[integration] `listMembersForCampaign` — empty for unknown campaign**
+  - Spec: ADDED `storage.listMembersForCampaign` / Scenario: Returns empty array
+  - Task: Execution §7
+
+- [ ] **[integration] `listCampaignsForMember` — returns `{ id, name }` for each campaign**
+  - Spec: ADDED `storage.listCampaignsForMember` / Scenario: Returns campaigns for member
+  - Task: Execution §7
+
+- [ ] **[integration] `listCampaignsForMember` — empty for non-member**
+  - Spec: ADDED `storage.listCampaignsForMember` / Scenario: Returns empty array for non-member
+  - Task: Execution §7
+
+- [ ] **[integration] POST `/api/campaigns` — 201 and DM member record exists**
+  - Spec: ADDED DM membership seeding / Scenario: Owner seeded as active DM
+  - Task: Execution §7

--- a/tests/integration/campaigns.members.integration.test.ts
+++ b/tests/integration/campaigns.members.integration.test.ts
@@ -191,87 +191,106 @@ describe("Campaign Members Integration Tests", () => {
       expect(list).toEqual([]);
     });
 
-    test("listCampaignsForMember — returns correct { id, name } for each campaign", async () => {
-      const db = await getDatabase();
+    describe("listCampaignsForMember", () => {
+      const TEST_CAMPAIGN_IDS = ["camp-1", "camp-2", "camp-3"];
 
-      const campaign1: Campaign = {
-        id: "camp-1",
-        userId: "user-dm",
-        name: "Lost Mine",
-        moduleName: "LMoP",
-        chapters: [],
-        status: "active",
-        notes: "",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+      afterEach(async () => {
+        const db = await getDatabase();
+        await db.collection("campaigns").deleteMany({ id: { $in: TEST_CAMPAIGN_IDS } });
+      });
 
-      const campaign2: Campaign = {
-        id: "camp-2",
-        userId: "user-dm",
-        name: "Dragon Heist",
-        moduleName: "DH",
-        chapters: [],
-        status: "active",
-        notes: "",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+      test("returns correct { id, name } for each campaign", async () => {
+        const db = await getDatabase();
 
-      const campaign3: Campaign = {
-        id: "camp-3",
-        userId: "user-dm",
-        name: "Out of the Abyss",
-        moduleName: "OotA",
-        chapters: [],
-        status: "active",
-        notes: "",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+        const campaign1: Campaign = {
+          id: "camp-1",
+          userId: "user-dm",
+          name: "Lost Mine",
+          moduleName: "LMoP",
+          chapters: [],
+          status: "active",
+          notes: "",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await db.collection("campaigns").insertMany([campaign1, campaign2, campaign3] as any[]);
+        const campaign2: Campaign = {
+          id: "camp-2",
+          userId: "user-dm",
+          name: "Dragon Heist",
+          moduleName: "DH",
+          chapters: [],
+          status: "active",
+          notes: "",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
 
-      const member1: CampaignMember = {
-        id: "mem-1",
-        campaignId: "camp-1",
-        userId: "user-alice",
-        role: "player",
-        status: "active",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
-      };
+        const campaign3: Campaign = {
+          id: "camp-3",
+          userId: "user-dm",
+          name: "Out of the Abyss",
+          moduleName: "OotA",
+          chapters: [],
+          status: "active",
+          notes: "",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
 
-      const member2: CampaignMember = {
-        id: "mem-2",
-        campaignId: "camp-3",
-        userId: "user-alice",
-        role: "player",
-        status: "pending",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
-      };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await db.collection("campaigns").insertMany([campaign1, campaign2, campaign3] as any[]);
 
-      await storage.addMember(member1);
-      await storage.addMember(member2);
+        const member1: CampaignMember = {
+          id: "mem-1",
+          campaignId: "camp-1",
+          userId: "user-alice",
+          role: "player",
+          status: "active",
+          invitedBy: "user-dm",
+          invitedAt: new Date(),
+        };
 
-      const list = await storage.listCampaignsForMember("user-alice");
-      expect(list).toHaveLength(2);
-      const sorted = list.sort((a, b) => a.id.localeCompare(b.id));
-      expect(sorted).toEqual([
-        { id: "camp-1", name: "Lost Mine" },
-        { id: "camp-3", name: "Out of the Abyss" },
-      ]);
-    });
+        const member2: CampaignMember = {
+          id: "mem-2",
+          campaignId: "camp-3",
+          userId: "user-alice",
+          role: "player",
+          status: "pending",
+          invitedBy: "user-dm",
+          invitedAt: new Date(),
+        };
 
-    test("listCampaignsForMember — returns empty for user with no memberships", async () => {
-      const list = await storage.listCampaignsForMember("user-none");
-      expect(list).toEqual([]);
+        await storage.addMember(member1);
+        await storage.addMember(member2);
+
+        const list = await storage.listCampaignsForMember("user-alice");
+        expect(list).toHaveLength(2);
+        const sorted = list.sort((a, b) => a.id.localeCompare(b.id));
+        expect(sorted).toEqual([
+          { id: "camp-1", name: "Lost Mine" },
+          { id: "camp-3", name: "Out of the Abyss" },
+        ]);
+      });
+
+      test("returns empty for user with no memberships", async () => {
+        const list = await storage.listCampaignsForMember("user-none");
+        expect(list).toEqual([]);
+      });
     });
   });
 
   describe("API POST Seeding Integration", () => {
+    let createdCampaignId: string | null = null;
+
+    afterEach(async () => {
+      if (createdCampaignId) {
+        const db = await getDatabase();
+        await db.collection("campaigns").deleteMany({ id: createdCampaignId });
+        createdCampaignId = null;
+      }
+    });
+
     test("POST /api/campaigns — response is 201 and campaign owner seeded as active DM", async () => {
       const res = await fetch(`${baseUrl}/api/campaigns`, {
         method: "POST",
@@ -286,6 +305,8 @@ describe("Campaign Members Integration Tests", () => {
       const body = (await res.json()) as any;
       expect(body.id).toBeDefined();
       expect(body.name).toBe("Seeded Campaign");
+
+      createdCampaignId = body.id;
 
       const db = await getDatabase();
       const members = await db

--- a/tests/integration/campaigns.members.integration.test.ts
+++ b/tests/integration/campaigns.members.integration.test.ts
@@ -1,0 +1,302 @@
+import fetch from "node-fetch";
+import { storage } from "@/lib/storage";
+import { connectToDatabase, closeDatabase, getDatabase } from "@/lib/db";
+import { DuplicateMemberError } from "@/lib/errors";
+import { CampaignMember, Campaign } from "@/lib/types";
+import { registerTestUser } from "./helpers/users";
+
+describe("Campaign Members Integration Tests", () => {
+  let baseUrl: string;
+  let authCookie: string;
+  let apiUserId: string;
+
+  beforeAll(async () => {
+    if (!process.env.MONGODB_URI) throw new Error("MONGODB_URI not set");
+
+    baseUrl = process.env.TEST_BASE_URL!;
+    if (!baseUrl) throw new Error("TEST_BASE_URL not set — globalSetup was not wired correctly");
+
+    await connectToDatabase();
+
+    const testUser = await registerTestUser(baseUrl, "members-integration-test");
+    authCookie = testUser.cookie;
+    apiUserId = testUser.userId;
+  }, 30000);
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    const db = await getDatabase();
+    await db.collection("campaignMembers").deleteMany({});
+  });
+
+  describe("Storage Methods Integration", () => {
+    test("addMember — inserts and listMembersForCampaign returns it", async () => {
+      const member: CampaignMember = {
+        id: "mem-123",
+        campaignId: "camp-123",
+        userId: "user-456",
+        role: "player",
+        status: "pending",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member);
+
+      const list = await storage.listMembersForCampaign("camp-123");
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe("mem-123");
+      expect(list[0].userId).toBe("user-456");
+      expect(list[0].role).toBe("player");
+      expect(list[0].status).toBe("pending");
+    });
+
+    test("addMember — duplicate throws DuplicateMemberError", async () => {
+      const member: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member);
+
+      // Attempt duplicate
+      await expect(storage.addMember(member)).rejects.toThrow(DuplicateMemberError);
+    });
+
+    test("addMember — same user, different campaign: both succeed", async () => {
+      const member1: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+
+      const member2: CampaignMember = {
+        id: "mem-2",
+        campaignId: "camp-2",
+        userId: "user-1",
+        role: "player",
+        status: "active",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member1);
+      await expect(storage.addMember(member2)).resolves.not.toThrow();
+
+      const list1 = await storage.listMembersForCampaign("camp-1");
+      const list2 = await storage.listMembersForCampaign("camp-2");
+      expect(list1).toHaveLength(1);
+      expect(list2).toHaveLength(1);
+    });
+
+    test("updateMember — status update persisted", async () => {
+      const member: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "player",
+        status: "pending",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member);
+      await storage.updateMember("camp-1", "user-1", undefined, "active");
+
+      const list = await storage.listMembersForCampaign("camp-1");
+      expect(list[0].status).toBe("active");
+      expect(list[0].role).toBe("player");
+    });
+
+    test("updateMember — role update persisted", async () => {
+      const member: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "player",
+        status: "active",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member);
+      await storage.updateMember("camp-1", "user-1", "dm", undefined);
+
+      const list = await storage.listMembersForCampaign("camp-1");
+      expect(list[0].role).toBe("dm");
+      expect(list[0].status).toBe("active");
+    });
+
+    test("updateMember — non-existent member: no error, no record created", async () => {
+      await expect(storage.updateMember("camp-none", "user-none", "dm", "active")).resolves.not.toThrow();
+      const list = await storage.listMembersForCampaign("camp-none");
+      expect(list).toHaveLength(0);
+    });
+
+    test("listMembersForCampaign — returns correct members for campaign", async () => {
+      const member1: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-abc",
+        userId: "user-1",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+
+      const member2: CampaignMember = {
+        id: "mem-2",
+        campaignId: "camp-abc",
+        userId: "user-2",
+        role: "player",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+
+      const member3: CampaignMember = {
+        id: "mem-3",
+        campaignId: "camp-other",
+        userId: "user-3",
+        role: "player",
+        status: "active",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member1);
+      await storage.addMember(member2);
+      await storage.addMember(member3);
+
+      const list = await storage.listMembersForCampaign("camp-abc");
+      expect(list).toHaveLength(2);
+      const ids = list.map(m => m.id).sort();
+      expect(ids).toEqual(["mem-1", "mem-2"]);
+    });
+
+    test("listMembersForCampaign — returns empty for unknown campaign", async () => {
+      const list = await storage.listMembersForCampaign("camp-unknown");
+      expect(list).toEqual([]);
+    });
+
+    test("listCampaignsForMember — returns correct { id, name } for each campaign", async () => {
+      const db = await getDatabase();
+
+      const campaign1: Campaign = {
+        id: "camp-1",
+        userId: "user-dm",
+        name: "Lost Mine",
+        moduleName: "LMoP",
+        chapters: [],
+        status: "active",
+        notes: "",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const campaign2: Campaign = {
+        id: "camp-2",
+        userId: "user-dm",
+        name: "Dragon Heist",
+        moduleName: "DH",
+        chapters: [],
+        status: "active",
+        notes: "",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const campaign3: Campaign = {
+        id: "camp-3",
+        userId: "user-dm",
+        name: "Out of the Abyss",
+        moduleName: "OotA",
+        chapters: [],
+        status: "active",
+        notes: "",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await db.collection("campaigns").insertMany([campaign1, campaign2, campaign3] as any[]);
+
+      const member1: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-alice",
+        role: "player",
+        status: "active",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      const member2: CampaignMember = {
+        id: "mem-2",
+        campaignId: "camp-3",
+        userId: "user-alice",
+        role: "player",
+        status: "pending",
+        invitedBy: "user-dm",
+        invitedAt: new Date(),
+      };
+
+      await storage.addMember(member1);
+      await storage.addMember(member2);
+
+      const list = await storage.listCampaignsForMember("user-alice");
+      expect(list).toHaveLength(2);
+      const sorted = list.sort((a, b) => a.id.localeCompare(b.id));
+      expect(sorted).toEqual([
+        { id: "camp-1", name: "Lost Mine" },
+        { id: "camp-3", name: "Out of the Abyss" },
+      ]);
+    });
+
+    test("listCampaignsForMember — returns empty for user with no memberships", async () => {
+      const list = await storage.listCampaignsForMember("user-none");
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe("API POST Seeding Integration", () => {
+    test("POST /api/campaigns — response is 201 and campaign owner seeded as active DM", async () => {
+      const res = await fetch(`${baseUrl}/api/campaigns`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: authCookie,
+        },
+        body: JSON.stringify({ name: "Seeded Campaign" }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      expect(body.id).toBeDefined();
+      expect(body.name).toBe("Seeded Campaign");
+
+      const db = await getDatabase();
+      const members = await db
+        .collection("campaignMembers")
+        .find({ campaignId: body.id })
+        .toArray();
+
+      expect(members).toHaveLength(1);
+      expect(members[0].userId).toBe(apiUserId);
+      expect(members[0].role).toBe("dm");
+      expect(members[0].status).toBe("active");
+    });
+  });
+});

--- a/tests/unit/api/campaigns/route.test.ts
+++ b/tests/unit/api/campaigns/route.test.ts
@@ -23,6 +23,7 @@ jest.mock("@/lib/storage", () => ({
     saveCampaign: jest.fn(),
     loadCampaignById: jest.fn(),
     deleteCampaign: jest.fn(),
+    addMember: jest.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/tests/unit/storage/campaigns.members.test.ts
+++ b/tests/unit/storage/campaigns.members.test.ts
@@ -160,6 +160,11 @@ describe("Campaign members storage and types", () => {
       mockCollection.updateOne.mockResolvedValue({ matchedCount: 0 } as never);
       await expect(storage.updateMember("camp-1", "user-1", "player", "active")).resolves.not.toThrow();
     });
+
+    test("no-op — no updateOne called when both params are undefined", async () => {
+      await storage.updateMember("camp-1", "user-1", undefined, undefined);
+      expect(mockCollection.updateOne).not.toHaveBeenCalled();
+    });
   });
 
   describe("listMembersForCampaign (mocked DB)", () => {

--- a/tests/unit/storage/campaigns.members.test.ts
+++ b/tests/unit/storage/campaigns.members.test.ts
@@ -1,0 +1,301 @@
+/**
+ * @jest-environment node
+ */
+import { storage } from "@/lib/storage";
+import { getDatabase } from "@/lib/db";
+import { DuplicateMemberError } from "@/lib/errors";
+import { MEMBER_ROLES, MemberRole, CampaignMember } from "@/lib/types";
+import { POST } from "@/app/api/campaigns/route";
+import { requireAuth } from "@/lib/middleware";
+import { makeRouteRequest } from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock("@/lib/middleware");
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+const mockedRequireAuth = jest.mocked(requireAuth);
+
+function makeMockCollection() {
+  const toArray = jest.fn<Promise<unknown[]>, []>();
+  const find = jest.fn(() => ({ toArray }));
+  const findOne = jest.fn<Promise<unknown>, []>();
+  const updateOne = jest.fn<Promise<unknown>, []>();
+  const insertOne = jest.fn<Promise<unknown>, []>();
+  const deleteOne = jest.fn<Promise<unknown>, []>();
+  return { find, toArray, findOne, updateOne, insertOne, deleteOne };
+}
+
+describe("Campaign members storage and types", () => {
+  describe("Types and errors", () => {
+    test("MEMBER_ROLES contains exactly ['dm', 'player']", () => {
+      expect(MEMBER_ROLES).toEqual(["dm", "player"]);
+    });
+
+    test("CampaignMember type check compiles", () => {
+      const member: CampaignMember = {
+        id: "member-1",
+        campaignId: "campaign-1",
+        userId: "user-1",
+        role: "player",
+        status: "pending",
+        invitedBy: "user-dm",
+        invitedAt: new Date("2026-05-30T12:00:00Z"),
+      };
+      expect(member.role).toBe("player");
+    });
+
+    test("DuplicateMemberError properties", () => {
+      const err = new DuplicateMemberError("camp-123", "user-456");
+      expect(err.name).toBe("DuplicateMemberError");
+      expect(err.message).toContain("camp-123");
+      expect(err.message).toContain("user-456");
+      expect(err instanceof Error).toBe(true);
+    });
+  });
+
+  describe("addMember (mocked DB)", () => {
+    let mockCollection: ReturnType<typeof makeMockCollection>;
+    let mockDb: { collection: ReturnType<typeof jest.fn> };
+
+    beforeEach(() => {
+      mockCollection = makeMockCollection();
+      mockDb = { collection: jest.fn(() => mockCollection) };
+      mockedGetDatabase.mockResolvedValue(mockDb as never);
+    });
+
+    test("happy path — resolves when insert succeeds", async () => {
+      mockCollection.insertOne.mockResolvedValue({ acknowledged: true } as never);
+      const member: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+      await expect(storage.addMember(member)).resolves.not.toThrow();
+      expect(mockDb.collection).toHaveBeenCalledWith("campaignMembers");
+      expect(mockCollection.insertOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "mem-1",
+          campaignId: "camp-1",
+          userId: "user-1",
+          role: "dm",
+          status: "active",
+        })
+      );
+    });
+
+    test("duplicate — throws DuplicateMemberError on mongo code 11000", async () => {
+      mockCollection.insertOne.mockRejectedValue({ code: 11000 } as never);
+      const member: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+      await expect(storage.addMember(member)).rejects.toThrow(DuplicateMemberError);
+    });
+
+    test("other DB error — throws original error", async () => {
+      mockCollection.insertOne.mockRejectedValue(new Error("DB failure") as never);
+      const member: CampaignMember = {
+        id: "mem-1",
+        campaignId: "camp-1",
+        userId: "user-1",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-1",
+        invitedAt: new Date(),
+      };
+      await expect(storage.addMember(member)).rejects.toThrow("DB failure");
+    });
+  });
+
+  describe("updateMember (mocked DB)", () => {
+    let mockCollection: ReturnType<typeof makeMockCollection>;
+    let mockDb: { collection: ReturnType<typeof jest.fn> };
+
+    beforeEach(() => {
+      mockCollection = makeMockCollection();
+      mockDb = { collection: jest.fn(() => mockCollection) };
+      mockedGetDatabase.mockResolvedValue(mockDb as never);
+    });
+
+    test("status only — set only status", async () => {
+      mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
+      await storage.updateMember("camp-1", "user-1", undefined, "active");
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { campaignId: "camp-1", userId: "user-1" },
+        { $set: { status: "active" } }
+      );
+    });
+
+    test("role only — set only role", async () => {
+      mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
+      await storage.updateMember("camp-1", "user-1", "dm", undefined);
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { campaignId: "camp-1", userId: "user-1" },
+        { $set: { role: "dm" } }
+      );
+    });
+
+    test("both fields — set both", async () => {
+      mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
+      await storage.updateMember("camp-1", "user-1", "player", "pending");
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { campaignId: "camp-1", userId: "user-1" },
+        { $set: { role: "player", status: "pending" } }
+      );
+    });
+
+    test("no match — no error when matchedCount is 0", async () => {
+      mockCollection.updateOne.mockResolvedValue({ matchedCount: 0 } as never);
+      await expect(storage.updateMember("camp-1", "user-1", "player", "active")).resolves.not.toThrow();
+    });
+  });
+
+  describe("listMembersForCampaign (mocked DB)", () => {
+    let mockCollection: ReturnType<typeof makeMockCollection>;
+    let mockDb: { collection: ReturnType<typeof jest.fn> };
+
+    beforeEach(() => {
+      mockCollection = makeMockCollection();
+      mockDb = { collection: jest.fn(() => mockCollection) };
+      mockedGetDatabase.mockResolvedValue(mockDb as never);
+    });
+
+    test("returns normalized members for campaign", async () => {
+      const rawDbMembers = [
+        { _id: "obj-1", id: "mem-1", campaignId: "camp-1", userId: "user-1", role: "dm", status: "active" },
+        { _id: "obj-2", id: "mem-2", campaignId: "camp-1", userId: "user-2", role: "player", status: "pending" },
+      ];
+      mockCollection.toArray.mockResolvedValue(rawDbMembers);
+
+      const result = await storage.listMembersForCampaign("camp-1");
+      expect(mockCollection.find).toHaveBeenCalledWith({ campaignId: "camp-1" });
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("mem-1");
+      expect(result[0]).not.toHaveProperty("_id");
+      expect(result[1].id).toBe("mem-2");
+      expect(result[1]).not.toHaveProperty("_id");
+    });
+
+    test("returns empty array when no members", async () => {
+      mockCollection.toArray.mockResolvedValue([]);
+      const result = await storage.listMembersForCampaign("camp-1");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("listCampaignsForMember (mocked DB)", () => {
+    let mockCollection: ReturnType<typeof makeMockCollection>;
+    let mockDb: { collection: ReturnType<typeof jest.fn> };
+
+    beforeEach(() => {
+      mockCollection = makeMockCollection();
+      mockDb = { collection: jest.fn(() => mockCollection) };
+      mockedGetDatabase.mockResolvedValue(mockDb as never);
+    });
+
+    test("returns CampaignMemberSummary[] when user has memberships", async () => {
+      const rawMemberships = [
+        { id: "m-1", campaignId: "camp-1", userId: "user-1" },
+        { id: "m-2", campaignId: "camp-2", userId: "user-1" },
+      ];
+      mockCollection.toArray.mockResolvedValueOnce(rawMemberships);
+
+      const mockCampaigns = [
+        { id: "camp-1", name: "Campaign One" },
+        { id: "camp-2", name: "Campaign Two" },
+      ];
+      mockCollection.toArray.mockResolvedValueOnce(mockCampaigns);
+
+      const result = await storage.listCampaignsForMember("user-1");
+      expect(mockDb.collection).toHaveBeenCalledWith("campaignMembers");
+      expect(mockCollection.find).toHaveBeenNthCalledWith(1, { userId: "user-1" });
+
+      expect(mockDb.collection).toHaveBeenCalledWith("campaigns");
+      expect(mockCollection.find).toHaveBeenNthCalledWith(
+        2,
+        { id: { $in: ["camp-1", "camp-2"] } },
+        { projection: { id: 1, name: 1 } }
+      );
+
+      expect(result).toEqual([
+        { id: "camp-1", name: "Campaign One" },
+        { id: "camp-2", name: "Campaign Two" },
+      ]);
+    });
+
+    test("returns [] without querying campaigns when user has no memberships", async () => {
+      mockCollection.toArray.mockResolvedValueOnce([]);
+      const result = await storage.listCampaignsForMember("user-1");
+      expect(result).toEqual([]);
+      expect(mockDb.collection).not.toHaveBeenCalledWith("campaigns");
+    });
+  });
+});
+
+describe("Route POST seeding (mocked storage)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("POST campaign — 201 returned and addMember called with correct DM payload", async () => {
+    mockedRequireAuth.mockReturnValue({ userId: "user-123", email: "user@test.com", tokenVersion: 1 });
+    const saveCampaignSpy = jest.spyOn(storage, "saveCampaign").mockResolvedValue(undefined as any);
+    const addMemberSpy = jest.spyOn(storage, "addMember").mockResolvedValue(undefined as any);
+    const req = makeRouteRequest("http://localhost/api/campaigns", "POST", { name: "New Epic Campaign" });
+    const response = await POST(req);
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.name).toBe("New Epic Campaign");
+
+    expect(saveCampaignSpy).toHaveBeenCalled();
+    expect(addMemberSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: body.id,
+        userId: "user-123",
+        role: "dm",
+        status: "active",
+        invitedBy: "user-123",
+      })
+    );
+
+    saveCampaignSpy.mockRestore();
+    addMemberSpy.mockRestore();
+  });
+
+  test("POST campaign — deleteCampaign called and 500 returned when addMember throws", async () => {
+    mockedRequireAuth.mockReturnValue({ userId: "user-123", email: "user@test.com", tokenVersion: 1 });
+
+    const saveCampaignSpy = jest.spyOn(storage, "saveCampaign").mockResolvedValue(undefined as any);
+    const addMemberSpy = jest.spyOn(storage, "addMember").mockRejectedValue(new Error("DB failure") as never);
+    const deleteCampaignSpy = jest.spyOn(storage, "deleteCampaign").mockResolvedValue(undefined as any);
+
+    const req = makeRouteRequest("http://localhost/api/campaigns", "POST", { name: "Failed Seeding Campaign" });
+    const response = await POST(req);
+
+    expect(response.status).toBe(500);
+
+    expect(saveCampaignSpy).toHaveBeenCalled();
+    expect(addMemberSpy).toHaveBeenCalled();
+    expect(deleteCampaignSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      "user-123"
+    );
+
+    saveCampaignSpy.mockRestore();
+    addMemberSpy.mockRestore();
+    deleteCampaignSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `campaignMembers` MongoDB collection as the foundation for multi-user campaign access (issue #303), contributing toward the multi-user campaigns epic (#293).

### Changes

- **Types** (`lib/types.ts`): `CampaignMember`, `CampaignMemberSummary`, `MemberRole` (const tuple), `MemberStatus`
- **Errors** (`lib/errors.ts`): `DuplicateMemberError` thrown on duplicate `{campaignId, userId}` inserts
- **DB** (`lib/db.ts`): Unique compound index on `campaignMembers.{campaignId, userId}`
- **Storage** (`lib/storage.ts`): `addMember`, `updateMember`, `listMembersForCampaign`, `listCampaignsForMember`
- **Route** (`app/api/campaigns/route.ts`): POST seeds active DM membership; rolls back campaign on member insert failure
- **Tests**: Unit (mocked DB) + integration (real MongoDB) covering all storage methods and route seeding

### Design decisions

See `openspec/changes/campaign-members-collection/design.md` for full rationale. Key decisions:
- `MemberRole` as const tuple (matches `CAMPAIGN_STATUSES` pattern)
- `DuplicateMemberError` in standalone `lib/errors.ts` (avoids circular imports)
- DM seeding at route boundary, not inside `saveCampaign` (keeps upsert contract clean)

Closes #303
Closes #293 (partial — epic remains open until all sub-issues close)