### PR TITLE
test: migrate 4 test files from createReactRoot to RTL (#355)

### DIFF
--- a/openspec/changes/migrate-createreactroot-to-rtl/tasks.md
+++ b/openspec/changes/migrate-createreactroot-to-rtl/tasks.md
@@ -1,0 +1,113 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b test/rtl-migration-issue-355` then immediately `git push -u origin test/rtl-migration-issue-355`
+
+## Execution
+
+### File 1 — Migrate `tests/unit/CombatStatsRow.test.tsx`
+
+- [x] Remove imports: `createReactRoot`, `unmountReactRoot`, `Root` from `react-dom/client`, `act` from `react`
+- [x] Add imports: `render`, `screen` from `@testing-library/react`
+- [x] Remove module-level `container` and `root` variables and `afterEach(() => unmountReactRoot(...))` block
+- [x] Replace `renderComponent()` helper (which calls `createReactRoot` + `act(() => root.render(...))`) with inline `render(<CombatStatsRow ... />)` at the top of each test
+- [x] Replace `container.textContent.toContain('18')` → `expect(screen.getByText('18')).toBeInTheDocument()`; apply same pattern for all `textContent` assertions
+- [x] Verify: `npx jest tests/unit/CombatStatsRow.test.tsx --no-coverage` passes
+
+### File 2 — Migrate `tests/unit/CharacterMiniSummary.test.tsx`
+
+- [x] Remove imports: `createReactRoot`, `unmountReactRoot`, `Root`, `act`
+- [x] Add imports: `render`, `screen` from `@testing-library/react`
+- [x] Remove module-level `container`/`root` variables and `afterEach` teardown
+- [x] Replace `renderComponent()` helper with inline `render(<CharacterMiniSummary ... />)` in each test
+- [x] Replace `container.textContent.toContain('X')` with `screen.getByText(/X/)` + `toBeInTheDocument()`; use `not.toBeInTheDocument()` for negative assertions
+- [x] Preserve `global.fetch` spy test; confirm it still passes with RTL render
+- [x] Verify: `npx jest tests/unit/CharacterMiniSummary.test.tsx --no-coverage` passes
+
+### File 3 — Migrate `tests/unit/LairForm.test.tsx`
+
+- [x] Remove imports: `createReactRoot`, `unmountReactRoot`, `Root`, `act`
+- [x] Add imports: `render`, `screen` from `@testing-library/react`; `userEvent` from `@testing-library/user-event`
+- [x] Remove `beforeEach`/`afterEach` container lifecycle blocks
+- [x] Replace the `render` helper (which wraps `await act(async () => { root.render(...) })`) with a new async helper that calls `render(<LairForm {...merged} />)` synchronously (no `act` wrapper needed)
+- [x] Replace `container.querySelector('[data-testid="lair-name-input"]')` → `screen.getByTestId('lair-name-input')`
+- [x] Replace `container.querySelectorAll('button').find(b => b.textContent?.includes('Add Lair'))` → `screen.getByRole('button', { name: /Add Lair/i })`
+- [x] Replace `btn.click()` interaction with `const user = userEvent.setup(); await user.click(btn)` inside each test that clicks
+- [x] Verify: `npx jest tests/unit/LairForm.test.tsx --no-coverage` passes
+
+### File 4 — Migrate `tests/unit/LairActionsSlot.test.tsx`
+
+- [x] Remove imports: `createReactRoot`, `unmountReactRoot`, `Root`, `act`
+- [x] Add imports: `render`, `screen` from `@testing-library/react`; `userEvent` from `@testing-library/user-event`
+- [x] Remove `beforeEach`/`afterEach` container lifecycle blocks (note: `LairActionsSlot` sets `root` in `beforeEach` — remove entirely)
+- [x] Replace `renderSlot()` helper: remove `await act(async () => { root.render(...) })`; use `render(<LairActionsSlot ... />)` synchronously
+- [x] Replace `container.querySelector('[data-testid="..."]')` in `clickEl()` helper with `screen.getByTestId('...')`
+- [x] Replace `el.click()` in `clickEl()` with `const user = userEvent.setup(); await user.click(el)` — or refactor `clickEl` to accept the user instance
+- [x] Replace any remaining `container.querySelector` or `container.textContent` assertions with RTL screen queries
+- [x] Verify: `npx jest tests/unit/LairActionsSlot.test.tsx --no-coverage` passes
+
+### Final checks
+
+- [x] Confirm no `reactRoot` imports remain in the 4 migrated files: `grep "reactRoot" tests/unit/LairForm.test.tsx tests/unit/CharacterMiniSummary.test.tsx tests/unit/LairActionsSlot.test.tsx tests/unit/CombatStatsRow.test.tsx` — expect no matches
+- [x] Confirm `tests/unit/helpers/reactRoot.ts` still exists (not deleted)
+- [x] Confirm `tests/unit/components/CampaignEditor.test.tsx` still imports `reactRoot` (not inadvertently broken)
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill targeting the 4 modified test files. The primary agent must automatically address all findings (complexity, duplication, style issues) before committing.
+
+## Validation
+
+- [x] Run full unit test suite: `npm run test:unit` — all tests must pass
+- [x] Run type check: `npm run typecheck` (or equivalent) — no new errors
+- [x] Run lint: `npm run lint` — no new errors
+- [x] Confirm test count is unchanged (no tests removed or newly skipped)
+- [x] All tasks in Execution section marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before the final commit
+- [ ] Commit all changes to `test/rtl-migration-issue-355` and push to remote
+- [ ] Open PR from `test/rtl-migration-issue-355` to `main` with body including `Closes #355`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (never `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address, commit, validate locally, push, wait 180 seconds, repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll via `gh pr checks <PR-URL> --json isRequired,state`; for any required failing check: diagnose, fix, validate locally, push, wait 180 seconds, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on main
+- [ ] Mark all remaining tasks complete
+- [ ] No documentation updates required (test-only change)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/migrate-createreactroot-to-rtl/` to `openspec/changes/archive/YYYY-MM-DD-migrate-createreactroot-to-rtl/` in a single commit (copy + delete staged together)
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-migrate-createreactroot-to-rtl/` exists and `openspec/changes/migrate-createreactroot-to-rtl/` is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-migrate-createreactroot-to-rtl` then `git push -u origin doc/archive-YYYY-MM-DD-migrate-createreactroot-to-rtl`
+- [ ] Open PR from doc branch to `main` with title `docs: archive migrate-createreactroot-to-rtl (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to same doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d test/rtl-migration-issue-355 doc/archive-YYYY-MM-DD-migrate-createreactroot-to-rtl`

--- a/tests/unit/CharacterMiniSummary.test.tsx
+++ b/tests/unit/CharacterMiniSummary.test.tsx
@@ -1,139 +1,124 @@
 import React from 'react';
-import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { CharacterMiniSummary } from '@/lib/components/CharacterMiniSummary';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
-import type { Root } from 'react-dom/client';
-
-let container: HTMLDivElement;
-let root: Root;
-
-afterEach(() => {
-  unmountReactRoot(container, root);
-});
-
-function renderComponent(element: React.ReactElement): HTMLDivElement {
-  ({ container, root } = createReactRoot());
-  act(() => { root.render(element); });
-  return container;
-}
 
 describe('CharacterMiniSummary', () => {
   test('renders full character identity and stats', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Aragorn',
-        race: 'Human',
-        characterType: 'character',
-        classes: [{ class: 'Fighter', level: 5 }],
-        ac: 18,
-        hp: 45,
-        maxHp: 58,
-      })
+    const { container } = render(
+      <CharacterMiniSummary
+        name="Aragorn"
+        race="Human"
+        characterType="character"
+        classes={[{ class: 'Fighter', level: 5 }]}
+        ac={18}
+        hp={45}
+        maxHp={58}
+      />
     );
-    expect(container.textContent).toContain('Aragorn');
-    expect(container.textContent).toContain('Human');
-    expect(container.textContent).toContain('Fighter');
-    expect(container.textContent).toContain('Lv 5');
-    expect(container.textContent).toContain('18');
-    expect(container.textContent).toContain('45/58');
+    expect(screen.getByText('Aragorn')).toBeInTheDocument();
+    expect(container).toHaveTextContent('Human');
+    expect(container).toHaveTextContent('Fighter');
+    expect(container).toHaveTextContent('Lv 5');
+    expect(screen.getByText('18')).toBeInTheDocument();
+    expect(screen.getByText('45/58')).toBeInTheDocument();
   });
 
   test('renders NPC badge for characterType npc', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Innkeeper',
-        characterType: 'npc',
-        classes: [],
-        ac: 10,
-        hp: 10,
-        maxHp: 10,
-      })
+    render(
+      <CharacterMiniSummary
+        name="Innkeeper"
+        characterType="npc"
+        classes={[]}
+        ac={10}
+        hp={10}
+        maxHp={10}
+      />
     );
-    expect(container.textContent).toContain('NPC');
+    expect(screen.getByText('NPC')).toBeInTheDocument();
   });
 
   test('renders Companion badge for characterType companion', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Wolf',
-        characterType: 'companion',
-        classes: [],
-        ac: 13,
-        hp: 11,
-        maxHp: 11,
-      })
+    render(
+      <CharacterMiniSummary
+        name="Wolf"
+        characterType="companion"
+        classes={[]}
+        ac={13}
+        hp={11}
+        maxHp={11}
+      />
     );
-    expect(container.textContent).toContain('Companion');
+    expect(screen.getByText('Companion')).toBeInTheDocument();
   });
 
   test('renders no badge for characterType character', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Thorin',
-        characterType: 'character',
-        classes: [{ class: 'Fighter', level: 5 }],
-        ac: 16,
-        hp: 40,
-        maxHp: 40,
-      })
+    render(
+      <CharacterMiniSummary
+        name="Thorin"
+        characterType="character"
+        classes={[{ class: 'Fighter', level: 5 }]}
+        ac={16}
+        hp={40}
+        maxHp={40}
+      />
     );
-    expect(container.textContent).not.toContain('NPC');
-    expect(container.textContent).not.toContain('Companion');
+    expect(screen.queryByText('NPC')).not.toBeInTheDocument();
+    expect(screen.queryByText('Companion')).not.toBeInTheDocument();
   });
 
   test('sums multiclass levels', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Robin',
-        classes: [{ class: 'Fighter', level: 3 }, { class: 'Rogue', level: 2 }],
-        ac: 15,
-        hp: 35,
-        maxHp: 35,
-      })
+    const { container } = render(
+      <CharacterMiniSummary
+        name="Robin"
+        classes={[{ class: 'Fighter', level: 3 }, { class: 'Rogue', level: 2 }]}
+        ac={15}
+        hp={35}
+        maxHp={35}
+      />
     );
-    expect(container.textContent).toContain('Lv 5');
+    expect(container).toHaveTextContent('Lv 5');
   });
 
   test('renders with race undefined', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Mystery',
-        race: undefined,
-        classes: [{ class: 'Wizard', level: 3 }],
-        ac: 12,
-        hp: 18,
-        maxHp: 18,
-      })
+    const { container } = render(
+      <CharacterMiniSummary
+        name="Mystery"
+        race={undefined}
+        classes={[{ class: 'Wizard', level: 3 }]}
+        ac={12}
+        hp={18}
+        maxHp={18}
+      />
     );
-    expect(container.textContent).toContain('—');
+    expect(container).toHaveTextContent('—');
   });
 
   test('renders without class/level line when classes is empty', () => {
-    const container = renderComponent(
-      React.createElement(CharacterMiniSummary, {
-        name: 'Commoner',
-        classes: [],
-        ac: 10,
-        hp: 8,
-        maxHp: 8,
-      })
+    const { container } = render(
+      <CharacterMiniSummary
+        name="Commoner"
+        classes={[]}
+        ac={10}
+        hp={8}
+        maxHp={8}
+      />
     );
-    expect(container.textContent).not.toContain('Lv');
+    expect(container).not.toHaveTextContent('Lv');
   });
 
   test('makes no network requests on mount', () => {
     const fetchSpy = jest.fn();
     const originalFetch = global.fetch;
-    global.fetch = fetchSpy as any;
+    global.fetch = fetchSpy as unknown as typeof global.fetch;
     try {
-      renderComponent(
-        React.createElement(CharacterMiniSummary, {
-          name: 'No Fetch',
-          classes: [],
-          ac: 10,
-          hp: 8,
-          maxHp: 8,
-        })
+      render(
+        <CharacterMiniSummary
+          name="No Fetch"
+          classes={[]}
+          ac={10}
+          hp={8}
+          maxHp={8}
+        />
       );
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {

--- a/tests/unit/CombatStatsRow.test.tsx
+++ b/tests/unit/CombatStatsRow.test.tsx
@@ -1,44 +1,23 @@
 import React from 'react';
-import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { CombatStatsRow } from '@/lib/components/CombatStatsRow';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
-import type { Root } from 'react-dom/client';
-
-let container: HTMLDivElement;
-let root: Root;
-
-afterEach(() => {
-  unmountReactRoot(container, root);
-});
-
-function renderComponent(element: React.ReactElement): HTMLDivElement {
-  ({ container, root } = createReactRoot());
-  act(() => { root.render(element); });
-  return container;
-}
 
 describe('CombatStatsRow', () => {
   test('renders AC and HP values', () => {
-    const container = renderComponent(
-      React.createElement(CombatStatsRow, { ac: 18, hp: 45, maxHp: 58 })
-    );
-    expect(container.textContent).toContain('18');
-    expect(container.textContent).toContain('AC');
-    expect(container.textContent).toContain('45/58');
-    expect(container.textContent).toContain('HP');
+    render(<CombatStatsRow ac={18} hp={45} maxHp={58} />);
+    expect(screen.getByText('18')).toBeInTheDocument();
+    expect(screen.getByText('AC')).toBeInTheDocument();
+    expect(screen.getByText('45/58')).toBeInTheDocument();
+    expect(screen.getByText('HP')).toBeInTheDocument();
   });
 
   test('renders acNote when provided', () => {
-    const container = renderComponent(
-      React.createElement(CombatStatsRow, { ac: 14, acNote: 'leather armor', hp: 20, maxHp: 20 })
-    );
-    expect(container.textContent).toContain('(leather armor)');
+    render(<CombatStatsRow ac={14} acNote="leather armor" hp={20} maxHp={20} />);
+    expect(screen.getByText('(leather armor)')).toBeInTheDocument();
   });
 
   test('renders without acNote when omitted', () => {
-    const container = renderComponent(
-      React.createElement(CombatStatsRow, { ac: 10, hp: 8, maxHp: 8 })
-    );
-    expect(container.textContent).not.toContain('(');
+    render(<CombatStatsRow ac={10} hp={8} maxHp={8} />);
+    expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/LairActionsSlot.test.tsx
+++ b/tests/unit/LairActionsSlot.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LairActionsSlot } from '@/lib/components/LairActionsSlot';
 import type { CombatantState } from '@/lib/types';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
-import type { Root } from 'react-dom/client';
 
 const DEFAULT_LAIR_ACTIONS = [
   { name: 'Earthquake', description: 'The ground shakes violently.', usesRemaining: 2 },
@@ -32,93 +31,78 @@ function getUpdatedLairActions(mock: jest.MockedFunction<(u: Partial<CombatantSt
 }
 
 describe('LairActionsSlot', () => {
-  let container: HTMLDivElement;
-  let root: Root;
-
-  const renderSlot = async (
+  const renderSlot = (
     overrides: Partial<CombatantState> = {},
     isActive = false,
     onUpdate: (u: Partial<CombatantState>) => void = () => {},
     onNextTurn: () => void = () => {},
   ) => {
+    const user = userEvent.setup();
     const combatant = makeLairCombatant(overrides);
-    await act(async () => {
-      root.render(
-        <LairActionsSlot
-          combatant={combatant}
-          isActive={isActive}
-          onUpdate={onUpdate}
-          onNextTurn={onNextTurn}
-        />
-      );
-    });
-    return { combatant };
+    const { container } = render(
+      <LairActionsSlot
+        combatant={combatant}
+        isActive={isActive}
+        onUpdate={onUpdate}
+        onNextTurn={onNextTurn}
+      />
+    );
+    return { combatant, user, container };
   };
 
-  const clickEl = async (testid: string) => {
-    const el = container.querySelector(`[data-testid="${testid}"]`) as HTMLElement;
-    expect(el).not.toBeNull();
-    await act(async () => { el.click(); });
+  const clickEl = async (testid: string, user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByTestId(testid));
   };
 
-  beforeEach(() => {
-    ({ container, root } = createReactRoot());
+  test('renders compact badge with lair name when inactive', () => {
+    renderSlot({}, false);
+    expect(screen.getByText(/Dragon's Lair/)).toBeInTheDocument();
+    expect(screen.queryByText('Earthquake')).not.toBeInTheDocument();
   });
 
-  afterEach(async () => {
-    await unmountReactRoot(container, root);
-  });
-
-  test('renders compact badge with lair name when inactive', async () => {
-    await renderSlot({}, false);
-    expect(container.textContent).toContain("Dragon's Lair");
-    // Should NOT show action list
-    expect(container.textContent).not.toContain('Earthquake');
-  });
-
-  test('renders full action list when active', async () => {
-    await renderSlot({}, true);
-    expect(container.textContent).toContain('Earthquake');
-    expect(container.textContent).toContain('The ground shakes violently.');
-    expect(container.textContent).toContain('Rockfall');
-    expect(container.textContent).toContain('Volcanic Gas');
+  test('renders full action list when active', () => {
+    renderSlot({}, true);
+    expect(screen.getByText('Earthquake')).toBeInTheDocument();
+    expect(screen.getByText('The ground shakes violently.')).toBeInTheDocument();
+    expect(screen.getByText('Rockfall')).toBeInTheDocument();
+    expect(screen.getByText('Volcanic Gas')).toBeInTheDocument();
   });
 
   test('Skip button calls onNextTurn', async () => {
-    const onNextTurn = jest.fn() as jest.MockedFunction<() => void>;
-    await renderSlot({}, true, () => {}, onNextTurn);
-    await clickEl('lair-action-skip');
+    const onNextTurn = jest.fn();
+    const { user } = renderSlot({}, true, () => {}, onNextTurn);
+    await clickEl('lair-action-skip', user);
     expect(onNextTurn).toHaveBeenCalledTimes(1);
   });
 
   test('Use button decrements charge via onUpdate', async () => {
     const onUpdate = jest.fn() as jest.MockedFunction<(u: Partial<CombatantState>) => void>;
-    await renderSlot({}, true, onUpdate);
-    await clickEl('lair-action-use-0');
+    const { user } = renderSlot({}, true, onUpdate);
+    await clickEl('lair-action-use-0', user);
     expect(onUpdate).toHaveBeenCalled();
     expect(getUpdatedLairActions(onUpdate)[0].usesRemaining).toBe(1);
   });
 
   test('[−] button decrements usesRemaining via onUpdate', async () => {
     const onUpdate = jest.fn() as jest.MockedFunction<(u: Partial<CombatantState>) => void>;
-    await renderSlot({}, true, onUpdate);
-    await clickEl('lair-action-decrement-0');
+    const { user } = renderSlot({}, true, onUpdate);
+    await clickEl('lair-action-decrement-0', user);
     expect(onUpdate).toHaveBeenCalled();
     expect(getUpdatedLairActions(onUpdate)[0].usesRemaining).toBe(1);
   });
 
   test('[+] button increments usesRemaining via onUpdate', async () => {
     const onUpdate = jest.fn() as jest.MockedFunction<(u: Partial<CombatantState>) => void>;
-    await renderSlot({}, true, onUpdate);
-    await clickEl('lair-action-increment-0');
+    const { user } = renderSlot({}, true, onUpdate);
+    await clickEl('lair-action-increment-0', user);
     expect(onUpdate).toHaveBeenCalled();
     expect(getUpdatedLairActions(onUpdate)[0].usesRemaining).toBe(3);
   });
 
   test('Restore All calls onUpdate with all charges incremented', async () => {
     const onUpdate = jest.fn() as jest.MockedFunction<(u: Partial<CombatantState>) => void>;
-    await renderSlot({}, true, onUpdate);
-    await clickEl('lair-action-restore-all');
+    const { user } = renderSlot({}, true, onUpdate);
+    await clickEl('lair-action-restore-all', user);
     expect(onUpdate).toHaveBeenCalled();
     const updatedActions = getUpdatedLairActions(onUpdate);
     // limited: 2→3, 0→1; unlimited: unchanged
@@ -127,39 +111,32 @@ describe('LairActionsSlot', () => {
     expect(updatedActions[2].usesRemaining).toBeUndefined();
   });
 
-  test('Use button disabled when usesRemaining is 0', async () => {
-    await renderSlot({}, true);
-    const useBtn = container.querySelector('[data-testid="lair-action-use-1"]') as HTMLButtonElement;
-    expect(useBtn).not.toBeNull();
-    expect(useBtn.disabled).toBe(true);
+  test('Use button disabled when usesRemaining is 0', () => {
+    renderSlot({}, true);
+    expect(screen.getByTestId('lair-action-use-1')).toBeDisabled();
   });
 
-  test('Use button enabled when usesRemaining > 0', async () => {
-    await renderSlot({}, true);
-    const useBtn = container.querySelector('[data-testid="lair-action-use-0"]') as HTMLButtonElement;
-    expect(useBtn.disabled).toBe(false);
+  test('Use button enabled when usesRemaining > 0', () => {
+    renderSlot({}, true);
+    expect(screen.getByTestId('lair-action-use-0')).not.toBeDisabled();
   });
 
-  test('charge controls hidden for actions without usesRemaining', async () => {
-    await renderSlot({}, true);
-    // Action at index 2 has no usesRemaining — no charge controls
-    expect(container.querySelector('[data-testid="lair-action-decrement-2"]')).toBeNull();
-    expect(container.querySelector('[data-testid="lair-action-increment-2"]')).toBeNull();
+  test('charge controls hidden for actions without usesRemaining', () => {
+    renderSlot({}, true);
+    expect(screen.queryByTestId('lair-action-decrement-2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('lair-action-increment-2')).not.toBeInTheDocument();
   });
 
-  test('no HP, AC, or conditions rendered', async () => {
-    await renderSlot({}, true);
-    expect(container.textContent).not.toMatch(/\bHP\b/);
-    expect(container.textContent).not.toMatch(/\bAC\b/);
-    // conditions section
-    expect(container.querySelector('[data-testid="conditions"]')).toBeNull();
+  test('no HP, AC, or conditions rendered', () => {
+    const { container } = renderSlot({}, true);
+    expect(container).not.toHaveTextContent(/\bHP\b/);
+    expect(container).not.toHaveTextContent(/\bAC\b/);
+    expect(screen.queryByTestId('conditions')).not.toBeInTheDocument();
   });
 
-  test('exhausted visual indicator shown when usesRemaining is 0', async () => {
-    await renderSlot({}, true);
-    // Action at index 1 has usesRemaining: 0 — expect exhausted class or text indicator
-    const actionEl = container.querySelector('[data-testid="lair-action-1"]');
-    expect(actionEl).not.toBeNull();
-    expect(actionEl!.className).toMatch(/exhausted|opacity|line-through/);
+  test('exhausted visual indicator shown when usesRemaining is 0', () => {
+    renderSlot({}, true);
+    const actionEl = screen.getByTestId('lair-action-1');
+    expect(actionEl.className).toMatch(/exhausted|opacity|line-through/);
   });
 });

--- a/tests/unit/LairForm.test.tsx
+++ b/tests/unit/LairForm.test.tsx
@@ -1,24 +1,12 @@
 import React from 'react';
-import { act } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LairForm } from '@/lib/components/LairForm';
-import { createReactRoot, unmountReactRoot } from '@/tests/unit/helpers/reactRoot';
-import type { Root } from 'react-dom/client';
 
 describe('LairForm', () => {
-  let container: HTMLDivElement;
-  let root: Root;
-
-  beforeEach(() => {
-    ({ container, root } = createReactRoot());
-  });
-
-  afterEach(async () => {
-    await unmountReactRoot(container, root);
-  });
-
-  const render = async (props: Partial<Parameters<typeof LairForm>[0]> = {}) => {
+  const renderLairForm = (props: Partial<Parameters<typeof LairForm>[0]> = {}) => {
     const defaults = {
-      seedOptions: [],
+      seedOptions: [] as string[],
       lairName: '',
       seedMonster: '',
       onNameChange: jest.fn() as jest.MockedFunction<(v: string) => void>,
@@ -27,119 +15,98 @@ describe('LairForm', () => {
       onCancel: jest.fn() as jest.MockedFunction<() => void>,
     };
     const merged = { ...defaults, ...props };
-    await act(async () => {
-      root.render(<LairForm {...merged} />);
-    });
-    return merged;
+    const { container } = render(<LairForm {...merged} />);
+    return { container, ...merged };
   };
 
-  test('renders lair name input', async () => {
-    await render();
-    const input = container.querySelector('[data-testid="lair-name-input"]') as HTMLInputElement;
-    expect(input).not.toBeNull();
+  test('renders lair name input', () => {
+    renderLairForm();
+    expect(screen.getByTestId('lair-name-input')).toBeInTheDocument();
   });
 
-  test('Add Lair button disabled when name is empty', async () => {
-    await render({ lairName: '' });
-    const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Add Lair')) as HTMLButtonElement;
-    expect(btn?.disabled).toBe(true);
+  test('Add Lair button disabled when name is empty', () => {
+    renderLairForm({ lairName: '' });
+    expect(screen.getByRole('button', { name: /Add Lair/i })).toBeDisabled();
   });
 
-  test('Add Lair button enabled when name has content', async () => {
-    await render({ lairName: "Dragon's Lair" });
-    const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Add Lair')) as HTMLButtonElement;
-    expect(btn?.disabled).toBe(false);
+  test('Add Lair button enabled when name has content', () => {
+    renderLairForm({ lairName: "Dragon's Lair" });
+    expect(screen.getByRole('button', { name: /Add Lair/i })).not.toBeDisabled();
   });
 
   test('calls onConfirm when Add Lair clicked', async () => {
-    const { onConfirm } = await render({ lairName: 'Test Lair' });
-    const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Add Lair')) as HTMLButtonElement;
-    await act(async () => { btn.click(); });
+    const user = userEvent.setup();
+    const { onConfirm } = renderLairForm({ lairName: 'Test Lair' });
+    await user.click(screen.getByRole('button', { name: /Add Lair/i }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
   test('calls onCancel when Cancel clicked', async () => {
-    const { onCancel } = await render();
-    const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Cancel')) as HTMLButtonElement;
-    await act(async () => { btn.click(); });
+    const user = userEvent.setup();
+    const { onCancel } = renderLairForm();
+    await user.click(screen.getByRole('button', { name: /Cancel/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  test('seed select hidden when seedOptions is empty', async () => {
-    await render({ seedOptions: [] });
-    expect(container.querySelector('[data-testid="lair-seed-select"]')).toBeNull();
+  test('seed select hidden when seedOptions is empty', () => {
+    renderLairForm({ seedOptions: [] });
+    expect(screen.queryByTestId('lair-seed-select')).not.toBeInTheDocument();
   });
 
-  test('seed select shown when seedOptions has entries', async () => {
-    await render({ seedOptions: ['Dragon', 'Lich'] });
-    const select = container.querySelector('[data-testid="lair-seed-select"]') as HTMLSelectElement;
-    expect(select).not.toBeNull();
+  test('seed select shown when seedOptions has entries', () => {
+    renderLairForm({ seedOptions: ['Dragon', 'Lich'] });
+    const select = screen.getByTestId('lair-seed-select') as HTMLSelectElement;
     expect(select.options.length).toBe(3); // "None" + 2 monsters
   });
 
-  test('input reflects lairName prop', async () => {
-    await render({ lairName: 'Test Lair' });
-    const input = container.querySelector('[data-testid="lair-name-input"]') as HTMLInputElement;
-    expect(input.value).toBe('Test Lair');
+  test('input reflects lairName prop', () => {
+    renderLairForm({ lairName: 'Test Lair' });
+    expect(screen.getByTestId('lair-name-input')).toHaveValue('Test Lair');
   });
 
   test('Escape key calls onCancel', async () => {
-    const { onCancel } = await render();
-    await act(async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-    });
+    const user = userEvent.setup();
+    const { onCancel } = renderLairForm();
+    await user.keyboard('{Escape}');
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  test('clicking the overlay calls onCancel', async () => {
-    const { onCancel } = await render();
-    const overlay = container.firstElementChild as HTMLDivElement;
-    await act(async () => {
-      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
+  test('clicking the overlay calls onCancel', () => {
+    const { container, onCancel } = renderLairForm();
+    // fireEvent is intentional: userEvent.click targets the visual center (the dialog),
+    // which stops propagation. We need to fire directly on the overlay element.
+    fireEvent.click(container.firstElementChild as HTMLDivElement);
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   test('clicking inside the dialog does not call onCancel', async () => {
-    const { onCancel } = await render();
-    const dialog = container.querySelector('[role="dialog"]') as HTMLDivElement;
-    await act(async () => {
-      dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
+    const user = userEvent.setup();
+    const { onCancel } = renderLairForm();
+    await user.click(screen.getByRole('dialog'));
     expect(onCancel).not.toHaveBeenCalled();
   });
 
-  test('dialog has correct ARIA attributes', async () => {
-    await render();
-    const dialog = container.querySelector('[role="dialog"]');
-    expect(dialog?.getAttribute('aria-modal')).toBe('true');
-    expect(dialog?.getAttribute('aria-labelledby')).toBeTruthy();
+  test('dialog has correct ARIA attributes', () => {
+    renderLairForm();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
   });
 
-  test('body scroll is locked while mounted', async () => {
-    await render();
+  test('body scroll is locked while mounted', () => {
+    renderLairForm();
     expect(document.body.style.overflow).toBe('hidden');
   });
 
-  test('input onChange fires onNameChange with new value', async () => {
-    const { onNameChange } = await render();
-    const input = container.querySelector('[data-testid="lair-name-input"]') as HTMLInputElement;
-    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
-    await act(async () => {
-      nativeSetter?.call(input, 'New Lair');
-      input.dispatchEvent(new Event('input', { bubbles: true }));
-    });
+  test('input onChange fires onNameChange with new value', () => {
+    const { onNameChange } = renderLairForm();
+    fireEvent.change(screen.getByTestId('lair-name-input'), { target: { value: 'New Lair' } });
     expect(onNameChange).toHaveBeenCalled();
   });
 
-  test('select onChange fires onSeedChange with selected value', async () => {
-    const { onSeedChange } = await render({ seedOptions: ['Dragon', 'Lich'] });
-    const select = container.querySelector('[data-testid="lair-seed-select"]') as HTMLSelectElement;
-    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')?.set;
-    await act(async () => {
-      nativeSetter?.call(select, 'Dragon');
-      select.dispatchEvent(new Event('change', { bubbles: true }));
-    });
+  test('select onChange fires onSeedChange with selected value', () => {
+    const { onSeedChange } = renderLairForm({ seedOptions: ['Dragon', 'Lich'] });
+    fireEvent.change(screen.getByTestId('lair-seed-select'), { target: { value: 'Dragon' } });
     expect(onSeedChange).toHaveBeenCalled();
   });
 });

--- a/tests/unit/LairForm.test.tsx
+++ b/tests/unit/LairForm.test.tsx
@@ -101,12 +101,12 @@ describe('LairForm', () => {
   test('input onChange fires onNameChange with new value', () => {
     const { onNameChange } = renderLairForm();
     fireEvent.change(screen.getByTestId('lair-name-input'), { target: { value: 'New Lair' } });
-    expect(onNameChange).toHaveBeenCalled();
+    expect(onNameChange).toHaveBeenCalledWith('New Lair');
   });
 
   test('select onChange fires onSeedChange with selected value', () => {
     const { onSeedChange } = renderLairForm({ seedOptions: ['Dragon', 'Lich'] });
     fireEvent.change(screen.getByTestId('lair-seed-select'), { target: { value: 'Dragon' } });
-    expect(onSeedChange).toHaveBeenCalled();
+    expect(onSeedChange).toHaveBeenCalledWith('Dragon');
   });
 });


### PR DESCRIPTION
## Summary

Migrates 4 unit test files from the legacy `createReactRoot`/`act` pattern to React Testing Library (RTL).

## Files Changed

- `tests/unit/CombatStatsRow.test.tsx`
- `tests/unit/CharacterMiniSummary.test.tsx`
- `tests/unit/LairForm.test.tsx`
- `tests/unit/LairActionsSlot.test.tsx`

## Changes

- Remove `createReactRoot`, `unmountReactRoot`, `Root`, `act` imports and manual container lifecycle
- Use `render` + `screen.getBy*`/`queryBy*` for all DOM queries
- Use `userEvent.setup()` per test for click/keyboard interactions
- Use `fireEvent` for low-level event dispatch (overlay click, controlled inputs)
- Use `toHaveTextContent` for assertions on mixed text content

## Test Results

- All 1901 unit tests pass ✓
- All 229 integration tests pass ✓
- Build succeeds ✓
- TypeScript: no new errors ✓
- Lint: no new errors ✓

Closes #355