### PR TITLE
docs: archive migrate-campaigneditor-test-to-rtl (2026-06-04)

### DIFF
--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-05

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/.openspec.yaml
@@ -1,2 +1,2 @@
 schema: sdd-with-feedback-loop
-created: 2026-06-05
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/design.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/design.md
@@ -1,0 +1,141 @@
+## Context
+
+- Relevant architecture: Next.js 15 app with a Jest + jsdom unit test suite. Page-level component tests live in `tests/unit/components/`. RTL (`@testing-library/react` v16, `@testing-library/user-event` v14) and `@testing-library/jest-dom` are already installed and configured in `jest.setup.ts`.
+- Dependencies: `lib/components/ui.tsx` (TextInputField), `app/campaigns/CampaignEditor.tsx` (component under test), `tests/unit/components/CampaignEditor.test.tsx` (test file being migrated), `tests/unit/helpers/reactRoot.ts` (legacy helper — imports removed, helper itself untouched).
+- Interfaces/contracts touched:
+  - `TextInputField` props: `id` remains optional; behaviour changes only when `id` is absent (auto-generated instead of undefined).
+  - `CampaignEditor` JSX: new `aria-label` attributes added to chapter title inputs and remove button. No prop or callback signature changes.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Eliminate all legacy `createRoot`/`act`/`container.querySelector` patterns from `CampaignEditor.test.tsx`.
+- Make `TextInputField` self-labelling (auto `id` from `label`) so RTL name queries work without caller changes.
+- Ensure all chapter interactive elements have accessible names RTL can query.
+- Keep all 25 existing tests passing with identical assertions on component behaviour.
+
+### Non-Goals
+
+- Changing `TextInputField` public prop API beyond the `id`-generation behaviour.
+- Adding new tests.
+- Modifying any other test file or component.
+
+## Decisions
+
+### Decision 1: TextInputField auto-generates `id` from `label`
+
+- Chosen: Derive `id` from `label` by lowercasing, replacing non-alphanumeric runs with `-`, and stripping leading/trailing hyphens. E.g., `"Campaign Name *"` → `"campaign-name"`. Apply only when `id` prop is absent.
+- Alternatives considered: Require callers to always pass `id` (too invasive — all existing call sites would need updates); use `React.useId()` (non-deterministic in tests without mocking; also unavailable in older React versions).
+- Rationale: Deterministic, human-readable, zero caller-side changes needed. The label text is already the semantic name for the input.
+- Trade-offs: If two `TextInputField` components on the same page share an identical label string, their `id`s will collide. Acceptable: label text is semantically unique by design; callers can always supply an explicit `id` to override.
+
+### Decision 2: Chapter element accessible names
+
+- Chosen:
+  - Chapter title input: `aria-label={`Chapter ${index + 1} title`}` — e.g., `"Chapter 1 title"`.
+  - Remove button: `aria-label={`Remove ${ch.title || `chapter ${index + 1}`}`}` — e.g., `"Remove Arrival"` or `"Remove chapter 1"` when untitled.
+  - Move-up / move-down buttons: existing `aria-label={`Move chapter ${index + 1} up`}` retained as-is (already RTL-queryable, already present on all buttons).
+- Alternatives considered: Title-based labels for all buttons (`"Move The Inn up"`) — rejected because the explore session confirmed position-based labels are acceptable and the remove button gap is the only missing aria-label.
+- Rationale: Consistent with decisions agreed during exploration. Minimises component diff while closing the accessibility gap on the remove button.
+- Trade-offs: Move button labels are position-based, not title-based. Tests that move a chapter must query by ordinal (`/move chapter 2 up/i`), which is still robust — the ordinal is derived from `index` which reflects the current render order.
+
+### Decision 3: RTL interaction strategy
+
+- Chosen: `userEvent.click` for buttons and accordion; `userEvent.selectOptions` for `<select>` elements; `userEvent.clear` + `userEvent.type` for text inputs. `userEvent.setup()` called once per test (or shared via `beforeEach`).
+- Alternatives considered: `fireEvent` — lower-level, does not simulate full browser event sequences; kept only if `userEvent` proves incompatible with a specific element.
+- Rationale: `userEvent` v14 fires the full pointer+keyboard event sequence, exercising React's synthetic event system correctly. This is the gap the current manual `dispatchEvent` hacks expose.
+- Trade-offs: `userEvent` is async (`await` required everywhere). Test bodies become slightly more verbose but far more readable.
+
+### Decision 4: `openChapters` helper retained as RTL version
+
+- Chosen: Keep the shared helper, rewritten to use `screen.queryByText` and `userEvent.click`. Called from 7+ tests.
+- Alternatives considered: Inline per-test — rejected for DRY reasons; the accordion toggle is a one-liner in concept but the guard condition (only click if not already open) saves brittle test-order coupling.
+- Rationale: Helper is cohesive, idempotent, and short. RTL version is equally readable.
+- Trade-offs: Shared helpers can obscure test setup. Mitigated by the helper being trivially small.
+
+## Proposal to Design Mapping
+
+- Proposal element: TextInputField generates `id` from `label`
+  - Design decision: Decision 1
+  - Validation approach: RTL `screen.getByRole('textbox', { name: /campaign name/i })` resolves correctly in migrated tests.
+
+- Proposal element: Chapter title inputs gain accessible name
+  - Design decision: Decision 2 (title input aria-label)
+  - Validation approach: `screen.getAllByRole('textbox', { name: /chapter \d+ title/i })` returns expected count.
+
+- Proposal element: Remove button gains aria-label; move buttons verified
+  - Design decision: Decision 2 (remove + move labels)
+  - Validation approach: `screen.getByRole('button', { name: /remove arrival/i })` resolves after chapters rendered.
+
+- Proposal element: All act() / dispatchEvent hacks removed
+  - Design decision: Decision 3
+  - Validation approach: No `act`, `dispatchEvent`, or `element.value =` appears in migrated test file (enforced by grep in CI via existing lint rules).
+
+- Proposal element: openChapters helper retained
+  - Design decision: Decision 4
+  - Validation approach: All tests that call `openChapters()` continue to pass; helper has no direct assertions.
+
+## Functional Requirements Mapping
+
+- Requirement: All 25 existing test cases pass after migration
+  - Design element: RTL render + screen + userEvent replacements (Decisions 3, 4)
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "All 25 test cases pass"
+  - Testability notes: `jest --testPathPattern CampaignEditor` — green run is the criterion.
+
+- Requirement: TextInputField accessible by label name
+  - Design element: Decision 1 (auto id generation)
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "Inputs queryable by accessible name"
+  - Testability notes: `screen.getByRole('textbox', { name: /campaign name \*/i })` must not throw.
+
+- Requirement: Chapter interactive elements have aria-labels
+  - Design element: Decision 2
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "Chapter elements have accessible names"
+  - Testability notes: `screen.getByRole('button', { name: /remove arrival/i })` and `screen.getByRole('button', { name: /move chapter 2 up/i })` must resolve.
+
+- Requirement: No legacy test boilerplate remains
+  - Design element: Import cleanup (remove React, Root, act, createReactRoot, unmountReactRoot)
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "Legacy boilerplate removed"
+  - Testability notes: Grep for `createReactRoot|IS_REACT_ACT_ENVIRONMENT|@jest-environment jsdom` in file returns no matches.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Tests must not be order-dependent or share mutable state
+  - Design element: RTL automatic cleanup (no manual `beforeEach`/`afterEach` for container); `jest.fn()` created fresh per test.
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "Tests are isolated"
+  - Testability notes: Running tests in random order (`--randomize`) must produce the same pass/fail result.
+
+- Requirement category: operability
+  - Requirement: Test file compiles with zero TypeScript errors
+  - Design element: RTL types are bundled with `@testing-library/react`; `userEvent` types with `@testing-library/user-event`. No extra `@types` needed.
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "TypeScript compiles cleanly"
+  - Testability notes: `tsc --noEmit` passes.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `userEvent.selectOptions` fires a different event sequence than `dispatchEvent('change')`, potentially exposing a pre-existing React state bug.
+  - Impact: A test that currently passes may fail after migration, indicating a real component bug.
+  - Mitigation: Treat test failures as signal to investigate the component, not to revert to `dispatchEvent`.
+
+- Risk/trade-off: Auto-generated `id` collisions if label text is non-unique.
+  - Impact: Low — form labels are conventionally unique. ARIA spec also requires unique IDs.
+  - Mitigation: Document in `TextInputField` JSDoc; existing callers can pass explicit `id`.
+
+## Rollback / Mitigation
+
+- Rollback trigger: CI red after migration and no fix found within one working day.
+- Rollback steps: Revert `CampaignEditor.test.tsx` to its pre-migration state (git revert); revert `ui.tsx` and `CampaignEditor.tsx` component changes if they introduced a regression.
+- Data migration considerations: None — test-only change plus minor a11y additions; no data model touched.
+- Verification after rollback: `jest --testPathPattern CampaignEditor` green; CI passes.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Investigate failing test output; fix the root cause in component or test before merging. Do not revert to legacy patterns to unblock.
+- If security checks fail: N/A — no new dependencies, no network calls, no secrets.
+- If required reviews are blocked/stale: Ping reviewer after 24 h; escalate to project lead after 48 h.
+- Escalation path and timeout: If blocked > 2 working days, raise in team standup and agree on unblocking approach.
+
+## Open Questions
+
+No open questions. All decisions confirmed during the explore session.

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/design.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/design.md
@@ -13,7 +13,7 @@
 - Eliminate all legacy `createRoot`/`act`/`container.querySelector` patterns from `CampaignEditor.test.tsx`.
 - Make `TextInputField` self-labelling (auto `id` from `label`) so RTL name queries work without caller changes.
 - Ensure all chapter interactive elements have accessible names RTL can query.
