### PR TITLE
feat: member-aware campaign access

### DIFF
--- a/app/api/campaigns/[id]/combat-events/route.ts
+++ b/app/api/campaigns/[id]/combat-events/route.ts
@@ -2,9 +2,13 @@ import { NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { getDatabase } from '@/lib/db';
 import { CombatState, SessionEvent } from '@/lib/types';
+import { assertCampaignAccess } from '@/lib/utils/campaign';
 
 export const GET = withAuthAndParams<{ id: string }>(async (request, auth, { id }) => {
   try {
+    const result = await assertCampaignAccess(id, auth.userId);
+    if (result instanceof NextResponse) return result;
+
     const { searchParams } = new URL(request.url);
     const sinceParam = searchParams.get('since');
     let sinceDate = new Date(0);

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
 import { CAMPAIGN_STATUSES } from '@/lib/types';

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -1,22 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
-import { Campaign, CAMPAIGN_STATUSES } from '@/lib/types';
-import { sanitizeChapters, sanitizeCurrentChapterId } from '@/lib/utils/campaign';
+import { CAMPAIGN_STATUSES } from '@/lib/types';
+import { sanitizeChapters, sanitizeCurrentChapterId, assertCampaignAccess } from '@/lib/utils/campaign';
 
 type Params = { id: string };
 
-async function findCampaign(id: string, userId: string): Promise<Campaign | NextResponse> {
-  const campaign = await storage.loadCampaignById(id, userId);
-  if (!campaign) return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
-  return campaign;
-}
-
 export const GET = withAuthAndParams<Params>(async (_request, auth, { id }) => {
   try {
-    const result = await findCampaign(id, auth.userId);
+    const result = await assertCampaignAccess(id, auth.userId);
     if (result instanceof NextResponse) return result;
-    return NextResponse.json(result);
+    return NextResponse.json(result.campaign);
   } catch (error) {
     console.error('Error fetching campaign:', error);
     return NextResponse.json({ error: 'Failed to fetch campaign' }, { status: 500 });
@@ -25,9 +19,11 @@ export const GET = withAuthAndParams<Params>(async (_request, auth, { id }) => {
 
 export const PATCH = withAuthAndParams<Params>(async (request, auth, { id }) => {
   try {
-    const result = await findCampaign(id, auth.userId);
+    const result = await assertCampaignAccess(id, auth.userId);
     if (result instanceof NextResponse) return result;
-    const campaign = result;
+    const { campaign, role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
     const body = await request.json();
     const { name, moduleName, status, notes, chapters, currentChapterId } = body;
@@ -89,8 +85,12 @@ export const PATCH = withAuthAndParams<Params>(async (request, auth, { id }) => 
 
 export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id }) => {
   try {
-    const result = await findCampaign(id, auth.userId);
+    const result = await assertCampaignAccess(id, auth.userId);
     if (result instanceof NextResponse) return result;
+    const { role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+
     await storage.deleteCampaign(id, auth.userId);
     return NextResponse.json({ message: 'Campaign deleted successfully' });
   } catch (error) {

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -87,11 +87,11 @@ export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id }) =
   try {
     const result = await assertCampaignAccess(id, auth.userId);
     if (result instanceof NextResponse) return result;
-    const { role } = result;
+    const { campaign, role } = result;
 
     if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
-    await storage.deleteCampaign(id, auth.userId);
+    await storage.deleteCampaign(id, campaign.userId);
     return NextResponse.json({ message: 'Campaign deleted successfully' });
   } catch (error) {
     console.error('Error deleting campaign:', error);

--- a/app/api/campaigns/[id]/sessions/[sessionId]/route.ts
+++ b/app/api/campaigns/[id]/sessions/[sessionId]/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
+import { assertCampaignAccess } from '@/lib/utils/campaign';
 
 type Params = { id: string; sessionId: string };
 
 export const PATCH = withAuthAndParams<Params>(async (request, auth, { id: campaignId, sessionId }) => {
   try {
+    const result = await assertCampaignAccess(campaignId, auth.userId);
+    if (result instanceof NextResponse) return result;
+    const { role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+
     const body = await request.json();
     const { title, datePlayed, summary, events, milestone, newLevel } = body;
     const patch = { title, datePlayed, summary, events, milestone, newLevel };

--- a/app/api/campaigns/[id]/sessions/[sessionId]/route.ts
+++ b/app/api/campaigns/[id]/sessions/[sessionId]/route.ts
@@ -9,14 +9,14 @@ export const PATCH = withAuthAndParams<Params>(async (request, auth, { id: campa
   try {
     const result = await assertCampaignAccess(campaignId, auth.userId);
     if (result instanceof NextResponse) return result;
-    const { role } = result;
+    const { campaign, role } = result;
 
     if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
     const body = await request.json();
     const { title, datePlayed, summary, events, milestone, newLevel } = body;
     const patch = { title, datePlayed, summary, events, milestone, newLevel };
-    const updated = await storage.updateSessionLog(sessionId, auth.userId, campaignId, patch);
+    const updated = await storage.updateSessionLog(sessionId, campaign.userId, campaignId, patch);
     if (!updated) {
       return NextResponse.json({ error: 'Session log not found' }, { status: 404 });
     }
@@ -31,11 +31,11 @@ export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: cam
   try {
     const result = await assertCampaignAccess(campaignId, auth.userId);
     if (result instanceof NextResponse) return result;
-    const { role } = result;
+    const { campaign, role } = result;
 
     if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
-    const deleted = await storage.deleteSessionLog(sessionId, auth.userId, campaignId);
+    const deleted = await storage.deleteSessionLog(sessionId, campaign.userId, campaignId);
     if (!deleted) {
       return NextResponse.json({ error: 'Session log not found' }, { status: 404 });
     }

--- a/app/api/campaigns/[id]/sessions/[sessionId]/route.ts
+++ b/app/api/campaigns/[id]/sessions/[sessionId]/route.ts
@@ -29,6 +29,12 @@ export const PATCH = withAuthAndParams<Params>(async (request, auth, { id: campa
 
 export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: campaignId, sessionId }) => {
   try {
+    const result = await assertCampaignAccess(campaignId, auth.userId);
+    if (result instanceof NextResponse) return result;
+    const { role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+
     const deleted = await storage.deleteSessionLog(sessionId, auth.userId, campaignId);
     if (!deleted) {
       return NextResponse.json({ error: 'Session log not found' }, { status: 404 });

--- a/app/api/campaigns/[id]/sessions/route.ts
+++ b/app/api/campaigns/[id]/sessions/route.ts
@@ -10,8 +10,9 @@ export const GET = withAuthAndParams<Params>(async (request, auth, { id: campaig
   try {
     const result = await assertCampaignAccess(campaignId, auth.userId);
     if (result instanceof NextResponse) return result;
+    const { campaign } = result;
 
-    const logs = await storage.loadSessionLogs(auth.userId, campaignId);
+    const logs = await storage.loadSessionLogs(campaign.userId, campaignId);
     const limitParam = new URL(request.url).searchParams.get('limit');
     const limit = limitParam ? parseInt(limitParam, 10) : undefined;
     return NextResponse.json(limit && limit > 0 ? logs.slice(0, limit) : logs);

--- a/app/api/campaigns/[id]/sessions/route.ts
+++ b/app/api/campaigns/[id]/sessions/route.ts
@@ -26,7 +26,7 @@ export const POST = withAuthAndParams<Params>(async (request, auth, { id: campai
   try {
     const result = await assertCampaignAccess(campaignId, auth.userId);
     if (result instanceof NextResponse) return result;
-    const { role } = result;
+    const { campaign, role } = result;
 
     if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
@@ -40,12 +40,12 @@ export const POST = withAuthAndParams<Params>(async (request, auth, { id: campai
     const resolvedSessionNumber =
       typeof sessionNumber === 'number' && Number.isInteger(sessionNumber) && sessionNumber >= 0
         ? sessionNumber
-        : await storage.getNextSessionNumber(auth.userId, campaignId);
+        : await storage.getNextSessionNumber(campaign.userId, campaignId);
 
     const now = new Date();
     const log: SessionLog = {
       id: crypto.randomUUID(),
-      userId: auth.userId,
+      userId: campaign.userId,
       campaignId,
       sessionNumber: resolvedSessionNumber,
       title: typeof title === 'string' ? title.trim() || undefined : undefined,

--- a/app/api/campaigns/[id]/sessions/route.ts
+++ b/app/api/campaigns/[id]/sessions/route.ts
@@ -2,15 +2,15 @@ import { NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
 import { SessionLog } from '@/lib/types';
+import { assertCampaignAccess } from '@/lib/utils/campaign';
 
 type Params = { id: string };
 
 export const GET = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
   try {
-    const campaign = await storage.loadCampaignById(campaignId, auth.userId);
-    if (!campaign) {
-      return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
-    }
+    const result = await assertCampaignAccess(campaignId, auth.userId);
+    if (result instanceof NextResponse) return result;
+
     const logs = await storage.loadSessionLogs(auth.userId, campaignId);
     const limitParam = new URL(request.url).searchParams.get('limit');
     const limit = limitParam ? parseInt(limitParam, 10) : undefined;
@@ -23,10 +23,11 @@ export const GET = withAuthAndParams<Params>(async (request, auth, { id: campaig
 
 export const POST = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
   try {
-    const campaign = await storage.loadCampaignById(campaignId, auth.userId);
-    if (!campaign) {
-      return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
-    }
+    const result = await assertCampaignAccess(campaignId, auth.userId);
+    if (result instanceof NextResponse) return result;
+    const { role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
     const body = await request.json();
     const { datePlayed, sessionNumber, title, summary, events, milestone, newLevel } = body;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -889,6 +889,35 @@ export const storage = {
     }
   },
 
+  async getMember(campaignId: string, userId: string): Promise<CampaignMember | null> {
+    try {
+      const db = await getDatabase();
+      const doc = await db
+        .collection<CampaignMember>("campaignMembers")
+        .findOne({ campaignId, userId });
+      if (!doc) return null;
+      const normalized = normalizeStoredEntityId(doc);
+      const { _id, ...rest } = normalized;
+      return rest as CampaignMember;
+    } catch (error) {
+      console.error("Error getting campaign member:", error);
+      throw error;
+    }
+  },
+
+  async loadCampaignByIdAny(id: string): Promise<Campaign | null> {
+    try {
+      const db = await getDatabase();
+      const campaign = await db
+        .collection<Campaign>("campaigns")
+        .findOne({ id });
+      return campaign ? normalizeCampaign(normalizeStoredEntityId(campaign)) : null;
+    } catch (error) {
+      console.error("Error loading campaign by ID (any):", error);
+      throw error;
+    }
+  },
+
   async listCampaignsForMember(userId: string): Promise<CampaignMemberSummary[]> {
     try {
       const db = await getDatabase();

--- a/lib/utils/campaign.ts
+++ b/lib/utils/campaign.ts
@@ -1,10 +1,25 @@
-import type { CampaignChapter } from '@/lib/types';
+import { NextResponse } from 'next/server';
+import type { Campaign, CampaignChapter, MemberRole } from '@/lib/types';
+import { storage } from '@/lib/storage';
 
 /**
  * Sanitizes and normalizes an input array of chapters.
  * Ensures each chapter has a unique ID, trimmed title, and sequence orders
  * that are sorted and contiguous starting from 0.
  */
+const notFound = () => NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+
+export async function assertCampaignAccess(
+  campaignId: string,
+  userId: string,
+): Promise<{ campaign: Campaign; role: MemberRole } | NextResponse> {
+  const member = await storage.getMember(campaignId, userId);
+  if (!member || member.status !== 'active') return notFound();
+  const campaign = await storage.loadCampaignByIdAny(campaignId);
+  if (!campaign) return notFound();
+  return { campaign, role: member.role };
+}
+
 export function sanitizeChapters(chapters: unknown): CampaignChapter[] {
   if (!Array.isArray(chapters)) {
     return [];

--- a/lib/utils/campaign.ts
+++ b/lib/utils/campaign.ts
@@ -2,11 +2,6 @@ import { NextResponse } from 'next/server';
 import type { Campaign, CampaignChapter, MemberRole } from '@/lib/types';
 import { storage } from '@/lib/storage';
 
-/**
- * Sanitizes and normalizes an input array of chapters.
- * Ensures each chapter has a unique ID, trimmed title, and sequence orders
- * that are sorted and contiguous starting from 0.
- */
 const notFound = () => NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
 
 export async function assertCampaignAccess(
@@ -20,6 +15,11 @@ export async function assertCampaignAccess(
   return { campaign, role: member.role };
 }
 
+/**
+ * Sanitizes and normalizes an input array of chapters.
+ * Ensures each chapter has a unique ID, trimmed title, and sequence orders
+ * that are sorted and contiguous starting from 0.
+ */
 export function sanitizeChapters(chapters: unknown): CampaignChapter[] {
   if (!Array.isArray(chapters)) {
     return [];

--- a/openspec/changes/member-aware-campaign-access/.openspec.yaml
+++ b/openspec/changes/member-aware-campaign-access/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-05

--- a/openspec/changes/member-aware-campaign-access/design.md
+++ b/openspec/changes/member-aware-campaign-access/design.md
@@ -1,0 +1,164 @@
+## Context
+
+- Relevant architecture: Next.js App Router API routes under `app/api/campaigns/[id]/**`. All routes use `withAuthAndParams` middleware which injects `auth.userId`. Storage layer is MongoDB via `lib/storage.ts`. Access helpers live in `lib/utils/campaign.ts`.
+- Dependencies: `campaignMembers` collection and storage methods (`addMember`, `updateMember`, `listMembersForCampaign`, `listCampaignsForMember`) shipped in issue #303 (1d). Owner is seeded as `active` DM in `campaignMembers` at campaign creation time.
+- Interfaces/contracts touched: `lib/storage.ts` (new methods), `lib/utils/campaign.ts` (new helper), all six route handlers under `app/api/campaigns/[id]/**`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Any `active` campaign member (DM or player) can execute GET requests on all `[id]/**` routes.
+- Write operations (PATCH, DELETE, POST, sessions PATCH) are restricted to members with `role === 'dm'`.
+- Non-members and inactive members receive 404 — no information about campaign existence is leaked.
+- The membership check is consolidated in one place (`assertCampaignAccess`) rather than duplicated across routes.
+
+### Non-Goals
+
+- Invite/accept flow or membership management UI
+- Exposing member roles in API response bodies
+- Changing access semantics for routes outside `app/api/campaigns/[id]/**`
+
+## Decisions
+
+### Decision 1: Membership as the sole access gate (no owner bypass)
+
+- Chosen: Always check `campaignMembers` for access. The owner (DM) is already seeded as an `active` member with `role: 'dm'`, so the membership table is authoritative for all users including the owner.
+- Alternatives considered: Check `campaign.userId === auth.userId` first, fall back to membership — this dual-path approach avoids touching the owner seeding but creates two code paths.
+- Rationale: Single code path, easier to reason about and test. Consistent with the 1d design where the owner is explicitly represented in `campaignMembers`.
+- Trade-offs: Depends on the owner-seeding backfill migration from #303 having run. Documented in proposal risks.
+
+### Decision 2: `assertCampaignAccess` return type follows existing `X | NextResponse` pattern
+
+- Chosen: `Promise<{ campaign: Campaign; role: MemberRole } | NextResponse>`. Routes check `instanceof NextResponse` and early-return, matching the existing `findCampaign` convention.
+- Alternatives considered: Throw a typed `CampaignAccessError`; return a discriminated union `{ ok: true; ... } | { ok: false; response: NextResponse }`.
+- Rationale: The existing `findCampaign` in `app/api/campaigns/[id]/route.ts` already returns `Campaign | NextResponse`. Using the same shape means route handlers change minimally and the pattern is already understood by readers of the codebase.
+- Trade-offs: Couples a utility function to `NextResponse`; acceptable because the utility is route-layer code.
+
+### Decision 3: Deny with 404 for non-members and role violations
+
+- Chosen: Both non-member access and player-attempts-write return `{ error: 'Campaign not found' }` with status 404.
+- Alternatives considered: 403 Forbidden for members who lack the right role.
+- Rationale: 404 prevents leaking that a campaign exists at all, or that the caller is a member but lacks permission. Matches the issue spec ("non-member gets 404/403" — 404 chosen for uniform denial).
+- Trade-offs: Slightly harder to debug for legitimate users who are misconfigured; acceptable at this stage.
+
+### Decision 4: Two new storage methods — `getMember` and `loadCampaignByIdAny`
+
+- Chosen: Add `getMember(campaignId, userId): Promise<CampaignMember | null>` for targeted member lookup, and `loadCampaignByIdAny(id): Promise<Campaign | null>` for owner-agnostic campaign load.
+- Alternatives considered: Reuse `listMembersForCampaign` and filter client-side (wastes bandwidth), modify `loadCampaignById` signature to make userId optional (breaks existing callers).
+- Rationale: Minimal footprint — both methods are small, targeted, and don't change existing method signatures. `loadCampaignByIdAny` is intentionally named to signal it bypasses ownership; only `assertCampaignAccess` should call it.
+- Trade-offs: Slight surface area expansion in storage; mitigated by clear naming.
+
+### Decision 5: Write routes use `assertCampaignAccess` + inline `role` check
+
+- Chosen: All write routes call `assertCampaignAccess`, destructure `role`, then return 404 if `role !== 'dm'`. The existing `findCampaign` helper is removed from the campaign route.
+- Alternatives considered: Keep `findCampaign` for write paths (owner-only stays as-is).
+- Rationale: Unified access pattern; paves the way for future multi-DM or ownership-transfer features without a second code path to update.
+- Trade-offs: Writes now incur two DB round trips (getMember + loadCampaignByIdAny) vs one; acceptable at this scale.
+
+## Proposal to Design Mapping
+
+- Proposal element: Player members blocked by `{ id, userId }` query
+  - Design decision: Decision 4 — `loadCampaignByIdAny` removes userId filter after membership is confirmed
+  - Validation approach: Integration test — player member GET returns 200 with campaign body
+
+- Proposal element: Non-members get 404
+  - Design decision: Decision 3 — uniform 404 for denied access
+  - Validation approach: Integration test — unknown userId GET returns 404
+
+- Proposal element: Writes remain DM-only
+  - Design decision: Decision 5 — `role !== 'dm'` → 404 in write routes
+  - Validation approach: Integration test — player member PATCH/DELETE/POST returns 404
+
+- Proposal element: Single authoritative gate
+  - Design decision: Decision 1 — membership is sole gate; Decision 2 — `assertCampaignAccess` consolidates logic
+  - Validation approach: Unit tests on `assertCampaignAccess` covering all branches
+
+- Proposal element: Backfill risk for legacy campaigns
+  - Design decision: Decision 1 (trade-off) — documented as prerequisite; no code mitigation in this change
+  - Validation approach: Manual verification that #303 backfill ran before deploy
+
+## Functional Requirements Mapping
+
+- Requirement: Active member (any role) can GET `/api/campaigns/[id]`
+  - Design element: `assertCampaignAccess` returns `{ campaign, role }` on success; route returns `NextResponse.json(campaign)`
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Player member GET succeeds
+  - Testability notes: Mock `storage.getMember` returning active player, `loadCampaignByIdAny` returning campaign
+
+- Requirement: Active DM can PATCH/DELETE `/api/campaigns/[id]`
+  - Design element: `assertCampaignAccess` + `role === 'dm'` check in route
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: DM write succeeds
+  - Testability notes: Mock getMember returning active dm, verify response 200/204
+
+- Requirement: Non-member gets 404
+  - Design element: `getMember` returns null → `assertCampaignAccess` returns 404 NextResponse
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Non-member denied
+  - Testability notes: Mock getMember returning null
+
+- Requirement: Pending/declined member gets 404
+  - Design element: `member.status !== 'active'` → 404
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Inactive member denied
+  - Testability notes: Mock getMember returning pending/declined member
+
+- Requirement: Player PATCH/DELETE/POST returns 404
+  - Design element: `role !== 'dm'` → 404 in write route handlers
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Player write denied
+  - Testability notes: Mock getMember returning active player; assert 404
+
+- Requirement: Sessions GET accessible to active members
+  - Design element: `assertCampaignAccess` replaces `loadCampaignById` gate in sessions GET
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Player sessions GET
+  - Testability notes: Mock membership + session logs
+
+- Requirement: Combat events GET accessible to active members
+  - Design element: `assertCampaignAccess` gate added to combat-events GET; query still filters `userId: auth.userId`
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Player combat events GET
+  - Testability notes: Gate check passes; underlying query unchanged
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: security
+  - Requirement: No campaign existence leakage to non-members
+  - Design element: Uniform 404 on all denial paths (Decision 3)
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Non-member denied
+  - Testability notes: Assert response body is `{ error: 'Campaign not found' }` and status is 404 in all denial cases
+
+- Requirement category: performance
+  - Requirement: Access check adds at most 2 DB round trips
+  - Design element: `getMember` (indexed query on `{ campaignId, userId }`) + `loadCampaignByIdAny` (indexed query on `{ id }`)
+  - Acceptance criteria reference: N/A — no perf regression test; existing indexes from #303 cover the compound key
+  - Testability notes: Index existence verified in #303 spec; no additional action needed here
+
+- Requirement category: reliability
+  - Requirement: Existing owner-only behavior unchanged for campaigns not yet using membership
+  - Design element: Owner seeded as active DM in #303 — same code path applies
+  - Acceptance criteria reference: specs/campaign-access.md — Scenario: Owner (DM) existing behavior unchanged
+  - Testability notes: Mock getMember returning active dm with matching userId
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `loadCampaignByIdAny` bypasses ownership filter
+  - Impact: If called without a prior membership check, any user could fetch any campaign
+  - Mitigation: Method is only called inside `assertCampaignAccess`. Code review to enforce this invariant.
+
+- Risk/trade-off: Backfill dependency on #303
+  - Impact: Pre-#303 campaigns have no membership record; their owners would receive 404 after this change deploys
+  - Mitigation: Confirm backfill ran before deploy; this is a prerequisite, not a code issue in this change.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Owners of existing campaigns unable to access their campaigns (404); or unexpected 404s in production after deploy.
+- Rollback steps: Revert the PR for this change. Routes revert to `findCampaign` / `loadCampaignById` owner-only pattern. No schema migration to undo.
+- Data migration considerations: None — this change only adds route logic and storage methods. No data is written or deleted.
+- Verification after rollback: Confirm campaign owner can GET their own campaign. Confirm campaign list endpoint still works.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check in the branch. Do not use `--no-verify` or admin bypass.
+- If security checks fail: Treat as a blocker. Review the flagged code and resolve before merging.
+- If required reviews are blocked/stale: Re-request review after 24 hours. Escalate to project owner after 48 hours.
+- Escalation path and timeout: Ping project owner directly if blocked more than 48 hours with no response.
+
+## Open Questions
+
+- No open questions. All design decisions were confirmed during the explore session preceding this proposal.

--- a/openspec/changes/member-aware-campaign-access/proposal.md
+++ b/openspec/changes/member-aware-campaign-access/proposal.md
@@ -1,0 +1,75 @@
+## GitHub Issues
+
+- #304
+- #293 (parent epic)
+
+## Why
+
+- Problem statement: Campaign read routes gate access by `userId === campaign.userId` (owner check), so player members added via the `campaignMembers` collection in issue #303 cannot read campaigns they have been invited to. They hit 404 on every GET.
+- Why now: Issue #303 (1d) landed the `campaignMembers` collection and storage methods; #304 is the next sub-issue in Phase 1 and the access layer must follow before any player-facing UI can be built.
+- Business/user impact: Without this, the multi-user campaigns initiative is blocked — players cannot load any campaign data despite being valid members.
+
+## Problem Space
+
+- Current behavior: `loadCampaignById(id, userId)` queries `{ id, userId }` — only the document owner matches. All campaign sub-routes (`/sessions`, `/combat-events`) use the same owner-only pattern. Write routes (PATCH, DELETE, POST) have no role distinction because there was only ever one role.
+- Desired behavior: Any `active` campaign member (DM or player) can read campaign data. Write operations remain DM-only. Non-members receive 404 (no information leakage about campaign existence).
+- Constraints: Owner is already seeded as an `active` DM member in `campaignMembers` (per #303), so membership is the single authoritative gate — no special-casing needed for owners.
+- Assumptions: Only `status === 'active'` members are granted access. `pending` and `declined` members are treated identically to non-members.
+- Edge cases considered:
+  - Campaign document exists but has no membership record (legacy data or bug): returns 404.
+  - Member record exists but campaign doc is missing: returns 404.
+  - Player attempts a DM-only write: returns 404 (not 403, to avoid leaking role info).
+
+## Scope
+
+### In Scope
+
+- New storage method `getMember(campaignId, userId): Promise<CampaignMember | null>`
+- New storage method `loadCampaignByIdAny(id: string): Promise<Campaign | null>` (no userId filter)
+- New `assertCampaignAccess(campaignId, userId)` utility in `lib/utils/campaign.ts` returning `{ campaign, role } | NextResponse`
+- Refactor all routes under `app/api/campaigns/[id]/**`:
+  - GET routes: use `assertCampaignAccess` (any active member)
+  - Write routes (PATCH, DELETE, POST, sessions PATCH): use `assertCampaignAccess` + `role === 'dm'` check
+- Unit tests for `assertCampaignAccess` and the two new storage methods
+- Integration/route tests covering player-can-read, non-member-gets-404, player-write-gets-404, DM-write-succeeds
+
+### Out of Scope
+
+- Invite/accept flow (Phase 2)
+- Exposing member role in API response bodies
+- Frontend changes
+- Any route outside `app/api/campaigns/[id]/**`
+
+## What Changes
+
+- `lib/storage.ts`: add `getMember` and `loadCampaignByIdAny`
+- `lib/utils/campaign.ts`: add `assertCampaignAccess`; existing `sanitizeChapters` / `sanitizeCurrentChapterId` unchanged
+- `app/api/campaigns/[id]/route.ts`: replace `findCampaign` calls with `assertCampaignAccess`; add DM check on PATCH and DELETE
+- `app/api/campaigns/[id]/sessions/route.ts`: replace `loadCampaignById` guard with `assertCampaignAccess`; add DM check on POST
+- `app/api/campaigns/[id]/sessions/[sessionId]/route.ts`: add `assertCampaignAccess` + DM check on PATCH (currently ungated at the campaign level)
+- `app/api/campaigns/[id]/combat-events/route.ts`: add `assertCampaignAccess` gate on GET (query still filters by `auth.userId` — players see their own events only)
+
+## Risks
+
+- Risk: `loadCampaignByIdAny` bypasses the userId ownership filter — any code that calls it without a prior membership check would leak data.
+  - Impact: Medium — wrong caller could expose campaign docs to arbitrary users.
+  - Mitigation: Keep `loadCampaignByIdAny` private to the storage layer; only `assertCampaignAccess` calls it. Name signals intent.
+
+- Risk: Legacy campaigns that predate `campaignMembers` seeding will be inaccessible even to their owners.
+  - Impact: High if any such campaigns exist in production.
+  - Mitigation: The owner-seeding in #303 must backfill existing campaigns. Confirm backfill migration ran before deploying this change.
+
+## Open Questions
+
+- No unresolved ambiguity exists. All design decisions were confirmed during explore session: sessions sub-routes in scope, Path B (assertCampaignAccess + role check) for writes, 404 for non-members, return type follows existing `X | NextResponse` pattern.
+
+## Non-Goals
+
+- Granting players write access to any resource (deferred to per-feature decisions in later phases)
+- Exposing membership metadata (roles, member lists) via campaign read endpoints
+- Changing how `loadCampaignById` behaves for existing callers outside the campaign routes
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/member-aware-campaign-access/specs/campaign-access.md
+++ b/openspec/changes/member-aware-campaign-access/specs/campaign-access.md
@@ -1,0 +1,231 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `getMember` storage method
+
+The system SHALL provide `storage.getMember(campaignId, userId)` returning the matching `CampaignMember` or `null`.
+
+#### Scenario: Member exists
+
+- **Given** a `campaignMembers` document exists with matching `campaignId` and `userId`
+- **When** `getMember(campaignId, userId)` is called
+- **Then** the normalized `CampaignMember` is returned with `_id` stripped
+
+#### Scenario: Member does not exist
+
+- **Given** no `campaignMembers` document matches the given `campaignId` and `userId`
+- **When** `getMember(campaignId, userId)` is called
+- **Then** `null` is returned
+
+---
+
+### Requirement: ADDED `loadCampaignByIdAny` storage method
+
+The system SHALL provide `storage.loadCampaignByIdAny(id)` returning the campaign with that `id`, regardless of `userId`.
+
+#### Scenario: Campaign exists
+
+- **Given** a `campaigns` document exists with the given `id`
+- **When** `loadCampaignByIdAny(id)` is called
+- **Then** the normalized `Campaign` is returned
+
+#### Scenario: Campaign does not exist
+
+- **Given** no `campaigns` document matches the given `id`
+- **When** `loadCampaignByIdAny(id)` is called
+- **Then** `null` is returned
+
+---
+
+### Requirement: ADDED `assertCampaignAccess` utility
+
+The system SHALL provide `assertCampaignAccess(campaignId, userId)` in `lib/utils/campaign.ts` that returns `{ campaign: Campaign; role: MemberRole }` for active members, or a `NextResponse` 404 for all denied cases.
+
+#### Scenario: Active member gains access
+
+- **Given** a `campaignMembers` record exists with `status: 'active'` for the given `campaignId` and `userId`
+- **And** the campaign document exists
+- **When** `assertCampaignAccess(campaignId, userId)` is called
+- **Then** `{ campaign, role }` is returned where `role` matches the member's role
+
+#### Scenario: Non-member is denied
+
+- **Given** no `campaignMembers` record exists for the given `campaignId` and `userId`
+- **When** `assertCampaignAccess(campaignId, userId)` is called
+- **Then** a `NextResponse` with status 404 and body `{ error: 'Campaign not found' }` is returned
+
+#### Scenario: Pending member is denied
+
+- **Given** a `campaignMembers` record exists with `status: 'pending'`
+- **When** `assertCampaignAccess(campaignId, userId)` is called
+- **Then** a `NextResponse` with status 404 and body `{ error: 'Campaign not found' }` is returned
+
+#### Scenario: Declined member is denied
+
+- **Given** a `campaignMembers` record exists with `status: 'declined'`
+- **When** `assertCampaignAccess(campaignId, userId)` is called
+- **Then** a `NextResponse` with status 404 and body `{ error: 'Campaign not found' }` is returned
+
+#### Scenario: Member record exists but campaign document is missing
+
+- **Given** an active `campaignMembers` record exists but no matching campaign document
+- **When** `assertCampaignAccess(campaignId, userId)` is called
+- **Then** a `NextResponse` with status 404 and body `{ error: 'Campaign not found' }` is returned
+
+---
+
+### Requirement: ADDED `GET /api/campaigns/[id]` accessible to active members
+
+The system SHALL allow any active campaign member (DM or player) to GET a campaign.
+
+#### Scenario: Player member GET succeeds
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `GET /api/campaigns/[id]` is called
+- **Then** HTTP 200 is returned with the campaign JSON body
+
+#### Scenario: DM member GET succeeds (existing owner behavior unchanged)
+
+- **Given** a user is an active `dm` member of a campaign (the owner)
+- **When** `GET /api/campaigns/[id]` is called
+- **Then** HTTP 200 is returned with the campaign JSON body
+
+#### Scenario: Non-member GET is denied
+
+- **Given** a user has no membership record for the campaign
+- **When** `GET /api/campaigns/[id]` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+---
+
+### Requirement: ADDED `GET /api/campaigns/[id]/sessions` accessible to active members
+
+The system SHALL allow any active campaign member to GET session logs.
+
+#### Scenario: Player sessions GET
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `GET /api/campaigns/[id]/sessions` is called
+- **Then** HTTP 200 is returned with the session log array
+
+#### Scenario: Non-member sessions GET is denied
+
+- **Given** a user has no membership record for the campaign
+- **When** `GET /api/campaigns/[id]/sessions` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+---
+
+### Requirement: ADDED `GET /api/campaigns/[id]/combat-events` accessible to active members
+
+The system SHALL allow any active campaign member to GET combat events. The underlying query filters by `auth.userId` so each member sees only their own events.
+
+#### Scenario: Player combat events GET
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `GET /api/campaigns/[id]/combat-events` is called
+- **Then** HTTP 200 is returned with events filtered to that user's own combat states
+
+#### Scenario: Non-member combat events GET is denied
+
+- **Given** a user has no membership record for the campaign
+- **When** `GET /api/campaigns/[id]/combat-events` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Campaign write routes are DM-only
+
+The system SHALL restrict PATCH, DELETE on `/api/campaigns/[id]`, POST and sub-resource PATCH on `/api/campaigns/[id]/sessions/**` to members with `role: 'dm'`. Non-DM members (including active players) SHALL receive 404.
+
+#### Scenario: DM PATCH succeeds
+
+- **Given** a user is an active `dm` member of a campaign
+- **When** `PATCH /api/campaigns/[id]` is called with valid body
+- **Then** HTTP 200 is returned with the updated campaign
+
+#### Scenario: Player PATCH is denied
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `PATCH /api/campaigns/[id]` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+#### Scenario: DM DELETE succeeds
+
+- **Given** a user is an active `dm` member of a campaign
+- **When** `DELETE /api/campaigns/[id]` is called
+- **Then** HTTP 200 is returned
+
+#### Scenario: Player DELETE is denied
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `DELETE /api/campaigns/[id]` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+#### Scenario: DM POST session succeeds
+
+- **Given** a user is an active `dm` member of a campaign
+- **When** `POST /api/campaigns/[id]/sessions` is called with valid body
+- **Then** HTTP 201 is returned with the new session log
+
+#### Scenario: Player POST session is denied
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `POST /api/campaigns/[id]/sessions` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+#### Scenario: DM PATCH session log succeeds
+
+- **Given** a user is an active `dm` member of a campaign
+- **When** `PATCH /api/campaigns/[id]/sessions/[sessionId]` is called with valid body
+- **Then** HTTP 200 is returned with the updated session log (or 404 if sessionId not found)
+
+#### Scenario: Player PATCH session log is denied
+
+- **Given** a user is an active `player` member of a campaign
+- **When** `PATCH /api/campaigns/[id]/sessions/[sessionId]` is called
+- **Then** HTTP 404 is returned with body `{ error: 'Campaign not found' }`
+
+## REMOVED Requirements
+
+### Requirement: REMOVED `findCampaign` owner-only helper
+
+Reason for removal: `findCampaign(id, userId)` in `app/api/campaigns/[id]/route.ts` is superseded by `assertCampaignAccess`. It is removed and replaced — not exported, so no external consumers exist.
+
+## Traceability
+
+- Proposal element: Player blocked by `{ id, userId }` query → Requirement: ADDED `loadCampaignByIdAny`, ADDED `assertCampaignAccess`
+- Proposal element: Non-members get 404 → Requirement: ADDED `assertCampaignAccess` (denial scenarios), MODIFIED write routes (player denial scenarios)
+- Proposal element: Writes DM-only → Requirement: MODIFIED Campaign write routes are DM-only
+- Proposal element: Single access gate → Requirement: ADDED `assertCampaignAccess`
+- Design Decision 1 (membership as sole gate) → ADDED `assertCampaignAccess`, ADDED `getMember`
+- Design Decision 2 (return type) → ADDED `assertCampaignAccess` (return shape scenarios)
+- Design Decision 3 (404 on denial) → all denial scenarios
+- Design Decision 4 (new storage methods) → ADDED `getMember`, ADDED `loadCampaignByIdAny`
+- Design Decision 5 (unified write pattern) → MODIFIED Campaign write routes
+- Requirements → Tasks: all added/modified requirements map to tasks in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+#### Scenario: No campaign existence leakage
+
+- **Given** a user with no membership record makes any request to `/api/campaigns/[id]/**`
+- **When** the request is processed
+- **Then** the response is always 404 with body `{ error: 'Campaign not found' }` — never 403 or any body that reveals the campaign exists
+
+#### Scenario: Player cannot escalate to DM write
+
+- **Given** a user is an active `player` member
+- **When** any write method (PATCH, DELETE, POST) is attempted on a campaign route
+- **Then** HTTP 404 is returned; the write is not executed
+
+### Requirement: Reliability
+
+#### Scenario: Orphaned membership record (campaign doc missing)
+
+- **Given** a `campaignMembers` record exists for a campaign that has been deleted
+- **When** `assertCampaignAccess` is called
+- **Then** HTTP 404 is returned; no unhandled error is thrown

--- a/openspec/changes/member-aware-campaign-access/tasks.md
+++ b/openspec/changes/member-aware-campaign-access/tasks.md
@@ -9,23 +9,23 @@
 
 ### 1. Add `getMember` to storage
 
-- [ ] In `lib/storage.ts`, add `getMember(campaignId: string, userId: string): Promise<CampaignMember | null>`
+- [x] In `lib/storage.ts`, add `getMember(campaignId: string, userId: string): Promise<CampaignMember | null>`
   - Query `campaignMembers` collection with `{ campaignId, userId }`
   - Normalize and strip `_id` before returning
   - Return `null` on not-found; rethrow on unexpected error
-- [ ] Write unit test: member exists → returns CampaignMember; not found → returns null
+- [x] Write unit test: member exists → returns CampaignMember; not found → returns null
 
 ### 2. Add `loadCampaignByIdAny` to storage
 
-- [ ] In `lib/storage.ts`, add `loadCampaignByIdAny(id: string): Promise<Campaign | null>`
+- [x] In `lib/storage.ts`, add `loadCampaignByIdAny(id: string): Promise<Campaign | null>`
   - Query `campaigns` collection with `{ id }` only (no `userId` filter)
   - Apply `normalizeStoredEntityId` + `normalizeCampaign`
   - Return `null` on not-found; rethrow on unexpected error
-- [ ] Write unit test: campaign exists → returns Campaign; not found → returns null
+- [x] Write unit test: campaign exists → returns Campaign; not found → returns null
 
 ### 3. Add `assertCampaignAccess` utility
 
-- [ ] In `lib/utils/campaign.ts`, add:
+- [x] In `lib/utils/campaign.ts`, add:
   ```ts
   export async function assertCampaignAccess(
     campaignId: string,
@@ -37,8 +37,8 @@
   - Call `storage.loadCampaignByIdAny(campaignId)`
   - If null → return `NextResponse.json({ error: 'Campaign not found' }, { status: 404 })`
   - Return `{ campaign, role: member.role }`
-- [ ] Add imports: `Campaign`, `MemberRole` from `@/lib/types`; `storage` from `@/lib/storage`; `NextResponse` from `next/server`
-- [ ] Write unit tests covering all branches:
+- [x] Add imports: `Campaign`, `MemberRole` from `@/lib/types`; `storage` from `@/lib/storage`; `NextResponse` from `next/server`
+- [x] Write unit tests covering all branches:
   - Active DM member → returns `{ campaign, role: 'dm' }`
   - Active player member → returns `{ campaign, role: 'player' }`
   - No member record → returns 404 NextResponse
@@ -48,15 +48,15 @@
 
 ### 4. Refactor `app/api/campaigns/[id]/route.ts`
 
-- [ ] Remove `findCampaign` helper
-- [ ] GET: replace `findCampaign(id, auth.userId)` with `assertCampaignAccess(id, auth.userId)`; destructure `{ campaign }` from result
-- [ ] PATCH: replace `findCampaign` with `assertCampaignAccess`; after access check add:
+- [x] Remove `findCampaign` helper
+- [x] GET: replace `findCampaign(id, auth.userId)` with `assertCampaignAccess(id, auth.userId)`; destructure `{ campaign }` from result
+- [x] PATCH: replace `findCampaign` with `assertCampaignAccess`; after access check add:
   ```ts
   if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
   ```
-- [ ] DELETE: same pattern as PATCH — `assertCampaignAccess` + `role !== 'dm'` → 404
-- [ ] Add import for `assertCampaignAccess` from `@/lib/utils/campaign`; remove `Campaign` import if no longer needed directly
-- [ ] Write/update route handler tests:
+- [x] DELETE: same pattern as PATCH — `assertCampaignAccess` + `role !== 'dm'` → 404
+- [x] Add import for `assertCampaignAccess` from `@/lib/utils/campaign`; remove `Campaign` import if no longer needed directly
+- [x] Write/update route handler tests:
   - GET as player → 200 with campaign
   - GET as non-member → 404
   - PATCH as DM → 200
@@ -66,10 +66,10 @@
 
 ### 5. Refactor `app/api/campaigns/[id]/sessions/route.ts`
 
-- [ ] GET: replace `storage.loadCampaignById(campaignId, auth.userId)` guard with `assertCampaignAccess(campaignId, auth.userId)`; destructure `{ campaign }` (campaign not used in GET body, guard is the purpose)
-- [ ] POST: same replacement; add `role !== 'dm'` → 404 check after access check
-- [ ] Add import for `assertCampaignAccess`; remove direct `storage` import if storage is no longer called at the route level (it still is for `loadSessionLogs`/`saveSessionLog`, so keep it)
-- [ ] Write/update route handler tests:
+- [x] GET: replace `storage.loadCampaignById(campaignId, auth.userId)` guard with `assertCampaignAccess(campaignId, auth.userId)`; destructure `{ campaign }` (campaign not used in GET body, guard is the purpose)
+- [x] POST: same replacement; add `role !== 'dm'` → 404 check after access check
+- [x] Add import for `assertCampaignAccess`; remove direct `storage` import if storage is no longer called at the route level (it still is for `loadSessionLogs`/`saveSessionLog`, so keep it)
+- [x] Write/update route handler tests:
   - GET as player → 200 with session logs
   - GET as non-member → 404
   - POST as DM → 201
@@ -77,31 +77,34 @@
 
 ### 6. Refactor `app/api/campaigns/[id]/sessions/[sessionId]/route.ts`
 
-- [ ] PATCH: add `assertCampaignAccess(campaignId, auth.userId)` at top of handler; add `role !== 'dm'` → 404 check; only then proceed to `storage.updateSessionLog`
-- [ ] Add import for `assertCampaignAccess`
-- [ ] Write/update route handler tests:
+- [x] PATCH: add `assertCampaignAccess(campaignId, auth.userId)` at top of handler; add `role !== 'dm'` → 404 check; only then proceed to `storage.updateSessionLog`
+- [x] Add import for `assertCampaignAccess`
+- [x] Write/update route handler tests:
   - PATCH as DM → 200 (or 404 if sessionId not found — pre-existing behavior)
   - PATCH as player → 404
   - PATCH as non-member → 404
+  - DELETE as DM → 200 (or 404 if sessionId not found — pre-existing behavior)
+  - DELETE as player → 404
+  - DELETE as non-member → 404
 
 ### 7. Refactor `app/api/campaigns/[id]/combat-events/route.ts`
 
-- [ ] GET: add `assertCampaignAccess(id, auth.userId)` gate at top of handler; if denied return early; proceed to existing DB query (which already filters `userId: auth.userId`)
-- [ ] Add import for `assertCampaignAccess`
-- [ ] Write/update route handler tests:
+- [x] GET: add `assertCampaignAccess(id, auth.userId)` gate at top of handler; if denied return early; proceed to existing DB query (which already filters `userId: auth.userId`)
+- [x] Add import for `assertCampaignAccess`
+- [x] Write/update route handler tests:
   - GET as active player → 200 (their own events)
   - GET as non-member → 404
 
 ## Pre-Commit Code Review
 
-- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
 
 ## Validation
 
-- [ ] `npm run test:unit` — all tests pass
-- [ ] `npm run build` — no type errors, build succeeds
-- [ ] All acceptance scenarios in `specs/campaign-access.md` covered by tests
-- [ ] Confirm `assertCampaignAccess` is the only caller of `loadCampaignByIdAny` (grep check)
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — no type errors, build succeeds
+- [x] All acceptance scenarios in `specs/campaign-access.md` covered by tests
+- [x] Confirm `assertCampaignAccess` is the only caller of `loadCampaignByIdAny` (grep check)
 - [ ] All completed tasks marked complete
 
 ## Remote push validation
@@ -114,10 +117,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to the working branch and push to remote
-- [ ] Open PR from `feat/member-aware-campaign-access` to `main`. PR body must include: `Closes #304`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to the working branch and push to remote
+- [x] Open PR from `feat/member-aware-campaign-access` to `main`. PR body must include: `Closes #304` — PR #359
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
 - [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly resolve threads. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any required (blocking) CI check fails, diagnose and fix, commit fixes, follow all steps in [Remote push validation] then push; wait 180 seconds then repeat until all required checks pass

--- a/openspec/changes/member-aware-campaign-access/tasks.md
+++ b/openspec/changes/member-aware-campaign-access/tasks.md
@@ -1,0 +1,150 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/member-aware-campaign-access` then immediately `git push -u origin feat/member-aware-campaign-access`
+
+## Execution
+
+### 1. Add `getMember` to storage
+
+- [ ] In `lib/storage.ts`, add `getMember(campaignId: string, userId: string): Promise<CampaignMember | null>`
+  - Query `campaignMembers` collection with `{ campaignId, userId }`
+  - Normalize and strip `_id` before returning
+  - Return `null` on not-found; rethrow on unexpected error
+- [ ] Write unit test: member exists → returns CampaignMember; not found → returns null
+
+### 2. Add `loadCampaignByIdAny` to storage
+
+- [ ] In `lib/storage.ts`, add `loadCampaignByIdAny(id: string): Promise<Campaign | null>`
+  - Query `campaigns` collection with `{ id }` only (no `userId` filter)
+  - Apply `normalizeStoredEntityId` + `normalizeCampaign`
+  - Return `null` on not-found; rethrow on unexpected error
+- [ ] Write unit test: campaign exists → returns Campaign; not found → returns null
+
+### 3. Add `assertCampaignAccess` utility
+
+- [ ] In `lib/utils/campaign.ts`, add:
+  ```ts
+  export async function assertCampaignAccess(
+    campaignId: string,
+    userId: string,
+  ): Promise<{ campaign: Campaign; role: MemberRole } | NextResponse>
+  ```
+  - Call `storage.getMember(campaignId, userId)`
+  - If null or `status !== 'active'` → return `NextResponse.json({ error: 'Campaign not found' }, { status: 404 })`
+  - Call `storage.loadCampaignByIdAny(campaignId)`
+  - If null → return `NextResponse.json({ error: 'Campaign not found' }, { status: 404 })`
+  - Return `{ campaign, role: member.role }`
+- [ ] Add imports: `Campaign`, `MemberRole` from `@/lib/types`; `storage` from `@/lib/storage`; `NextResponse` from `next/server`
+- [ ] Write unit tests covering all branches:
+  - Active DM member → returns `{ campaign, role: 'dm' }`
+  - Active player member → returns `{ campaign, role: 'player' }`
+  - No member record → returns 404 NextResponse
+  - Pending member → returns 404 NextResponse
+  - Declined member → returns 404 NextResponse
+  - Active member but campaign missing → returns 404 NextResponse
+
+### 4. Refactor `app/api/campaigns/[id]/route.ts`
+
+- [ ] Remove `findCampaign` helper
+- [ ] GET: replace `findCampaign(id, auth.userId)` with `assertCampaignAccess(id, auth.userId)`; destructure `{ campaign }` from result
+- [ ] PATCH: replace `findCampaign` with `assertCampaignAccess`; after access check add:
+  ```ts
+  if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+  ```
+- [ ] DELETE: same pattern as PATCH — `assertCampaignAccess` + `role !== 'dm'` → 404
+- [ ] Add import for `assertCampaignAccess` from `@/lib/utils/campaign`; remove `Campaign` import if no longer needed directly
+- [ ] Write/update route handler tests:
+  - GET as player → 200 with campaign
+  - GET as non-member → 404
+  - PATCH as DM → 200
+  - PATCH as player → 404
+  - DELETE as DM → 200
+  - DELETE as player → 404
+
+### 5. Refactor `app/api/campaigns/[id]/sessions/route.ts`
+
+- [ ] GET: replace `storage.loadCampaignById(campaignId, auth.userId)` guard with `assertCampaignAccess(campaignId, auth.userId)`; destructure `{ campaign }` (campaign not used in GET body, guard is the purpose)
+- [ ] POST: same replacement; add `role !== 'dm'` → 404 check after access check
+- [ ] Add import for `assertCampaignAccess`; remove direct `storage` import if storage is no longer called at the route level (it still is for `loadSessionLogs`/`saveSessionLog`, so keep it)
+- [ ] Write/update route handler tests:
+  - GET as player → 200 with session logs
+  - GET as non-member → 404
+  - POST as DM → 201
+  - POST as player → 404
+
+### 6. Refactor `app/api/campaigns/[id]/sessions/[sessionId]/route.ts`
+
+- [ ] PATCH: add `assertCampaignAccess(campaignId, auth.userId)` at top of handler; add `role !== 'dm'` → 404 check; only then proceed to `storage.updateSessionLog`
+- [ ] Add import for `assertCampaignAccess`
+- [ ] Write/update route handler tests:
+  - PATCH as DM → 200 (or 404 if sessionId not found — pre-existing behavior)
+  - PATCH as player → 404
+  - PATCH as non-member → 404
+
+### 7. Refactor `app/api/campaigns/[id]/combat-events/route.ts`
+
+- [ ] GET: add `assertCampaignAccess(id, auth.userId)` gate at top of handler; if denied return early; proceed to existing DB query (which already filters `userId: auth.userId`)
+- [ ] Add import for `assertCampaignAccess`
+- [ ] Write/update route handler tests:
+  - GET as active player → 200 (their own events)
+  - GET as non-member → 404
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [ ] `npm run test:unit` — all tests pass
+- [ ] `npm run build` — no type errors, build succeeds
+- [ ] All acceptance scenarios in `specs/campaign-access.md` covered by tests
+- [ ] Confirm `assertCampaignAccess` is the only caller of `loadCampaignByIdAny` (grep check)
+- [ ] All completed tasks marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `feat/member-aware-campaign-access` to `main`. PR body must include: `Closes #304`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly resolve threads. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any required (blocking) CI check fails, diagnose and fix, commit fixes, follow all steps in [Remote push validation] then push; wait 180 seconds then repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+
+Ownership metadata:
+
+- Implementer: claude
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → `npm run test:unit && npm run build` → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm thread resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main: `git log --oneline -5`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No documentation updates needed (API behavior change only; no public-facing docs affected)
+- [ ] Sync approved spec deltas: copy `openspec/changes/member-aware-campaign-access/specs/campaign-access.md` to `openspec/specs/campaign-access/spec.md` (create directory if needed)
+- [ ] Archive the change: move `openspec/changes/member-aware-campaign-access/` to `openspec/changes/archive/YYYY-MM-DD-member-aware-campaign-access/` and stage both the copy and deletion in a single commit
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-member-aware-campaign-access/` exists and `openspec/changes/member-aware-campaign-access/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-member-aware-campaign-access` then `git push -u origin doc/archive-YYYY-MM-DD-member-aware-campaign-access`
+- [ ] Open a PR from that branch to `main` with title `docs: archive member-aware-campaign-access (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until it merges (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/member-aware-campaign-access doc/archive-YYYY-MM-DD-member-aware-campaign-access`

--- a/openspec/changes/member-aware-campaign-access/tests.md
+++ b/openspec/changes/member-aware-campaign-access/tests.md
@@ -1,0 +1,108 @@
+---
+name: tests
+description: Tests for the member-aware-campaign-access change
+---
+
+# Tests
+
+## Overview
+
+All work follows strict TDD: write a failing test → write minimal code to pass → refactor.
+
+Test files:
+- `tests/unit/storage/campaignMembers.test.ts` — storage methods (`getMember`, `loadCampaignByIdAny`)
+- `tests/unit/utils/assertCampaignAccess.test.ts` — utility function
+- `tests/unit/api/campaigns/[id]/route.test.ts` — updated route handler (add new cases to existing file)
+- `tests/unit/api/campaigns/[id]/sessions/route.test.ts` — sessions route (add new cases)
+- `tests/unit/api/campaigns/[id]/sessions/[sessionId]/route.test.ts` — session PATCH route
+- `tests/unit/api/campaigns/[id]/combat-events/route.test.ts` — combat-events GET route
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2. **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3. **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### Task 1 — `getMember` storage method
+
+- [ ] `getMember` returns normalized `CampaignMember` when record exists (strips `_id`)
+  - Spec: ADDED `getMember` — Scenario: Member exists
+- [ ] `getMember` returns `null` when no matching record
+  - Spec: ADDED `getMember` — Scenario: Member does not exist
+
+### Task 2 — `loadCampaignByIdAny` storage method
+
+- [ ] `loadCampaignByIdAny` returns normalized `Campaign` when campaign exists
+  - Spec: ADDED `loadCampaignByIdAny` — Scenario: Campaign exists
+- [ ] `loadCampaignByIdAny` returns `null` when campaign does not exist
+  - Spec: ADDED `loadCampaignByIdAny` — Scenario: Campaign does not exist
+
+### Task 3 — `assertCampaignAccess` utility
+
+- [ ] Active DM member → returns `{ campaign, role: 'dm' }`
+  - Spec: ADDED `assertCampaignAccess` — Scenario: Active member gains access
+- [ ] Active player member → returns `{ campaign, role: 'player' }`
+  - Spec: ADDED `assertCampaignAccess` — Scenario: Active member gains access
+- [ ] `getMember` returns `null` → returns 404 NextResponse with `{ error: 'Campaign not found' }`
+  - Spec: ADDED `assertCampaignAccess` — Scenario: Non-member is denied
+- [ ] Member status `'pending'` → returns 404 NextResponse
+  - Spec: ADDED `assertCampaignAccess` — Scenario: Pending member is denied
+- [ ] Member status `'declined'` → returns 404 NextResponse
+  - Spec: ADDED `assertCampaignAccess` — Scenario: Declined member is denied
+- [ ] Active member but `loadCampaignByIdAny` returns `null` → returns 404 NextResponse
+  - Spec: ADDED `assertCampaignAccess` — Scenario: Member record exists but campaign document is missing
+
+### Task 4 — `app/api/campaigns/[id]/route.ts` refactor
+
+- [ ] GET as active player member → 200 with campaign body
+  - Spec: ADDED `GET /api/campaigns/[id]` — Scenario: Player member GET succeeds
+- [ ] GET as active DM member → 200 with campaign body (regression)
+  - Spec: ADDED `GET /api/campaigns/[id]` — Scenario: DM member GET succeeds
+- [ ] GET as non-member → 404 with `{ error: 'Campaign not found' }`
+  - Spec: ADDED `GET /api/campaigns/[id]` — Scenario: Non-member GET is denied
+- [ ] PATCH as active DM → 200 with updated campaign
+  - Spec: MODIFIED write routes — Scenario: DM PATCH succeeds
+- [ ] PATCH as active player → 404
+  - Spec: MODIFIED write routes — Scenario: Player PATCH is denied
+- [ ] DELETE as active DM → 200
+  - Spec: MODIFIED write routes — Scenario: DM DELETE succeeds
+- [ ] DELETE as active player → 404
+  - Spec: MODIFIED write routes — Scenario: Player DELETE is denied
+
+### Task 5 — `app/api/campaigns/[id]/sessions/route.ts` refactor
+
+- [ ] GET as active player → 200 with session log array
+  - Spec: ADDED sessions GET — Scenario: Player sessions GET
+- [ ] GET as non-member → 404
+  - Spec: ADDED sessions GET — Scenario: Non-member sessions GET is denied
+- [ ] POST as active DM → 201 with new session log
+  - Spec: MODIFIED write routes — Scenario: DM POST session succeeds
+- [ ] POST as active player → 404
+  - Spec: MODIFIED write routes — Scenario: Player POST session is denied
+
+### Task 6 — `app/api/campaigns/[id]/sessions/[sessionId]/route.ts`
+
+- [ ] PATCH as active DM → 200 (or 404 if sessionId not found — pre-existing behavior)
+  - Spec: MODIFIED write routes — Scenario: DM PATCH session log succeeds
+- [ ] PATCH as active player → 404
+  - Spec: MODIFIED write routes — Scenario: Player PATCH session log is denied
+- [ ] PATCH as non-member → 404
+  - Spec: Non-functional security — Scenario: Player cannot escalate to DM write
+
+### Task 7 — `app/api/campaigns/[id]/combat-events/route.ts`
+
+- [ ] GET as active player → 200 with events filtered to `auth.userId`
+  - Spec: ADDED combat events GET — Scenario: Player combat events GET
+- [ ] GET as non-member → 404
+  - Spec: ADDED combat events GET — Scenario: Non-member combat events GET is denied
+
+### Non-functional / security
+
+- [ ] All denial responses use status 404 with body `{ error: 'Campaign not found' }` — not 403 or any body revealing campaign existence
+  - Spec: Non-functional — Scenario: No campaign existence leakage
+- [ ] Grep assertion: `loadCampaignByIdAny` is called only inside `lib/utils/campaign.ts`
+  - Spec: Non-functional — security invariant (manual or CI grep step)

--- a/tests/integration/campaigns.members.integration.test.ts
+++ b/tests/integration/campaigns.members.integration.test.ts
@@ -29,7 +29,10 @@ describe("Campaign Members Integration Tests", () => {
 
   beforeEach(async () => {
     const db = await getDatabase();
-    await db.collection("campaignMembers").deleteMany({});
+    // Only delete members with the fake "camp-*" IDs used in this test file.
+    // Real campaign IDs are UUIDs and must not be wiped — parallel test files
+    // depend on member records created during campaign creation.
+    await db.collection("campaignMembers").deleteMany({ campaignId: { $regex: "^camp-" } });
   });
 
   describe("Storage Methods Integration", () => {

--- a/tests/integration/characters/softDelete.integration.test.ts
+++ b/tests/integration/characters/softDelete.integration.test.ts
@@ -136,15 +136,18 @@ describe("Character Soft Delete API Integration", () => {
         }),
       });
 
+      expect(createRes.status).toBe(201);
       const character = await createRes.json();
-      const characterId = character.id;
+      const characterId: string = character.id;
+      expect(characterId).toBeDefined();
       const originalData = { ...character };
 
       // Delete the character
-      await fetch(`${baseUrl}/api/characters/${characterId}`, {
+      const deleteRes = await fetch(`${baseUrl}/api/characters/${characterId}`, {
         method: "DELETE",
         headers: { Cookie: authCookie },
       });
+      expect(deleteRes.status).toBe(200);
 
       // Verify character data is preserved in the raw collection with deletedAt set
       const mongoClient = new MongoClient(process.env.MONGODB_URI!);

--- a/tests/unit/api/campaigns/combat-events.route.test.ts
+++ b/tests/unit/api/campaigns/combat-events.route.test.ts
@@ -1,9 +1,11 @@
 /**
  * @jest-environment node
  */
+import { NextResponse } from "next/server";
 import { GET } from "@/app/api/campaigns/[id]/combat-events/route";
 import { requireAuth } from "@/lib/middleware";
 import { getDatabase } from "@/lib/db";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
 import {
   MOCK_AUTH,
   mockDbCollection,
@@ -14,9 +16,16 @@ import {
 
 jest.mock("@/lib/middleware");
 jest.mock("@/lib/db", () => ({ getDatabase: jest.fn() }));
+jest.mock("@/lib/utils/campaign", () => ({
+  ...jest.requireActual("@/lib/utils/campaign"),
+  assertCampaignAccess: jest.fn(),
+}));
 
 const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedGetDatabase = jest.mocked(getDatabase);
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
+
+const MOCK_CAMPAIGN = { id: "camp-abc", userId: "user-123", name: "Test", chapters: [], status: "active" as const, notes: "" };
 
 const CAMPAIGN_ID = "camp-abc";
 const BASE_URL = `http://localhost/api/campaigns/${CAMPAIGN_ID}/combat-events`;
@@ -41,10 +50,29 @@ const MOCK_DOC = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+  mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
 });
 
 describe("GET /api/campaigns/[id]/combat-events", () => {
   itReturns401WithParams(GET, makeGetReq, params, mockedRequireAuth);
+
+  it("returns 404 when non-member accesses combat events", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Campaign not found");
+  });
+
+  it("returns 200 with events for active player member", async () => {
+    mockDbCollection(mockedGetDatabase, { find: makeFind([MOCK_DOC]) });
+    const res = await GET(makeGetReq(), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].type).toBe("combat_completed");
+  });
 
   it("returns empty array when no documents match", async () => {
     mockDbCollection(mockedGetDatabase, { find: makeFind([]) });

--- a/tests/unit/api/campaigns/route.test.ts
+++ b/tests/unit/api/campaigns/route.test.ts
@@ -1,17 +1,18 @@
 /**
  * @jest-environment node
  */
+import { NextResponse } from "next/server";
 import { GET, POST } from "@/app/api/campaigns/route";
 import { GET as GET_ONE, PATCH, DELETE } from "@/app/api/campaigns/[id]/route";
 import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
 import {
   MOCK_AUTH,
   makeRouteRequest,
   itReturns401,
   itReturns500,
   itReturns401WithParams,
-  itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
@@ -21,11 +22,17 @@ jest.mock("@/lib/storage", () => ({
   storage: {
     loadCampaigns: jest.fn(),
     saveCampaign: jest.fn(),
-    loadCampaignById: jest.fn(),
     deleteCampaign: jest.fn(),
     addMember: jest.fn().mockResolvedValue(undefined),
   },
 }));
+
+jest.mock("@/lib/utils/campaign", () => ({
+  ...jest.requireActual("@/lib/utils/campaign"),
+  assertCampaignAccess: jest.fn(),
+}));
+
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
 
 const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
@@ -226,32 +233,44 @@ describe("POST /api/campaigns", () => {
 // ─── GET /api/campaigns/[id] ─────────────────────────────────────────────────
 
 describe("GET /api/campaigns/[id]", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+  });
 
   itReturns401WithParams(GET_ONE, () => makeIdRequest("GET"), PARAMS, mockedRequireAuth);
 
-  it("returns campaign when found", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
-    mockedStorage.loadCampaignById.mockResolvedValue(MOCK_CAMPAIGN as any);
+  it("returns 200 with campaign for active DM member", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "dm" });
 
     const response = await GET_ONE(makeIdRequest("GET"), { params: PARAMS });
     expect(response.status).toBe(200);
     expect((await response.json()).name).toBe("Lost Mine of Phandelver");
   });
 
-  itReturns404WithParams(
-    GET_ONE,
-    () => makeIdRequest("GET"),
-    PARAMS,
-    () => mockedStorage.loadCampaignById.mockResolvedValue(null),
-    mockedRequireAuth
-  );
+  it("returns 200 with campaign for active player member", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+
+    const response = await GET_ONE(makeIdRequest("GET"), { params: PARAMS });
+    expect(response.status).toBe(200);
+    expect((await response.json()).name).toBe("Lost Mine of Phandelver");
+  });
+
+  it("returns 404 when assertCampaignAccess denies (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+
+    const response = await GET_ONE(makeIdRequest("GET"), { params: PARAMS });
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe("Campaign not found");
+  });
 
   itReturns500WithParams(
     GET_ONE,
     () => makeIdRequest("GET"),
     PARAMS,
-    () => mockedStorage.loadCampaignById.mockRejectedValue(new Error("DB error")),
+    () => mockedAssertCampaignAccess.mockRejectedValue(new Error("DB error")),
     mockedRequireAuth
   );
 });
@@ -262,7 +281,7 @@ describe("PATCH /api/campaigns/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedRequireAuth.mockReturnValue(MOCK_AUTH);
-    mockedStorage.loadCampaignById.mockResolvedValue({ ...MOCK_CAMPAIGN } as any);
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: { ...MOCK_CAMPAIGN } as any, role: "dm" });
     mockedStorage.saveCampaign.mockResolvedValue(undefined as any);
   });
 
@@ -344,7 +363,7 @@ describe("PATCH /api/campaigns/[id]", () => {
   });
 
   it("treats missing status field on stored document as active (backwards compat)", async () => {
-    mockedStorage.loadCampaignById.mockResolvedValue({ ...MOCK_CAMPAIGN, status: undefined } as any);
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: { ...MOCK_CAMPAIGN, status: undefined } as any, role: "dm" });
     const response = await PATCH(
       makeIdRequest("PATCH", { name: "Test" }),
       { params: PARAMS }
@@ -354,13 +373,20 @@ describe("PATCH /api/campaigns/[id]", () => {
   });
 
   it("strips legacy active field from stored document in PATCH response", async () => {
-    mockedStorage.loadCampaignById.mockResolvedValue({ ...MOCK_CAMPAIGN, active: true } as any);
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: { ...MOCK_CAMPAIGN, active: true } as any, role: "dm" });
     const response = await PATCH(
       makeIdRequest("PATCH", { name: "Test" }),
       { params: PARAMS }
     );
     expect(response.status).toBe(200);
     expect(await response.json()).not.toHaveProperty("active");
+  });
+
+  it("returns 404 when active player attempts PATCH", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const response = await PATCH(makeIdRequest("PATCH", { name: "X" }), { params: PARAMS });
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe("Campaign not found");
   });
 
   it("returns 400 when name is blank", async () => {
@@ -419,19 +445,19 @@ describe("PATCH /api/campaigns/[id]", () => {
     expect(body.currentChapterId).toBeUndefined();
   });
 
-  itReturns404WithParams(
-    PATCH,
-    () => makeIdRequest("PATCH", { name: "X" }),
-    PARAMS,
-    () => mockedStorage.loadCampaignById.mockResolvedValue(null),
-    mockedRequireAuth
-  );
+  it("returns 404 when assertCampaignAccess denies (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const response = await PATCH(makeIdRequest("PATCH", { name: "X" }), { params: PARAMS });
+    expect(response.status).toBe(404);
+  });
 
   itReturns500WithParams(
     PATCH,
     () => makeIdRequest("PATCH", { name: "X" }),
     PARAMS,
-    () => mockedStorage.loadCampaignById.mockRejectedValue(new Error("DB error")),
+    () => mockedAssertCampaignAccess.mockRejectedValue(new Error("DB error")),
     mockedRequireAuth
   );
 });
@@ -442,31 +468,38 @@ describe("DELETE /api/campaigns/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedRequireAuth.mockReturnValue(MOCK_AUTH);
-    mockedStorage.loadCampaignById.mockResolvedValue({ ...MOCK_CAMPAIGN } as any);
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: { ...MOCK_CAMPAIGN } as any, role: "dm" });
     mockedStorage.deleteCampaign.mockResolvedValue(undefined as any);
   });
 
   itReturns401WithParams(DELETE, () => makeIdRequest("DELETE"), PARAMS, mockedRequireAuth);
 
-  it("deletes campaign and returns 200", async () => {
+  it("deletes campaign and returns 200 for DM", async () => {
     const response = await DELETE(makeIdRequest("DELETE"), { params: PARAMS });
     expect(response.status).toBe(200);
     expect(mockedStorage.deleteCampaign).toHaveBeenCalledWith("campaign-1", "user-123");
   });
 
-  itReturns404WithParams(
-    DELETE,
-    () => makeIdRequest("DELETE"),
-    PARAMS,
-    () => mockedStorage.loadCampaignById.mockResolvedValue(null),
-    mockedRequireAuth
-  );
+  it("returns 404 when active player attempts DELETE", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const response = await DELETE(makeIdRequest("DELETE"), { params: PARAMS });
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe("Campaign not found");
+  });
+
+  it("returns 404 when assertCampaignAccess denies (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const response = await DELETE(makeIdRequest("DELETE"), { params: PARAMS });
+    expect(response.status).toBe(404);
+  });
 
   itReturns500WithParams(
     DELETE,
     () => makeIdRequest("DELETE"),
     PARAMS,
-    () => mockedStorage.loadCampaignById.mockRejectedValue(new Error("DB error")),
+    () => mockedAssertCampaignAccess.mockRejectedValue(new Error("DB error")),
     mockedRequireAuth
   );
 });

--- a/tests/unit/api/campaigns/sessions.id.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.id.route.test.ts
@@ -109,11 +109,28 @@ describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
 describe("DELETE /api/campaigns/[id]/sessions/[sessionId]", () => {
   itReturns401WithParams(DELETE, makeDeleteReq, PARAMS, mockedRequireAuth);
 
-  it("returns 200 when deleted", async () => {
+  it("returns 200 when DM deletes a session log", async () => {
     mockedStorage.deleteSessionLog.mockResolvedValue(true as any);
     const res = await DELETE(makeDeleteReq(), { params: PARAMS });
     expect(res.status).toBe(200);
     expect(mockedStorage.deleteSessionLog).toHaveBeenCalledWith(SESSION_ID, "user-123", CAMPAIGN_ID);
+  });
+
+  it("returns 404 when active player attempts DELETE", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const res = await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Campaign not found");
+    expect(mockedStorage.deleteSessionLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when non-member attempts DELETE", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect(mockedStorage.deleteSessionLog).not.toHaveBeenCalled();
   });
 
   itReturns404WithParams(

--- a/tests/unit/api/campaigns/sessions.id.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.id.route.test.ts
@@ -1,9 +1,11 @@
 /**
  * @jest-environment node
  */
+import { NextResponse } from "next/server";
 import { PATCH, DELETE } from "@/app/api/campaigns/[id]/sessions/[sessionId]/route";
 import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
 import {
   MOCK_AUTH,
   MOCK_SESSION_LOG,
@@ -20,14 +22,21 @@ jest.mock("@/lib/storage", () => ({
     deleteSessionLog: jest.fn(),
   },
 }));
+jest.mock("@/lib/utils/campaign", () => ({
+  ...jest.requireActual("@/lib/utils/campaign"),
+  assertCampaignAccess: jest.fn(),
+}));
 
 const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
 
 const CAMPAIGN_ID = "campaign-1";
 const SESSION_ID = "log-1";
 const BASE_URL = `http://localhost/api/campaigns/${CAMPAIGN_ID}/sessions/${SESSION_ID}`;
 const PARAMS = Promise.resolve({ id: CAMPAIGN_ID, sessionId: SESSION_ID });
+
+const MOCK_CAMPAIGN = { id: CAMPAIGN_ID, userId: "user-123", name: "Test Campaign", chapters: [], status: "active" as const, notes: "" };
 
 const makePatchReq = (body: unknown) => makeRouteRequest(BASE_URL, "PATCH", body);
 const makeDeleteReq = () => makeRouteRequest(BASE_URL, "DELETE");
@@ -35,6 +44,7 @@ const makeDeleteReq = () => makeRouteRequest(BASE_URL, "DELETE");
 beforeEach(() => {
   jest.clearAllMocks();
   mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+  mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "dm" });
 });
 
 // ─── PATCH /api/campaigns/[id]/sessions/[sessionId] ───────────────────────────
@@ -42,7 +52,7 @@ beforeEach(() => {
 describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
   itReturns401WithParams(PATCH, () => makePatchReq({ title: "Updated" }), PARAMS, mockedRequireAuth);
 
-  it("returns 200 with updated log", async () => {
+  it("returns 200 with updated log for DM", async () => {
     const updated = { ...MOCK_SESSION_LOG, title: "Updated Title" };
     mockedStorage.updateSessionLog.mockResolvedValue(updated as any);
     const res = await PATCH(makePatchReq({ title: "Updated Title" }), { params: PARAMS });
@@ -59,6 +69,21 @@ describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
     const patch = (mockedStorage.updateSessionLog as jest.Mock).mock.calls[0][3];
     expect(patch.campaignId).toBeUndefined();
     expect(patch.title).toBe("Safe");
+  });
+
+  it("returns 404 when active player attempts PATCH", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const res = await PATCH(makePatchReq({ title: "X" }), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Campaign not found");
+  });
+
+  it("returns 404 when non-member attempts PATCH", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await PATCH(makePatchReq({ title: "X" }), { params: PARAMS });
+    expect(res.status).toBe(404);
   });
 
   itReturns404WithParams(

--- a/tests/unit/api/campaigns/sessions.id.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.id.route.test.ts
@@ -58,6 +58,9 @@ describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
     const res = await PATCH(makePatchReq({ title: "Updated Title" }), { params: PARAMS });
     expect(res.status).toBe(200);
     expect((await res.json()).title).toBe("Updated Title");
+    expect(mockedStorage.updateSessionLog).toHaveBeenCalledWith(
+      SESSION_ID, MOCK_CAMPAIGN.userId, CAMPAIGN_ID, expect.any(Object)
+    );
   });
 
   it("whitelists only allowed fields — does not pass campaignId to storage", async () => {
@@ -113,7 +116,7 @@ describe("DELETE /api/campaigns/[id]/sessions/[sessionId]", () => {
     mockedStorage.deleteSessionLog.mockResolvedValue(true as any);
     const res = await DELETE(makeDeleteReq(), { params: PARAMS });
     expect(res.status).toBe(200);
-    expect(mockedStorage.deleteSessionLog).toHaveBeenCalledWith(SESSION_ID, "user-123", CAMPAIGN_ID);
+    expect(mockedStorage.deleteSessionLog).toHaveBeenCalledWith(SESSION_ID, MOCK_CAMPAIGN.userId, CAMPAIGN_ID);
   });
 
   it("returns 404 when active player attempts DELETE", async () => {

--- a/tests/unit/api/campaigns/sessions.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.route.test.ts
@@ -59,6 +59,7 @@ describe("GET /api/campaigns/[id]/sessions", () => {
     const body = await res.json();
     expect(body).toHaveLength(1);
     expect(body[0].sessionNumber).toBe(1);
+    expect(mockedStorage.loadSessionLogs).toHaveBeenCalledWith(MOCK_CAMPAIGN.userId, CAMPAIGN_ID);
   });
 
   it("returns 200 with empty array when no logs", async () => {

--- a/tests/unit/api/campaigns/sessions.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.route.test.ts
@@ -1,31 +1,36 @@
 /**
  * @jest-environment node
  */
+import { NextResponse } from "next/server";
 import { GET, POST } from "@/app/api/campaigns/[id]/sessions/route";
 import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
 import {
   MOCK_AUTH,
   MOCK_SESSION_LOG,
   makeRouteRequest,
   itReturns401WithParams,
-  itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
 jest.mock("@/lib/middleware");
 jest.mock("@/lib/storage", () => ({
   storage: {
-    loadCampaignById: jest.fn(),
     loadSessionLogs: jest.fn(),
     saveSessionLog: jest.fn(),
     getNextSessionNumber: jest.fn(),
   },
 }));
+jest.mock("@/lib/utils/campaign", () => ({
+  ...jest.requireActual("@/lib/utils/campaign"),
+  assertCampaignAccess: jest.fn(),
+}));
 jest.mock("crypto", () => ({ randomUUID: jest.fn(() => "test-uuid") }));
 
 const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
 
 const CAMPAIGN_ID = "campaign-1";
 const BASE_URL = `http://localhost/api/campaigns/${CAMPAIGN_ID}/sessions`;
@@ -33,12 +38,12 @@ const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
 const makeGetReq = () => makeRouteRequest(BASE_URL, "GET");
 const makePostReq = (body: unknown) => makeRouteRequest(BASE_URL, "POST", body);
 
-const MOCK_CAMPAIGN = { id: CAMPAIGN_ID, userId: "user-123", name: "Test Campaign" };
+const MOCK_CAMPAIGN = { id: CAMPAIGN_ID, userId: "user-123", name: "Test Campaign", chapters: [], status: "active" as const, notes: "" };
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockedRequireAuth.mockReturnValue(MOCK_AUTH);
-  mockedStorage.loadCampaignById.mockResolvedValue(MOCK_CAMPAIGN as any);
+  mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "dm" });
 });
 
 // ─── GET /api/campaigns/[id]/sessions ─────────────────────────────────────────
@@ -46,7 +51,8 @@ beforeEach(() => {
 describe("GET /api/campaigns/[id]/sessions", () => {
   itReturns401WithParams(GET, makeGetReq, PARAMS, mockedRequireAuth);
 
-  it("returns 200 with session logs", async () => {
+  it("returns 200 with session logs for active player", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
     mockedStorage.loadSessionLogs.mockResolvedValue([MOCK_SESSION_LOG] as any);
     const res = await GET(makeGetReq(), { params: PARAMS });
     expect(res.status).toBe(200);
@@ -62,14 +68,13 @@ describe("GET /api/campaigns/[id]/sessions", () => {
     expect(await res.json()).toEqual([]);
   });
 
-  itReturns404WithParams(
-    GET,
-    makeGetReq,
-    PARAMS,
-    () => mockedStorage.loadCampaignById.mockResolvedValue(null as any),
-    mockedRequireAuth,
-    "returns 404 when campaign not found"
-  );
+  it("returns 404 when assertCampaignAccess denies (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await GET(makeGetReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
 
   itReturns500WithParams(
     GET,
@@ -157,14 +162,20 @@ describe("POST /api/campaigns/[id]/sessions", () => {
     expect(body.newLevel).toBe(5);
   });
 
-  itReturns404WithParams(
-    POST,
-    () => makePostReq({ datePlayed: "2026-05-01" }),
-    PARAMS,
-    () => mockedStorage.loadCampaignById.mockResolvedValue(null as any),
-    mockedRequireAuth,
-    "returns 404 when campaign not found"
-  );
+  it("returns 404 when active player attempts POST", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const res = await POST(makePostReq({ datePlayed: "2026-05-01" }), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Campaign not found");
+  });
+
+  it("returns 404 when assertCampaignAccess denies (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await POST(makePostReq({ datePlayed: "2026-05-01" }), { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
 
   itReturns500WithParams(
     POST,

--- a/tests/unit/api/campaigns/sessions.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.route.test.ts
@@ -111,7 +111,9 @@ describe("POST /api/campaigns/[id]/sessions", () => {
     expect(body.sessionNumber).toBe(2);
     expect(body.title).toBe("First Session");
     expect(body.milestone).toBe(false);
+    expect(body.userId).toBe(MOCK_CAMPAIGN.userId);
     expect(mockedStorage.saveSessionLog).toHaveBeenCalledTimes(1);
+    expect(mockedStorage.getNextSessionNumber).toHaveBeenCalledWith(MOCK_CAMPAIGN.userId, CAMPAIGN_ID);
   });
 
   it("uses provided sessionNumber when valid positive integer", async () => {

--- a/tests/unit/storage/campaignMembers.test.ts
+++ b/tests/unit/storage/campaignMembers.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment node
+ */
+import { storage } from "@/lib/storage";
+import { getDatabase } from "@/lib/db";
+import { CampaignMember } from "@/lib/types";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+function makeMockCollection() {
+  const toArray = jest.fn<Promise<unknown[]>, []>();
+  const find = jest.fn(() => ({ toArray }));
+  const findOne = jest.fn<Promise<unknown>, []>();
+  const updateOne = jest.fn<Promise<unknown>, []>();
+  const insertOne = jest.fn<Promise<unknown>, []>();
+  const deleteOne = jest.fn<Promise<unknown>, []>();
+  return { find, toArray, findOne, updateOne, insertOne, deleteOne };
+}
+
+const MOCK_MEMBER: CampaignMember = {
+  id: "mem-1",
+  campaignId: "camp-1",
+  userId: "user-1",
+  role: "dm",
+  status: "active",
+  invitedBy: "user-1",
+  invitedAt: new Date("2026-06-01T00:00:00Z"),
+};
+
+describe("getMember", () => {
+  let mockCollection: ReturnType<typeof makeMockCollection>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection = makeMockCollection();
+    mockDb = { collection: jest.fn(() => mockCollection) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  it("returns normalized CampaignMember (without _id) when record exists", async () => {
+    const rawDoc = { _id: "mongo-oid-1", ...MOCK_MEMBER };
+    mockCollection.findOne.mockResolvedValue(rawDoc as never);
+
+    const result = await storage.getMember("camp-1", "user-1");
+
+    expect(mockDb.collection).toHaveBeenCalledWith("campaignMembers");
+    expect(mockCollection.findOne).toHaveBeenCalledWith({ campaignId: "camp-1", userId: "user-1" });
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("mem-1");
+    expect(result!.role).toBe("dm");
+    expect(result!.status).toBe("active");
+    expect(result).not.toHaveProperty("_id");
+  });
+
+  it("returns null when no matching record", async () => {
+    mockCollection.findOne.mockResolvedValue(null as never);
+
+    const result = await storage.getMember("camp-1", "unknown-user");
+
+    expect(result).toBeNull();
+  });
+
+  it("rethrows on unexpected error", async () => {
+    mockCollection.findOne.mockRejectedValue(new Error("DB failure") as never);
+
+    await expect(storage.getMember("camp-1", "user-1")).rejects.toThrow("DB failure");
+  });
+});
+
+describe("loadCampaignByIdAny", () => {
+  let mockCollection: ReturnType<typeof makeMockCollection>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection = makeMockCollection();
+    mockDb = { collection: jest.fn(() => mockCollection) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  const MOCK_CAMPAIGN_DOC = {
+    _id: "mongo-oid-2",
+    id: "camp-1",
+    userId: "owner-user",
+    name: "Test Campaign",
+    chapters: [],
+    status: "active" as const,
+    notes: "",
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+  };
+
+  it("returns normalized Campaign when campaign exists (no userId filter)", async () => {
+    mockCollection.findOne.mockResolvedValue(MOCK_CAMPAIGN_DOC as never);
+
+    const result = await storage.loadCampaignByIdAny("camp-1");
+
+    expect(mockDb.collection).toHaveBeenCalledWith("campaigns");
+    expect(mockCollection.findOne).toHaveBeenCalledWith({ id: "camp-1" });
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("camp-1");
+    expect(result!.name).toBe("Test Campaign");
+  });
+
+  it("returns null when campaign does not exist", async () => {
+    mockCollection.findOne.mockResolvedValue(null as never);
+
+    const result = await storage.loadCampaignByIdAny("nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("rethrows on unexpected error", async () => {
+    mockCollection.findOne.mockRejectedValue(new Error("DB failure") as never);
+
+    await expect(storage.loadCampaignByIdAny("camp-1")).rejects.toThrow("DB failure");
+  });
+});

--- a/tests/unit/utils/assertCampaignAccess.test.ts
+++ b/tests/unit/utils/assertCampaignAccess.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from "next/server";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
+import { storage } from "@/lib/storage";
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+    loadCampaignByIdAny: jest.fn(),
+  },
+}));
+
+const mockedStorage = jest.mocked(storage) as {
+  getMember: jest.MockedFunction<typeof storage.getMember>;
+  loadCampaignByIdAny: jest.MockedFunction<typeof storage.loadCampaignByIdAny>;
+};
+
+const MOCK_CAMPAIGN = {
+  id: "camp-1",
+  userId: "owner-user",
+  name: "Test Campaign",
+  chapters: [],
+  status: "active" as const,
+  notes: "",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+const makeMember = (role: "dm" | "player", status: "active" | "pending" | "declined") => ({
+  id: "mem-1",
+  campaignId: "camp-1",
+  userId: "user-1",
+  role,
+  status,
+  invitedBy: "owner-user",
+  invitedAt: new Date("2026-06-01"),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("assertCampaignAccess", () => {
+  it("returns { campaign, role: 'dm' } for active DM member", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "active"));
+    mockedStorage.loadCampaignByIdAny.mockResolvedValue(MOCK_CAMPAIGN);
+
+    const result = await assertCampaignAccess("camp-1", "user-1");
+
+    expect(result).not.toBeInstanceOf(NextResponse);
+    const { campaign, role } = result as { campaign: typeof MOCK_CAMPAIGN; role: string };
+    expect(role).toBe("dm");
+    expect(campaign.id).toBe("camp-1");
+  });
+
+  it("returns { campaign, role: 'player' } for active player member", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("player", "active"));
+    mockedStorage.loadCampaignByIdAny.mockResolvedValue(MOCK_CAMPAIGN);
+
+    const result = await assertCampaignAccess("camp-1", "user-1");
+
+    expect(result).not.toBeInstanceOf(NextResponse);
+    const { role } = result as { campaign: unknown; role: string };
+    expect(role).toBe("player");
+  });
+
+  it("returns 404 NextResponse when getMember returns null (non-member)", async () => {
+    mockedStorage.getMember.mockResolvedValue(null);
+
+    const result = await assertCampaignAccess("camp-1", "unknown-user");
+
+    expect(result).toBeInstanceOf(NextResponse);
+    const res = result as NextResponse;
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Campaign not found" });
+  });
+
+  it("returns 404 NextResponse when member status is 'pending'", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "pending"));
+
+    const result = await assertCampaignAccess("camp-1", "user-1");
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(404);
+  });
+
+  it("returns 404 NextResponse when member status is 'declined'", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("player", "declined"));
+
+    const result = await assertCampaignAccess("camp-1", "user-1");
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(404);
+  });
+
+  it("returns 404 NextResponse when active member but campaign document is missing", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "active"));
+    mockedStorage.loadCampaignByIdAny.mockResolvedValue(null);
+
+    const result = await assertCampaignAccess("camp-1", "user-1");
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(404);
+    const body = await (result as NextResponse).json();
+    expect(body).toEqual({ error: "Campaign not found" });
+  });
+
+  it("does not call loadCampaignByIdAny when member is not active", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "pending"));
+
+    await assertCampaignAccess("camp-1", "user-1");
+
+    expect(mockedStorage.loadCampaignByIdAny).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements member-aware campaign access so that active campaign members (players and DMs) can read campaign data, while write operations remain DM-only.

Closes #304

## Changes

### New Storage Methods
- `storage.getMember(campaignId, userId)` — targeted lookup of a campaign membership record
- `storage.loadCampaignByIdAny(id)` — owner-agnostic campaign load (only called by `assertCampaignAccess`)

### New Utility
- `assertCampaignAccess(campaignId, userId)` in `lib/utils/campaign.ts`
  - Returns `{ campaign, role }` for active members (DM or player)
  - Returns 404 NextResponse for non-members, pending/declined members, or missing campaigns

### Route Refactors
- `GET /api/campaigns/[id]` — now accessible to any active member (was owner-only)
- `PATCH/DELETE /api/campaigns/[id]` — uses `assertCampaignAccess` + DM-only role check
- `GET/POST /api/campaigns/[id]/sessions` — same pattern
- `PATCH /api/campaigns/[id]/sessions/[sessionId]` — added `assertCampaignAccess` + DM-only check
- `GET /api/campaigns/[id]/combat-events` — added `assertCampaignAccess` gate

### Removed
- `findCampaign` owner-only helper from `app/api/campaigns/[id]/route.ts`

## Test Coverage
- Unit tests for `getMember` and `loadCampaignByIdAny` storage methods
- Unit tests for all `assertCampaignAccess` branches (active DM, active player, non-member, pending, declined, missing campaign)
- Route handler tests updated/added for all player/non-member access scenarios

## Notes
- Depends on #303 backfill migration having run (owner seeded as active DM in `campaignMembers`)
- `loadCampaignByIdAny` bypasses userId ownership — only `assertCampaignAccess` calls it (enforced by grep check in CI)