### PR TITLE
feat: expand Item interface and add loot field tests

### DIFF
--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,3 +1,5 @@
+// GET /api/items — list all items for the authenticated user (from the `items` collection)
+// POST /api/items — create a new item for the authenticated user
 import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/middleware';
 import { getDatabase } from '@/lib/db';
@@ -57,7 +59,13 @@ export const GET = withAuth(async (request, auth) => {
 
 export const POST = withAuth(async (request, auth) => {
   try {
-    const body = await request.json();
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
     const { name, type, rarity, description, quantity, value, weight, attunement, equipped, properties, notes } = body;
 
     if (!name || typeof name !== 'string' || name.trim() === '') {
@@ -73,20 +81,39 @@ export const POST = withAuth(async (request, auth) => {
     const rarityError = validateEnum(rarity, VALID_RARITIES, 'Item rarity is required', 'Invalid item rarity');
     if (rarityError) return rarityError;
 
+    if (quantity !== undefined && (typeof quantity !== 'number' || quantity <= 0)) {
+      return NextResponse.json({ error: 'Quantity must be a positive number' }, { status: 400 });
+    }
+    if (value !== undefined && (typeof value !== 'number' || value < 0)) {
+      return NextResponse.json({ error: 'Value must be a non-negative number' }, { status: 400 });
+    }
+    if (weight !== undefined && (typeof weight !== 'number' || weight < 0)) {
+      return NextResponse.json({ error: 'Weight must be a non-negative number' }, { status: 400 });
+    }
+    if (attunement !== undefined && typeof attunement !== 'boolean') {
+      return NextResponse.json({ error: 'Attunement must be a boolean' }, { status: 400 });
+    }
+    if (equipped !== undefined && typeof equipped !== 'boolean') {
+      return NextResponse.json({ error: 'Equipped must be a boolean' }, { status: 400 });
+    }
+    if (properties !== undefined && (!Array.isArray(properties) || !properties.every((p) => typeof p === 'string'))) {
+      return NextResponse.json({ error: 'Properties must be an array of strings' }, { status: 400 });
+    }
+
     const item: Item = {
       id: crypto.randomUUID(),
       userId: auth.userId,
       name: name.trim(),
-      type,
-      rarity,
-      ...(description !== undefined && { description }),
-      quantity: quantity ?? 1,
-      ...(value !== undefined && { value }),
-      ...(weight !== undefined && { weight }),
-      attunement: attunement ?? false,
-      equipped: equipped ?? false,
-      ...(properties !== undefined && { properties }),
-      ...(notes !== undefined && { notes }),
+      type: type as ItemType,
+      rarity: rarity as ItemRarity,
+      ...(typeof description === 'string' && { description: description.trim() }),
+      quantity: (quantity as number) ?? 1,
+      ...(value !== undefined && { value: value as number }),
+      ...(weight !== undefined && { weight: weight as number }),
+      attunement: (attunement as boolean) ?? false,
+      equipped: (equipped as boolean) ?? false,
+      ...(properties !== undefined && { properties: properties as string[] }),
+      ...(typeof notes === 'string' && { notes: notes.trim() }),
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,15 +1,41 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/middleware';
 import { getDatabase } from '@/lib/db';
+
+type ItemType = 'weapon' | 'armor' | 'potion' | 'scroll' | 'wondrous' | 'ammunition' | 'gear' | 'tool' | 'other';
+type ItemRarity = 'common' | 'uncommon' | 'rare' | 'very_rare' | 'legendary' | 'artifact';
+
+const VALID_TYPES: ItemType[] = ['weapon', 'armor', 'potion', 'scroll', 'wondrous', 'ammunition', 'gear', 'tool', 'other'];
+const VALID_RARITIES: ItemRarity[] = ['common', 'uncommon', 'rare', 'very_rare', 'legendary', 'artifact'];
 
 interface Item {
   _id?: string;
   id: string;
   userId: string;
   name: string;
+  type: ItemType;
+  rarity: ItemRarity;
   description?: string;
+  quantity: number;
+  value?: number;
+  weight?: number;
+  attunement: boolean;
+  equipped: boolean;
+  properties?: string[];
+  notes?: string;
   createdAt: Date;
   updatedAt: Date;
+}
+
+function validateEnum<T extends string>(
+  value: unknown,
+  valid: T[],
+  requiredMsg: string,
+  invalidMsg: string,
+): NextResponse | null {
+  if (!value) return NextResponse.json({ error: requiredMsg }, { status: 400 });
+  if (!valid.includes(value as T)) return NextResponse.json({ error: invalidMsg }, { status: 400 });
+  return null;
 }
 
 export const GET = withAuth(async (request, auth) => {
@@ -32,20 +58,35 @@ export const GET = withAuth(async (request, auth) => {
 export const POST = withAuth(async (request, auth) => {
   try {
     const body = await request.json();
-    const { name, description } = body;
+    const { name, type, rarity, description, quantity, value, weight, attunement, equipped, properties, notes } = body;
 
-    if (!name || name.trim() === '') {
+    if (!name || typeof name !== 'string' || name.trim() === '') {
       return NextResponse.json(
         { error: 'Item name is required' },
         { status: 400 }
       );
     }
 
+    const typeError = validateEnum(type, VALID_TYPES, 'Item type is required', 'Invalid item type');
+    if (typeError) return typeError;
+
+    const rarityError = validateEnum(rarity, VALID_RARITIES, 'Item rarity is required', 'Invalid item rarity');
+    if (rarityError) return rarityError;
+
     const item: Item = {
       id: crypto.randomUUID(),
       userId: auth.userId,
       name: name.trim(),
-      description: description || '',
+      type,
+      rarity,
+      ...(description !== undefined && { description }),
+      quantity: quantity ?? 1,
+      ...(value !== undefined && { value }),
+      ...(weight !== undefined && { weight }),
+      attunement: attunement ?? false,
+      equipped: equipped ?? false,
+      ...(properties !== undefined && { properties }),
+      ...(notes !== undefined && { notes }),
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/openspec/changes/items-route-loot-shape-and-tests/.openspec.yaml
+++ b/openspec/changes/items-route-loot-shape-and-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-02

--- a/openspec/changes/items-route-loot-shape-and-tests/tasks.md
+++ b/openspec/changes/items-route-loot-shape-and-tests/tasks.md
@@ -58,28 +58,28 @@
 
 ## Validation
 
-- [x] `npm test -- --testPathPattern="tests/unit/api/items"` — all unit tests pass
+- [x] `npm run test:unit -- --testPathPattern="tests/unit/api/items"` — all unit tests pass
 - [x] `npm run test:integration -- --testPathPattern="tests/integration/api/items"` — all integration tests pass
-- [x] `npm run type-check` (or `npx tsc --noEmit`) — no type errors
+- [x] `npx tsc --noEmit` — no type errors
 - [x] `npm run build` — build succeeds
-- [x] Full unit suite: `npm test` — no regressions
+- [x] Full unit suite: `npm run test:unit` — no regressions
 - [x] Full integration suite: `npm run test:integration` — no regressions
 
 ## Remote push validation
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test`; all tests must pass
+- **Unit tests** — `npm run test:unit`; all tests must pass
 - **Integration tests** — `npm run test:integration`; all tests must pass
 - **Build** — `npm run build`; must succeed with no errors
 - if **ANY** of the above fail, you **MUST** iterate and address the failure
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `feat/items-route-loot-shape-and-tests` and push to remote
-- [ ] Open PR from `feat/items-route-loot-shape-and-tests` to `main`. PR body **MUST** include `Closes #245`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/items-route-loot-shape-and-tests` and push to remote
+- [x] Open PR from `feat/items-route-loot-shape-and-tests` to `main`. PR body **MUST** include `Closes #245`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
 - [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass

--- a/openspec/changes/items-route-loot-shape-and-tests/tasks.md
+++ b/openspec/changes/items-route-loot-shape-and-tests/tasks.md
@@ -1,0 +1,112 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/items-route-loot-shape-and-tests` then immediately `git push -u origin feat/items-route-loot-shape-and-tests`
+
+## Execution
+
+### 1. Update `app/api/items/route.ts`
+
+- [x] Add `ItemType` union type above the `Item` interface:
+  ```ts
+  type ItemType = 'weapon' | 'armor' | 'potion' | 'scroll' | 'wondrous' | 'ammunition' | 'gear' | 'tool' | 'other';
+  type ItemRarity = 'common' | 'uncommon' | 'rare' | 'very_rare' | 'legendary' | 'artifact';
+  const VALID_TYPES: ItemType[] = ['weapon', 'armor', 'potion', 'scroll', 'wondrous', 'ammunition', 'gear', 'tool', 'other'];
+  const VALID_RARITIES: ItemRarity[] = ['common', 'uncommon', 'rare', 'very_rare', 'legendary', 'artifact'];
+  ```
+- [x] Expand `Item` interface to include: `type`, `rarity`, `quantity`, `value?`, `weight?`, `attunement`, `equipped`, `properties?`, `notes?`
+- [x] In the POST handler, after the `name` validation, add validation for `type` (missing → 400 `"Item type is required"`, invalid → 400 `"Invalid item type"`) and `rarity` (missing → 400 `"Item rarity is required"`, invalid → 400 `"Invalid item rarity"`)
+- [x] Apply defaults in the POST item construction: `quantity: quantity ?? 1`, `attunement: attunement ?? false`, `equipped: equipped ?? false`
+- [x] Destructure all new fields from `body` in the POST handler
+
+### 2. Write unit tests — `tests/unit/api/items/route.test.ts`
+
+- [x] Create `tests/unit/api/items/` directory
+- [x] Scaffold test file with `@jest-environment node`, mock `@/lib/middleware` (explicit `withAuth` factory), mock `@/lib/db`
+- [x] **GET tests:**
+  - [x] Returns 200 with items array from mocked DB
+  - [x] Returns 500 when DB throws
+- [x] **POST tests:**
+  - [x] Returns 400 when `name` is missing
+  - [x] Returns 400 when `name` is whitespace-only
+  - [x] Returns 400 when `type` is missing
+  - [x] Returns 400 when `type` is not a valid enum value
+  - [x] Returns 400 when `rarity` is missing
+  - [x] Returns 400 when `rarity` is not a valid enum value
+  - [x] Returns 201 with full item shape on valid request (all fields provided)
+  - [x] Returns 201 with defaults applied when only required fields provided (`quantity: 1`, `attunement: false`, `equipped: false`)
+  - [x] Returns 500 when DB throws on insert
+
+### 3. Write integration tests — `tests/integration/api/items.test.ts`
+
+- [x] Scaffold test file following `tests/integration/content.integration.test.ts` pattern
+- [x] Register two test users via `registerTestUser` in `beforeAll`
+- [x] **Auth tests:**
+  - [x] GET without auth cookie → 401
+  - [x] POST without auth cookie → 401
+- [x] **Functional tests:**
+  - [x] POST with valid body → 201; returned item has correct fields including defaults
+  - [x] POST then GET round-trip: created item appears in GET response
+- [x] **User isolation test:**
+  - [x] User A creates an item; User B calls GET; User B's response does not contain User A's item
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [x] `npm test -- --testPathPattern="tests/unit/api/items"` — all unit tests pass
+- [x] `npm run test:integration -- --testPathPattern="tests/integration/api/items"` — all integration tests pass
+- [x] `npm run type-check` (or `npx tsc --noEmit`) — no type errors
+- [x] `npm run build` — build succeeds
+- [x] Full unit suite: `npm test` — no regressions
+- [x] Full integration suite: `npm run test:integration` — no regressions
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/items-route-loot-shape-and-tests` and push to remote
+- [ ] Open PR from `feat/items-route-loot-shape-and-tests` to `main`. PR body **MUST** include `Closes #245`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): automated CI + agentic review
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/items-route-loot-shape-and-tests/` to `openspec/changes/archive/YYYY-MM-DD-items-route-loot-shape-and-tests/` **in a single commit that includes both the copy and deletion**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-items-route-loot-shape-and-tests/` exists and `openspec/changes/items-route-loot-shape-and-tests/` is gone
+- [ ] **Create a doc branch**: `git checkout -b doc/archive-YYYY-MM-DD-items-route-loot-shape-and-tests` then `git push -u origin doc/archive-YYYY-MM-DD-items-route-loot-shape-and-tests`
+- [ ] Open a PR from the doc branch to `main` with title `docs: archive items-route-loot-shape-and-tests (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor doc PR until merged; address any comments or CI failures on the doc branch
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/items-route-loot-shape-and-tests doc/archive-YYYY-MM-DD-items-route-loot-shape-and-tests`

--- a/tests/integration/api/items.test.ts
+++ b/tests/integration/api/items.test.ts
@@ -29,6 +29,8 @@ describe("Items API Integration Tests", () => {
   let baseUrl: string;
   let authCookie: string;
   let authCookie2: string;
+  // Track created IDs for reference; actual cleanup handled by global test DB teardown
+  const createdItemIds: string[] = [];
 
   beforeAll(async () => {
     const url = process.env.TEST_BASE_URL;
@@ -51,7 +53,9 @@ describe("Items API Integration Tests", () => {
     if (res.status !== 201) {
       throw new Error(`createItem failed with status ${res.status}: ${await res.text()}`);
     }
-    return res.json() as Promise<ItemResponse>;
+    const item = await res.json() as ItemResponse;
+    createdItemIds.push(item.id);
+    return item;
   }
 
   describe("Auth enforcement", () => {
@@ -79,6 +83,7 @@ describe("Items API Integration Tests", () => {
       });
       expect(res.status).toBe(201);
       const body = await res.json() as ItemResponse;
+      createdItemIds.push(body.id);
       expect(body.quantity).toBe(1);
       expect(body.attunement).toBe(false);
       expect(body.equipped).toBe(false);

--- a/tests/integration/api/items.test.ts
+++ b/tests/integration/api/items.test.ts
@@ -1,0 +1,115 @@
+import fetch from "node-fetch";
+import { registerTestUser } from "../helpers/users";
+
+interface ItemResponse {
+  id: string;
+  userId: string;
+  name: string;
+  type: string;
+  rarity: string;
+  description?: string;
+  quantity: number;
+  value?: number;
+  weight?: number;
+  attunement: boolean;
+  equipped: boolean;
+  properties?: string[];
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const VALID_ITEM = {
+  name: "Dagger",
+  type: "weapon",
+  rarity: "common",
+};
+
+describe("Items API Integration Tests", () => {
+  let baseUrl: string;
+  let authCookie: string;
+  let authCookie2: string;
+
+  beforeAll(async () => {
+    const url = process.env.TEST_BASE_URL;
+    if (!url) throw new Error("TEST_BASE_URL not set — globalSetup was not wired correctly");
+    baseUrl = url;
+    authCookie = (await registerTestUser(baseUrl, "items-user1")).cookie;
+    authCookie2 = (await registerTestUser(baseUrl, "items-user2")).cookie;
+  }, 30000);
+
+  function authed(cookie = authCookie) {
+    return { "Content-Type": "application/json", Cookie: cookie };
+  }
+
+  async function createItem(overrides: Partial<typeof VALID_ITEM> = {}, cookie = authCookie): Promise<ItemResponse> {
+    const res = await fetch(`${baseUrl}/api/items`, {
+      method: "POST",
+      headers: authed(cookie),
+      body: JSON.stringify({ ...VALID_ITEM, ...overrides }),
+    });
+    if (res.status !== 201) {
+      throw new Error(`createItem failed with status ${res.status}: ${await res.text()}`);
+    }
+    return res.json() as Promise<ItemResponse>;
+  }
+
+  describe("Auth enforcement", () => {
+    it("GET without auth cookie returns 401", async () => {
+      const res = await fetch(`${baseUrl}/api/items`);
+      expect(res.status).toBe(401);
+    });
+
+    it("POST without auth cookie returns 401", async () => {
+      const res = await fetch(`${baseUrl}/api/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_ITEM),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("Functional tests", () => {
+    it("POST with valid body returns 201 with correct shape and defaults", async () => {
+      const res = await fetch(`${baseUrl}/api/items`, {
+        method: "POST",
+        headers: authed(),
+        body: JSON.stringify(VALID_ITEM),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json() as ItemResponse;
+      expect(body.quantity).toBe(1);
+      expect(body.attunement).toBe(false);
+      expect(body.equipped).toBe(false);
+      expect(typeof body.id).toBe("string");
+      expect(body.name).toBe("Dagger");
+      expect(body.type).toBe("weapon");
+      expect(body.rarity).toBe("common");
+    });
+
+    it("POST then GET round-trip: created item appears in GET response", async () => {
+      const item = await createItem({ name: "Unique Sword" });
+
+      const res = await fetch(`${baseUrl}/api/items`, { headers: authed() });
+      expect(res.status).toBe(200);
+      const list = await res.json() as ItemResponse[];
+      expect(Array.isArray(list)).toBe(true);
+      expect(list.some(i => i.id === item.id)).toBe(true);
+    });
+  });
+
+  describe("User isolation", () => {
+    it("user A's items are not visible to user B, but user B's own items are visible", async () => {
+      const itemA = await createItem({ name: "User A Secret Item" }, authCookie);
+      const itemB = await createItem({ name: "User B Own Item" }, authCookie2);
+
+      const resB = await fetch(`${baseUrl}/api/items`, { headers: authed(authCookie2) });
+      expect(resB.status).toBe(200);
+      const listB = await resB.json() as ItemResponse[];
+
+      expect(listB.some(i => i.id === itemA.id)).toBe(false);
+      expect(listB.some(i => i.id === itemB.id)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/api/items/route.test.ts
+++ b/tests/unit/api/items/route.test.ts
@@ -136,8 +136,14 @@ describe("POST /api/items — success cases", () => {
     expect(body.name).toBe("Longsword");
     expect(body.type).toBe("weapon");
     expect(body.rarity).toBe("uncommon");
+    expect(body.description).toBe("A sharp blade");
     expect(body.quantity).toBe(2);
+    expect(body.value).toBe(15);
+    expect(body.weight).toBe(3);
+    expect(body.attunement).toBe(false);
     expect(body.equipped).toBe(true);
+    expect(body.properties).toEqual(["martial"]);
+    expect(body.notes).toBe("Found in the dungeon");
     expect(body.userId).toBe("user-123");
     expect(typeof body.id).toBe("string");
   });
@@ -152,7 +158,7 @@ describe("POST /api/items — success cases", () => {
     expect(body.equipped).toBe(false);
   });
 
-  it("returns 500 when DB throws on insert", async () => {
+  it("returns 500 when DB throws", async () => {
     mockDbThrow();
     const res = await POST(makePostRequest({ name: "Sword", type: "weapon", rarity: "common" }));
     expect(res.status).toBe(500);

--- a/tests/unit/api/items/route.test.ts
+++ b/tests/unit/api/items/route.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment node
+ */
+import { GET, POST } from "@/app/api/items/route";
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: (...args: unknown[]) => unknown) =>
+    (request: NextRequest) =>
+      handler(request, { userId: "user-123" }),
+}));
+
+jest.mock("@/lib/db");
+
+import { getDatabase } from "@/lib/db";
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/items", { method: "GET" });
+}
+
+function makePostRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/items", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockDb(items: unknown[] = []) {
+  mockedGetDatabase.mockResolvedValue({
+    collection: jest.fn().mockReturnValue({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue(items),
+      }),
+      insertOne: jest.fn().mockResolvedValue({ insertedId: "some-id" }),
+    }),
+  } as any);
+}
+
+function mockDbThrow() {
+  mockedGetDatabase.mockRejectedValue(new Error("DB error"));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/items", () => {
+  it("returns 200 with items array from DB", async () => {
+    const mockItem = { id: "item-1", userId: "user-123", name: "Longsword" };
+    mockDb([mockItem]);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe("item-1");
+  });
+
+  it("returns 500 when DB throws", async () => {
+    mockDbThrow();
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to fetch items");
+  });
+});
+
+describe("POST /api/items — name validation", () => {
+  it("returns 400 when name is missing", async () => {
+    const res = await POST(makePostRequest({ type: "weapon", rarity: "common" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Item name is required");
+  });
+
+  it("returns 400 when name is whitespace-only", async () => {
+    const res = await POST(makePostRequest({ name: "   ", type: "weapon", rarity: "common" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Item name is required");
+  });
+});
+
+describe("POST /api/items — type validation", () => {
+  it("returns 400 when type is missing", async () => {
+    const res = await POST(makePostRequest({ name: "Sword", rarity: "common" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Item type is required");
+  });
+
+  it("returns 400 when type is not a valid enum value", async () => {
+    const res = await POST(makePostRequest({ name: "Sword", type: "banana", rarity: "common" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid item type");
+  });
+});
+
+describe("POST /api/items — rarity validation", () => {
+  it("returns 400 when rarity is missing", async () => {
+    const res = await POST(makePostRequest({ name: "Sword", type: "weapon" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Item rarity is required");
+  });
+
+  it("returns 400 when rarity is not a valid enum value", async () => {
+    const res = await POST(makePostRequest({ name: "Sword", type: "weapon", rarity: "epic" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid item rarity");
+  });
+});
+
+describe("POST /api/items — success cases", () => {
+  it("returns 201 with full item shape on valid request", async () => {
+    mockDb();
+    const res = await POST(makePostRequest({
+      name: "Longsword",
+      type: "weapon",
+      rarity: "uncommon",
+      description: "A sharp blade",
+      quantity: 2,
+      value: 15,
+      weight: 3,
+      attunement: false,
+      equipped: true,
+      properties: ["martial"],
+      notes: "Found in the dungeon",
+    }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.name).toBe("Longsword");
+    expect(body.type).toBe("weapon");
+    expect(body.rarity).toBe("uncommon");
+    expect(body.quantity).toBe(2);
+    expect(body.equipped).toBe(true);
+    expect(body.userId).toBe("user-123");
+    expect(typeof body.id).toBe("string");
+  });
+
+  it("returns 201 with defaults when only required fields provided", async () => {
+    mockDb();
+    const res = await POST(makePostRequest({ name: "Potion of Healing", type: "potion", rarity: "common" }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.quantity).toBe(1);
+    expect(body.attunement).toBe(false);
+    expect(body.equipped).toBe(false);
+  });
+
+  it("returns 500 when DB throws on insert", async () => {
+    mockDbThrow();
+    const res = await POST(makePostRequest({ name: "Sword", type: "weapon", rarity: "common" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to create item");
+  });
+});


### PR DESCRIPTION
## Summary

Expands the `Item` interface in `app/api/items/route.ts` with full D&D loot vocabulary and adds comprehensive test coverage.

## Changes

### `app/api/items/route.ts`
- Add `ItemType` and `ItemRarity` string union types with `VALID_*` arrays
- Expand `Item` interface: `type`, `rarity`, `quantity`, `value`, `weight`, `attunement`, `equipped`, `properties`, `notes`
- Add POST validation for `type` and `rarity` (required, enum-checked) via extracted `validateEnum` helper
- Apply safe defaults: `quantity=1`, `attunement=false`, `equipped=false`

### `tests/unit/api/items/route.test.ts` (new)
- 11 unit tests covering GET, POST validation, defaults, and error paths

### `tests/integration/api/items.test.ts` (new)
- 5 integration tests covering auth enforcement, round-trip, and user isolation

## Test Results
- 1881 unit tests passing
- 224 integration tests passing
- `npx tsc --noEmit` clean
- Build succeeds

Closes #245