### PR TITLE
docs: archive combat-info-icon-test-coverage (2026-05-31)

### DIFF
--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-31

--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/design.md
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/design.md
@@ -1,0 +1,159 @@
+## Context
+
+- Relevant architecture: `CombatInfoIcon` is a self-contained presentational component at `lib/components/CombatInfoIcon.tsx`. It owns all grouping and display logic internally — no external hooks or stores.
+- Dependencies: `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom` (all installed). Jest config already covers `lib/**` and `tests/unit/**` with jsdom environment.
+- Interfaces/contracts touched: `CombatantState` (type from `lib/types`) — specifically `id`, `name`, `type`, `hp`, `maxHp`, `ac`, `initiative`, `conditions`, `abilityScores`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Full RTL coverage of all uncovered acceptance criteria from issue #62
+- All assertions grounded in actual rendered output of the current component implementation
+- Tests appended to existing file without disrupting the 6 passing tests
+
+### Non-Goals
+
+- Changing the component
+- Snapshot or visual regression tests
+- Coverage of other components
+
+## Decisions
+
+### Decision 1: Append tests to existing file, not a new file
+
+- Chosen: Add new `describe` blocks to `tests/unit/components/CombatInfoIcon.test.tsx`
+- Alternatives considered: New sibling file (e.g., `CombatInfoIcon.extended.test.tsx`)
+- Rationale: Issue #62 calls for a single test file; splitting creates maintenance overhead with no benefit
+- Trade-offs: File grows moderately; acceptable for a single focused component
+
+### Decision 2: Ground all selectors in actual component output
+
+- Chosen: Read component source before writing assertions; use exact text the component renders (`PLAYERS (N)`, `MONSTERS (N)`, `×N`, `DEFEATED`, `None`, `• conditionName (duration)`)
+- Alternatives considered: Guessing/approximating selectors
+- Rationale: Prevents false-failure tests that don't match real output; component source was reviewed in full
+- Trade-offs: Tests are coupled to exact copy strings — acceptable for a presentational component
+
+### Decision 3: Shared fixture helpers for new test data
+
+- Chosen: Define additional fixture objects (e.g. `ALIVE_MONSTER`, `ALIVE_PLAYER_WITH_CONDITION`, duplicate-name combatants) alongside existing `ALIVE_PLAYER` / `DEAD_MONSTER`
+- Alternatives considered: Inline anonymous objects per test
+- Rationale: Keeps tests readable and avoids repetition across the new describe blocks
+- Trade-offs: Minor increase in fixture boilerplate at the top of the file
+
+## Proposal to Design Mapping
+
+- Proposal element: Two-column layout with "Players" / "Monsters" headings
+  - Design decision: Decision 2 — assert `PLAYERS (N)` and `MONSTERS (N)` text after hover
+  - Validation approach: `screen.getByText(/PLAYERS \(\d+\)/)`
+
+- Proposal element: Alive-count in column headers
+  - Design decision: Decision 2 — assert exact counts (`PLAYERS (1)`, `MONSTERS (0)`, etc.)
+  - Validation approach: Exact text match or regex against column heading
+
+- Proposal element: ×N grouping for same-name combatants
+  - Design decision: Decision 3 — fixture with two combatants sharing a name; assert `×2` text
+  - Validation approach: `screen.getByText('×2')`
+
+- Proposal element: Status conditions with durations
+  - Design decision: Decision 3 — fixture with `conditions: [{ id, name, duration }]`; assert `• Poisoned (3)` text in yellow-class element
+  - Validation approach: `screen.getByText(/• Poisoned \(3\)/)`
+
+- Proposal element: Horizontal delimiter between alive and dead
+  - Design decision: Decision 2 — assert `DEFEATED` heading appears when dead combatants exist
+  - Validation approach: `screen.getByText(/DEFEATED/i)` (component renders a `<div class="border-t ...">` + DEFEATED label)
+
+- Proposal element: Strikethrough on dead combatants
+  - Design decision: Decision 2 — assert dead combatant name has `line-through` class
+  - Validation approach: `expect(el.closest('.line-through')).toBeInTheDocument()`
+
+- Proposal element: "None" text when no alive combatants of a type
+  - Design decision: Decision 2 — render only monsters, assert "None" appears in Players column area
+  - Validation approach: `screen.getByText('None')` (component renders `<p class="... italic">None</p>`)
+
+- Proposal element: Independent columns alive+dead sections
+  - Design decision: Decision 3 — fixture mixing alive player + dead monster; assert both columns show appropriate sections
+  - Validation approach: Multiple `getByText` / `queryByText` calls
+
+- Proposal element: Empty state (no combatants)
+  - Design decision: Decision 2 — render with `[]`; assert "No combatants" text after hover
+  - Validation approach: `screen.getByText(/No combatants/i)`
+
+## Functional Requirements Mapping
+
+- Requirement: Two-column headings visible after hover
+  - Design element: Decision 2
+  - Acceptance criteria reference: issue #62 "Two-column layout renders with Players and Monsters headings"
+  - Testability notes: Column headings are plain text nodes, easily queried by regex
+
+- Requirement: Only alive combatants counted in header
+  - Design element: Decision 2
+  - Acceptance criteria reference: issue #62 "Only alive combatants are counted in column headers"
+  - Testability notes: Render a mix of alive + dead; assert count in heading matches only alive
+
+- Requirement: ×N grouping
+  - Design element: Decision 3
+  - Acceptance criteria reference: issue #62 "Combatants with the same name are grouped with a ×N multiplier"
+  - Testability notes: Component renders `×{group.length}` as a `<span>` — query by text `×2`
+
+- Requirement: Status conditions with durations in yellow
+  - Design element: Decision 3
+  - Acceptance criteria reference: issue #62 "Status conditions display with their remaining durations in yellow"
+  - Testability notes: Component renders `• {name} ({duration})` in a `text-yellow-400` div — assert text; optionally assert class
+
+- Requirement: Delimiter and DEFEATED label
+  - Design element: Decision 2
+  - Acceptance criteria reference: issue #62 "A horizontal delimiter separates alive from dead combatants"
+  - Testability notes: DEFEATED label is the queryable signal for the delimiter section
+
+- Requirement: Strikethrough on dead combatants
+  - Design element: Decision 2
+  - Acceptance criteria reference: issue #62 "Dead combatants appear with strikethrough styling below the delimiter"
+  - Testability notes: Nearest ancestor with `line-through` class; use `closest()`
+
+- Requirement: "None" fallback text
+  - Design element: Decision 2
+  - Acceptance criteria reference: issue #62 "'None' text shows in a column when no alive combatants of that type exist"
+  - Testability notes: `<p class="... italic">None</p>` — query by text
+
+- Requirement: Independent column sections
+  - Design element: Decision 3
+  - Acceptance criteria reference: issue #62 "Both columns independently show alive and dead sections"
+  - Testability notes: Mixed fixture; assert one column has DEFEATED while the other does not
+
+- Requirement: Empty state
+  - Design element: Decision 2
+  - Acceptance criteria reference: issue #62 "Empty state (no combatants at all) renders without errors"
+  - Testability notes: Render with `[]`; assert "No combatants" text
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Tests must not flake; hover interactions must be deterministic
+  - Design element: Use `userEvent.setup()` (already established in existing tests)
+  - Acceptance criteria reference: N/A — test quality concern
+  - Testability notes: `@testing-library/user-event` v14 setup pattern already proven in existing tests
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Condition fixture shape must match `CombatantState['conditions']` exactly
+  - Impact: Type error or runtime mismatch causes test to always pass/fail incorrectly
+  - Mitigation: Read `lib/types.ts` before writing fixtures to confirm condition object shape
+
+## Rollback / Mitigation
+
+- Rollback trigger: New tests fail unexpectedly after merge
+- Rollback steps: Revert the test file to the previous 6-test state; no production code was changed
+- Data migration considerations: None
+- Verification after rollback: `npx jest tests/unit/components/CombatInfoIcon.test.tsx --no-coverage` passes
+
+## Operational Blocking Policy
+
+- If CI checks fail: Investigate test failures; do not merge until all pass
+- If security checks fail: N/A — test-only change with no new dependencies
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate after 48 hours
+- Escalation path and timeout: Tag repo owner after 48 hours of no review activity
+
+## Open Questions
+
+No open questions. Component source, existing tests, and issue #62 fully specify the required behaviour.

