### PR TITLE
docs: archive user-search-endpoint (2026-06-01)

### DIFF
--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-05-31

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/design.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/design.md
@@ -1,0 +1,157 @@
+## Context
+
+- Relevant architecture: Next.js App Router API routes under `app/api/`. Auth via `withAuth` middleware (`lib/middleware.ts`). Rate limiting via `lib/rate-limit.ts` (in-memory, per-key). MongoDB accessed via `lib/db.ts` (`getDatabase()`). User type defined in `lib/types.ts`.
+- Dependencies: 1a complete — `username` field exists on all users; sparse unique index on `users.username` in MongoDB.
+- Interfaces/contracts touched: New route `app/api/users/search/route.ts` (no changes to existing files).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Authenticated prefix-search for users by username
+- Minimal PII exposure (id + username only)
+- Rate-limited to 20 req/min per authenticated user
+- Input sanitized against regex injection
+- Caller excluded from own results
+
+### Non-Goals
+
+- Fuzzy search
+- Pagination
+- Unauthenticated access
+- Any UI implementation
+
+## Decisions
+
+### Decision 1: Authentication approach
+
+- Chosen: `withAuth` wrapper — same pattern as all other protected routes
+- Alternatives considered: API key header, session cookie only
+- Rationale: Consistent with project conventions; provides `auth.userId` for rate-limit key and result exclusion
+- Trade-offs: Requires a valid session token; no guest search possible (intentional)
+
+### Decision 2: Search strategy — prefix regex vs fuse.js
+
+- Chosen: MongoDB `$regex: /^\<escaped-q\>/i` anchored prefix query
+- Alternatives considered: Load all users into memory → fuse.js fuzzy search
+- Rationale: Uses the sparse unique index from 1a; O(log n) at the DB level; no memory bloat; invite flow needs exact-prefix behavior not typo tolerance
+- Trade-offs: No fuzzy matching; slight complexity around regex escaping
+
+### Decision 3: Rate-limit key
+
+- Chosen: `search:user:<userId>` as the rate-limit key (20 req/min, 60 s window)
+- Alternatives considered: IP address; bare `auth.userId`
+- Rationale: IP is unreliable (NAT, proxies); userId ties the limit to the authenticated actor; namespaced key (`search:user:`) scopes the limit to this endpoint and prevents accidental coupling with other routes that may also rate-limit by userId
+- Trade-offs: Per-user limit resets on cold start (existing known limitation)
+
+### Decision 4: Input validation
+
+- Chosen: `q` must be present, length 1–50 chars; return 400 otherwise
+- Alternatives considered: Silently return empty array for missing `q`
+- Rationale: Explicit errors are easier to debug from client; min 1 prevents missing-param confusion; max 50 prevents regex pathology
+- Trade-offs: Slightly stricter API contract; documented in spec
+
+### Decision 5: Regex injection mitigation
+
+- Chosen: Escape special regex characters in `q` before use: replace `/[.*+?^${}()|[\]\\]/g` with `\\$&`
+- Alternatives considered: Allowlist charset (alphanumeric + `_` + `-`); usernames already constrained by validation from 1b, but input sanitization is defence-in-depth
+- Rationale: Safe regardless of upstream validation; zero overhead
+- Trade-offs: None
+
+### Decision 6: Result shape and cap
+
+- Chosen: `{ results: Array<{ id: string; username: string }> }`, max 15 results
+- Alternatives considered: Flat array; including `createdAt` for tie-breaking display
+- Rationale: Envelope allows future metadata addition without breaking clients; 15 is enough for a picker dropdown; keeps payload small
+- Trade-offs: Envelope adds one nesting level
+
+## Proposal to Design Mapping
+
+- Proposal element: Authenticated access only
+  - Design decision: Decision 1 (withAuth)
+  - Validation approach: Integration test with unauthenticated request → 401
+
+- Proposal element: Prefix search via MongoDB regex
+  - Design decision: Decision 2
+  - Validation approach: Integration test with known usernames; assert partial prefix matches and non-matches
+
+- Proposal element: Rate limit 20 req/min per userId
+  - Design decision: Decision 3
+  - Validation approach: Unit test calling checkRateLimit 21 times → 21st throws RateLimitError
+
+- Proposal element: `q` required, length 1–50
+  - Design decision: Decision 4
+  - Validation approach: Unit tests for missing q, empty q, q.length > 50; all → 400
+
+- Proposal element: Regex injection prevention
+  - Design decision: Decision 5
+  - Validation approach: Unit test with `q` containing regex metacharacters; assert escaped pattern
+
+- Proposal element: `{ id, username }` response, max 15, caller excluded
+  - Design decision: Decision 6
+  - Validation approach: Integration test asserting response shape; assert caller not in results
+
+## Functional Requirements Mapping
+
+- Requirement: Return matching users by username prefix
+  - Design element: MongoDB `$regex: /^\<q\>/i` with limit 15
+  - Acceptance criteria reference: specs/search.md — successful search
+  - Testability notes: Integration test with seeded users; assert matches and non-matches
+
+- Requirement: Never return PII fields
+  - Design element: MongoDB projection `{ username: 1 }` only; map to `{ id, username }`
+  - Acceptance criteria reference: specs/search.md — PII safety
+  - Testability notes: Assert response objects have no keys beyond `id` and `username`
+
+- Requirement: Caller excluded from results
+  - Design element: `{ _id: { $ne: new ObjectId(auth.userId) } }` in query
+  - Acceptance criteria reference: specs/search.md — self-exclusion
+  - Testability notes: Integration test where caller's username matches `q`; assert absent from results
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: security
+  - Requirement: Rate-limited to prevent enumeration
+  - Design element: `checkRateLimit(auth.userId, 20, 60_000)` at route entry
+  - Acceptance criteria reference: specs/search.md — rate limit
+  - Testability notes: Unit test driving rate limiter to limit; assert 429 response
+
+- Requirement category: security
+  - Requirement: Regex injection prevention
+  - Design element: Escape `q` before use in regex
+  - Acceptance criteria reference: specs/search.md — input validation
+  - Testability notes: Unit test with metacharacter input; assert no unintended match expansion
+
+- Requirement category: reliability
+  - Requirement: Graceful handling of missing/invalid input
+  - Design element: Validate `q` at route start; return 400 before DB query
+  - Acceptance criteria reference: specs/search.md — input validation
+  - Testability notes: Unit tests for all invalid input forms
+
+## Risks / Trade-offs
+
+- Risk/trade-off: In-memory rate limit resets on cold start (Fly.io stop/start)
+  - Impact: Burst beyond 20 req/min possible across cold starts
+  - Mitigation: Documented limitation in `lib/rate-limit.ts`; acceptable at current scale; Redis path documented for future
+
+- Risk/trade-off: Anchored prefix regex is case-insensitive collation-dependent
+  - Impact: MongoDB default collation is case-sensitive for regex; `/i` flag handles this explicitly
+  - Mitigation: Always use `/i` flag; covered by test with mixed-case input
+
+## Rollback / Mitigation
+
+- Rollback trigger: Route causes unintended data exposure or production errors
+- Rollback steps: Delete or gate `app/api/users/search/route.ts`; no DB schema changes to reverse
+- Data migration considerations: None — read-only endpoint
+- Verification after rollback: 404 on `GET /api/users/search`
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge; fix failing tests or type errors before proceeding
+- If security checks fail: Treat as blocker; address regex escaping or PII leakage before merge
+- If required reviews are blocked/stale: Re-request review; do not merge without approval
+- Escalation path and timeout: If review stale >48 h, ping reviewer in PR thread
+
+## Open Questions
+
+No open questions — all design decisions confirmed during exploration phase.

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/design.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/design.md
@@ -112,7 +112,7 @@
 
 - Requirement category: security
   - Requirement: Rate-limited to prevent enumeration
