### PR TITLE
test(CombatInfoIcon): add RTL coverage for tooltip layout and behaviour

### DIFF
--- a/openspec/changes/combat-info-icon-test-coverage/tasks.md
+++ b/openspec/changes/combat-info-icon-test-coverage/tasks.md
@@ -1,0 +1,91 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/combat-info-icon-test-coverage` then immediately `git push -u origin feat/combat-info-icon-test-coverage`
+
+## Execution
+
+- [x] Read `lib/types.ts` to confirm the exact shape of `CombatantState['conditions']` (field names: `id`, `name`, `duration`)
+- [x] Add fixture helpers to `tests/unit/components/CombatInfoIcon.test.tsx`:
+  - `ALIVE_MONSTER` — alive monster (hp > 0)
+  - `ALIVE_PLAYER_WITH_CONDITION` — alive player with one condition (`Poisoned`, duration 3)
+  - `ALIVE_PLAYER_CONDITION_NO_DURATION` — alive player with one condition (`Blinded`, no duration)
+  - `GOBLIN_1`, `GOBLIN_2` — two alive monsters sharing the name "Goblin" (for ×N grouping)
+- [x] Add `describe('Column layout and headings')` block covering:
+  - Both column headings visible after hover (`PLAYERS (1)`, `MONSTERS (1)`)
+  - Dead combatants excluded from header count (`PLAYERS (1)`, `MONSTERS (0)`)
+- [x] Add `describe('×N grouping')` block covering:
+  - Two same-name monsters grouped with "×2"
+  - Single combatant renders without multiplier
+- [x] Add `describe('Status conditions')` block covering:
+  - Condition with duration: `• Poisoned (3)` visible after hover
+  - Condition without duration: `• Blinded` visible without trailing parenthesis
+- [x] Add `describe('DEFEATED section')` block covering:
+  - DEFEATED label present when dead combatant exists
+  - DEFEATED label absent when all combatants alive
+- [x] Add `describe('Strikethrough on dead combatants')` block covering:
+  - Dead combatant name's ancestor has class `line-through`
+- [x] Add `describe('"None" fallback text')` block covering:
+  - Players column shows "None" when only monsters present
+  - Monsters column shows "None" when only players present
+- [x] Add `describe('Independent column sections')` block covering:
+  - One alive player + one dead monster: Players column has no DEFEATED, Monsters column does
+- [x] Add `describe('Empty state')` block covering:
+  - Empty combatant array: tooltip shows "No combatants" after hover
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [x] `npx jest tests/unit/components/CombatInfoIcon.test.tsx --no-coverage` — all tests pass (existing 6 + new)
+- [x] `npx tsc --noEmit` — no type errors
+- [x] `npx jest --no-coverage` — full suite passes (no regressions)
+- [x] All completed tasks marked as complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npx jest --no-coverage` — all pass
+- **Build** — `npm run build` — succeeds with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `feat/combat-info-icon-test-coverage` to `main`. PR body must state **"Closes #62"**
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, validate locally, push; wait 180 seconds; repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, commit, validate locally, push; wait 180 seconds; repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify user
+
+Ownership metadata:
+
+- Implementer: Claude Code agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on main
+- [ ] Mark all remaining tasks as complete
+- [ ] Sync approved spec deltas into `openspec/specs/`
+- [ ] Archive the change: move `openspec/changes/combat-info-icon-test-coverage/` to `openspec/changes/archive/YYYY-MM-DD-combat-info-icon-test-coverage/` in a single commit (copy + delete staged together)
+- [ ] Confirm archive path exists and original path is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-combat-info-icon-test-coverage` then push
+- [ ] Open PR from doc branch to `main` titled `docs: archive combat-info-icon-test-coverage (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR
+- [ ] Monitor doc PR until merged (same loop as implementation PR)
+- [ ] Prune local branches: `git fetch --prune` and `git branch -d feat/combat-info-icon-test-coverage doc/archive-YYYY-MM-DD-combat-info-icon-test-coverage`

--- a/tests/unit/components/CombatInfoIcon.test.tsx
+++ b/tests/unit/components/CombatInfoIcon.test.tsx
@@ -19,6 +19,15 @@ import userEvent from '@testing-library/user-event';
 import { CombatInfoIcon } from '@/lib/components/CombatInfoIcon';
 import type { CombatantState } from '@/lib/types';
 
+const BASE_ABILITY_SCORES = {
+  strength: 10,
+  dexterity: 10,
+  constitution: 10,
+  intelligence: 10,
+  wisdom: 10,
+  charisma: 10,
+};
+
 const ALIVE_PLAYER: Partial<CombatantState> = {
   id: 'p1',
   name: 'Elara',
@@ -28,14 +37,7 @@ const ALIVE_PLAYER: Partial<CombatantState> = {
   ac: 14,
   initiative: 15,
   conditions: [],
-  abilityScores: {
-    strength: 10,
-    dexterity: 14,
-    constitution: 10,
-    intelligence: 10,
-    wisdom: 10,
-    charisma: 10,
-  },
+  abilityScores: BASE_ABILITY_SCORES,
 };
 
 const DEAD_MONSTER: Partial<CombatantState> = {
@@ -47,14 +49,67 @@ const DEAD_MONSTER: Partial<CombatantState> = {
   ac: 12,
   initiative: 8,
   conditions: [],
-  abilityScores: {
-    strength: 8,
-    dexterity: 14,
-    constitution: 10,
-    intelligence: 6,
-    wisdom: 8,
-    charisma: 8,
-  },
+  abilityScores: BASE_ABILITY_SCORES,
+};
+
+const ALIVE_MONSTER: Partial<CombatantState> = {
+  id: 'm2',
+  name: 'Dragon',
+  type: 'monster',
+  hp: 30,
+  maxHp: 30,
+  ac: 15,
+  initiative: 10,
+  conditions: [],
+  abilityScores: BASE_ABILITY_SCORES,
+};
+
+const ALIVE_PLAYER_WITH_CONDITION: Partial<CombatantState> = {
+  id: 'p2',
+  name: 'Theron',
+  type: 'player',
+  hp: 15,
+  maxHp: 15,
+  ac: 13,
+  initiative: 12,
+  conditions: [{ id: 'c1', name: 'Poisoned', description: '', duration: 3 }],
+  abilityScores: BASE_ABILITY_SCORES,
+};
+
+const ALIVE_PLAYER_CONDITION_NO_DURATION: Partial<CombatantState> = {
+  id: 'p3',
+  name: 'Kira',
+  type: 'player',
+  hp: 10,
+  maxHp: 10,
+  ac: 12,
+  initiative: 9,
+  conditions: [{ id: 'c2', name: 'Blinded', description: '' }],
+  abilityScores: BASE_ABILITY_SCORES,
+};
+
+const GOBLIN_1: Partial<CombatantState> = {
+  id: 'g1',
+  name: 'Goblin',
+  type: 'monster',
+  hp: 7,
+  maxHp: 7,
+  ac: 12,
+  initiative: 6,
+  conditions: [],
+  abilityScores: BASE_ABILITY_SCORES,
+};
+
+const GOBLIN_2: Partial<CombatantState> = {
+  id: 'g2',
+  name: 'Goblin',
+  type: 'monster',
+  hp: 7,
+  maxHp: 7,
+  ac: 12,
+  initiative: 4,
+  conditions: [],
+  abilityScores: BASE_ABILITY_SCORES,
 };
 
 function renderIcon(combatants: Partial<CombatantState>[]) {
@@ -105,5 +160,124 @@ describe('CombatInfoIcon', () => {
     await user.hover(screen.getByRole('button', { name: /combat information/i }));
     expect(screen.getByText(/DEFEATED/i)).toBeInTheDocument();
     expect(screen.getByText('Goblin')).toBeInTheDocument();
+  });
+});
+
+async function hoverIcon(user: ReturnType<typeof userEvent.setup>) {
+  await user.hover(screen.getByRole('button', { name: /combat information/i }));
+}
+
+describe('Column layout and headings', () => {
+  it('shows PLAYERS (1) and MONSTERS (1) after hover with one alive of each', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER, ALIVE_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.getByText(/PLAYERS \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/MONSTERS \(1\)/)).toBeInTheDocument();
+  });
+
+  it('excludes dead combatants from header count', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER, DEAD_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.getByText(/PLAYERS \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/MONSTERS \(0\)/)).toBeInTheDocument();
+  });
+});
+
+describe('×N grouping', () => {
+  it('groups two same-name monsters with ×2 multiplier', async () => {
+    const user = userEvent.setup();
+    renderIcon([GOBLIN_1, GOBLIN_2]);
+    await hoverIcon(user);
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+    expect(screen.getByText('×2')).toBeInTheDocument();
+  });
+
+  it('single combatant renders without multiplier', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.getByText('Dragon')).toBeInTheDocument();
+    expect(screen.queryByText(/×/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Status conditions', () => {
+  it('renders condition with duration as "• Poisoned (3)"', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER_WITH_CONDITION]);
+    await hoverIcon(user);
+    expect(screen.getByText('• Poisoned (3)')).toBeInTheDocument();
+  });
+
+  it('renders condition without duration without trailing parenthesis', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER_CONDITION_NO_DURATION]);
+    await hoverIcon(user);
+    expect(screen.getByText('• Blinded')).toBeInTheDocument();
+    expect(screen.queryByText(/Blinded \(/)).not.toBeInTheDocument();
+  });
+});
+
+describe('DEFEATED section', () => {
+  it('shows DEFEATED label when a dead combatant exists', async () => {
+    const user = userEvent.setup();
+    renderIcon([DEAD_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.getByText(/DEFEATED/i)).toBeInTheDocument();
+  });
+
+  it('omits DEFEATED label when all combatants are alive', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER, ALIVE_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.queryByText(/DEFEATED/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('Strikethrough on dead combatants', () => {
+  it('dead combatant name has an ancestor with class line-through', async () => {
+    const user = userEvent.setup();
+    renderIcon([DEAD_MONSTER]);
+    await hoverIcon(user);
+    const nameEl = screen.getByText('Goblin');
+    expect(nameEl.closest('.line-through')).not.toBeNull();
+  });
+});
+
+describe('"None" fallback text', () => {
+  it('shows "None" in Players column when only monsters are present', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.getByText('None')).toBeInTheDocument();
+  });
+
+  it('shows "None" in Monsters column when only players are present', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER]);
+    await hoverIcon(user);
+    expect(screen.getByText('None')).toBeInTheDocument();
+  });
+});
+
+describe('Independent column sections', () => {
+  it('one alive player + one dead monster: Players has no DEFEATED, Monsters does', async () => {
+    const user = userEvent.setup();
+    renderIcon([ALIVE_PLAYER, DEAD_MONSTER]);
+    await hoverIcon(user);
+    expect(screen.getByText(/DEFEATED/i)).toBeInTheDocument();
+    expect(screen.getByText('Elara')).toBeInTheDocument();
+    expect(screen.getByText('Elara').closest('.line-through')).toBeNull();
+  });
+});
+
+describe('Empty state', () => {
+  it('shows "No combatants" when combatant array is empty', async () => {
+    const user = userEvent.setup();
+    renderIcon([]);
+    await hoverIcon(user);
+    expect(screen.getByText(/No combatants/i)).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/CombatInfoIcon.test.tsx
+++ b/tests/unit/components/CombatInfoIcon.test.tsx
@@ -242,7 +242,7 @@ describe('Strikethrough on dead combatants', () => {
     renderIcon([DEAD_MONSTER]);
     await hoverIcon(user);
     const nameEl = screen.getByText('Goblin');
-    expect(nameEl.closest('.line-through')).not.toBeNull();
+    expect(nameEl.closest('.line-through')).toBeInTheDocument();
   });
 });
 
@@ -269,7 +269,7 @@ describe('Independent column sections', () => {
     await hoverIcon(user);
     expect(screen.getByText(/DEFEATED/i)).toBeInTheDocument();
     expect(screen.getByText('Elara')).toBeInTheDocument();
-    expect(screen.getByText('Elara').closest('.line-through')).toBeNull();
+    expect(screen.getByText('Elara').closest('.line-through')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Adds comprehensive RTL test coverage for CombatInfoIcon tooltip:

- Column layout headings (PLAYERS/MONSTERS counts)
- ×N grouping for same-name combatants
- Status conditions with and without duration
- DEFEATED section presence/absence
- Strikethrough styling on dead combatants
- "None" fallback when a column has no alive entries
- Independent column sections (alive player + dead monster)
- Empty state ("No combatants")

19 tests total (6 existing + 13 new), all passing.

Closes #62