--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/proposal.md
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/proposal.md
@@ -1,0 +1,55 @@
+## GitHub Issues
+
+- #62
+
+## Why
+
+- Problem statement: `CombatInfoIcon` has a test file with 6 passing RTL tests, but roughly half the acceptance criteria from issue #62 remain uncovered — specifically the two-column layout, alive-count logic in headers, ×N grouping, status-condition display, the alive/dead delimiter, strikethrough styling, "None" fallback text, independent column behaviour, and the empty-state edge case.
+- Why now: The RTL infrastructure (jest-dom, jsdom, @testing-library/react) is already set up. The cost of adding these tests is low and the risk of regression in this component is meaningful as combat logic evolves.
+- Business/user impact: Without these tests, regressions in the tooltip's grouping and display logic will go undetected until manual QA.
+
+## Problem Space
+
+- Current behavior: Six tests cover icon presence, tooltip show/hide on hover, and basic alive/dead combatant display. None of the structural, grouping, or edge-case criteria are tested.
+- Desired behavior: Full coverage of all acceptance criteria listed in issue #62 — rendering, count logic, grouping & display, and edge cases.
+- Constraints: Tests must live alongside the existing 6 tests in `tests/unit/components/CombatInfoIcon.test.tsx`. No new test infrastructure is needed.
+- Assumptions: The component already implements all described behaviour; we are only adding missing test coverage, not changing the component.
+- Edge cases considered: empty combatant list, all-dead column (should show "None" for alive section), multiple combatants sharing a name (×N), combatants with active conditions.
+
+## Scope
+
+### In Scope
+
+- New `describe` blocks / `it` cases appended to `tests/unit/components/CombatInfoIcon.test.tsx`
+- Coverage of: two-column headings, alive-count headers, ×N name grouping, status conditions with durations, alive/dead delimiter, strikethrough on dead, "None" text, independent column sections, empty-state render
+
+### Out of Scope
+
+- Changes to `CombatInfoIcon.tsx` component implementation
+- New test infrastructure or configuration
+- Tests for any other component
+
+## What Changes
+
+- `tests/unit/components/CombatInfoIcon.test.tsx` — new test cases added to existing file
+
+## Risks
+
+- Risk: Component implementation does not match the acceptance criteria (e.g., "None" text or ×N grouping not actually rendered).
+  - Impact: Tests will fail and surface a real gap in the component.
+  - Mitigation: Read `lib/components/CombatInfoIcon.tsx` carefully before writing assertions; match selectors to actual rendered output.
+
+## Open Questions
+
+No unresolved ambiguity exists. The component file, existing tests, and issue #62 acceptance criteria together provide sufficient specification.
+
+## Non-Goals
+
+- Refactoring or improving the component itself
+- Adding snapshot tests
+- Adding tests for any related component (e.g., `ActiveCombatView`)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/specs/combat-info-icon-tests.md
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/specs/combat-info-icon-tests.md
@@ -1,0 +1,163 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Two-column layout heading visibility
+
+The system SHALL render "PLAYERS (N)" and "MONSTERS (N)" headings in the tooltip, where N reflects only alive combatants.
+
+#### Scenario: Both column headings visible after hover
+
+- **Given** a mix of alive player and alive monster combatants
+- **When** the user hovers the info icon
+- **Then** text matching `PLAYERS (1)` and `MONSTERS (1)` appears in the tooltip
+
+#### Scenario: Dead combatants excluded from header counts
+
+- **Given** one alive player and one dead monster
+- **When** the user hovers the info icon
+- **Then** `PLAYERS (1)` and `MONSTERS (0)` appear (dead monster not counted)
+
+---
+
+### Requirement: ADDED Same-name combatant grouping with ×N multiplier
+
+The system SHALL group alive combatants sharing a name and display a `×N` multiplier when N > 1.
+
+#### Scenario: Two monsters with the same name are grouped
+
+- **Given** two alive monsters both named "Goblin"
+- **When** the user hovers the info icon
+- **Then** "Goblin" appears once with "×2" as a sibling text node
+- **And** `MONSTERS (2)` appears in the column header
+
+#### Scenario: Single combatant has no multiplier
+
+- **Given** one alive monster named "Dragon"
+- **When** the user hovers the info icon
+- **Then** "Dragon" appears without any "×" multiplier text
+
+---
+
+### Requirement: ADDED Status condition display with duration
+
+The system SHALL render each condition name and its duration (if set) below the combatant name.
+
+#### Scenario: Condition with duration renders correctly
+
+- **Given** an alive player with condition `{ name: "Poisoned", duration: 3 }`
+- **When** the user hovers the info icon
+- **Then** text "• Poisoned (3)" appears in the tooltip
+
+#### Scenario: Condition without duration renders name only
+
+- **Given** an alive player with condition `{ name: "Blinded", duration: undefined }`
+- **When** the user hovers the info icon
+- **Then** text "• Blinded" appears (no trailing parenthesis)
+
+---
+
+### Requirement: ADDED DEFEATED section with delimiter
+
+The system SHALL render a "DEFEATED" label (and a visual delimiter) within a column when dead combatants of that type exist.
+
+#### Scenario: DEFEATED label appears for dead monsters
+
+- **Given** one dead monster
+- **When** the user hovers the info icon
+- **Then** the text "DEFEATED" appears in the Monsters column area
+
+#### Scenario: No DEFEATED label when no dead combatants
+
+- **Given** only alive combatants
+- **When** the user hovers the info icon
+- **Then** "DEFEATED" is not present in the tooltip
+
+---
+
+### Requirement: ADDED Strikethrough styling on dead combatants
+
+The system SHALL render dead combatant names with CSS `line-through` applied via a parent element's class.
+
+#### Scenario: Dead combatant name wrapped in line-through element
+
+- **Given** one dead monster named "Goblin"
+- **When** the user hovers the info icon
+- **Then** the element containing "Goblin" has an ancestor with class `line-through`
+
+---
+
+### Requirement: ADDED "None" fallback text for empty alive section
+
+The system SHALL display "None" (italic) in a column when no alive combatants of that type exist.
+
+#### Scenario: Players column shows "None" when only monsters present
+
+- **Given** one alive monster and no players
+- **When** the user hovers the info icon
+- **Then** "None" appears in the tooltip (Players column has no alive entries)
+
+#### Scenario: Monsters column shows "None" when only players present
+
+- **Given** one alive player and no monsters
+- **When** the user hovers the info icon
+- **Then** "None" appears in the tooltip (Monsters column has no alive entries)
+
+---
+
+### Requirement: ADDED Independent column alive+dead sections
+
+The system SHALL render alive and dead sections per column independently; a dead entry in one column does not affect the other column's display.
+
+#### Scenario: One alive player and one dead monster shows mixed state
+
+- **Given** one alive player and one dead monster
+- **When** the user hovers the info icon
+- **Then** the Players column shows the alive player (no DEFEATED section)
+- **And** the Monsters column shows a DEFEATED section with the dead monster
+
+---
+
+### Requirement: ADDED Empty state rendering
+
+The system SHALL render without errors and show "No combatants" text when the combatant list is empty.
+
+#### Scenario: Empty combatant list renders gracefully
+
+- **Given** no combatants (empty array passed as prop)
+- **When** the user hovers the info icon
+- **Then** the tooltip shows "No combatants" and does not throw
+
+## MODIFIED Requirements
+
+None. No existing requirements are changed; only new test coverage is being added.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "two-column layout headings" -> Requirement: Two-column layout heading visibility
+- Proposal element "alive-count in headers" -> Requirement: Two-column layout heading visibility
+- Proposal element "×N grouping" -> Requirement: Same-name combatant grouping with ×N multiplier
+- Proposal element "status conditions with durations" -> Requirement: Status condition display with duration
+- Proposal element "delimiter / DEFEATED label" -> Requirement: DEFEATED section with delimiter
+- Proposal element "strikethrough on dead" -> Requirement: Strikethrough styling on dead combatants
+- Proposal element "'None' fallback" -> Requirement: "None" fallback text for empty alive section
+- Proposal element "independent columns" -> Requirement: Independent column alive+dead sections
+- Proposal element "empty state" -> Requirement: Empty state rendering
+- Design Decision 1 -> All requirements (all tests go in the single existing file)
+- Design Decision 2 -> All requirements (selectors grounded in actual component output)
+- Design Decision 3 -> Grouping, condition, and independent-column requirements
+- All requirements -> Task: Add missing RTL tests to CombatInfoIcon.test.tsx
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No test flake from async hover interactions
+
+- **Given** `userEvent.setup()` pattern already used in the file
+- **When** hover tests run in jsdom
+- **Then** all tests pass consistently across runs (no timing-dependent failures)

