### PR TITLE
docs: archive extract-combatant-grouping-util (2026-06-05)

### DIFF
--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-05

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/design.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/design.md
@@ -1,0 +1,110 @@
+## Context
+
+- Relevant architecture: `lib/utils/combat.ts` — existing module of pure combatant data transformations (`applyDamage`, `applyHealing`, `useLegendaryAction`, etc.) importing `CombatantState` from `lib/types`. `lib/components/CombatInfoIcon.tsx` — React component with hover-triggered tooltip; currently does grouping inline.
+- Dependencies: `CombatantState` type from `lib/types` (already imported in `combat.ts`).
+- Interfaces/contracts touched: `CombatInfoIcon` internal data flow only. No props, no exports, no parent components change.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Isolate the grouping logic into a pure, exported, independently-testable function
+- Leave `CombatInfoIcon` behavior, props, and render output identical
+
+### Non-Goals
+
+- Adding tests for the extracted function (out of scope per proposal)
+- Changing any other function in `combat.ts`
+- Modifying `CombatInfoIcon` beyond removing the inline logic
+
+## Decisions
+
+### Decision 1: Placement in `lib/utils/combat.ts`
+
+- Chosen: Add `groupCombatantsForDisplay` to the existing `lib/utils/combat.ts`
+- Alternatives considered: Co-locate alongside the component (`lib/components/combatInfoIcon.utils.ts`); create a new `lib/utils/combatDisplay.ts`
+- Rationale: `combat.ts` already owns pure `CombatantState` transformations and already imports the type. No new file needed. Consistent with project pattern.
+- Trade-offs: Slightly mixes "display" logic into a file otherwise concerned with mechanics — acceptable given the function is pure and the project doesn't yet distinguish display utils from mechanic utils.
+
+### Decision 2: Return type shape `GroupedCombatants`
+
+- Chosen: Nested structure `{ alive: { players, monsters }, dead: { players, monsters }, totals: { players, monsters } }`
+- Alternatives considered: Flat object with 6 keys (`alivePlayersByName`, `aliveMonstersByName`, etc.)
+- Rationale: Richer structure is self-documenting; callers destructure `alive.players` rather than `alivePlayersByName`. Matches the user's stated preference confirmed in exploration.
+- Trade-offs: Slightly more destructuring at call site; negligible.
+
+### Decision 3: `totals` counts alive combatants only
+
+- Chosen: `totals.players` and `totals.monsters` reflect only alive combatants
+- Alternatives considered: Count all combatants regardless of alive/dead status
+- Rationale: Matches existing component behavior — the `PLAYERS (N)` header shows alive count. Dead combatants appear separately in the DEFEATED section.
+- Trade-offs: None — this is a direct lift of the existing calculation.
+
+## Proposal to Design Mapping
+
+- Proposal element: Extract filtering + grouping from `CombatInfoIcon`
+  - Design decision: Decision 1 (placement), Decision 2 (return shape)
+  - Validation approach: Existing `CombatInfoIcon.test.tsx` suite must pass unchanged
+
+- Proposal element: `groupCombatantsForDisplay` exported from `lib/utils/combat.ts`
+  - Design decision: Decision 1
+  - Validation approach: Import resolves; TypeScript compiles cleanly
+
+- Proposal element: `totals` counts alive combatants only
+  - Design decision: Decision 3
+  - Validation approach: Column heading tests (`PLAYERS (1)`, `MONSTERS (0)`) in existing test suite
+
+## Functional Requirements Mapping
+
+- Requirement: Alive/dead split preserves `hp > 0` / `hp <= 0` boundary
+  - Design element: `groupCombatantsForDisplay` filter logic
+  - Acceptance criteria reference: specs/grouping.md — alive/dead split
+  - Testability notes: Direct unit test on the function; also covered by existing component tests
+
+- Requirement: Combatants grouped by type then name into `Map<string, CombatantState[]>`
+  - Design element: `groupCombatantsForDisplay` grouping logic
+  - Acceptance criteria reference: specs/grouping.md — grouping by type and name
+  - Testability notes: Assert Map keys and values for same-name and different-name inputs
+
+- Requirement: `CombatInfoIcon` render output unchanged
+  - Design element: Component calls `groupCombatantsForDisplay` and destructures result
+  - Acceptance criteria reference: All existing `CombatInfoIcon.test.tsx` cases
+  - Testability notes: No new component tests needed; existing suite is the regression guard
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: No runtime behavior change
+  - Design element: Pure extraction — logic is moved not modified
+  - Acceptance criteria reference: Existing test suite green
+  - Testability notes: TypeScript strict mode; existing tests provide full behavioral coverage
+
+- Requirement category: operability
+  - Requirement: Function is exported and accessible to future test files
+  - Design element: `export function groupCombatantsForDisplay` in `combat.ts`
+  - Acceptance criteria reference: TypeScript compilation succeeds
+  - Testability notes: Import from `@/lib/utils/combat` in a future test file
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Accidental logic change during extraction (e.g., wrong filter predicate)
+  - Impact: Incorrect alive/dead bucketing; wrong counts in tooltip
+  - Mitigation: Existing component tests cover all split/grouping/count scenarios; they serve as the regression gate
+
+## Rollback / Mitigation
+
+- Rollback trigger: Any existing `CombatInfoIcon` test fails after the change
+- Rollback steps: Revert `lib/utils/combat.ts` addition and `lib/components/CombatInfoIcon.tsx` edit; no data or config changes involved
+- Data migration considerations: None
+- Verification after rollback: Run `npm test -- --testPathPattern CombatInfoIcon`
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge; fix the failing test or TypeScript error before proceeding
+- If security checks fail: N/A — no auth, network, or dependency changes
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to project owner after 48 hours
+- Escalation path and timeout: Project owner (@dougis) after 48-hour stale review
+
+## Open Questions
+
+No open questions. All decisions confirmed during exploration and proposal phases.

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/proposal.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/proposal.md
@@ -1,0 +1,60 @@
+## GitHub Issues
+
+- #274
+
+## Why
+
+- Problem statement: `CombatInfoIcon` contains ~30 lines of pure data transformation (filtering alive/dead combatants, grouping by type and name) directly in the component body. This logic is unreachable by unit tests without rendering the full component.
+- Why now: Issue #257 surfaced a coverage gap caused by this complexity. The refactor is a prerequisite to adding targeted unit tests for the grouping logic.
+- Business/user impact: No user-visible change. Developer impact: the grouping logic becomes independently testable, and `CombatInfoIcon` becomes a thin render layer that is easier to reason about and test in isolation.
+
+## Problem Space
+
+- Current behavior: Lines 14–53 of `lib/components/CombatInfoIcon.tsx` filter combatants into alive/dead subsets and group each subset by type (`player`/monster) and name into four `Map` instances, then derive two totals — all inside the component function body.
+- Desired behavior: A pure utility function `groupCombatantsForDisplay` lives in `lib/utils/combat.ts`, accepts `CombatantState[]`, and returns a structured result. `CombatInfoIcon` calls it and renders from the result.
+- Constraints: `lib/utils/combat.ts` already imports `CombatantState` and houses pure combatant transformations — the new function fits naturally there with no new files required.
+- Assumptions: No other component or utility currently performs equivalent grouping logic (no duplication to consolidate).
+- Edge cases considered: Empty combatant array; all combatants dead; all combatants alive; multiple combatants with the same name (×N grouping); mixed player/monster in alive and dead subsets.
+
+## Scope
+
+### In Scope
+
+- Extract filtering + grouping logic from `CombatInfoIcon` into `groupCombatantsForDisplay` in `lib/utils/combat.ts`
+- Update `CombatInfoIcon` to call the utility and destructure its result
+- Export the function so it is unit-testable
+
+### Out of Scope
+
+- Unit tests for `groupCombatantsForDisplay` (can follow separately per issue #274)
+- Any behavior or visual changes to `CombatInfoIcon`
+- Changes to any other component or utility
+
+## What Changes
+
+- `lib/utils/combat.ts` — new exported function `groupCombatantsForDisplay` with return type `GroupedCombatants`
+- `lib/components/CombatInfoIcon.tsx` — remove inline data transformation; call `groupCombatantsForDisplay`; destructure `{ alive, dead, totals }`
+
+## Risks
+
+- Risk: Accidental behavior change during extraction (e.g., off-by-one in alive/dead filter boundary)
+  - Impact: Incorrect display of combatant counts or DEFEATED section
+  - Mitigation: Existing component tests cover all grouping scenarios; they must stay green after the refactor
+
+## Open Questions
+
+No unresolved ambiguity. All design decisions were confirmed in the exploration session:
+- Placement: `lib/utils/combat.ts` (follows existing pattern, no new files)
+- Return shape: nested `{ alive, dead, totals }` (richer, self-documenting)
+- `totals` counts alive combatants only (matches current header count behavior)
+
+## Non-Goals
+
+- Adding new tests as part of this change
+- Changing the public API or props of `CombatInfoIcon`
+- Refactoring unrelated logic in `CombatInfoIcon` or `combat.ts`
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/proposal.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/proposal.md
@@ -6,7 +6,7 @@
 
 - Problem statement: `CombatInfoIcon` contains ~30 lines of pure data transformation (filtering alive/dead combatants, grouping by type and name) directly in the component body. This logic is unreachable by unit tests without rendering the full component.
 - Why now: Issue #257 surfaced a coverage gap caused by this complexity. The refactor is a prerequisite to adding targeted unit tests for the grouping logic.
-- Business/user impact: No user-visible change. Developer impact: the grouping logic becomes independently testable, and `CombatInfoIcon` becomes a thin render layer that is easier to reason about and test in isolation.
+- Business/user impact: One user-visible behavior fix — lair pseudo-combatants no longer appear as defeated monsters in the tooltip. Developer impact: the grouping logic becomes independently testable, and `CombatInfoIcon` becomes a thin render layer that is easier to reason about and test in isolation.
 
 ## Problem Space
 

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/specs/grouping.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/specs/grouping.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED groupCombatantsForDisplay utility function
+
+The system SHALL provide an exported pure function `groupCombatantsForDisplay(combatants: CombatantState[]): GroupedCombatants` in `lib/utils/combat.ts` that partitions and groups combatants for display without side effects.
+
+#### Scenario: Alive/dead split on hp boundary
+
+- **Given** a mixed array containing combatants with `hp > 0` and combatants with `hp <= 0`
+- **When** `groupCombatantsForDisplay` is called
+- **Then** combatants with `hp > 0` appear in `alive.players` or `alive.monsters`; combatants with `hp <= 0` appear in `dead.players` or `dead.monsters`; no combatant appears in both alive and dead
+
+#### Scenario: Grouping by type — player vs monster
+
+- **Given** an array containing both `type: 'player'` and `type: 'monster'` alive combatants
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `alive.players` contains only players; `alive.monsters` contains only monsters
+
+#### Scenario: Grouping by name within type
+
+- **Given** two alive monsters both named "Goblin"
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `alive.monsters.get('Goblin')` returns an array of length 2 containing both combatants
+
+#### Scenario: Totals count alive combatants only
+
+- **Given** 2 alive players and 1 dead player, 1 alive monster and 2 dead monsters
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `totals.players` equals 2; `totals.monsters` equals 1
+
+#### Scenario: Empty input
+
+- **Given** an empty combatants array
+- **When** `groupCombatantsForDisplay` is called
+- **Then** all four Maps are empty and both totals are 0
+
+#### Scenario: All combatants dead
+
+- **Given** an array where every combatant has `hp <= 0`
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `alive.players` and `alive.monsters` are empty Maps; `totals.players` and `totals.monsters` are 0; dead Maps are populated correctly
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CombatInfoIcon data transformation
+
+The system SHALL compute grouping data by calling `groupCombatantsForDisplay` rather than performing inline filtering and Map construction inside the component body.
+
+#### Scenario: Render output unchanged after refactor
+
+- **Given** `CombatInfoIcon` receives a combatants array
+- **When** the user hovers the info icon
+- **Then** the tooltip renders identically to the pre-refactor behavior — same combatant names, same ×N multipliers, same DEFEATED sections, same header counts
+
+## REMOVED Requirements
+
+No requirements removed. The inline grouping logic is moved, not deleted — its behavior is fully preserved.
+
+## Traceability
+
+- Proposal: "Extract filtering + grouping from `CombatInfoIcon`" → Requirement: ADDED groupCombatantsForDisplay
+- Proposal: "Update `CombatInfoIcon` to call the utility" → Requirement: MODIFIED CombatInfoIcon data transformation
+- Design Decision 1 (placement in `combat.ts`) → ADDED groupCombatantsForDisplay
+- Design Decision 2 (nested return shape) → ADDED groupCombatantsForDisplay — return type
+- Design Decision 3 (`totals` = alive only) → ADDED groupCombatantsForDisplay — totals scenario
+- ADDED groupCombatantsForDisplay → Task: Add `GroupedCombatants` type and `groupCombatantsForDisplay` to `combat.ts`
+- MODIFIED CombatInfoIcon → Task: Refactor `CombatInfoIcon` to call utility
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Existing test suite remains green
+
+- **Given** the refactor is applied to `lib/utils/combat.ts` and `lib/components/CombatInfoIcon.tsx`
+- **When** `npm test -- --testPathPattern CombatInfoIcon` is run
+- **Then** all tests pass with no failures or skips
+
+### Requirement: Operability
+
+#### Scenario: TypeScript compilation succeeds
+
+- **Given** `groupCombatantsForDisplay` and `GroupedCombatants` are added to `combat.ts` and imported in `CombatInfoIcon.tsx`
+- **When** `tsc --noEmit` is run
+- **Then** zero type errors are reported

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/specs/grouping.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/specs/grouping.md
@@ -42,21 +42,33 @@ The system SHALL provide an exported pure function `groupCombatantsForDisplay(co
 - **When** `groupCombatantsForDisplay` is called
 - **Then** `alive.players` and `alive.monsters` are empty Maps; `totals.players` and `totals.monsters` are 0; dead Maps are populated correctly
 
+#### Scenario: Lair pseudo-combatants are excluded
+
+- **Given** an array containing one or more combatants with `type: 'lair'`
+- **When** `groupCombatantsForDisplay` is called
+- **Then** no lair combatant appears in any alive or dead Map; lair combatants do not contribute to totals
+
 ## MODIFIED Requirements
 
 ### Requirement: MODIFIED CombatInfoIcon data transformation
 
 The system SHALL compute grouping data by calling `groupCombatantsForDisplay` rather than performing inline filtering and Map construction inside the component body.
 
-#### Scenario: Render output unchanged after refactor
+#### Scenario: Render output after refactor
 
-- **Given** `CombatInfoIcon` receives a combatants array
+- **Given** `CombatInfoIcon` receives a combatants array (without lair entries)
 - **When** the user hovers the info icon
 - **Then** the tooltip renders identically to the pre-refactor behavior — same combatant names, same ×N multipliers, same DEFEATED sections, same header counts
 
+#### Scenario: Lair entries excluded from tooltip
+
+- **Given** `CombatInfoIcon` receives a combatants array that includes lair pseudo-combatants
+- **When** the user hovers the info icon
+- **Then** lair combatants do not appear in any section of the tooltip
+
 ## REMOVED Requirements
 
-No requirements removed. The inline grouping logic is moved, not deleted — its behavior is fully preserved.
+No requirements removed. The inline grouping logic is moved, not deleted. One latent bug was fixed during extraction: lair pseudo-combatants (`type: 'lair'`) previously appeared in the dead-monster bucket; they are now correctly excluded.
 
 ## Traceability
 
@@ -75,7 +87,7 @@ No requirements removed. The inline grouping logic is moved, not deleted — its
 #### Scenario: Existing test suite remains green
 
 - **Given** the refactor is applied to `lib/utils/combat.ts` and `lib/components/CombatInfoIcon.tsx`
-- **When** `npm test -- --testPathPattern CombatInfoIcon` is run
+- **When** `npm run test:unit -- --testPathPattern CombatInfoIcon` is run
 - **Then** all tests pass with no failures or skips
 
 ### Requirement: Operability

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tasks.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tasks.md
@@ -54,7 +54,7 @@
 - [x] Run unit tests: `npm run test:unit`
 - [x] Run type checks: `npx tsc --noEmit`
 - [x] Run build: `npm run build`
-- [ ] All completed tasks marked as complete
+- [x] All completed tasks marked as complete
 - [x] All steps in [Remote push validation]
 
 ## Remote push validation
@@ -90,15 +90,15 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on the default branch
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] No documentation updates required (pure internal refactor)
-- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
-- [ ] Archive the change: move `openspec/changes/extract-combatant-grouping-util/` to `openspec/changes/archive/YYYY-MM-DD-extract-combatant-grouping-util/` **in a single commit** — stage both the new location and the deletion of the old in the same commit
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-extract-combatant-grouping-util/` exists and `openspec/changes/extract-combatant-grouping-util/` is gone
-- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-extract-combatant-grouping-util` then push
-- [ ] Open PR from doc branch to `main` with title `docs: archive extract-combatant-grouping-util (YYYY-MM-DD)`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on the default branch
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] No documentation updates required (pure internal refactor)
+- [x] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/extract-combatant-grouping-util/` to `openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/` **in a single commit** — stage both the new location and the deletion of the old in the same commit
+- [ ] Confirm `openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/` exists and `openspec/changes/extract-combatant-grouping-util/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-2026-06-05-extract-combatant-grouping-util` then push
+- [ ] Open PR from doc branch to `main` with title `docs: archive extract-combatant-grouping-util (2026-06-05)`
 - [ ] **IMMEDIATELY** enable auto-merge on the doc PR
 - [ ] Monitor the doc PR until it merges
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d refactor/extract-combatant-grouping-util doc/archive-YYYY-MM-DD-extract-combatant-grouping-util`
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d refactor/extract-combatant-grouping-util doc/archive-2026-06-05-extract-combatant-grouping-util`

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tasks.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tasks.md
@@ -95,10 +95,10 @@ Blocking resolution flow:
 - [x] Mark all remaining tasks as complete (`- [x]`)
 - [x] No documentation updates required (pure internal refactor)
 - [x] Sync approved spec deltas into `openspec/specs/` (global spec)
-- [ ] Archive the change: move `openspec/changes/extract-combatant-grouping-util/` to `openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/` **in a single commit** — stage both the new location and the deletion of the old in the same commit
-- [ ] Confirm `openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/` exists and `openspec/changes/extract-combatant-grouping-util/` is gone
-- [ ] **Create a doc branch:** `git checkout -b doc/archive-2026-06-05-extract-combatant-grouping-util` then push
-- [ ] Open PR from doc branch to `main` with title `docs: archive extract-combatant-grouping-util (2026-06-05)`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR
+- [x] Archive the change: move `openspec/changes/extract-combatant-grouping-util/` to `openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/` **in a single commit** — stage both the new location and the deletion of the old in the same commit
+- [x] Confirm `openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/` exists and `openspec/changes/extract-combatant-grouping-util/` is gone
+- [x] **Create a doc branch:** `git checkout -b doc/archive-2026-06-05-extract-combatant-grouping-util` then push
+- [x] Open PR from doc branch to `main` with title `docs: archive extract-combatant-grouping-util (2026-06-05)`
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR
 - [ ] Monitor the doc PR until it merges
 - [ ] Prune merged local branches: `git fetch --prune` and `git branch -d refactor/extract-combatant-grouping-util doc/archive-2026-06-05-extract-combatant-grouping-util`

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tests.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tests.md
@@ -9,7 +9,7 @@ description: Tests for the extract-combatant-grouping-util change
 
 This document outlines the tests for the `extract-combatant-grouping-util` change. All work follows strict TDD: write a failing test first, then implement the minimum code to pass it, then refactor.
 
-This is a pure refactor — the existing `CombatInfoIcon.test.tsx` suite is the primary regression guard. The TDD work here focuses on new unit tests for `groupCombatantsForDisplay` itself, which are written before the function is extracted.
+This is primarily a refactor with one intentional behavior fix (lair exclusion). The existing `CombatInfoIcon.test.tsx` suite is the primary regression guard. The TDD work here focuses on new unit tests for `groupCombatantsForDisplay` itself, which are written before the function is extracted.
 
 ## Testing Steps
 
@@ -25,22 +25,22 @@ For each task in `tasks.md`:
 
 Test file: `tests/unit/utils/groupCombatantsForDisplay.test.ts` (new)
 
-- [ ] **Alive/dead split — mixed input:** Given combatants with `hp > 0` and `hp <= 0`, alive combatants appear only in `alive.*` and dead appear only in `dead.*`
-- [ ] **Alive/dead split — boundary `hp === 0`:** A combatant with `hp === 0` appears in `dead.*`, not `alive.*`
-- [ ] **Type routing — players go to `alive.players`:** Given alive players, they appear in `alive.players` and not in `alive.monsters`
-- [ ] **Type routing — monsters go to `alive.monsters`:** Given alive monsters, they appear in `alive.monsters` and not in `alive.players`
-- [ ] **Grouping by name — same name → single Map key:** Two alive monsters named "Goblin" produce `alive.monsters.get("Goblin")` with length 2
-- [ ] **Grouping by name — different names → separate keys:** Two alive monsters with different names produce two separate Map entries
-- [ ] **Totals count alive combatants only:** 2 alive players + 1 dead player → `totals.players === 2`
-- [ ] **Totals count alive monsters only:** 1 alive monster + 2 dead monsters → `totals.monsters === 1`
-- [ ] **Empty input:** Empty array → all Maps empty, both totals 0
-- [ ] **All dead:** Array with all `hp <= 0` → `alive.*` Maps empty, `totals` both 0, `dead.*` Maps populated
+- [x] **Alive/dead split — mixed input:** Given combatants with `hp > 0` and `hp <= 0`, alive combatants appear only in `alive.*` and dead appear only in `dead.*`
+- [x] **Alive/dead split — boundary `hp === 0`:** A combatant with `hp === 0` appears in `dead.*`, not `alive.*`
+- [x] **Type routing — players go to `alive.players`:** Given alive players, they appear in `alive.players` and not in `alive.monsters`
+- [x] **Type routing — monsters go to `alive.monsters`:** Given alive monsters, they appear in `alive.monsters` and not in `alive.players`
+- [x] **Grouping by name — same name → single Map key:** Two alive monsters named "Goblin" produce `alive.monsters.get("Goblin")` with length 2
+- [x] **Grouping by name — different names → separate keys:** Two alive monsters with different names produce two separate Map entries
+- [x] **Totals count alive combatants only:** 2 alive players + 1 dead player → `totals.players === 2`
+- [x] **Totals count alive monsters only:** 1 alive monster + 2 dead monsters → `totals.monsters === 1`
+- [x] **Empty input:** Empty array → all Maps empty, both totals 0
+- [x] **All dead:** Array with all `hp <= 0` → `alive.*` Maps empty, `totals` both 0, `dead.*` Maps populated
 
 ### Task: Refactor `CombatInfoIcon` to call utility
 
 No new tests for this task — the existing `tests/unit/components/CombatInfoIcon.test.tsx` suite provides full regression coverage. All tests must pass after the refactor without modification.
 
-- [ ] **Regression: existing CombatInfoIcon tests pass unchanged** — run `npm test -- --testPathPattern CombatInfoIcon`; all 18 tests green
+- [x] **Regression: existing CombatInfoIcon tests pass unchanged** — run `npm run test:unit -- --testPathPattern CombatInfoIcon`; all 18 tests green
 
 ## Spec Traceability
 

--- a/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tests.md
+++ b/openspec/changes/archive/2026-06-05-extract-combatant-grouping-util/tests.md
@@ -1,0 +1,57 @@
+---
+name: tests
+description: Tests for the extract-combatant-grouping-util change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `extract-combatant-grouping-util` change. All work follows strict TDD: write a failing test first, then implement the minimum code to pass it, then refactor.
+
+This is a pure refactor — the existing `CombatInfoIcon.test.tsx` suite is the primary regression guard. The TDD work here focuses on new unit tests for `groupCombatantsForDisplay` itself, which are written before the function is extracted.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing any implementation code, write a test that captures the requirements. Run it and confirm it fails.
+2. **Write code to pass the test:** Write the simplest code to make the test pass.
+3. **Refactor:** Improve structure while keeping tests green.
+
+## Test Cases
+
+### Task: Add `groupCombatantsForDisplay` to `lib/utils/combat.ts`
+
+Test file: `tests/unit/utils/groupCombatantsForDisplay.test.ts` (new)
+
+- [ ] **Alive/dead split — mixed input:** Given combatants with `hp > 0` and `hp <= 0`, alive combatants appear only in `alive.*` and dead appear only in `dead.*`
+- [ ] **Alive/dead split — boundary `hp === 0`:** A combatant with `hp === 0` appears in `dead.*`, not `alive.*`
+- [ ] **Type routing — players go to `alive.players`:** Given alive players, they appear in `alive.players` and not in `alive.monsters`
+- [ ] **Type routing — monsters go to `alive.monsters`:** Given alive monsters, they appear in `alive.monsters` and not in `alive.players`
+- [ ] **Grouping by name — same name → single Map key:** Two alive monsters named "Goblin" produce `alive.monsters.get("Goblin")` with length 2
+- [ ] **Grouping by name — different names → separate keys:** Two alive monsters with different names produce two separate Map entries
+- [ ] **Totals count alive combatants only:** 2 alive players + 1 dead player → `totals.players === 2`
+- [ ] **Totals count alive monsters only:** 1 alive monster + 2 dead monsters → `totals.monsters === 1`
+- [ ] **Empty input:** Empty array → all Maps empty, both totals 0
+- [ ] **All dead:** Array with all `hp <= 0` → `alive.*` Maps empty, `totals` both 0, `dead.*` Maps populated
+
+### Task: Refactor `CombatInfoIcon` to call utility
+
+No new tests for this task — the existing `tests/unit/components/CombatInfoIcon.test.tsx` suite provides full regression coverage. All tests must pass after the refactor without modification.
+
+- [ ] **Regression: existing CombatInfoIcon tests pass unchanged** — run `npm test -- --testPathPattern CombatInfoIcon`; all 18 tests green
+
+## Spec Traceability
+
+| Test case | Spec scenario | Task |
+|---|---|---|
+| Alive/dead split — mixed input | specs/grouping.md — Alive/dead split on hp boundary | Add `groupCombatantsForDisplay` |
+| Alive/dead split — boundary `hp === 0` | specs/grouping.md — Alive/dead split on hp boundary | Add `groupCombatantsForDisplay` |
+| Type routing — players | specs/grouping.md — Grouping by type | Add `groupCombatantsForDisplay` |
+| Type routing — monsters | specs/grouping.md — Grouping by type | Add `groupCombatantsForDisplay` |
+| Grouping by name — same name | specs/grouping.md — Grouping by name within type | Add `groupCombatantsForDisplay` |
+| Totals count alive only | specs/grouping.md — Totals count alive combatants only | Add `groupCombatantsForDisplay` |
+| Empty input | specs/grouping.md — Empty input | Add `groupCombatantsForDisplay` |
+| All dead | specs/grouping.md — All combatants dead | Add `groupCombatantsForDisplay` |
+| Regression: CombatInfoIcon suite | specs/grouping.md — Render output unchanged after refactor | Refactor `CombatInfoIcon` |

--- a/openspec/specs/combat-info-icon/grouping.md
+++ b/openspec/specs/combat-info-icon/grouping.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED groupCombatantsForDisplay utility function
+
+The system SHALL provide an exported pure function `groupCombatantsForDisplay(combatants: CombatantState[]): GroupedCombatants` in `lib/utils/combat.ts` that partitions and groups combatants for display without side effects.
+
+#### Scenario: Alive/dead split on hp boundary
+
+- **Given** a mixed array containing combatants with `hp > 0` and combatants with `hp <= 0`
+- **When** `groupCombatantsForDisplay` is called
+- **Then** combatants with `hp > 0` appear in `alive.players` or `alive.monsters`; combatants with `hp <= 0` appear in `dead.players` or `dead.monsters`; no combatant appears in both alive and dead
+
+#### Scenario: Grouping by type — player vs monster
+
+- **Given** an array containing both `type: 'player'` and `type: 'monster'` alive combatants
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `alive.players` contains only players; `alive.monsters` contains only monsters
+
+#### Scenario: Grouping by name within type
+
+- **Given** two alive monsters both named "Goblin"
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `alive.monsters.get('Goblin')` returns an array of length 2 containing both combatants
+
+#### Scenario: Totals count alive combatants only
+
+- **Given** 2 alive players and 1 dead player, 1 alive monster and 2 dead monsters
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `totals.players` equals 2; `totals.monsters` equals 1
+
+#### Scenario: Empty input
+
+- **Given** an empty combatants array
+- **When** `groupCombatantsForDisplay` is called
+- **Then** all four Maps are empty and both totals are 0
+
+#### Scenario: All combatants dead
+
+- **Given** an array where every combatant has `hp <= 0`
+- **When** `groupCombatantsForDisplay` is called
+- **Then** `alive.players` and `alive.monsters` are empty Maps; `totals.players` and `totals.monsters` are 0; dead Maps are populated correctly
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CombatInfoIcon data transformation
+
+The system SHALL compute grouping data by calling `groupCombatantsForDisplay` rather than performing inline filtering and Map construction inside the component body.
+
+#### Scenario: Render output unchanged after refactor
+
+- **Given** `CombatInfoIcon` receives a combatants array
+- **When** the user hovers the info icon
+- **Then** the tooltip renders identically to the pre-refactor behavior — same combatant names, same ×N multipliers, same DEFEATED sections, same header counts
+
+## REMOVED Requirements
+
+No requirements removed. The inline grouping logic is moved, not deleted — its behavior is fully preserved.
+
+## Traceability
+
+- Proposal: "Extract filtering + grouping from `CombatInfoIcon`" → Requirement: ADDED groupCombatantsForDisplay
+- Proposal: "Update `CombatInfoIcon` to call the utility" → Requirement: MODIFIED CombatInfoIcon data transformation
+- Design Decision 1 (placement in `combat.ts`) → ADDED groupCombatantsForDisplay
+- Design Decision 2 (nested return shape) → ADDED groupCombatantsForDisplay — return type
+- Design Decision 3 (`totals` = alive only) → ADDED groupCombatantsForDisplay — totals scenario
+- ADDED groupCombatantsForDisplay → Task: Add `GroupedCombatants` type and `groupCombatantsForDisplay` to `combat.ts`
+- MODIFIED CombatInfoIcon → Task: Refactor `CombatInfoIcon` to call utility
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Existing test suite remains green
+
+- **Given** the refactor is applied to `lib/utils/combat.ts` and `lib/components/CombatInfoIcon.tsx`
+- **When** `npm test -- --testPathPattern CombatInfoIcon` is run
+- **Then** all tests pass with no failures or skips
+
+### Requirement: Operability
+
+#### Scenario: TypeScript compilation succeeds
+
+- **Given** `groupCombatantsForDisplay` and `GroupedCombatants` are added to `combat.ts` and imported in `CombatInfoIcon.tsx`
+- **When** `tsc --noEmit` is run
+- **Then** zero type errors are reported

--- a/openspec/specs/combat-info-icon/grouping.md
+++ b/openspec/specs/combat-info-icon/grouping.md
@@ -42,21 +42,33 @@ The system SHALL provide an exported pure function `groupCombatantsForDisplay(co
 - **When** `groupCombatantsForDisplay` is called
 - **Then** `alive.players` and `alive.monsters` are empty Maps; `totals.players` and `totals.monsters` are 0; dead Maps are populated correctly
 
+#### Scenario: Lair pseudo-combatants are excluded
+
+- **Given** an array containing one or more combatants with `type: 'lair'`
+- **When** `groupCombatantsForDisplay` is called
+- **Then** no lair combatant appears in any alive or dead Map; lair combatants do not contribute to totals
+
 ## MODIFIED Requirements
 
 ### Requirement: MODIFIED CombatInfoIcon data transformation
 
 The system SHALL compute grouping data by calling `groupCombatantsForDisplay` rather than performing inline filtering and Map construction inside the component body.
 
-#### Scenario: Render output unchanged after refactor
+#### Scenario: Render output after refactor
 
-- **Given** `CombatInfoIcon` receives a combatants array
+- **Given** `CombatInfoIcon` receives a combatants array (without lair entries)
 - **When** the user hovers the info icon
 - **Then** the tooltip renders identically to the pre-refactor behavior — same combatant names, same ×N multipliers, same DEFEATED sections, same header counts
 
+#### Scenario: Lair entries excluded from tooltip
+
+- **Given** `CombatInfoIcon` receives a combatants array that includes lair pseudo-combatants
+- **When** the user hovers the info icon
+- **Then** lair combatants do not appear in any section of the tooltip
+
 ## REMOVED Requirements
 
-No requirements removed. The inline grouping logic is moved, not deleted — its behavior is fully preserved.
+No requirements removed. The inline grouping logic is moved, not deleted. One latent bug was fixed during extraction: lair pseudo-combatants (`type: 'lair'`) previously appeared in the dead-monster bucket; they are now correctly excluded.
 
 ## Traceability
 
@@ -75,7 +87,7 @@ No requirements removed. The inline grouping logic is moved, not deleted — its
 #### Scenario: Existing test suite remains green
 
 - **Given** the refactor is applied to `lib/utils/combat.ts` and `lib/components/CombatInfoIcon.tsx`
-- **When** `npm test -- --testPathPattern CombatInfoIcon` is run
+- **When** `npm run test:unit -- --testPathPattern CombatInfoIcon` is run
 - **Then** all tests pass with no failures or skips
 
 ### Requirement: Operability


### PR DESCRIPTION
Archives the extract-combatant-grouping-util change after merge of PR #351. Syncs grouping spec to openspec/specs/combat-info-icon/.