-  - Design element: `checkRateLimit(auth.userId, 20, 60_000)` at route entry
+  - Design element: `checkRateLimit(\`search:user:${auth.userId}\`, 20, 60_000)` at route entry
   - Acceptance criteria reference: specs/search.md — rate limit
   - Testability notes: Unit test driving rate limiter to limit; assert 429 response
 

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/proposal.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/proposal.md
@@ -1,0 +1,92 @@
+## GitHub Issues
+
+- #302
+
+## Why
+
+- Problem statement: There is no way for a logged-in user to discover other users by handle. The campaign invite flow (Phase 1d/1e) requires this to add members to a campaign.
+- Why now: Issue 302 is the next unblocked sub-issue of Phase 1 (after 1a adds `username` to the User model). The invite flow cannot be built without a user search surface.
+- Business/user impact: Without search, DMs have no way to find and invite players by username. It blocks the entire multi-user campaign initiative.
+
+## Problem Space
+
+- Current behavior: There is no `GET /api/users/search` route. User records exist in the `users` collection but are not publicly queryable.
+- Desired behavior: Authenticated users can search for other users by a partial username prefix and receive a minimal list of `{ id, username }` pairs — enough to power an invite picker UI.
+- Constraints:
+  - Must never return PII fields (email, passwordHash, tokenVersion, isAdmin).
+  - Must be rate-limited to prevent enumeration attacks.
+  - Requires authentication — anonymous access is not permitted.
+  - Depends on 1a being complete (all users have a `username`; sparse unique index exists).
+- Assumptions:
+  - All users have a `username` set (1a backfill complete); no `$exists` filter needed.
+  - The sparse unique index on `users.username` from 1a makes prefix regex queries efficient.
+  - The caller should not appear in their own search results.
+- Edge cases considered:
+  - Empty or missing `q` → 400.
+  - `q` exceeding max length → 400.
+  - No matches → 200 with empty array (not 404).
+  - Rate limit exceeded → 429.
+  - MongoDB regex injection: query is anchored (`^`) and escaped before use.
+
+## Scope
+
+### In Scope
+
+- `GET /api/users/search?q=<prefix>` route under `app/api/users/search/route.ts`
+- Authentication via `withAuth` middleware
+- Rate limiting via `checkRateLimit` (20 req/min per userId)
+- Prefix search using MongoDB `$regex` on `username` field
+- Response shape: `{ results: Array<{ id: string; username: string }> }`
+- Input validation: `q` required, length 1–50 chars
+- Result cap: 15 results maximum
+- Caller excluded from results
+- Unit tests for validation and rate-limit logic
+- Integration test for the route
+
+### Out of Scope
+
+- Fuzzy/fuse.js search
+- Pagination
+- Searching by email or display name
+- Unauthenticated access
+- Admin-only user listing
+- Any UI components (invite picker is a separate concern)
+
+## What Changes
+
+- New file: `app/api/users/search/route.ts`
+- New file (possibly): `app/api/users/search/` directory
+- Test files: unit + integration coverage for the new route
+
+## Risks
+
+- Risk: MongoDB regex injection via `q` parameter
+  - Impact: Could match unintended usernames or cause ReDoS
+  - Mitigation: Escape special regex characters in `q` before constructing the pattern; anchor with `^`; enforce max length of 50 chars
+- Risk: Username enumeration even with rate limiting
+  - Impact: An attacker could script requests across multiple authenticated accounts
+  - Mitigation: Single-char minimum is acceptable given auth requirement and rate limit; consider increasing if product concern arises
+- Risk: Cold-start resets in-memory rate limit state (existing known limitation of `lib/rate-limit.ts`)
+  - Impact: Rate limit resets on Fly.io machine stop/start
+  - Mitigation: Documented in `lib/rate-limit.ts`; acceptable at current scale
+
+## Open Questions
+
+No unresolved ambiguity. All design decisions confirmed during exploration:
+- Min `q` length: 1 character ✓
+- Rate limit: 20 req/min per userId ✓
+- Username required for all users (no `$exists` filter) ✓
+- Prefix query (not fuse.js) ✓
+
+## Non-Goals
+
+- Fuzzy matching or typo tolerance
+- Paginated results
+- Searching users who have not set a username
+- Public (unauthenticated) user discovery
+- Exposing any user fields beyond `id` and `username`
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/specs/search.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/specs/search.md
@@ -135,7 +135,7 @@ None.
 
 - **Given** a user is authenticated
 - **When** `GET /api/users/search?q=.*` or `q=(test` is requested