--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/tasks.md
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/tasks.md
@@ -58,12 +58,12 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
 - [x] Commit all changes to the working branch and push to remote
-- [ ] Open PR from `feat/combat-info-icon-test-coverage` to `main`. PR body must state **"Closes #62"**
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
-- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, validate locally, push; wait 180 seconds; repeat until no unresolved comments remain
-- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, commit, validate locally, push; wait 180 seconds; repeat
-- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify user
+- [x] Open PR from `feat/combat-info-icon-test-coverage` to `main`. PR body must state **"Closes #62"**
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [x] **Monitor PR comments** — poll autonomously; address comments, commit fixes, validate locally, push; wait 180 seconds; repeat until no unresolved comments remain
+- [x] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing check, commit, validate locally, push; wait 180 seconds; repeat
+- [x] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify user
 
 Ownership metadata:
 
@@ -78,14 +78,14 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify merged changes appear on main
-- [ ] Mark all remaining tasks as complete
-- [ ] Sync approved spec deltas into `openspec/specs/`
-- [ ] Archive the change: move `openspec/changes/combat-info-icon-test-coverage/` to `openspec/changes/archive/YYYY-MM-DD-combat-info-icon-test-coverage/` in a single commit (copy + delete staged together)
-- [ ] Confirm archive path exists and original path is gone
-- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-combat-info-icon-test-coverage` then push
-- [ ] Open PR from doc branch to `main` titled `docs: archive combat-info-icon-test-coverage (YYYY-MM-DD)`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR
-- [ ] Monitor doc PR until merged (same loop as implementation PR)
-- [ ] Prune local branches: `git fetch --prune` and `git branch -d feat/combat-info-icon-test-coverage doc/archive-YYYY-MM-DD-combat-info-icon-test-coverage`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify merged changes appear on main
+- [x] Mark all remaining tasks as complete
+- [x] Sync approved spec deltas into `openspec/specs/`
+- [x] Archive the change: move `openspec/changes/combat-info-icon-test-coverage/` to `openspec/changes/archive/YYYY-MM-DD-combat-info-icon-test-coverage/` in a single commit (copy + delete staged together)
+- [x] Confirm archive path exists and original path is gone
+- [x] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-combat-info-icon-test-coverage` then push
+- [x] Open PR from doc branch to `main` titled `docs: archive combat-info-icon-test-coverage (YYYY-MM-DD)`
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR
+- [x] Monitor doc PR until merged (same loop as implementation PR)
+- [x] Prune local branches: `git fetch --prune` and `git branch -d feat/combat-info-icon-test-coverage doc/archive-YYYY-MM-DD-combat-info-icon-test-coverage`