-- Keep all 25 existing tests passing with identical assertions on component behaviour.
+- Keep all 26 existing tests passing with identical assertions on component behaviour.
 
 ### Non-Goals
 
@@ -78,9 +78,9 @@
 
 ## Functional Requirements Mapping
 
-- Requirement: All 25 existing test cases pass after migration
+- Requirement: All 26 existing test cases pass after migration
   - Design element: RTL render + screen + userEvent replacements (Decisions 3, 4)
-  - Acceptance criteria reference: specs/rtl-migration/spec.md — "All 25 test cases pass"
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — "All 26 test cases pass"
   - Testability notes: `jest --testPathPattern CampaignEditor` — green run is the criterion.
 
 - Requirement: TextInputField accessible by label name

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/proposal.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/proposal.md
@@ -1,0 +1,83 @@
+## GitHub Issues
+
+- #343
+- #263 (prerequisite — RTL infrastructure)
+
+## Why
+
+- Problem statement: `CampaignEditor.test.tsx` uses the legacy `createRoot`/`act`/`container.querySelector` pattern throughout. It carries 25+ `act()` calls, manual DOM mutation hacks (`element.value = …; dispatchEvent(…)`), positional `querySelectorAll(…)[index]` queries, and broad `container.textContent` assertions — all of which are brittle, opaque, and do not exercise React's synthetic event system correctly.
+- Why now: #263 already installed `@testing-library/react` and `@testing-library/user-event`. This is the last and most complex of the page-level RTL migrations — completing it closes out the migration series and removes all remaining legacy test infrastructure from the unit suite.
+- Business/user impact: Tests that use manual DOM mutations may pass while masking React state bugs. Completing this migration makes the test suite a reliable indicator of actual component behaviour.
+
+## Problem Space
+
+- Current behavior: Tests render via `createReactRoot`, interact via `element.click()` / `element.value = …; dispatchEvent(…)`, and assert via `container.textContent.includes(…)` and positional `querySelectorAll(…)[index]`.
+- Desired behavior: Tests render via RTL `render()`, interact via `userEvent`, and assert via `screen.getBy*` / `screen.queryBy*` — all tied to accessible names rather than DOM position.
+- Constraints:
+  - All 25 existing test cases must continue to pass (no behaviour changes, no test deletions).
+  - `TextInputField` in `lib/components/ui.tsx` must auto-generate a stable `id` from its `label` prop when no explicit `id` is supplied, so that `<label htmlFor>` links correctly and RTL can resolve accessible names without requiring callers to pass `id`.
+  - Chapter action buttons (move-up, move-down, remove) must have `aria-label` values that include chapter title when available, falling back to ordinal position (e.g. "Chapter 2") when title is empty. Existing positional `aria-label` patterns on move buttons are acceptable for RTL queries; only the remove button currently lacks an `aria-label` and must gain one.
+  - Chapter title inputs must gain an `aria-label` (e.g. `Chapter 1 title`) so they can be queried by accessible name.
+- Assumptions:
+  - RTL and `user-event` v14 are already installed (confirmed — see `package.json`).
+  - `jest-dom` matchers (`toBeInTheDocument`) are already configured in `jest.setup.ts` (confirmed).
+  - The `@jest-environment jsdom` docblock and `IS_REACT_ACT_ENVIRONMENT` global are already removed from other migrated files; they must be removed here too.
+- Edge cases considered:
+  - Chapter with empty title: `aria-label` falls back to ordinal — `Remove Chapter 1`, `Move Chapter 1 up`, `Move Chapter 1 down`.
+  - `TextInputField` called with an explicit `id`: explicit `id` takes precedence over the generated one.
+  - Auto-generated `id` from label must be deterministic: lowercase, spaces replaced with hyphens, special characters stripped — e.g., "Campaign Name *" → `campaign-name`.
+
+## Scope
+
+### In Scope
+
+- Migrate `tests/unit/components/CampaignEditor.test.tsx` from legacy root/act to RTL.
+- Update `lib/components/ui.tsx` — `TextInputField` auto-generates `id` from `label` when none supplied.
+- Update `app/campaigns/CampaignEditor.tsx` — add `aria-label` to chapter title inputs and remove button; verify move buttons retain usable `aria-label` values.
+- Remove `@jest-environment jsdom` docblock and `IS_REACT_ACT_ENVIRONMENT` assignment from the test file.
+- Replace all `act()`, `createReactRoot`, `unmountReactRoot`, `findButton`, `getInput` usages.
+- Replace `openChapters()` helper with an RTL-based version.
+
+### Out of Scope
+
+- Other test files (already migrated under #263).
+- Any changes to the `createReactRoot` / `unmountReactRoot` helper themselves (they remain for any non-migrated tests).
+- Adding new test cases beyond the existing 25.
+- Changing the visual design or functional behaviour of `CampaignEditor`.
+
+## What Changes
+
+- `lib/components/ui.tsx`: `TextInputField` generates a stable `id` from `label` when `id` prop is absent.
+- `app/campaigns/CampaignEditor.tsx`: chapter title inputs gain `aria-label`; remove button gains `aria-label`; move button `aria-label` values verified to be RTL-queryable.
+- `tests/unit/components/CampaignEditor.test.tsx`: full rewrite to RTL — render, screen, userEvent; all legacy imports and helpers removed; all 25 tests ported.
+
+## Risks
+
+- Risk: Auto-generated `id` from label could collide if two `TextInputField`s on the same page share a label string.
+  - Impact: Low — label text is generally unique per form; collision would be a pre-existing design problem.
+  - Mitigation: Document the convention; callers can always pass an explicit `id` to override.
+- Risk: `userEvent.selectOptions` behaves differently from `dispatchEvent('change')` for the `<select>` elements.
+  - Impact: Medium — could surface latent React event-handling bugs.
+  - Mitigation: This is the desired outcome; if a test fails it indicates a real bug to investigate before patching around.
+- Risk: `userEvent.type` into an input clears the existing value differently than `input.value = …`.
+  - Impact: Low — `userEvent.clear` + `userEvent.type` is the idiomatic replacement.
+  - Mitigation: Use `userEvent.clear` before `userEvent.type` for inputs that have a pre-populated value.
+
+## Open Questions
+
+No unresolved ambiguity. Decisions confirmed during exploration:
+- `TextInputField` generates `id` from `label` (auto, callers need not change).
+- Empty-title fallback for `aria-label`: ordinal position ("Chapter 2"), not blank.
+- Move button `aria-label` strategy: keep existing position-based labels; they are RTL-queryable and the remove button gap is the only accessibility fix needed.
+
+## Non-Goals
+
+- Replacing `data-testid` on `<select>` and `<textarea>` elements (they already work and are not the source of fragility).
+- Converting the file to Vitest or any other test runner.
+- Adding snapshot tests.
+- Achieving 100% branch coverage beyond what the existing 25 tests exercise.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/proposal.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/proposal.md
@@ -14,7 +14,7 @@
 - Current behavior: Tests render via `createReactRoot`, interact via `element.click()` / `element.value = …; dispatchEvent(…)`, and assert via `container.textContent.includes(…)` and positional `querySelectorAll(…)[index]`.
 - Desired behavior: Tests render via RTL `render()`, interact via `userEvent`, and assert via `screen.getBy*` / `screen.queryBy*` — all tied to accessible names rather than DOM position.
 - Constraints:
-  - All 25 existing test cases must continue to pass (no behaviour changes, no test deletions).
+  - All 26 existing test cases must continue to pass (no behaviour changes, no test deletions).
   - `TextInputField` in `lib/components/ui.tsx` must auto-generate a stable `id` from its `label` prop when no explicit `id` is supplied, so that `<label htmlFor>` links correctly and RTL can resolve accessible names without requiring callers to pass `id`.
   - Chapter action buttons (move-up, move-down, remove) must have `aria-label` values that include chapter title when available, falling back to ordinal position (e.g. "Chapter 2") when title is empty. Existing positional `aria-label` patterns on move buttons are acceptable for RTL queries; only the remove button currently lacks an `aria-label` and must gain one.
   - Chapter title inputs must gain an `aria-label` (e.g. `Chapter 1 title`) so they can be queried by accessible name.

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/proposal.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/proposal.md
@@ -49,7 +49,7 @@
 
 - `lib/components/ui.tsx`: `TextInputField` generates a stable `id` from `label` when `id` prop is absent.
 - `app/campaigns/CampaignEditor.tsx`: chapter title inputs gain `aria-label`; remove button gains `aria-label`; move button `aria-label` values verified to be RTL-queryable.
-- `tests/unit/components/CampaignEditor.test.tsx`: full rewrite to RTL — render, screen, userEvent; all legacy imports and helpers removed; all 25 tests ported.
+- `tests/unit/components/CampaignEditor.test.tsx`: full rewrite to RTL — render, screen, userEvent; all legacy imports and helpers removed; all 26 tests ported.
 
 ## Risks
 
@@ -75,7 +75,7 @@ No unresolved ambiguity. Decisions confirmed during exploration:
 - Replacing `data-testid` on `<select>` and `<textarea>` elements (they already work and are not the source of fragility).
 - Converting the file to Vitest or any other test runner.
 - Adding snapshot tests.
-- Achieving 100% branch coverage beyond what the existing 25 tests exercise.
+- Achieving 100% branch coverage beyond what the existing 26 tests exercise.
 
 ## Change Control
 

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/specs/rtl-migration/spec.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/specs/rtl-migration/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED TextInputField generates accessible id from label
+
+The system SHALL derive a stable `id` attribute for `TextInputField`'s `<input>` element from the `label` prop when no explicit `id` is supplied, by lowercasing, replacing non-alphanumeric character runs with `-`, and stripping leading/trailing hyphens.
+
+#### Scenario: Auto-generated id links label to input
+
+- **Given** a `TextInputField` rendered with `label="Campaign Name *"` and no `id` prop
+- **When** the DOM is inspected
+- **Then** the `<input>` has `id="campaign-name"` and the associated `<label>` has `for="campaign-name"`
+
+#### Scenario: Explicit id overrides auto-generation
+
+- **Given** a `TextInputField` rendered with `label="Campaign Name *"` and `id="my-custom-id"`
+- **When** the DOM is inspected
+- **Then** the `<input>` has `id="my-custom-id"` and the `<label>` has `for="my-custom-id"`
+
+#### Scenario: RTL resolves input by accessible name
+
+- **Given** `CampaignEditor` rendered with `campaign.name = "Test Campaign"`
+- **When** `screen.getByRole('textbox', { name: /campaign name/i })` is called
+- **Then** it returns the name input without throwing
+
+---
+
+### Requirement: ADDED Chapter title inputs have accessible names
+
+The system SHALL render each chapter title `<input>` with `aria-label="Chapter N title"` where N is the 1-based position of the chapter in the list.
+
+#### Scenario: Single chapter input is named
+
+- **Given** `CampaignEditor` rendered with one chapter and the chapters accordion open
+- **When** `screen.getByRole('textbox', { name: /chapter 1 title/i })` is called
+- **Then** it returns the chapter title input without throwing
+
+#### Scenario: Multiple chapter inputs are individually named
+
+- **Given** `CampaignEditor` rendered with three chapters and the accordion open
+- **When** `screen.getAllByRole('textbox', { name: /chapter \d+ title/i })` is called
+- **Then** it returns an array of exactly 3 elements
+
+---
+
+### Requirement: ADDED Chapter remove button has accessible name
+
+The system SHALL render each chapter's remove button with `aria-label="Remove <title>"` when the chapter has a non-empty title, or `aria-label="Remove chapter N"` when the title is empty.
+
+#### Scenario: Remove button named by chapter title
+
+- **Given** `CampaignEditor` rendered with a chapter titled "Arrival" and the accordion open
+- **When** `screen.getByRole('button', { name: /remove arrival/i })` is called
+- **Then** it returns the remove button without throwing
+
+#### Scenario: Remove button named by ordinal when title is empty
+
+- **Given** `CampaignEditor` rendered with an untitled (just-added) chapter and the accordion open
+- **When** `screen.getByRole('button', { name: /remove chapter 1/i })` is called
+- **Then** it returns the remove button without throwing
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CampaignEditor unit tests use React Testing Library exclusively
+
+The test file `tests/unit/components/CampaignEditor.test.tsx` SHALL use `@testing-library/react` and `@testing-library/user-event` for all rendering, querying, and interaction — with no remaining usage of `createReactRoot`, `unmountReactRoot`, `act`, `IS_REACT_ACT_ENVIRONMENT`, or manual DOM mutation.
+
+#### Scenario: Legacy boilerplate is absent
+
+- **Given** the migrated `CampaignEditor.test.tsx`
+- **When** the file is grepped for `createReactRoot|unmountReactRoot|IS_REACT_ACT_ENVIRONMENT|@jest-environment jsdom`
+- **Then** zero matches are found
+
+#### Scenario: No manual DOM mutations remain
+
+- **Given** the migrated `CampaignEditor.test.tsx`
+- **When** the file is grepped for `\.value\s*=|dispatchEvent|\.click()`
+- **Then** zero matches are found
+
+#### Scenario: All 25 existing tests pass
+
+- **Given** the migrated test file and updated component files
+- **When** `jest --testPathPattern CampaignEditor` is run
+- **Then** all 25 test cases report `pass` and the suite exits 0
+
+#### Scenario: Tests are isolated (no shared mutable state)
+
+- **Given** the migrated test file
+- **When** tests are run in any order (including `--randomize`)
+- **Then** pass/fail results are identical regardless of order
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Direct DOM container access in CampaignEditor tests
+
+The `container` variable and all `container.querySelector*`, `container.textContent`, `Array.from(container.querySelectorAll(…))` patterns are removed from `CampaignEditor.test.tsx`.
+
+Reason for removal: Replaced by `screen.getBy*` / `screen.queryBy*` queries, which are more resilient and semantically correct.
+
+---
+
+## Traceability
+
+- Proposal element "TextInputField generates id from label" → Requirement "TextInputField generates accessible id from label" → Task: Update `lib/components/ui.tsx`
+- Proposal element "Chapter title inputs gain accessible name" → Requirement "Chapter title inputs have accessible names" → Task: Update `app/campaigns/CampaignEditor.tsx`
+- Proposal element "Remove button gains aria-label" → Requirement "Chapter remove button has accessible name" → Task: Update `app/campaigns/CampaignEditor.tsx`
+- Proposal element "All act()/dispatchEvent hacks removed" → Requirement "CampaignEditor tests use RTL exclusively" → Task: Rewrite `tests/unit/components/CampaignEditor.test.tsx`
+- Design Decision 1 → Requirement "TextInputField generates accessible id"
+- Design Decision 2 → Requirements "Chapter title inputs" + "Chapter remove button"
+- Design Decision 3 → Requirement "CampaignEditor tests use RTL exclusively"
+- Design Decision 4 → Requirement "CampaignEditor tests use RTL exclusively" (openChapters helper)
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Test isolation
+
+- **Given** the migrated test suite
+- **When** tests run in random order
+- **Then** all 25 pass regardless of order (RTL automatic cleanup between tests)
+
+### Requirement: Operability — TypeScript
+
+#### Scenario: Clean compilation
+
+- **Given** the updated source files (`ui.tsx`, `CampaignEditor.tsx`, `CampaignEditor.test.tsx`)
+- **When** `tsc --noEmit` is run
+- **Then** zero TypeScript errors are reported

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/specs/rtl-migration/spec.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/specs/rtl-migration/spec.md
@@ -80,11 +80,11 @@ The test file `tests/unit/components/CampaignEditor.test.tsx` SHALL use `@testin
 - **When** the file is grepped for `\.value\s*=|dispatchEvent|\.click()`
 - **Then** zero matches are found
 
-#### Scenario: All 25 existing tests pass
+#### Scenario: All 26 existing tests pass
 
 - **Given** the migrated test file and updated component files
 - **When** `jest --testPathPattern CampaignEditor` is run
-- **Then** all 25 test cases report `pass` and the suite exits 0
+- **Then** all 26 test cases report `pass` and the suite exits 0
 
 #### Scenario: Tests are isolated (no shared mutable state)
 
@@ -125,7 +125,7 @@ Reason for removal: Replaced by `screen.getBy*` / `screen.queryBy*` queries, whi
 
 - **Given** the migrated test suite
 - **When** tests run in random order
-- **Then** all 25 pass regardless of order (RTL automatic cleanup between tests)
+- **Then** all 26 pass regardless of order (RTL automatic cleanup between tests)
 
 ### Requirement: Operability — TypeScript
 

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/tasks.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/tasks.md
@@ -156,15 +156,15 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`.
-- [ ] Verify merged changes appear on `main`.
-- [ ] Mark all remaining tasks complete.
-- [ ] No doc updates required beyond this change (test-only + minor a11y attrs).
-- [ ] Sync approved spec delta: copy `openspec/changes/migrate-campaigneditor-test-to-rtl/specs/rtl-migration/spec.md` to `openspec/specs/rtl-migration/spec.md` (create directory if absent).
-- [ ] Archive the change: move `openspec/changes/migrate-campaigneditor-test-to-rtl/` to `openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/` **as a single atomic commit** (stage both the new location and the deletion of the old in one commit — never split).
-- [ ] Confirm `openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/` exists and `openspec/changes/migrate-campaigneditor-test-to-rtl/` is gone.
-- [ ] Create doc branch: `git checkout -b doc/archive-2026-06-04-migrate-campaigneditor-test-to-rtl` then `git push -u origin doc/archive-…`
-- [ ] Open PR from doc branch to `main` with title `docs: archive migrate-campaigneditor-test-to-rtl (2026-06-04)`.
-- [ ] Immediately enable auto-merge on doc PR.
-- [ ] Monitor doc PR until merged (same loop).
-- [ ] Prune merged local branches: `git fetch --prune && git branch -d feat/migrate-campaigneditor-test-to-rtl doc/archive-2026-06-04-migrate-campaigneditor-test-to-rtl`
+- [x] `git checkout main` and `git pull --ff-only`.
+- [x] Verify merged changes appear on `main`.
+- [x] Mark all remaining tasks complete.
+- [x] No doc updates required beyond this change (test-only + minor a11y attrs).
+- [x] Sync approved spec delta: copy `openspec/changes/migrate-campaigneditor-test-to-rtl/specs/rtl-migration/spec.md` to `openspec/specs/rtl-migration/spec.md` (create directory if absent).
+- [x] Archive the change: move `openspec/changes/migrate-campaigneditor-test-to-rtl/` to `openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/` **as a single atomic commit** (stage both the new location and the deletion of the old in one commit — never split).
+- [x] Confirm `openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/` exists and `openspec/changes/migrate-campaigneditor-test-to-rtl/` is gone.
+- [x] Create doc branch: `git checkout -b doc/archive-2026-06-04-migrate-campaigneditor-test-to-rtl` then `git push -u origin doc/archive-…`
+- [x] Open PR from doc branch to `main` with title `docs: archive migrate-campaigneditor-test-to-rtl (2026-06-04)`.
+- [x] Immediately enable auto-merge on doc PR.
+- [x] Monitor doc PR until merged (same loop).
+- [x] Prune merged local branches: `git fetch --prune && git branch -d feat/migrate-campaigneditor-test-to-rtl doc/archive-2026-06-04-migrate-campaigneditor-test-to-rtl`

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/tests.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/tests.md
@@ -57,7 +57,7 @@ These tests are written in the migrated test file and fail until component chang
 
 ### Task 3 — Migrated test cases (tests/unit/components/CampaignEditor.test.tsx)
 
-Each migrated test is its own TDD cycle: convert to RTL syntax → run → confirm green before proceeding. The 25 tests are grouped by describe block.
+Each migrated test is its own TDD cycle: convert to RTL syntax → run → confirm green before proceeding. The 26 tests are grouped by describe block.
 
 #### rendering (7 tests)
 - [ ] **TC-3.01** "Create Campaign" heading present when `isNew=true`

--- a/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/tests.md
+++ b/openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/tests.md
@@ -1,0 +1,116 @@
+---
+name: tests
+description: TDD test cases for migrate-campaigneditor-test-to-rtl
+---
+
+# Tests
+
+## Overview
+
+This document maps each implementation task to its TDD cycle. Because this change is primarily a test migration (the test file *is* the artifact), the TDD discipline applies to the two component changes (`ui.tsx` and `CampaignEditor.tsx`) — write a failing RTL test first, then implement to make it pass. For the test file itself, each migrated test case should be run after conversion to confirm it is green before moving to the next.
+
+All test commands: `npx jest --testPathPattern CampaignEditor`
+
+---
+
+## Test Cases
+
+### Task 1 — TextInputField auto-id (lib/components/ui.tsx)
+
+These tests are written in the migrated `CampaignEditor.test.tsx` and will initially fail until `ui.tsx` is updated.
+
+- [ ] **TC-1.1** `screen.getByRole('textbox', { name: /campaign name/i })` resolves after `renderEditor()` — fails before auto-id; passes after.
+  - Spec: `specs/rtl-migration/spec.md` — "RTL resolves input by accessible name"
+  - Task: Execution §1
+
+- [ ] **TC-1.2** `screen.getByRole('textbox', { name: /module \/ adventure/i })` resolves after `renderEditor()` — same cycle.
+  - Spec: `specs/rtl-migration/spec.md` — "RTL resolves input by accessible name"
+  - Task: Execution §1
+
+- [ ] **TC-1.3** Rendering `TextInputField` with an explicit `id` prop: the `<input>` carries that exact `id`, not the derived one. (Manual DOM inspection via `document.getElementById('my-custom-id')` or attribute assertion.)
+  - Spec: `specs/rtl-migration/spec.md` — "Explicit id overrides auto-generation"
+  - Task: Execution §1
+
+---
+
+### Task 2 — Component aria-labels (app/campaigns/CampaignEditor.tsx)
+
+These tests are written in the migrated test file and fail until component changes are in place.
+
+- [ ] **TC-2.1** After opening chapters with one chapter titled "Arrival": `screen.getByRole('textbox', { name: /chapter 1 title/i })` resolves.
+  - Spec: "Chapter title inputs have accessible names"
+  - Task: Execution §2
+
+- [ ] **TC-2.2** After opening chapters with three chapters: `screen.getAllByRole('textbox', { name: /chapter \d+ title/i })` has length 3.
+  - Spec: "Chapter title inputs have accessible names"
+  - Task: Execution §2
+
+- [ ] **TC-2.3** After opening chapters with a chapter titled "Arrival": `screen.getByRole('button', { name: /remove arrival/i })` resolves.
+  - Spec: "Chapter remove button has accessible name"
+  - Task: Execution §2
+
+- [ ] **TC-2.4** After adding a new (untitled) chapter: `screen.getByRole('button', { name: /remove chapter 1/i })` resolves.
+  - Spec: "Chapter remove button — ordinal fallback"
+  - Task: Execution §2
+
+---
+
+### Task 3 — Migrated test cases (tests/unit/components/CampaignEditor.test.tsx)
+
+Each migrated test is its own TDD cycle: convert to RTL syntax → run → confirm green before proceeding. The 25 tests are grouped by describe block.
+
+#### rendering (7 tests)
+- [ ] **TC-3.01** "Create Campaign" heading present when `isNew=true`
+- [ ] **TC-3.02** "Edit Campaign" heading present when `isNew=false`
+- [ ] **TC-3.03** Name input `toHaveValue('Test Campaign')`
+- [ ] **TC-3.04** Module input `toHaveValue('LMoP')`
+- [ ] **TC-3.05** Status select `toHaveValue('on-hold')` when campaign status is `on-hold`
+- [ ] **TC-3.06** Notes textarea `toHaveValue('Party at level 5')`
+- [ ] **TC-3.07** Notes textarea has `maxLength` attribute of `10000`
+- [ ] **TC-3.08** Character counter shows `5/10000`
+
+#### validation (2 tests)
+- [ ] **TC-3.09** Save button is disabled when name is empty
+- [ ] **TC-3.10** Save button is enabled when name has content
+
+#### saving (4 tests)
+- [ ] **TC-3.11** `onSave` called with trimmed name
+- [ ] **TC-3.12** `onSave` called with trimmed moduleName
+- [ ] **TC-3.13** `onSave` called with `status: 'completed'` after `userEvent.selectOptions`
+- [ ] **TC-3.14** `onSave` called with `status: 'on-hold'` after `userEvent.selectOptions`
+
+#### cancel (1 test)
+- [ ] **TC-3.15** `onCancel` called when Cancel button clicked via `userEvent.click`
+
+#### legacy fields removed (2 tests)
+- [ ] **TC-3.16** No "Current Chapter" label in DOM (when accordion closed, chapters empty)
+- [ ] **TC-3.17** No "Chapter Order" label in DOM
+
+#### chapters display (2 tests)
+- [ ] **TC-3.18** Chapter titles visible in DOM when chapters present (chapters accordion auto-open)
+- [ ] **TC-3.19** `onSave` called with `chapters: []` when no chapters
+
+#### chapters editing (7 tests)
+- [ ] **TC-3.20** Accordion toggles: "+ Add Chapter" appears then disappears on two clicks
+- [ ] **TC-3.21** "+ Add Chapter" click adds one chapter title input; "No chapters defined" disappears
+- [ ] **TC-3.22** Remove button deletes chapter, shifts remaining, clears `currentChapterId`
+- [ ] **TC-3.23** Move-up button reorders chapters correctly; subsequent move-down restores order
+- [ ] **TC-3.24** `currentChapterId` saved correctly after `userEvent.selectOptions` on chapter select
+- [ ] **TC-3.25** Chapter title updated after `userEvent.clear` + `userEvent.type`
+- [ ] **TC-3.26** Removing active chapter sets `currentChapterId` to `undefined` in saved payload
+
+---
+
+### Task 4 — Regression (full suite)
+
+- [ ] **TC-4.1** `npx jest` (all unit tests) — zero failures after all component and test changes are in place.
+  - Spec: "Tests are isolated (no shared mutable state)"
+  - Task: Execution §4
+
+- [ ] **TC-4.2** `npx tsc --noEmit` — zero TypeScript errors.
+  - Spec: "TypeScript compiles cleanly"
+  - Task: Execution §4
+
+- [ ] **TC-4.3** Grep sanity: `grep -n "createReactRoot\|IS_REACT_ACT_ENVIRONMENT\|@jest-environment jsdom\|\.click()\|\.value =" tests/unit/components/CampaignEditor.test.tsx` → zero results.
+  - Spec: "Legacy boilerplate absent" + "No manual DOM mutations"
+  - Task: Execution §4

--- a/openspec/changes/archive/2026-06-05-centralize-admin-helper/tasks.md
+++ b/openspec/changes/archive/2026-06-05-centralize-admin-helper/tasks.md
@@ -49,7 +49,7 @@ Use the project's documented commands for each of the above (see project README 
 - [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
 - [x] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved to allow the process to progress. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
 - [x] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass
-- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
+- [x] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
 
 Ownership metadata:
 
@@ -65,17 +65,17 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on the default branch
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Update repository documentation impacted by the change
-- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
-- [ ] Archive the change: move `openspec/changes/centralize-admin-helper/` to `openspec/changes/archive/2026-06-04-centralize-admin-helper/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
-- [ ] Confirm `openspec/changes/archive/2026-06-04-centralize-admin-helper/` exists and `openspec/changes/centralize-admin-helper/` is gone
-- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-2026-06-04-centralize-admin-helper` then `git push -u origin doc/archive-2026-06-04-centralize-admin-helper`
-- [ ] Open a PR from `doc/archive-2026-06-04-centralize-admin-helper` to `main` with title `docs: archive centralize-admin-helper (2026-06-04)` — **do NOT push directly to `main`**
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
-- [ ] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-04-centralize-admin-helper`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on the default branch
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Update repository documentation impacted by the change
+- [x] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [x] Archive the change: move `openspec/changes/centralize-admin-helper/` to `openspec/changes/archive/2026-06-04-centralize-admin-helper/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
+- [x] Confirm `openspec/changes/archive/2026-06-04-centralize-admin-helper/` exists and `openspec/changes/centralize-admin-helper/` is gone
+- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-2026-06-04-centralize-admin-helper` then `git push -u origin doc/archive-2026-06-04-centralize-admin-helper`
+- [x] Open a PR from `doc/archive-2026-06-04-centralize-admin-helper` to `main` with title `docs: archive centralize-admin-helper (2026-06-04)` — **do NOT push directly to `main`**
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-04-centralize-admin-helper`
 
 Required cleanup after archive: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-04-centralize-admin-helper`

--- a/openspec/changes/archive/2026-06-05-centralize-admin-helper/tasks.md
+++ b/openspec/changes/archive/2026-06-05-centralize-admin-helper/tasks.md
@@ -70,12 +70,12 @@ Blocking resolution flow:
 - [x] Mark all remaining tasks as complete (`- [x]`)
 - [x] Update repository documentation impacted by the change
 - [x] Sync approved spec deltas into `openspec/specs/` (global spec)
-- [x] Archive the change: move `openspec/changes/centralize-admin-helper/` to `openspec/changes/archive/2026-06-04-centralize-admin-helper/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
-- [x] Confirm `openspec/changes/archive/2026-06-04-centralize-admin-helper/` exists and `openspec/changes/centralize-admin-helper/` is gone
-- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-2026-06-04-centralize-admin-helper` then `git push -u origin doc/archive-2026-06-04-centralize-admin-helper`
-- [x] Open a PR from `doc/archive-2026-06-04-centralize-admin-helper` to `main` with title `docs: archive centralize-admin-helper (2026-06-04)` — **do NOT push directly to `main`**
+- [x] Archive the change: move `openspec/changes/centralize-admin-helper/` to `openspec/changes/archive/2026-06-05-centralize-admin-helper/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
+- [x] Confirm `openspec/changes/archive/2026-06-05-centralize-admin-helper/` exists and `openspec/changes/centralize-admin-helper/` is gone
+- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-2026-06-05-centralize-admin-helper` then `git push -u origin doc/archive-2026-06-05-centralize-admin-helper`
+- [x] Open a PR from `doc/archive-2026-06-05-centralize-admin-helper` to `main` with title `docs: archive centralize-admin-helper (2026-06-04)` — **do NOT push directly to `main`**
 - [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
 - [x] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
-- [x] Prune merged local branches: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-04-centralize-admin-helper`
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-05-centralize-admin-helper`
 
-Required cleanup after archive: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-04-centralize-admin-helper`
+Required cleanup after archive: `git fetch --prune` and `git branch -d feature/centralize-admin-helper doc/archive-2026-06-05-centralize-admin-helper`

--- a/openspec/specs/rtl-migration/spec.md
+++ b/openspec/specs/rtl-migration/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED TextInputField generates accessible id from label
+
+The system SHALL derive a stable `id` attribute for `TextInputField`'s `<input>` element from the `label` prop when no explicit `id` is supplied, by lowercasing, replacing non-alphanumeric character runs with `-`, and stripping leading/trailing hyphens.
+
+#### Scenario: Auto-generated id links label to input
+
+- **Given** a `TextInputField` rendered with `label="Campaign Name *"` and no `id` prop
+- **When** the DOM is inspected
+- **Then** the `<input>` has `id="campaign-name"` and the associated `<label>` has `for="campaign-name"`
+
+#### Scenario: Explicit id overrides auto-generation
+
+- **Given** a `TextInputField` rendered with `label="Campaign Name *"` and `id="my-custom-id"`
+- **When** the DOM is inspected
+- **Then** the `<input>` has `id="my-custom-id"` and the `<label>` has `for="my-custom-id"`
+
+#### Scenario: RTL resolves input by accessible name
+
+- **Given** `CampaignEditor` rendered with `campaign.name = "Test Campaign"`
+- **When** `screen.getByRole('textbox', { name: /campaign name/i })` is called
+- **Then** it returns the name input without throwing
+
+---
+
+### Requirement: ADDED Chapter title inputs have accessible names
+
+The system SHALL render each chapter title `<input>` with `aria-label="Chapter N title"` where N is the 1-based position of the chapter in the list.
+
+#### Scenario: Single chapter input is named
+
+- **Given** `CampaignEditor` rendered with one chapter and the chapters accordion open
+- **When** `screen.getByRole('textbox', { name: /chapter 1 title/i })` is called
+- **Then** it returns the chapter title input without throwing
+
+#### Scenario: Multiple chapter inputs are individually named
+
+- **Given** `CampaignEditor` rendered with three chapters and the accordion open
+- **When** `screen.getAllByRole('textbox', { name: /chapter \d+ title/i })` is called
+- **Then** it returns an array of exactly 3 elements
+
+---
+
+### Requirement: ADDED Chapter remove button has accessible name
+
+The system SHALL render each chapter's remove button with `aria-label="Remove <title>"` when the chapter has a non-empty title, or `aria-label="Remove chapter N"` when the title is empty.
+
+#### Scenario: Remove button named by chapter title
+
+- **Given** `CampaignEditor` rendered with a chapter titled "Arrival" and the accordion open
+- **When** `screen.getByRole('button', { name: /remove arrival/i })` is called
+- **Then** it returns the remove button without throwing
+
+#### Scenario: Remove button named by ordinal when title is empty
+
+- **Given** `CampaignEditor` rendered with an untitled (just-added) chapter and the accordion open
+- **When** `screen.getByRole('button', { name: /remove chapter 1/i })` is called
+- **Then** it returns the remove button without throwing
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CampaignEditor unit tests use React Testing Library exclusively
+
+The test file `tests/unit/components/CampaignEditor.test.tsx` SHALL use `@testing-library/react` and `@testing-library/user-event` for all rendering, querying, and interaction — with no remaining usage of `createReactRoot`, `unmountReactRoot`, `act`, `IS_REACT_ACT_ENVIRONMENT`, or manual DOM mutation.
+
+#### Scenario: Legacy boilerplate is absent
+
+- **Given** the migrated `CampaignEditor.test.tsx`
+- **When** the file is grepped for `createReactRoot|unmountReactRoot|IS_REACT_ACT_ENVIRONMENT|@jest-environment jsdom`
+- **Then** zero matches are found
+
+#### Scenario: No manual DOM mutations remain
+
+- **Given** the migrated `CampaignEditor.test.tsx`
+- **When** the file is grepped for `\.value\s*=|dispatchEvent|\.click()`
+- **Then** zero matches are found
+
+#### Scenario: All 25 existing tests pass
+
+- **Given** the migrated test file and updated component files
+- **When** `jest --testPathPattern CampaignEditor` is run
+- **Then** all 25 test cases report `pass` and the suite exits 0
+
+#### Scenario: Tests are isolated (no shared mutable state)
+
+- **Given** the migrated test file
+- **When** tests are run in any order (including `--randomize`)
+- **Then** pass/fail results are identical regardless of order
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Direct DOM container access in CampaignEditor tests
+
+The `container` variable and all `container.querySelector*`, `container.textContent`, `Array.from(container.querySelectorAll(…))` patterns are removed from `CampaignEditor.test.tsx`.
+
+Reason for removal: Replaced by `screen.getBy*` / `screen.queryBy*` queries, which are more resilient and semantically correct.
+
+---
+
+## Traceability
+
+- Proposal element "TextInputField generates id from label" → Requirement "TextInputField generates accessible id from label" → Task: Update `lib/components/ui.tsx`
+- Proposal element "Chapter title inputs gain accessible name" → Requirement "Chapter title inputs have accessible names" → Task: Update `app/campaigns/CampaignEditor.tsx`
+- Proposal element "Remove button gains aria-label" → Requirement "Chapter remove button has accessible name" → Task: Update `app/campaigns/CampaignEditor.tsx`
+- Proposal element "All act()/dispatchEvent hacks removed" → Requirement "CampaignEditor tests use RTL exclusively" → Task: Rewrite `tests/unit/components/CampaignEditor.test.tsx`
+- Design Decision 1 → Requirement "TextInputField generates accessible id"
+- Design Decision 2 → Requirements "Chapter title inputs" + "Chapter remove button"
+- Design Decision 3 → Requirement "CampaignEditor tests use RTL exclusively"
+- Design Decision 4 → Requirement "CampaignEditor tests use RTL exclusively" (openChapters helper)
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Test isolation
+
+- **Given** the migrated test suite
+- **When** tests run in random order
+- **Then** all 25 pass regardless of order (RTL automatic cleanup between tests)
+
+### Requirement: Operability — TypeScript
+
+#### Scenario: Clean compilation
+
+- **Given** the updated source files (`ui.tsx`, `CampaignEditor.tsx`, `CampaignEditor.test.tsx`)
+- **When** `tsc --noEmit` is run
+- **Then** zero TypeScript errors are reported

--- a/openspec/specs/rtl-migration/spec.md
+++ b/openspec/specs/rtl-migration/spec.md
@@ -80,11 +80,11 @@ The test file `tests/unit/components/CampaignEditor.test.tsx` SHALL use `@testin
 - **When** the file is grepped for `\.value\s*=|dispatchEvent|\.click()`
 - **Then** zero matches are found
 
-#### Scenario: All 25 existing tests pass
+#### Scenario: All 26 existing tests pass
 
 - **Given** the migrated test file and updated component files
 - **When** `jest --testPathPattern CampaignEditor` is run
-- **Then** all 25 test cases report `pass` and the suite exits 0
+- **Then** all 26 test cases report `pass` and the suite exits 0
 
 #### Scenario: Tests are isolated (no shared mutable state)
 
@@ -125,7 +125,7 @@ Reason for removal: Replaced by `screen.getBy*` / `screen.queryBy*` queries, whi
 
 - **Given** the migrated test suite
 - **When** tests run in random order
-- **Then** all 25 pass regardless of order (RTL automatic cleanup between tests)
+- **Then** all 26 pass regardless of order (RTL automatic cleanup between tests)
 
 ### Requirement: Operability — TypeScript
 


### PR DESCRIPTION
Archives the `migrate-campaigneditor-test-to-rtl` OpenSpec change following merge of PR #354.

- Moves `openspec/changes/migrate-campaigneditor-test-to-rtl/` → `openspec/changes/archive/2026-06-04-migrate-campaigneditor-test-to-rtl/`
- Syncs approved spec to `openspec/specs/rtl-migration/spec.md`