### PR TITLE
refactor: extract groupCombatantsForDisplay into lib/utils/combat.ts

### DIFF
--- a/lib/components/CombatInfoIcon.tsx
+++ b/lib/components/CombatInfoIcon.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { CombatantState } from '@/lib/types';
+import { groupCombatantsForDisplay } from '@/lib/utils/combat';
 
 interface CombatInfoIconProps {
   combatants: CombatantState[];
@@ -10,47 +11,7 @@ interface CombatInfoIconProps {
 export function CombatInfoIcon({ combatants }: CombatInfoIconProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
-  // Separate alive and dead combatants
-  const aliveCombatants = combatants.filter((c) => c.hp > 0);
-  const deadCombatants = combatants.filter((c) => c.hp <= 0);
-
-  // Group alive combatants by type and name
-  const alivePlayersByName = new Map<string, CombatantState[]>();
-  const aliveMonstersByName = new Map<string, CombatantState[]>();
-
-  aliveCombatants.forEach((combatant) => {
-    if (combatant.type === 'player') {
-      const existing = alivePlayersByName.get(combatant.name) || [];
-      alivePlayersByName.set(combatant.name, [...existing, combatant]);
-    } else {
-      const existing = aliveMonstersByName.get(combatant.name) || [];
-      aliveMonstersByName.set(combatant.name, [...existing, combatant]);
-    }
-  });
-
-  // Group dead combatants by type and name
-  const deadPlayersByName = new Map<string, CombatantState[]>();
-  const deadMonstersByName = new Map<string, CombatantState[]>();
-
-  deadCombatants.forEach((combatant) => {
-    if (combatant.type === 'player') {
-      const existing = deadPlayersByName.get(combatant.name) || [];
-      deadPlayersByName.set(combatant.name, [...existing, combatant]);
-    } else {
-      const existing = deadMonstersByName.get(combatant.name) || [];
-      deadMonstersByName.set(combatant.name, [...existing, combatant]);
-    }
-  });
-
-  // Count totals
-  const totalPlayers = Array.from(alivePlayersByName.values()).reduce(
-    (sum, group) => sum + group.length,
-    0
-  );
-  const totalMonsters = Array.from(aliveMonstersByName.values()).reduce(
-    (sum, group) => sum + group.length,
-    0
-  );
+  const { alive, dead, totals } = groupCombatantsForDisplay(combatants);
 
   return (
     <div className="relative inline-block">
@@ -80,12 +41,12 @@ export function CombatInfoIcon({ combatants }: CombatInfoIconProps) {
           <div className="grid grid-cols-2 gap-4">
             {/* Players Column */}
             <div>
-              <p className="text-xs text-gray-400 font-semibold mb-2">PLAYERS ({totalPlayers})</p>
+              <p className="text-xs text-gray-400 font-semibold mb-2">PLAYERS ({totals.players})</p>
               
               {/* Alive Players */}
-              {alivePlayersByName.size > 0 ? (
+              {alive.players.size > 0 ? (
                 <div className="space-y-1">
-                  {Array.from(alivePlayersByName.entries()).map(([name, group]) => (
+                  {Array.from(alive.players.entries()).map(([name, group]) => (
                     <div key={name} className="text-xs text-gray-300">
                       <div className="flex items-baseline gap-1">
                         <span className="font-medium">{name}</span>
@@ -113,12 +74,12 @@ export function CombatInfoIcon({ combatants }: CombatInfoIconProps) {
               )}
 
               {/* Dead Players Separator */}
-              {deadPlayersByName.size > 0 && (
+              {dead.players.size > 0 && (
                 <>
                   <div className="border-t border-gray-600 my-2"></div>
                   <p className="text-xs text-red-400 font-semibold mb-1">DEFEATED</p>
                   <div className="space-y-1">
-                    {Array.from(deadPlayersByName.entries()).map(([name, group]) => (
+                    {Array.from(dead.players.entries()).map(([name, group]) => (
                       <div key={`dead-${name}`} className="text-xs text-gray-500 line-through">
                         <div className="flex items-baseline gap-1">
                           <span className="font-medium">{name}</span>
@@ -135,12 +96,12 @@ export function CombatInfoIcon({ combatants }: CombatInfoIconProps) {
 
             {/* Monsters Column */}
             <div>
-              <p className="text-xs text-gray-400 font-semibold mb-2">MONSTERS ({totalMonsters})</p>
+              <p className="text-xs text-gray-400 font-semibold mb-2">MONSTERS ({totals.monsters})</p>
               
               {/* Alive Monsters */}
-              {aliveMonstersByName.size > 0 ? (
+              {alive.monsters.size > 0 ? (
                 <div className="space-y-1">
-                  {Array.from(aliveMonstersByName.entries()).map(([name, group]) => (
+                  {Array.from(alive.monsters.entries()).map(([name, group]) => (
                     <div key={name} className="text-xs text-gray-300">
                       <div className="flex items-baseline gap-1">
                         <span className="font-medium">{name}</span>
@@ -168,12 +129,12 @@ export function CombatInfoIcon({ combatants }: CombatInfoIconProps) {
               )}
 
               {/* Dead Monsters Separator */}
-              {deadMonstersByName.size > 0 && (
+              {dead.monsters.size > 0 && (
                 <>
                   <div className="border-t border-gray-600 my-2"></div>
                   <p className="text-xs text-red-400 font-semibold mb-1">DEFEATED</p>
                   <div className="space-y-1">
-                    {Array.from(deadMonstersByName.entries()).map(([name, group]) => (
+                    {Array.from(dead.monsters.entries()).map(([name, group]) => (
                       <div key={`dead-${name}`} className="text-xs text-gray-500 line-through">
                         <div className="flex items-baseline gap-1">
                           <span className="font-medium">{name}</span>
@@ -190,7 +151,7 @@ export function CombatInfoIcon({ combatants }: CombatInfoIconProps) {
           </div>
 
           {/* Empty state */}
-          {totalPlayers === 0 && totalMonsters === 0 && deadPlayersByName.size === 0 && deadMonstersByName.size === 0 && (
+          {totals.players === 0 && totals.monsters === 0 && dead.players.size === 0 && dead.monsters.size === 0 && (
             <p className="text-xs text-gray-400 col-span-2">No combatants</p>
           )}
         </div>

--- a/lib/utils/combat.ts
+++ b/lib/utils/combat.ts
@@ -3,6 +3,21 @@ import type { ActiveDamageEffect, CreatureAbility, CombatantState, InitiativeRol
 import type { DamageType } from '@/lib/constants';
 import { rollDie } from '@/lib/utils/dice';
 
+export interface GroupedCombatants {
+  alive: {
+    players: Map<string, CombatantState[]>;
+    monsters: Map<string, CombatantState[]>;
+  };
+  dead: {
+    players: Map<string, CombatantState[]>;
+    monsters: Map<string, CombatantState[]>;
+  };
+  totals: {
+    players: number;  // alive only
+    monsters: number; // alive only
+  };
+}
+
 /**
  * Apply damage to a combatant, draining temp HP first.
  * Overflow damage carries through to regular HP, which floors at 0.
@@ -336,6 +351,50 @@ export function buildCombatantFromSource(
     lairActions: 'lairActions' in source ? source.lairActions : undefined,
     legendaryActionCount: lacCount,
     legendaryActionsRemaining: lacCount,
+  };
+}
+
+/**
+ * Partition combatants into alive/dead subsets and group each subset by type then name.
+ * `totals` reflects alive counts only (matches the header display in CombatInfoIcon).
+ */
+export function groupCombatantsForDisplay(combatants: CombatantState[]): GroupedCombatants {
+  const aliveCombatants = combatants.filter((c) => c.hp > 0);
+  const deadCombatants = combatants.filter((c) => c.hp <= 0);
+
+  const alivePlayersByName = new Map<string, CombatantState[]>();
+  const aliveMonstersByName = new Map<string, CombatantState[]>();
+
+  aliveCombatants.forEach((combatant) => {
+    if (combatant.type === 'player') {
+      const existing = alivePlayersByName.get(combatant.name) || [];
+      alivePlayersByName.set(combatant.name, [...existing, combatant]);
+    } else {
+      const existing = aliveMonstersByName.get(combatant.name) || [];
+      aliveMonstersByName.set(combatant.name, [...existing, combatant]);
+    }
+  });
+
+  const deadPlayersByName = new Map<string, CombatantState[]>();
+  const deadMonstersByName = new Map<string, CombatantState[]>();
+
+  deadCombatants.forEach((combatant) => {
+    if (combatant.type === 'player') {
+      const existing = deadPlayersByName.get(combatant.name) || [];
+      deadPlayersByName.set(combatant.name, [...existing, combatant]);
+    } else {
+      const existing = deadMonstersByName.get(combatant.name) || [];
+      deadMonstersByName.set(combatant.name, [...existing, combatant]);
+    }
+  });
+
+  const totalPlayers = Array.from(alivePlayersByName.values()).reduce((sum, group) => sum + group.length, 0);
+  const totalMonsters = Array.from(aliveMonstersByName.values()).reduce((sum, group) => sum + group.length, 0);
+
+  return {
+    alive: { players: alivePlayersByName, monsters: aliveMonstersByName },
+    dead: { players: deadPlayersByName, monsters: deadMonstersByName },
+    totals: { players: totalPlayers, monsters: totalMonsters },
   };
 }
 

--- a/lib/utils/combat.ts
+++ b/lib/utils/combat.ts
@@ -359,37 +359,42 @@ export function buildCombatantFromSource(
  * `totals` reflects alive counts only (matches the header display in CombatInfoIcon).
  */
 export function groupCombatantsForDisplay(combatants: CombatantState[]): GroupedCombatants {
-  const aliveCombatants = combatants.filter((c) => c.hp > 0);
-  const deadCombatants = combatants.filter((c) => c.hp <= 0);
-
   const alivePlayersByName = new Map<string, CombatantState[]>();
   const aliveMonstersByName = new Map<string, CombatantState[]>();
-
-  aliveCombatants.forEach((combatant) => {
-    if (combatant.type === 'player') {
-      const existing = alivePlayersByName.get(combatant.name) || [];
-      alivePlayersByName.set(combatant.name, [...existing, combatant]);
-    } else {
-      const existing = aliveMonstersByName.get(combatant.name) || [];
-      aliveMonstersByName.set(combatant.name, [...existing, combatant]);
-    }
-  });
-
   const deadPlayersByName = new Map<string, CombatantState[]>();
   const deadMonstersByName = new Map<string, CombatantState[]>();
 
-  deadCombatants.forEach((combatant) => {
-    if (combatant.type === 'player') {
-      const existing = deadPlayersByName.get(combatant.name) || [];
-      deadPlayersByName.set(combatant.name, [...existing, combatant]);
-    } else {
-      const existing = deadMonstersByName.get(combatant.name) || [];
-      deadMonstersByName.set(combatant.name, [...existing, combatant]);
-    }
-  });
+  let totalPlayers = 0;
+  let totalMonsters = 0;
 
-  const totalPlayers = Array.from(alivePlayersByName.values()).reduce((sum, group) => sum + group.length, 0);
-  const totalMonsters = Array.from(aliveMonstersByName.values()).reduce((sum, group) => sum + group.length, 0);
+  for (const combatant of combatants) {
+    if (combatant.type === 'lair') continue;
+
+    const isAlive = combatant.hp > 0;
+    if (combatant.type === 'player') {
+      if (isAlive) {
+        const existing = alivePlayersByName.get(combatant.name) || [];
+        existing.push(combatant);
+        alivePlayersByName.set(combatant.name, existing);
+        totalPlayers++;
+      } else {
+        const existing = deadPlayersByName.get(combatant.name) || [];
+        existing.push(combatant);
+        deadPlayersByName.set(combatant.name, existing);
+      }
+    } else {
+      if (isAlive) {
+        const existing = aliveMonstersByName.get(combatant.name) || [];
+        existing.push(combatant);
+        aliveMonstersByName.set(combatant.name, existing);
+        totalMonsters++;
+      } else {
+        const existing = deadMonstersByName.get(combatant.name) || [];
+        existing.push(combatant);
+        deadMonstersByName.set(combatant.name, existing);
+      }
+    }
+  }
 
   return {
     alive: { players: alivePlayersByName, monsters: aliveMonstersByName },

--- a/openspec/changes/extract-combatant-grouping-util/tasks.md
+++ b/openspec/changes/extract-combatant-grouping-util/tasks.md
@@ -43,7 +43,7 @@
     - `totalMonsters` → `totals.monsters`
 
 - [x] **Verify TypeScript compiles:** `npx tsc --noEmit`
-- [x] **Verify existing tests pass:** `npm test -- --testPathPattern CombatInfoIcon`
+- [x] **Verify existing tests pass:** `npm run test:unit -- --testPathPattern CombatInfoIcon`
 
 ## Pre-Commit Code Review
 
@@ -51,7 +51,7 @@
 
 ## Validation
 
-- [x] Run unit tests: `npm test`
+- [x] Run unit tests: `npm run test:unit`
 - [x] Run type checks: `npx tsc --noEmit`
 - [x] Run build: `npm run build`
 - [ ] All completed tasks marked as complete
@@ -61,18 +61,18 @@
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test`; all tests must pass
-- **Integration tests** — `npm run test:e2e` if applicable; all tests must pass
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration` if applicable; all tests must pass
 - **Build** — `npm run build`; must succeed with no errors
 - If **ANY** of the above fail, you **MUST** iterate and address the failure
 
 ## PR and Merge
 
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to the working branch and push to remote
-- [ ] Open PR from `refactor/extract-combatant-grouping-util` to `main`. PR body must include **`Closes #274`**.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] Commit all changes to the working branch and push to remote
+- [x] Open PR from `refactor/extract-combatant-grouping-util` to `main`. PR body must include **`Closes #274`**.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
 - [ ] **Monitor PR comments** — poll for new comments autonomously; address, commit, follow remote push validation, push; wait 180 seconds; repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — poll using `gh pr checks <PR-URL> --json isRequired,state`; fix any required-check failures, commit, follow remote push validation, push; wait 180 seconds; repeat until all required checks pass
 - [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify user

--- a/openspec/changes/extract-combatant-grouping-util/tasks.md
+++ b/openspec/changes/extract-combatant-grouping-util/tasks.md
@@ -1,0 +1,104 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b refactor/extract-combatant-grouping-util` then immediately `git push -u origin refactor/extract-combatant-grouping-util`
+
+## Execution
+
+- [x] **Add `GroupedCombatants` interface to `lib/utils/combat.ts`**
+  - Add after the existing imports:
+    ```ts
+    export interface GroupedCombatants {
+      alive: {
+        players: Map<string, CombatantState[]>;
+        monsters: Map<string, CombatantState[]>;
+      };
+      dead: {
+        players: Map<string, CombatantState[]>;
+        monsters: Map<string, CombatantState[]>;
+      };
+      totals: {
+        players: number;  // alive only
+        monsters: number; // alive only
+      };
+    }
+    ```
+
+- [x] **Add `groupCombatantsForDisplay` function to `lib/utils/combat.ts`**
+  - Extract the filtering and grouping logic verbatim from `lib/components/CombatInfoIcon.tsx` lines 14–53
+  - Function signature: `export function groupCombatantsForDisplay(combatants: CombatantState[]): GroupedCombatants`
+  - Return `{ alive: { players: alivePlayersByName, monsters: aliveMonstersByName }, dead: { players: deadPlayersByName, monsters: deadMonstersByName }, totals: { players: totalPlayers, monsters: totalMonsters } }`
+
+- [x] **Refactor `lib/components/CombatInfoIcon.tsx`**
+  - Import `groupCombatantsForDisplay` from `@/lib/utils/combat`
+  - Replace lines 14–53 with: `const { alive, dead, totals } = groupCombatantsForDisplay(combatants);`
+  - Update all references in JSX:
+    - `alivePlayersByName` → `alive.players`
+    - `aliveMonstersByName` → `alive.monsters`
+    - `deadPlayersByName` → `dead.players`
+    - `deadMonstersByName` → `dead.monsters`
+    - `totalPlayers` → `totals.players`
+    - `totalMonsters` → `totals.monsters`
+
+- [x] **Verify TypeScript compiles:** `npx tsc --noEmit`
+- [x] **Verify existing tests pass:** `npm test -- --testPathPattern CombatInfoIcon`
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [x] Run unit tests: `npm test`
+- [x] Run type checks: `npx tsc --noEmit`
+- [x] Run build: `npm run build`
+- [ ] All completed tasks marked as complete
+- [x] All steps in [Remote push validation]
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Integration tests** — `npm run test:e2e` if applicable; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `refactor/extract-combatant-grouping-util` to `main`. PR body must include **`Closes #274`**.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll for new comments autonomously; address, commit, follow remote push validation, push; wait 180 seconds; repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll using `gh pr checks <PR-URL> --json isRequired,state`; fix any required-check failures, commit, follow remote push validation, push; wait 180 seconds; repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify user
+
+Ownership metadata:
+
+- Implementer: @dougis
+- Reviewer(s): automated CI + agentic reviewer
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No documentation updates required (pure internal refactor)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/extract-combatant-grouping-util/` to `openspec/changes/archive/YYYY-MM-DD-extract-combatant-grouping-util/` **in a single commit** — stage both the new location and the deletion of the old in the same commit
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-extract-combatant-grouping-util/` exists and `openspec/changes/extract-combatant-grouping-util/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-extract-combatant-grouping-util` then push
+- [ ] Open PR from doc branch to `main` with title `docs: archive extract-combatant-grouping-util (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR
+- [ ] Monitor the doc PR until it merges
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d refactor/extract-combatant-grouping-util doc/archive-YYYY-MM-DD-extract-combatant-grouping-util`


### PR DESCRIPTION
Move inline filtering and grouping logic from `CombatInfoIcon` into a pure exported utility function `groupCombatantsForDisplay`. Returns a `GroupedCombatants` object with alive/dead subsets keyed by type and name, plus totals for alive combatants only.

`CombatInfoIcon` is now a thin render layer.

**Intentional behavior fix (caught in review):** Lair pseudo-combatants (`type: 'lair'`, `hp: 0`) were silently appearing as defeated monsters in the tooltip. They are now correctly excluded from display groupings.

Closes #274