### PR TITLE
fix: resolve password reset email delivery failures

### DIFF
--- a/app/api/auth/password/forgot/route.ts
+++ b/app/api/auth/password/forgot/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: NextRequest) {
           .catch((err) => {
             const status = err?.response?.status ?? err?.status ?? 'unknown';
             const data = err?.response?.data ?? err?.message ?? String(err);
-            console.error(`[reset-email] failed userId=${userId} status=${status}`, data, err);
+            console.error(`[reset-email] failed userId=${userId} status=${status}`, data);
           });
       }
     }

--- a/app/api/auth/password/forgot/route.ts
+++ b/app/api/auth/password/forgot/route.ts
@@ -62,7 +62,8 @@ export async function POST(request: NextRequest) {
       if (userId) {
         const token = generateResetToken();
         const tokenHash = hashToken(token);
-        const resetUrl = `${process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? 'http://localhost:3000'}/reset-password?token=${token}`;
+        const baseUrl = (process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+        const resetUrl = `${baseUrl}/reset-password?token=${token}`;
 
         storeResetToken(userId, tokenHash)
           .then(() => sendPasswordResetEmail(trimmedEmail, resetUrl))
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
           .catch((err) => {
             const status = err?.response?.status ?? err?.status ?? 'unknown';
             const data = err?.response?.data ?? err?.message ?? String(err);
-            console.error(`[reset-email] failed userId=${userId} status=${status}`, data);
+            console.error(`[reset-email] failed userId=${userId} status=${status}`, data, err);
           });
       }
     }

--- a/app/api/auth/password/forgot/route.ts
+++ b/app/api/auth/password/forgot/route.ts
@@ -62,11 +62,16 @@ export async function POST(request: NextRequest) {
       if (userId) {
         const token = generateResetToken();
         const tokenHash = hashToken(token);
-        const resetUrl = `${process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/reset-password?token=${token}`;
+        const resetUrl = `${process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? 'http://localhost:3000'}/reset-password?token=${token}`;
 
         storeResetToken(userId, tokenHash)
           .then(() => sendPasswordResetEmail(trimmedEmail, resetUrl))
-          .catch((err) => console.error('Password reset email failed:', err));
+          .then(() => console.log(`[reset-email] sent userId=${userId}`))
+          .catch((err) => {
+            const status = err?.response?.status ?? err?.status ?? 'unknown';
+            const data = err?.response?.data ?? err?.message ?? String(err);
+            console.error(`[reset-email] failed userId=${userId} status=${status}`, data);
+          });
       }
     }
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -29,6 +29,7 @@ export async function sendPasswordResetEmail(
   await client.send({
     from: { email: fromEmail, name: "Session Combat" },
     to: [{ email: to }],
+    category: "password-reset",
     subject: "Reset your Session Combat password",
     html: `<p>You requested a password reset.</p>
 <p><a href="${resetUrl}">Click here to reset your password</a></p>

--- a/tests/unit/api/auth/password/forgot.route.test.ts
+++ b/tests/unit/api/auth/password/forgot.route.test.ts
@@ -176,4 +176,39 @@ describe("POST /api/auth/password/forgot", () => {
       expect(url).toContain("http://localhost:3000/reset-password");
     });
   });
+
+  describe("email send error handling", () => {
+    it("logs structured error when sendPasswordResetEmail rejects", async () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const apiError = Object.assign(new Error("Unauthorized"), {
+        response: { status: 401, data: { errors: ["Invalid token"] } },
+      });
+      mockedSendPasswordResetEmail.mockRejectedValueOnce(apiError);
+      mockDb({ _id: { toString: () => "uid-err" } });
+
+      await POST(makeRequest({ email: "user@example.com" }));
+      await new Promise((r) => setImmediate(r));
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[reset-email] failed"),
+        expect.anything()
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("logs structured error when storeResetToken rejects", async () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      mockedStoreResetToken.mockRejectedValueOnce(new Error("DB down"));
+      mockDb({ _id: { toString: () => "uid-store-err" } });
+
+      await POST(makeRequest({ email: "user@example.com" }));
+      await new Promise((r) => setImmediate(r));
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[reset-email] failed"),
+        expect.anything()
+      );
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/tests/unit/api/auth/password/forgot.route.test.ts
+++ b/tests/unit/api/auth/password/forgot.route.test.ts
@@ -128,4 +128,52 @@ describe("POST /api/auth/password/forgot", () => {
     const res = await POST(makeRequest({ email: "user@example.com" }));
     expect(res.status).toBe(500);
   });
+
+  describe("reset URL construction", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+      delete process.env.NEXTAUTH_URL;
+      delete process.env.NEXT_PUBLIC_APP_URL;
+      delete process.env.APP_URL;
+      mockDb({ _id: { toString: () => "uid-1" } });
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    async function captureResetUrl(): Promise<string> {
+      await POST(makeRequest({ email: "user@example.com" }));
+      await new Promise((r) => setImmediate(r));
+      const call = mockedSendPasswordResetEmail.mock.calls[0];
+      return call?.[1] ?? "";
+    }
+
+    it("uses APP_URL when NEXTAUTH_URL and NEXT_PUBLIC_APP_URL are absent", async () => {
+      process.env.APP_URL = "https://session-combat.fly.dev";
+      const url = await captureResetUrl();
+      expect(url).toContain("https://session-combat.fly.dev/reset-password");
+    });
+
+    it("strips trailing slash from APP_URL", async () => {
+      process.env.APP_URL = "https://session-combat.fly.dev/";
+      const url = await captureResetUrl();
+      expect(url).not.toContain("//reset-password");
+      expect(url).toContain("https://session-combat.fly.dev/reset-password");
+    });
+
+    it("prefers NEXTAUTH_URL over APP_URL", async () => {
+      process.env.NEXTAUTH_URL = "https://via-nextauth.example.com";
+      process.env.APP_URL = "https://session-combat.fly.dev";
+      const url = await captureResetUrl();
+      expect(url).toContain("https://via-nextauth.example.com/reset-password");
+    });
+
+    it("falls back to localhost:3000 when no URL env var is set", async () => {
+      const url = await captureResetUrl();
+      expect(url).toContain("http://localhost:3000/reset-password");
+    });
+  });
 });

--- a/tests/unit/lib/email.test.ts
+++ b/tests/unit/lib/email.test.ts
@@ -49,27 +49,22 @@ describe("lib/email.ts", () => {
       expect(call.category).toBe("password-reset");
     });
 
-    it("uses MAILTRAP_FROM_EMAIL as sender when set", async () => {
-      process.env.MAILTRAP_TOKEN = "test-token";
-      process.env.MAILTRAP_FROM_EMAIL = "custom@example.com";
-      const { sendPasswordResetEmail } = await import("@/lib/email");
+    it.each([
+      ["custom@example.com", "custom@example.com"],
+      [undefined, "noreply@session-combat.app"],
+    ])(
+      "uses correct sender when MAILTRAP_FROM_EMAIL is %s",
+      async (envVal, expected) => {
+        process.env.MAILTRAP_TOKEN = "test-token";
+        if (envVal) process.env.MAILTRAP_FROM_EMAIL = envVal;
+        else delete process.env.MAILTRAP_FROM_EMAIL;
 
-      await sendPasswordResetEmail(RECIPIENT, RESET_URL);
+        const { sendPasswordResetEmail } = await import("@/lib/email");
+        await sendPasswordResetEmail(RECIPIENT, RESET_URL);
 
-      const call = mockSend.mock.calls[0][0];
-      expect(call.from.email).toBe("custom@example.com");
-      delete process.env.MAILTRAP_FROM_EMAIL;
-    });
-
-    it("falls back to default sender when MAILTRAP_FROM_EMAIL is not set", async () => {
-      process.env.MAILTRAP_TOKEN = "test-token";
-      delete process.env.MAILTRAP_FROM_EMAIL;
-      const { sendPasswordResetEmail } = await import("@/lib/email");
-
-      await sendPasswordResetEmail(RECIPIENT, RESET_URL);
-
-      const call = mockSend.mock.calls[0][0];
-      expect(call.from.email).toBe("noreply@session-combat.app");
-    });
+        const call = mockSend.mock.calls[0][0];
+        expect(call.from.email).toBe(expected);
+      }
+    );
   });
 });

--- a/tests/unit/lib/email.test.ts
+++ b/tests/unit/lib/email.test.ts
@@ -38,5 +38,38 @@ describe("lib/email.ts", () => {
       );
       expect(mockSend).not.toHaveBeenCalled();
     });
+
+    it("sends with category password-reset", async () => {
+      process.env.MAILTRAP_TOKEN = "test-token";
+      const { sendPasswordResetEmail } = await import("@/lib/email");
+
+      await sendPasswordResetEmail(RECIPIENT, RESET_URL);
+
+      const call = mockSend.mock.calls[0][0];
+      expect(call.category).toBe("password-reset");
+    });
+
+    it("uses MAILTRAP_FROM_EMAIL as sender when set", async () => {
+      process.env.MAILTRAP_TOKEN = "test-token";
+      process.env.MAILTRAP_FROM_EMAIL = "custom@example.com";
+      const { sendPasswordResetEmail } = await import("@/lib/email");
+
+      await sendPasswordResetEmail(RECIPIENT, RESET_URL);
+
+      const call = mockSend.mock.calls[0][0];
+      expect(call.from.email).toBe("custom@example.com");
+      delete process.env.MAILTRAP_FROM_EMAIL;
+    });
+
+    it("falls back to default sender when MAILTRAP_FROM_EMAIL is not set", async () => {
+      process.env.MAILTRAP_TOKEN = "test-token";
+      delete process.env.MAILTRAP_FROM_EMAIL;
+      const { sendPasswordResetEmail } = await import("@/lib/email");
+
+      await sendPasswordResetEmail(RECIPIENT, RESET_URL);
+
+      const call = mockSend.mock.calls[0][0];
+      expect(call.from.email).toBe("noreply@session-combat.app");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #326 — password reset emails not being received in production.

## Root causes (found via Fly logs)

1. **Reset URL pointed to localhost** — `APP_URL` was set as a Fly secret but the code only checked `NEXTAUTH_URL` and `NEXT_PUBLIC_APP_URL`, falling through to the `localhost:3000` default. Every reset link in every email was broken.

2. **401 from Mailtrap** — stale token in production (resolved by rotating the secret).

## Changes

- **`app/api/auth/password/forgot/route.ts`** — add `APP_URL` to the reset URL fallback chain; replace noisy Axios object dump with structured `[reset-email] sent/failed userId=...` log lines for easy monitoring via `fly logs | grep reset-email`
- **`lib/email.ts`** — add Mailtrap `category: "password-reset"` for dashboard filtering