--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/tests.md
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/tests.md
@@ -19,50 +19,50 @@ Because this change is _test-only_ (adding tests to `tests/unit/components/Comba
 
 ### Column layout and headings (maps to Execution task: "Add `describe('Column layout and headings')`")
 
-- [ ] After hover, `screen.getByText(/PLAYERS \(1\)/)` is in the document — one alive player, one alive monster
-- [ ] After hover, `screen.getByText(/MONSTERS \(1\)/)` is in the document — one alive player, one alive monster
-- [ ] After hover with one alive player + one dead monster: `PLAYERS (1)` appears and `MONSTERS (0)` appears
+- [x] After hover, `screen.getByText(/PLAYERS \(1\)/)` is in the document — one alive player, one alive monster
+- [x] After hover, `screen.getByText(/MONSTERS \(1\)/)` is in the document — one alive player, one alive monster
+- [x] After hover with one alive player + one dead monster: `PLAYERS (1)` appears and `MONSTERS (0)` appears
   - Spec: "Dead combatants excluded from header count"
 
 ### ×N grouping (maps to Execution task: "Add `describe('×N grouping')`")
 
-- [ ] Two monsters named "Goblin": after hover, `screen.getByText('Goblin')` is in the document and `screen.getByText('×2')` is in the document
+- [x] Two monsters named "Goblin": after hover, `screen.getByText('Goblin')` is in the document and `screen.getByText('×2')` is in the document
   - Spec: "Two same-name monsters grouped with ×2"
-- [ ] One monster named "Dragon": after hover, `screen.queryByText(/×/)` returns null
+- [x] One monster named "Dragon": after hover, `screen.queryByText(/×/)` returns null
   - Spec: "Single combatant renders without multiplier"
 
 ### Status conditions (maps to Execution task: "Add `describe('Status conditions')`")
 
-- [ ] Player with `{ name: 'Poisoned', duration: 3 }`: after hover, `screen.getByText('• Poisoned (3)')` is in the document
+- [x] Player with `{ name: 'Poisoned', duration: 3 }`: after hover, `screen.getByText('• Poisoned (3)')` is in the document
   - Spec: "Condition with duration renders correctly"
-- [ ] Player with `{ name: 'Blinded', duration: undefined }`: after hover, `screen.getByText('• Blinded')` is in the document and `screen.queryByText(/Blinded \(/)` returns null
+- [x] Player with `{ name: 'Blinded', duration: undefined }`: after hover, `screen.getByText('• Blinded')` is in the document and `screen.queryByText(/Blinded \(/)` returns null
   - Spec: "Condition without duration renders name only"
 
 ### DEFEATED section (maps to Execution task: "Add `describe('DEFEATED section')`")
 
-- [ ] One dead monster: after hover, `screen.getByText(/DEFEATED/i)` is in the document
+- [x] One dead monster: after hover, `screen.getByText(/DEFEATED/i)` is in the document
   - Spec: "DEFEATED label present when dead combatant exists"
-- [ ] All alive combatants: after hover, `screen.queryByText(/DEFEATED/i)` returns null
+- [x] All alive combatants: after hover, `screen.queryByText(/DEFEATED/i)` returns null
   - Spec: "DEFEATED label absent when all combatants alive"
 
 ### Strikethrough (maps to Execution task: "Add `describe('Strikethrough on dead combatants')`")
 
-- [ ] One dead monster "Goblin": after hover, `screen.getByText('Goblin').closest('.line-through')` is not null
+- [x] One dead monster "Goblin": after hover, `screen.getByText('Goblin').closest('.line-through')` is not null
   - Spec: "Dead combatant name's ancestor has class line-through"
 
 ### "None" fallback (maps to Execution task: "Add `describe('\"None\" fallback text')`")
 
-- [ ] Only monsters (no players): after hover, `screen.getByText('None')` is in the document (Players column)
+- [x] Only monsters (no players): after hover, `screen.getByText('None')` is in the document (Players column)
   - Spec: "Players column shows 'None' when only monsters present"
-- [ ] Only players (no monsters): after hover, `screen.getByText('None')` is in the document (Monsters column)
+- [x] Only players (no monsters): after hover, `screen.getByText('None')` is in the document (Monsters column)
   - Spec: "Monsters column shows 'None' when only players present"
 
 ### Independent columns (maps to Execution task: "Add `describe('Independent column sections')`")
 
-- [ ] One alive player + one dead monster: after hover, `screen.getByText(/DEFEATED/i)` is in the document AND `screen.getByText(alivePlayerName)` is in the document with no line-through on it
+- [x] One alive player + one dead monster: after hover, `screen.getByText(/DEFEATED/i)` is in the document AND `screen.getByText(alivePlayerName)` is in the document with no line-through on it
   - Spec: "Players column has no DEFEATED, Monsters column does"
 
 ### Empty state (maps to Execution task: "Add `describe('Empty state')`")
 
-- [ ] Empty array `[]`: after hover, `screen.getByText(/No combatants/i)` is in the document and no error is thrown
+- [x] Empty array `[]`: after hover, `screen.getByText(/No combatants/i)` is in the document and no error is thrown
   - Spec: "Empty combatant array renders gracefully"

--- a/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/tests.md
+++ b/openspec/changes/archive/2026-05-31-combat-info-icon-test-coverage/tests.md
@@ -1,0 +1,68 @@
+---
+name: tests
+description: Tests for the combat-info-icon-test-coverage change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the test cases for the `combat-info-icon-test-coverage` change. All work should follow a strict TDD process: write a failing test first, then make it pass, then refactor if needed.
+
+Because this change is _test-only_ (adding tests to `tests/unit/components/CombatInfoIcon.test.tsx` with no implementation changes), the TDD cycle here means:
+
+1. Write the new test case — it may pass immediately if the component already implements the behaviour, or fail if a selector is wrong.
+2. Confirm the test correctly targets the intended rendered output.
+3. Refactor selector/fixture if the assertion was imprecise.
+
+## Test Cases
+
+### Column layout and headings (maps to Execution task: "Add `describe('Column layout and headings')`")
+
+- [ ] After hover, `screen.getByText(/PLAYERS \(1\)/)` is in the document — one alive player, one alive monster
+- [ ] After hover, `screen.getByText(/MONSTERS \(1\)/)` is in the document — one alive player, one alive monster
+- [ ] After hover with one alive player + one dead monster: `PLAYERS (1)` appears and `MONSTERS (0)` appears
+  - Spec: "Dead combatants excluded from header count"
+
+### ×N grouping (maps to Execution task: "Add `describe('×N grouping')`")
+
+- [ ] Two monsters named "Goblin": after hover, `screen.getByText('Goblin')` is in the document and `screen.getByText('×2')` is in the document
+  - Spec: "Two same-name monsters grouped with ×2"
+- [ ] One monster named "Dragon": after hover, `screen.queryByText(/×/)` returns null
+  - Spec: "Single combatant renders without multiplier"
+
+### Status conditions (maps to Execution task: "Add `describe('Status conditions')`")
+
+- [ ] Player with `{ name: 'Poisoned', duration: 3 }`: after hover, `screen.getByText('• Poisoned (3)')` is in the document
+  - Spec: "Condition with duration renders correctly"
+- [ ] Player with `{ name: 'Blinded', duration: undefined }`: after hover, `screen.getByText('• Blinded')` is in the document and `screen.queryByText(/Blinded \(/)` returns null
+  - Spec: "Condition without duration renders name only"
+
+### DEFEATED section (maps to Execution task: "Add `describe('DEFEATED section')`")
+
+- [ ] One dead monster: after hover, `screen.getByText(/DEFEATED/i)` is in the document
+  - Spec: "DEFEATED label present when dead combatant exists"
+- [ ] All alive combatants: after hover, `screen.queryByText(/DEFEATED/i)` returns null
+  - Spec: "DEFEATED label absent when all combatants alive"
+
+### Strikethrough (maps to Execution task: "Add `describe('Strikethrough on dead combatants')`")
+
+- [ ] One dead monster "Goblin": after hover, `screen.getByText('Goblin').closest('.line-through')` is not null
+  - Spec: "Dead combatant name's ancestor has class line-through"
+
+### "None" fallback (maps to Execution task: "Add `describe('\"None\" fallback text')`")
+
+- [ ] Only monsters (no players): after hover, `screen.getByText('None')` is in the document (Players column)
+  - Spec: "Players column shows 'None' when only monsters present"
+- [ ] Only players (no monsters): after hover, `screen.getByText('None')` is in the document (Monsters column)
+  - Spec: "Monsters column shows 'None' when only players present"
+
+### Independent columns (maps to Execution task: "Add `describe('Independent column sections')`")
+
+- [ ] One alive player + one dead monster: after hover, `screen.getByText(/DEFEATED/i)` is in the document AND `screen.getByText(alivePlayerName)` is in the document with no line-through on it
+  - Spec: "Players column has no DEFEATED, Monsters column does"
+
+### Empty state (maps to Execution task: "Add `describe('Empty state')`")
+
+- [ ] Empty array `[]`: after hover, `screen.getByText(/No combatants/i)` is in the document and no error is thrown
+  - Spec: "Empty combatant array renders gracefully"

--- a/openspec/specs/combat-info-icon/combat-info-icon-tests.md
+++ b/openspec/specs/combat-info-icon/combat-info-icon-tests.md
@@ -1,0 +1,163 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Two-column layout heading visibility
+
+The system SHALL render "PLAYERS (N)" and "MONSTERS (N)" headings in the tooltip, where N reflects only alive combatants.
+
+#### Scenario: Both column headings visible after hover
+
+- **Given** a mix of alive player and alive monster combatants
+- **When** the user hovers the info icon
+- **Then** text matching `PLAYERS (1)` and `MONSTERS (1)` appears in the tooltip
+
+#### Scenario: Dead combatants excluded from header counts
+
+- **Given** one alive player and one dead monster
+- **When** the user hovers the info icon
+- **Then** `PLAYERS (1)` and `MONSTERS (0)` appear (dead monster not counted)
+
+---
+
+### Requirement: ADDED Same-name combatant grouping with ×N multiplier
+
+The system SHALL group alive combatants sharing a name and display a `×N` multiplier when N > 1.
+
+#### Scenario: Two monsters with the same name are grouped
+
+- **Given** two alive monsters both named "Goblin"
+- **When** the user hovers the info icon
+- **Then** "Goblin" appears once with "×2" as a sibling text node
+- **And** `MONSTERS (2)` appears in the column header
+
+#### Scenario: Single combatant has no multiplier
+
+- **Given** one alive monster named "Dragon"
+- **When** the user hovers the info icon
+- **Then** "Dragon" appears without any "×" multiplier text
+
+---
+
+### Requirement: ADDED Status condition display with duration
+
+The system SHALL render each condition name and its duration (if set) below the combatant name.
+
+#### Scenario: Condition with duration renders correctly
+
+- **Given** an alive player with condition `{ name: "Poisoned", duration: 3 }`
+- **When** the user hovers the info icon
+- **Then** text "• Poisoned (3)" appears in the tooltip
+
+#### Scenario: Condition without duration renders name only
+
+- **Given** an alive player with condition `{ name: "Blinded", duration: undefined }`
+- **When** the user hovers the info icon
+- **Then** text "• Blinded" appears (no trailing parenthesis)
+
+---
+
+### Requirement: ADDED DEFEATED section with delimiter
+
+The system SHALL render a "DEFEATED" label (and a visual delimiter) within a column when dead combatants of that type exist.
+
+#### Scenario: DEFEATED label appears for dead monsters
+
+- **Given** one dead monster
+- **When** the user hovers the info icon
+- **Then** the text "DEFEATED" appears in the Monsters column area
+
+#### Scenario: No DEFEATED label when no dead combatants
+
+- **Given** only alive combatants
+- **When** the user hovers the info icon
+- **Then** "DEFEATED" is not present in the tooltip
+
+---
+
+### Requirement: ADDED Strikethrough styling on dead combatants
+
+The system SHALL render dead combatant names with CSS `line-through` applied via a parent element's class.
+
+#### Scenario: Dead combatant name wrapped in line-through element
+
+- **Given** one dead monster named "Goblin"
+- **When** the user hovers the info icon
+- **Then** the element containing "Goblin" has an ancestor with class `line-through`
+
+---
+
+### Requirement: ADDED "None" fallback text for empty alive section
+
+The system SHALL display "None" (italic) in a column when no alive combatants of that type exist.
+
+#### Scenario: Players column shows "None" when only monsters present
+
+- **Given** one alive monster and no players
+- **When** the user hovers the info icon
+- **Then** "None" appears in the tooltip (Players column has no alive entries)
+
+#### Scenario: Monsters column shows "None" when only players present
+
+- **Given** one alive player and no monsters
+- **When** the user hovers the info icon
+- **Then** "None" appears in the tooltip (Monsters column has no alive entries)
+
+---
+
+### Requirement: ADDED Independent column alive+dead sections
+
+The system SHALL render alive and dead sections per column independently; a dead entry in one column does not affect the other column's display.
+
+#### Scenario: One alive player and one dead monster shows mixed state
+
+- **Given** one alive player and one dead monster
+- **When** the user hovers the info icon
+- **Then** the Players column shows the alive player (no DEFEATED section)
+- **And** the Monsters column shows a DEFEATED section with the dead monster
+
+---
+
+### Requirement: ADDED Empty state rendering
+
+The system SHALL render without errors and show "No combatants" text when the combatant list is empty.
+
+#### Scenario: Empty combatant list renders gracefully
+
+- **Given** no combatants (empty array passed as prop)
+- **When** the user hovers the info icon
+- **Then** the tooltip shows "No combatants" and does not throw
+
+## MODIFIED Requirements
+
+None. No existing requirements are changed; only new test coverage is being added.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "two-column layout headings" -> Requirement: Two-column layout heading visibility
+- Proposal element "alive-count in headers" -> Requirement: Two-column layout heading visibility
+- Proposal element "×N grouping" -> Requirement: Same-name combatant grouping with ×N multiplier
+- Proposal element "status conditions with durations" -> Requirement: Status condition display with duration
+- Proposal element "delimiter / DEFEATED label" -> Requirement: DEFEATED section with delimiter
+- Proposal element "strikethrough on dead" -> Requirement: Strikethrough styling on dead combatants
+- Proposal element "'None' fallback" -> Requirement: "None" fallback text for empty alive section
+- Proposal element "independent columns" -> Requirement: Independent column alive+dead sections
+- Proposal element "empty state" -> Requirement: Empty state rendering
+- Design Decision 1 -> All requirements (all tests go in the single existing file)
+- Design Decision 2 -> All requirements (selectors grounded in actual component output)
+- Design Decision 3 -> Grouping, condition, and independent-column requirements
+- All requirements -> Task: Add missing RTL tests to CombatInfoIcon.test.tsx
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No test flake from async hover interactions
+
+- **Given** `userEvent.setup()` pattern already used in the file
+- **When** hover tests run in jsdom
+- **Then** all tests pass consistently across runs (no timing-dependent failures)


### PR DESCRIPTION
Archives completed change combat-info-icon-test-coverage and syncs spec delta into openspec/specs/.