-- **Then** the response is 200 with results matching only literal usernames containing those characters (not a wildcard match); no server error
+- **Then** the response is 200 with results matching only literal usernames starting with those characters as a literal prefix (not a wildcard match); no server error
 
 ### Requirement: Security — Access control
 

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/specs/search.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/specs/search.md
@@ -1,0 +1,154 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED User search endpoint
+
+The system SHALL expose `GET /api/users/search?q=<prefix>` returning a list of `{ id, username }` pairs for authenticated users.
+
+#### Scenario: Successful prefix search
+
+- **Given** a user is authenticated and other users with usernames exist in the database
+- **When** `GET /api/users/search?q=dou` is requested
+- **Then** the response is 200 with `{ results: [{ id: string, username: string }, ...] }` containing only users whose username starts with "dou" (case-insensitive), up to 15 results
+
+#### Scenario: No matches
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=zzznomatch` is requested
+- **Then** the response is 200 with `{ results: [] }`
+
+#### Scenario: Single character query
+
+- **Given** a user is authenticated and users exist
+- **When** `GET /api/users/search?q=a` is requested
+- **Then** the response is 200 with results containing users whose username starts with "a"
+
+#### Scenario: Result cap at 15
+
+- **Given** a user is authenticated and 20+ users have usernames beginning with "test"
+- **When** `GET /api/users/search?q=test` is requested
+- **Then** the response is 200 with exactly 15 results
+
+### Requirement: ADDED Self-exclusion from search results
+
+The system SHALL never include the authenticated caller in their own search results.
+
+#### Scenario: Caller matches search prefix
+
+- **Given** a user with username "dougis" is authenticated
+- **When** `GET /api/users/search?q=doug` is requested
+- **Then** the response does not include an entry with the caller's own `id`
+
+### Requirement: ADDED Input validation
+
+The system SHALL reject requests with missing or out-of-range `q` parameters with HTTP 400.
+
+#### Scenario: Missing q parameter
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search` is requested (no `q` parameter)
+- **Then** the response is 400
+
+#### Scenario: Empty q parameter
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=` is requested
+- **Then** the response is 400
+
+#### Scenario: q exceeds maximum length
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=<51-character-string>` is requested
+- **Then** the response is 400
+
+#### Scenario: q at maximum length (boundary)
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=<50-character-string>` is requested
+- **Then** the response is 200 (valid request)
+
+### Requirement: ADDED PII safety
+
+The system SHALL never return email, passwordHash, tokenVersion, isAdmin, or any field other than `id` and `username` in search results.
+
+#### Scenario: Response shape enforcement
+
+- **Given** a user is authenticated and search returns results
+- **When** `GET /api/users/search?q=<prefix>` is requested
+- **Then** each result object contains only `id` and `username` keys; no other fields are present
+
+### Requirement: ADDED Rate limiting on search endpoint
+
+The system SHALL enforce a rate limit of 20 requests per minute per authenticated user, returning HTTP 429 on excess.
+
+#### Scenario: Under rate limit
+
+- **Given** a user is authenticated
+- **When** fewer than 20 search requests are made within a 60-second window
+- **Then** all responses are 200
+
+#### Scenario: Rate limit exceeded
+
+- **Given** a user is authenticated
+- **When** the 21st search request is made within the same 60-second window
+- **Then** the response is 429
+
+### Requirement: ADDED Unauthenticated access denied
+
+The system SHALL return HTTP 401 for requests without a valid session token.
+
+#### Scenario: No auth token
+
+- **Given** no authenticated session
+- **When** `GET /api/users/search?q=test` is requested
+- **Then** the response is 401
+
+## MODIFIED Requirements
+
+None — this is a net-new capability with no changes to existing behavior.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal: "Authenticated access only" → Requirement: Unauthenticated access denied
+- Proposal: "Prefix search via MongoDB regex" → Requirement: User search endpoint (successful prefix search)
+- Proposal: "Rate limit 20 req/min per userId" → Requirement: Rate limiting on search endpoint
+- Proposal: "`q` required, length 1–50" → Requirement: Input validation
+- Proposal: "Regex injection prevention" → Non-functional: Security
+- Proposal: "`{ id, username }` response, max 15, caller excluded" → Requirements: PII safety, Self-exclusion, Result cap
+- Design Decision 1 (withAuth) → Requirement: Unauthenticated access denied → Task: implement route with withAuth
+- Design Decision 2 (prefix regex) → Requirement: User search endpoint → Task: implement DB query
+- Design Decision 3 (rate limit key) → Requirement: Rate limiting → Task: add checkRateLimit call
+- Design Decision 4 (input validation) → Requirement: Input validation → Task: validate q parameter
+- Design Decision 5 (regex escaping) → Non-functional: Security → Task: escape q before regex use
+- Design Decision 6 (result shape + cap) → Requirements: PII safety, Result cap → Task: projection + limit
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security — Regex injection prevention
+
+#### Scenario: Metacharacter in query
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=.*` or `q=(test` is requested
+- **Then** the response is 200 with results matching only literal usernames containing those characters (not a wildcard match); no server error
+
+### Requirement: Security — Access control
+
+#### Scenario: No session token
+
+- **Given** no valid authentication token is present
+- **When** `GET /api/users/search?q=test` is requested
+- **Then** the response is 401 and no user data is returned
+
+### Requirement: Reliability — Graceful empty state
+
+#### Scenario: No users match query
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=zzz` is requested and no usernames start with "zzz"
+- **Then** the response is 200 with `{ results: [] }` (not 404, not 500)

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/specs/search.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/specs/search.md
@@ -139,16 +139,8 @@ None.
 
 ### Requirement: Security — Access control
 
-#### Scenario: No session token
-
-- **Given** no valid authentication token is present
-- **When** `GET /api/users/search?q=test` is requested
-- **Then** the response is 401 and no user data is returned
+See "Unauthenticated access denied" above.
 
 ### Requirement: Reliability — Graceful empty state
 
-#### Scenario: No users match query
-
-- **Given** a user is authenticated
-- **When** `GET /api/users/search?q=zzz` is requested and no usernames start with "zzz"
-- **Then** the response is 200 with `{ results: [] }` (not 404, not 500)
+See "No matches" scenario under "User search endpoint" above.

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/tasks.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/tasks.md
@@ -29,7 +29,7 @@
 ### 4. Implement regex-escaped prefix DB query
 
 - [x] Escape `q` for regex metacharacters: `/[.*+?^${}()|[\]\\]/g` → `\\$&`
-- [x] Build MongoDB query: `{ username: { $regex: new RegExp('^' + escapedQ) }, _id: { $ne: new ObjectId(auth.userId) } }` with collation for case-insensitivity
+- [x] Build MongoDB query: `{ username: { $regex: new RegExp('^' + escapedQ, 'i') }, _id: { $ne: new ObjectId(auth.userId) } }` — `i` flag for case-insensitive match
 - [x] Use projection `{ username: 1 }`, limit 15
 - [x] Map results to `{ id: string; username: string }` (convert `_id` to string)
 - [x] Return `{ results }` with status 200
@@ -96,10 +96,10 @@ Blocking resolution flow:
 - [x] Verify `app/api/users/search/route.ts` appears on `main`
 - [x] Mark all remaining tasks as complete
 - [x] Sync approved spec deltas into `openspec/specs/` (global spec)
-- [ ] Archive the change: move `openspec/changes/user-search-endpoint/` to `openspec/changes/archive/YYYY-MM-DD-user-search-endpoint/` — stage both the copy and the deletion in a single commit
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-user-search-endpoint/` exists and `openspec/changes/user-search-endpoint/` is gone
-- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-user-search-endpoint` then `git push -u origin doc/archive-YYYY-MM-DD-user-search-endpoint`
-- [ ] Open PR from doc branch to `main` with title `docs: archive user-search-endpoint (YYYY-MM-DD)` — do NOT push directly to `main`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
-- [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/user-search-endpoint doc/archive-YYYY-MM-DD-user-search-endpoint`
+- [x] Archive the change: move `openspec/changes/user-search-endpoint/` to `openspec/changes/archive/2026-06-01-user-search-endpoint/` — stage both the copy and the deletion in a single commit
+- [x] Confirm `openspec/changes/archive/2026-06-01-user-search-endpoint/` exists and `openspec/changes/user-search-endpoint/` is gone
+- [x] **Create a doc branch:** `git checkout -b doc/archive-2026-06-01-user-search-endpoint` then `git push -u origin doc/archive-2026-06-01-user-search-endpoint`
+- [x] Open PR from doc branch to `main` with title `docs: archive user-search-endpoint (2026-06-01)` — do NOT push directly to `main`
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [x] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d feat/user-search-endpoint doc/archive-2026-06-01-user-search-endpoint`

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/tasks.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/tasks.md
@@ -1,0 +1,105 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/user-search-endpoint` then immediately `git push -u origin feat/user-search-endpoint`
+
+## Execution
+
+### 1. Create route file scaffold
+
+- [x] Create `app/api/users/search/route.ts` with `withAuth` wrapper and empty GET handler
+- [x] Verify TypeScript compiles: `npm run build`
+
+### 2. Add input validation
+
+- [x] Validate `q` param: present, length 1–50 chars; return 400 otherwise
+- [x] Write unit tests in `tests/unit/api/users/search/route.unit.test.ts` covering:
+  - Missing `q` → 400
+  - Empty `q` → 400
+  - `q.length > 50` → 400
+  - `q.length === 50` (boundary) → passes validation
+
+### 3. Add rate limiting
+
+- [x] Call `checkRateLimit(\`search:user:${auth.userId}\`, 20, 60_000)` at route entry; catch `RateLimitError` and return 429
+- [x] Add unit test: mock `checkRateLimit` throwing `RateLimitError` → assert 429 response
+
+### 4. Implement regex-escaped prefix DB query
+
+- [x] Escape `q` for regex metacharacters: `/[.*+?^${}()|[\]\\]/g` → `\\$&`
+- [x] Build MongoDB query: `{ username: { $regex: new RegExp('^' + escapedQ) }, _id: { $ne: new ObjectId(auth.userId) } }` with collation for case-insensitivity
+- [x] Use projection `{ username: 1 }`, limit 15
+- [x] Map results to `{ id: string; username: string }` (convert `_id` to string)
+- [x] Return `{ results }` with status 200
+- [x] Add unit test: assert regex escaping of metacharacter input produces correct escaped pattern
+
+### 5. Write integration test
+
+- [x] Create `tests/integration/users-search.integration.test.ts`
+- [x] Seed test users with known usernames
+- [x] Assert: prefix match returns correct users
+- [x] Assert: caller is not in results
+- [x] Assert: no PII fields (email, passwordHash, etc.) in response
+- [x] Assert: unauthenticated request → 401
+- [x] Assert: no matches → `{ results: [] }`
+- [x] Assert: result count capped at 15 when more matches exist
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [x] `npm run test:unit` — all unit tests pass
+- [x] `npm run test:integration` — all integration tests pass
+- [x] `npm run build` — build succeeds with no type errors
+- [x] Manually verify no PII fields appear in response shape
+- [x] All execution tasks marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/user-search-endpoint` and push to remote
+- [x] Open PR from `feat/user-search-endpoint` to `main`. PR body must include `Closes #302`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow Remote push validation, push to `feat/user-search-endpoint`; wait 180 seconds; repeat until no unresolved threads remain
+- [x] **Monitor CI checks** — poll `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, commit, follow Remote push validation, push; wait 180 seconds; repeat until all required checks pass
+- [x] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user; never wait for a human to report the merge
+
+Ownership metadata:
+
+- Implementer: (agent)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally (`npm run test:unit && npm run test:integration && npm run build`) → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify `app/api/users/search/route.ts` appears on `main`
+- [x] Mark all remaining tasks as complete
+- [x] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/user-search-endpoint/` to `openspec/changes/archive/YYYY-MM-DD-user-search-endpoint/` — stage both the copy and the deletion in a single commit
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-user-search-endpoint/` exists and `openspec/changes/user-search-endpoint/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-user-search-endpoint` then `git push -u origin doc/archive-YYYY-MM-DD-user-search-endpoint`
+- [ ] Open PR from doc branch to `main` with title `docs: archive user-search-endpoint (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/user-search-endpoint doc/archive-YYYY-MM-DD-user-search-endpoint`

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/tests.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/tests.md
@@ -1,0 +1,72 @@
+---
+name: tests
+description: Tests for the user-search-endpoint change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `user-search-endpoint` change. All work follows strict TDD: write a failing test, make it pass with the simplest code, then refactor.
+
+Test files:
+- Unit: `tests/unit/api/users/search/route.unit.test.ts`
+- Integration: `tests/integration/users-search.integration.test.ts`
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — capture the requirement before writing implementation code; run it and confirm it fails
+2. **Write code to pass the test** — minimal implementation to make it green
+3. **Refactor** — clean up while keeping tests green
+
+---
+
+## Test Cases
+
+### Task 2 — Input validation (unit)
+
+- [ ] Missing `q` param → `checkRateLimit` not called; response is 400
+  - Spec: specs/search.md — "Missing q parameter"
+- [ ] Empty string `q=""` → response is 400
+  - Spec: specs/search.md — "Empty q parameter"
+- [ ] `q` with length 51 → response is 400
+  - Spec: specs/search.md — "q exceeds maximum length"
+- [ ] `q` with length 50 → passes validation (no 400)
+  - Spec: specs/search.md — "q at maximum length (boundary)"
+- [ ] `q` with length 1 → passes validation (no 400)
+  - Spec: specs/search.md — "Single character query"
+
+### Task 3 — Rate limiting (unit)
+
+- [ ] `checkRateLimit` throws `RateLimitError` → response is 429
+  - Spec: specs/search.md — "Rate limit exceeded"
+- [ ] `checkRateLimit` does not throw → request proceeds past rate-limit check
+  - Spec: specs/search.md — "Under rate limit"
+
+### Task 4 — Regex escaping (unit)
+
+- [ ] `q = ".*"` → escaped to `\.\*`; regex does not match all usernames
+  - Spec: specs/search.md — "Metacharacter in query"
+- [ ] `q = "(test"` → escaped to `\(test`; treated as literal
+  - Spec: specs/search.md — "Metacharacter in query"
+- [ ] `q = "doug"` (no metacharacters) → unchanged; regex is `^doug`
+  - Spec: specs/search.md — "Successful prefix search"
+
+### Task 5 — Integration tests
+
+- [ ] Authenticated GET with `?q=dou` returns users whose username starts with "dou" (case-insensitive)
+  - Spec: specs/search.md — "Successful prefix search"
+- [ ] Authenticated GET where no usernames match `q` → 200 with `{ results: [] }`
+  - Spec: specs/search.md — "No matches"
+- [ ] Caller's own username matches `q` → caller not present in results
+  - Spec: specs/search.md — "Caller matches search prefix"
+- [ ] 20+ users match `q` → exactly 15 results returned
+  - Spec: specs/search.md — "Result cap at 15"
+- [ ] Each result object has only `id` and `username` keys (no email, passwordHash, etc.)
+  - Spec: specs/search.md — "Response shape enforcement"
+- [ ] Unauthenticated request (no token) → 401
+  - Spec: specs/search.md — "No auth token" / "No session token"
+- [ ] Single-char `q` → valid; returns matching users
+  - Spec: specs/search.md — "Single character query"

--- a/openspec/changes/archive/2026-06-01-user-search-endpoint/tests.md
+++ b/openspec/changes/archive/2026-06-01-user-search-endpoint/tests.md
@@ -27,46 +27,46 @@ For each task in `tasks.md`:
 
 ### Task 2 — Input validation (unit)
 
-- [ ] Missing `q` param → `checkRateLimit` not called; response is 400
+- [x] Missing `q` param → `checkRateLimit` not called; response is 400
   - Spec: specs/search.md — "Missing q parameter"
-- [ ] Empty string `q=""` → response is 400
+- [x] Empty string `q=""` → response is 400
   - Spec: specs/search.md — "Empty q parameter"
-- [ ] `q` with length 51 → response is 400
+- [x] `q` with length 51 → response is 400
   - Spec: specs/search.md — "q exceeds maximum length"
-- [ ] `q` with length 50 → passes validation (no 400)
+- [x] `q` with length 50 → passes validation (no 400)
   - Spec: specs/search.md — "q at maximum length (boundary)"
-- [ ] `q` with length 1 → passes validation (no 400)
+- [x] `q` with length 1 → passes validation (no 400)
   - Spec: specs/search.md — "Single character query"
 
 ### Task 3 — Rate limiting (unit)
 
-- [ ] `checkRateLimit` throws `RateLimitError` → response is 429
+- [x] `checkRateLimit` throws `RateLimitError` → response is 429
   - Spec: specs/search.md — "Rate limit exceeded"
-- [ ] `checkRateLimit` does not throw → request proceeds past rate-limit check
+- [x] `checkRateLimit` does not throw → request proceeds past rate-limit check
   - Spec: specs/search.md — "Under rate limit"
 
 ### Task 4 — Regex escaping (unit)
 
-- [ ] `q = ".*"` → escaped to `\.\*`; regex does not match all usernames
+- [x] `q = ".*"` → escaped to `\.\*`; regex does not match all usernames
   - Spec: specs/search.md — "Metacharacter in query"
-- [ ] `q = "(test"` → escaped to `\(test`; treated as literal
+- [x] `q = "(test"` → escaped to `\(test`; treated as literal
   - Spec: specs/search.md — "Metacharacter in query"
-- [ ] `q = "doug"` (no metacharacters) → unchanged; regex is `^doug`
+- [x] `q = "doug"` (no metacharacters) → unchanged; regex is `^doug`
   - Spec: specs/search.md — "Successful prefix search"
 
 ### Task 5 — Integration tests
 
-- [ ] Authenticated GET with `?q=dou` returns users whose username starts with "dou" (case-insensitive)
+- [x] Authenticated GET with `?q=dou` returns users whose username starts with "dou" (case-insensitive)
   - Spec: specs/search.md — "Successful prefix search"
-- [ ] Authenticated GET where no usernames match `q` → 200 with `{ results: [] }`
+- [x] Authenticated GET where no usernames match `q` → 200 with `{ results: [] }`
   - Spec: specs/search.md — "No matches"
-- [ ] Caller's own username matches `q` → caller not present in results
+- [x] Caller's own username matches `q` → caller not present in results
   - Spec: specs/search.md — "Caller matches search prefix"
-- [ ] 20+ users match `q` → exactly 15 results returned
+- [x] 20+ users match `q` → exactly 15 results returned
   - Spec: specs/search.md — "Result cap at 15"
-- [ ] Each result object has only `id` and `username` keys (no email, passwordHash, etc.)
+- [x] Each result object has only `id` and `username` keys (no email, passwordHash, etc.)
   - Spec: specs/search.md — "Response shape enforcement"
-- [ ] Unauthenticated request (no token) → 401
+- [x] Unauthenticated request (no token) → 401
   - Spec: specs/search.md — "No auth token" / "No session token"
-- [ ] Single-char `q` → valid; returns matching users
+- [x] Single-char `q` → valid; returns matching users
   - Spec: specs/search.md — "Single character query"

--- a/openspec/specs/user-search/spec.md
+++ b/openspec/specs/user-search/spec.md
@@ -135,7 +135,7 @@ None.
 
 - **Given** a user is authenticated
 - **When** `GET /api/users/search?q=.*` or `q=(test` is requested
-- **Then** the response is 200 with results matching only literal usernames containing those characters (not a wildcard match); no server error
+- **Then** the response is 200 with results matching only literal usernames starting with those characters as a literal prefix (not a wildcard match); no server error
 
 ### Requirement: Security — Access control
 

--- a/openspec/specs/user-search/spec.md
+++ b/openspec/specs/user-search/spec.md
@@ -1,0 +1,154 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED User search endpoint
+
+The system SHALL expose `GET /api/users/search?q=<prefix>` returning a list of `{ id, username }` pairs for authenticated users.
+
+#### Scenario: Successful prefix search
+
+- **Given** a user is authenticated and other users with usernames exist in the database
+- **When** `GET /api/users/search?q=dou` is requested
+- **Then** the response is 200 with `{ results: [{ id: string, username: string }, ...] }` containing only users whose username starts with "dou" (case-insensitive), up to 15 results
+
+#### Scenario: No matches
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=zzznomatch` is requested
+- **Then** the response is 200 with `{ results: [] }`
+
+#### Scenario: Single character query
+
+- **Given** a user is authenticated and users exist
+- **When** `GET /api/users/search?q=a` is requested
+- **Then** the response is 200 with results containing users whose username starts with "a"
+
+#### Scenario: Result cap at 15
+
+- **Given** a user is authenticated and 20+ users have usernames beginning with "test"
+- **When** `GET /api/users/search?q=test` is requested
+- **Then** the response is 200 with exactly 15 results
+
+### Requirement: ADDED Self-exclusion from search results
+
+The system SHALL never include the authenticated caller in their own search results.
+
+#### Scenario: Caller matches search prefix
+
+- **Given** a user with username "dougis" is authenticated
+- **When** `GET /api/users/search?q=doug` is requested
+- **Then** the response does not include an entry with the caller's own `id`
+
+### Requirement: ADDED Input validation
+
+The system SHALL reject requests with missing or out-of-range `q` parameters with HTTP 400.
+
+#### Scenario: Missing q parameter
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search` is requested (no `q` parameter)
+- **Then** the response is 400
+
+#### Scenario: Empty q parameter
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=` is requested
+- **Then** the response is 400
+
+#### Scenario: q exceeds maximum length
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=<51-character-string>` is requested
+- **Then** the response is 400
+
+#### Scenario: q at maximum length (boundary)
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=<50-character-string>` is requested
+- **Then** the response is 200 (valid request)
+
+### Requirement: ADDED PII safety
+
+The system SHALL never return email, passwordHash, tokenVersion, isAdmin, or any field other than `id` and `username` in search results.
+
+#### Scenario: Response shape enforcement
+
+- **Given** a user is authenticated and search returns results
+- **When** `GET /api/users/search?q=<prefix>` is requested
+- **Then** each result object contains only `id` and `username` keys; no other fields are present
+
+### Requirement: ADDED Rate limiting on search endpoint
+
+The system SHALL enforce a rate limit of 20 requests per minute per authenticated user, returning HTTP 429 on excess.
+
+#### Scenario: Under rate limit
+
+- **Given** a user is authenticated
+- **When** fewer than 20 search requests are made within a 60-second window
+- **Then** all responses are 200
+
+#### Scenario: Rate limit exceeded
+
+- **Given** a user is authenticated
+- **When** the 21st search request is made within the same 60-second window
+- **Then** the response is 429
+
+### Requirement: ADDED Unauthenticated access denied
+
+The system SHALL return HTTP 401 for requests without a valid session token.
+
+#### Scenario: No auth token
+
+- **Given** no authenticated session
+- **When** `GET /api/users/search?q=test` is requested
+- **Then** the response is 401
+
+## MODIFIED Requirements
+
+None — this is a net-new capability with no changes to existing behavior.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal: "Authenticated access only" → Requirement: Unauthenticated access denied
+- Proposal: "Prefix search via MongoDB regex" → Requirement: User search endpoint (successful prefix search)
+- Proposal: "Rate limit 20 req/min per userId" → Requirement: Rate limiting on search endpoint
+- Proposal: "`q` required, length 1–50" → Requirement: Input validation
+- Proposal: "Regex injection prevention" → Non-functional: Security
+- Proposal: "`{ id, username }` response, max 15, caller excluded" → Requirements: PII safety, Self-exclusion, Result cap
+- Design Decision 1 (withAuth) → Requirement: Unauthenticated access denied → Task: implement route with withAuth
+- Design Decision 2 (prefix regex) → Requirement: User search endpoint → Task: implement DB query
+- Design Decision 3 (rate limit key) → Requirement: Rate limiting → Task: add checkRateLimit call
+- Design Decision 4 (input validation) → Requirement: Input validation → Task: validate q parameter
+- Design Decision 5 (regex escaping) → Non-functional: Security → Task: escape q before regex use
+- Design Decision 6 (result shape + cap) → Requirements: PII safety, Result cap → Task: projection + limit
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security — Regex injection prevention
+
+#### Scenario: Metacharacter in query
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=.*` or `q=(test` is requested
+- **Then** the response is 200 with results matching only literal usernames containing those characters (not a wildcard match); no server error
+
+### Requirement: Security — Access control
+
+#### Scenario: No session token
+
+- **Given** no valid authentication token is present
+- **When** `GET /api/users/search?q=test` is requested
+- **Then** the response is 401 and no user data is returned
+
+### Requirement: Reliability — Graceful empty state
+
+#### Scenario: No users match query
+
+- **Given** a user is authenticated
+- **When** `GET /api/users/search?q=zzz` is requested and no usernames start with "zzz"
+- **Then** the response is 200 with `{ results: [] }` (not 404, not 500)

--- a/openspec/specs/user-search/spec.md
+++ b/openspec/specs/user-search/spec.md
@@ -139,16 +139,8 @@ None.
 
 ### Requirement: Security — Access control
 
-#### Scenario: No session token
-
-- **Given** no valid authentication token is present
-- **When** `GET /api/users/search?q=test` is requested
-- **Then** the response is 401 and no user data is returned
+See "Unauthenticated access denied" above.
 
 ### Requirement: Reliability — Graceful empty state
 
-#### Scenario: No users match query
-
-- **Given** a user is authenticated
-- **When** `GET /api/users/search?q=zzz` is requested and no usernames start with "zzz"
-- **Then** the response is 200 with `{ results: [] }` (not 404, not 500)
+See "No matches" scenario under "User search endpoint" above.


### PR DESCRIPTION
Archives the user-search-endpoint OpenSpec change after PR #335 merged to main.

- Moves change artifacts to `openspec/changes/archive/2026-06-01-user-search-endpoint/`
- Syncs spec to `openspec/specs/user-search/spec.md`