### PR TITLE
docs: archive migrate-createreactroot-to-rtl (2026-06-05)

### DIFF
--- a/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-05

--- a/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/design.md
+++ b/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/design.md
@@ -1,0 +1,125 @@
+## Context
+
+- Relevant architecture: Unit tests live under `tests/unit/`. Component tests use RTL (`@testing-library/react`, `@testing-library/user-event`) with Jest + jsdom. The global Jest config (`jest.config.js`) already sets `testEnvironment: "jsdom"` and `jest.setup.ts` sets `IS_REACT_ACT_ENVIRONMENT = true`.
+- Dependencies: `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom` (all installed via #254).
+- Interfaces/contracts touched: The 4 test files only. No production code changes. `tests/unit/helpers/reactRoot.ts` is untouched (still needed by `CampaignEditor.test.tsx`).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Replace `createReactRoot` / `unmountReactRoot` / `act` boilerplate with RTL `render` in all 4 files
+- Adopt semantic RTL queries (`getByRole`, `getByText`, `getByTestId`) in place of `container.textContent` / `container.querySelector`
+- Use `userEvent.setup()` per-test for click interactions (project convention)
+- All 4 files pass `npm run test:unit` with zero regressions
+
+### Non-Goals
+
+- Migrating `CampaignEditor.test.tsx`
+- Deleting `reactRoot.ts`
+- Adding new test coverage
+- Changing production components
+
+## Decisions
+
+### Decision 1: Query strategy — semantic RTL queries (Option B)
+
+- Chosen: Use `getByRole`, `getByText`, `getByTestId`, `getByLabelText` where applicable. Fall back to `getByTestId` for elements without accessible names.
+- Alternatives considered: Option A (minimal swap — `container.textContent.toContain` → `screen.getByText(...).textContent`). Rejected: doesn't improve test quality or accessibility signal.
+- Rationale: Role-based queries verify the component renders accessible elements, not just raw DOM text. Consistent with RTL's design philosophy and the project's existing higher-quality tests.
+- Trade-offs: Requires understanding each component's DOM structure. If a component lacks accessible names, `getByRole` will throw and `getByTestId` is the fallback.
+
+### Decision 2: Interaction style — `userEvent.setup()` per test
+
+- Chosen: `const user = userEvent.setup()` inside each `test()` block, then `await user.click(element)`.
+- Alternatives considered: `fireEvent.click(element)` (synchronous, no setup needed). Rejected: project convention uses `userEvent` (`CombatantCard.callbacks.test.tsx`, `ActiveCombatView.test.tsx`, `LegendaryActionsPanel.test.tsx`).
+- Rationale: Consistency with the rest of the test suite. `userEvent` more accurately simulates real browser interactions.
+- Trade-offs: Requires `async/await` in tests that have click interactions. Tests that only verify render output (no clicks) don't need `userEvent`.
+
+### Decision 3: Async render wrapping
+
+- Chosen: Drop `async act(() => { root.render(...) })` entirely. Use synchronous `render(<Component />)` from RTL.
+- Alternatives considered: Keep `await act(...)` wrappers. Rejected: RTL's `render` wraps in `act` internally; double-wrapping is noise.
+- Rationale: RTL handles `act` automatically. Explicit `act` wrapping is only needed for state updates triggered outside of RTL's event system.
+- Trade-offs: None — this is strictly simpler.
+
+### Decision 4: `reactRoot.ts` lifecycle
+
+- Chosen: Leave `tests/unit/helpers/reactRoot.ts` untouched. Do not delete.
+- Rationale: `tests/unit/components/CampaignEditor.test.tsx` still imports it. Deletion is deferred to the #356 migration.
+- Trade-offs: The helper file remains in the codebase temporarily, which is acceptable given it's clearly tagged for removal.
+
+## Proposal to Design Mapping
+
+- Proposal element: Replace `createReactRoot`/`act` setup
+  - Design decision: Decision 3 (drop async `act` wrapping, use RTL `render`)
+  - Validation approach: Tests compile and pass; no `act` warnings in Jest output
+
+- Proposal element: Replace `container.textContent.toContain` assertions
+  - Design decision: Decision 1 (semantic RTL queries)
+  - Validation approach: Assertions use `screen.getBy*` + `toBeInTheDocument()` or `toHaveTextContent`
+
+- Proposal element: Replace `querySelectorAll('button').find(...)` in `LairForm`
+  - Design decision: Decision 1 (`getByRole('button', { name: /.../ })`)
+  - Validation approach: Button queries match accessible name
+
+- Proposal element: Replace `el.click()` / `btn.click()` interactions
+  - Design decision: Decision 2 (`userEvent.setup()` + `await user.click()`)
+  - Validation approach: Callback mocks receive expected call counts
+
+- Proposal element: Do not delete `reactRoot.ts`
+  - Design decision: Decision 4
+  - Validation approach: `CampaignEditor.test.tsx` still imports and passes
+
+## Functional Requirements Mapping
+
+- Requirement: All 4 files use RTL `render` / `screen` queries
+  - Design element: Decisions 1, 2, 3
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — AC1
+  - Testability notes: `npm run test:unit` must pass; grep confirms no `createReactRoot` imports remain in the 4 files
+
+- Requirement: No imports from `@/tests/unit/helpers/reactRoot` in the 4 migrated files
+  - Design element: Decision 3
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — AC2
+  - Testability notes: `grep "reactRoot" tests/unit/LairForm.test.tsx tests/unit/CharacterMiniSummary.test.tsx tests/unit/LairActionsSlot.test.tsx tests/unit/CombatStatsRow.test.tsx` returns no matches
+
+- Requirement: `npm test` passes with zero regressions
+  - Design element: All decisions
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — AC3
+  - Testability notes: Full unit test run must be green
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: maintainability
+  - Requirement: Tests must follow the same pattern as the rest of the component test suite
+  - Design element: Decisions 1 and 2 (query style and `userEvent` convention)
+  - Acceptance criteria reference: specs/rtl-migration/spec.md — AC4
+  - Testability notes: Code review against `CombatantCard.callbacks.test.tsx` as the reference
+
+## Risks / Trade-offs
+
+- Risk/trade-off: A component may not expose accessible roles/names, causing `getByRole` to throw
+  - Impact: Low — all components use standard HTML elements (buttons, inputs) with visible text
+  - Mitigation: Fall back to `getByTestId` for elements that lack accessible names; note in tasks
+
+- Risk/trade-off: `userEvent` interactions may expose timing differences vs raw `click()`
+  - Impact: Low — all interactions are simple, synchronous button clicks
+  - Mitigation: Run tests immediately after each file migration; address any failures before proceeding to next file
+
+## Rollback / Mitigation
+
+- Rollback trigger: Any test file causes regressions that cannot be resolved within the PR
+- Rollback steps: Revert the specific file's changes (each file is an independent commit); leave other files migrated
+- Data migration considerations: None — test files only
+- Verification after rollback: `npm run test:unit` green on the reverted file
+
+## Operational Blocking Policy
+
+- If CI checks fail: Investigate immediately; do not merge with failing tests. Each file is independently committable, so a partial merge is acceptable if one file is blocking.
+- If security checks fail: N/A — test-only change with no production code impact.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to maintainer after 48 hours.
+- Escalation path and timeout: Author resolves within 3 business days or splits into smaller PRs per file.
+
+## Open Questions
+
+No open questions. All decisions confirmed during exploration.

--- a/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/proposal.md
+++ b/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/proposal.md
@@ -1,0 +1,77 @@
+## GitHub Issues
+
+- #355
+
+## Why
+
+- Problem statement: Four component test files (`LairForm`, `CharacterMiniSummary`, `LairActionsSlot`, `CombatStatsRow`) still use the legacy `createReactRoot` / `act` / `container.querySelector` pattern from before React Testing Library (RTL) was installed in #254. These pre-RTL tests are inconsistent with every other component test in the project and use a lower-quality assertion style (`container.textContent.toContain`) that doesn't verify accessibility semantics or component roles.
+- Why now: The prerequisite work is complete — RTL is installed (#254), `jest.config.js` uses `jsdom` globally, and the boilerplate cleanup (#264) is in progress. These 4 files are the next logical step.
+- Business/user impact: Consistent test patterns across the codebase reduce cognitive overhead, make it easier to write new tests correctly, and improve test quality by using role- and label-based queries.
+
+## Problem Space
+
+- Current behavior: The 4 files import `createReactRoot` / `unmountReactRoot` from `tests/unit/helpers/reactRoot.ts`, manually set up a DOM container, wrap renders in `act()`, and assert using `container.textContent` or `container.querySelector`.
+- Desired behavior: All 4 files use RTL `render` / `screen` queries with `getByRole`, `getByText`, `getByTestId`, etc., and `userEvent.setup()` for interactions — consistent with the rest of the component test suite.
+- Constraints:
+  - `tests/unit/components/CampaignEditor.test.tsx` also imports `createReactRoot` and is tracked separately in #356; `reactRoot.ts` must NOT be deleted in this change.
+  - Interaction tests must use `userEvent.setup()` per test (project convention — see `CombatantCard.callbacks.test.tsx`, `ActiveCombatView.test.tsx`).
+  - All existing test assertions must be preserved (no test removal, no narrowing of coverage).
+- Assumptions: RTL and `@testing-library/user-event` are already installed and configured.
+- Edge cases considered:
+  - `LairForm` and `LairActionsSlot` use `async act(() => { root.render(...) })` — RTL's `render` is synchronous and handles `act` internally; the async wrapping is unnecessary after migration.
+  - `LairForm` finds buttons via `querySelectorAll('button').find(b => b.textContent?.includes('Add Lair'))` — this must be replaced with `screen.getByRole('button', { name: /Add Lair/ })`.
+  - `CharacterMiniSummary` tests a `fetch` spy — this is a unit-level concern unrelated to RTL and should be preserved as-is.
+
+## Scope
+
+### In Scope
+
+- Migrate `tests/unit/CombatStatsRow.test.tsx` to RTL
+- Migrate `tests/unit/CharacterMiniSummary.test.tsx` to RTL
+- Migrate `tests/unit/LairForm.test.tsx` to RTL
+- Migrate `tests/unit/LairActionsSlot.test.tsx` to RTL
+- Use `screen.getByRole`, `screen.getByText`, `screen.getByTestId`, `screen.getByLabelText` (Option B: embrace RTL idioms)
+- Use `userEvent.setup()` per-test for click/interaction assertions (project convention)
+- Verify `npm run test:unit` passes with zero regressions after all 4 migrations
+
+### Out of Scope
+
+- Migrating `tests/unit/components/CampaignEditor.test.tsx` (tracked in #356)
+- Deleting `tests/unit/helpers/reactRoot.ts` (still needed by `CampaignEditor.test.tsx`)
+- Changes to `jest.config.js`, `jest.setup.ts`, or any other configuration
+- Adding new test cases beyond what currently exists
+
+## What Changes
+
+- `tests/unit/CombatStatsRow.test.tsx`: replace `createReactRoot`/`act` setup with RTL `render`; replace `container.textContent.toContain` with `screen.getByText` / `toBeInTheDocument`
+- `tests/unit/CharacterMiniSummary.test.tsx`: same pattern; also preserve `global.fetch` spy test
+- `tests/unit/LairForm.test.tsx`: replace setup; replace `querySelectorAll('button').find(...)` with `screen.getByRole('button', { name: /.../ })`; replace `btn.click()` with `userEvent.setup()` + `await user.click(btn)`
+- `tests/unit/LairActionsSlot.test.tsx`: replace setup; replace `container.querySelector('[data-testid="..."]')` with `screen.getByTestId`; replace `el.click()` with `userEvent.setup()` + `await user.click(el)`
+
+## Risks
+
+- Risk: RTL's `cleanup` (automatic after each test) may surface issues if components have global side effects that the old manual `unmountReactRoot` was masking.
+  - Impact: Low — tests would fail loudly rather than silently.
+  - Mitigation: Run full unit test suite after each file migration to catch regressions early.
+- Risk: `getByRole` queries require correct ARIA roles in components; if a button lacks accessible text the query will throw.
+  - Impact: Low — the components use standard HTML elements with visible text.
+  - Mitigation: Inspect rendered output if a query fails; fall back to `getByTestId` for elements without accessible names.
+
+## Open Questions
+
+No unresolved ambiguity. Decisions confirmed in exploration:
+- Query style: Option B (role/semantic RTL queries) ✅
+- Interaction library: `userEvent.setup()` per test (matches project convention) ✅
+- `reactRoot.ts` deletion: deferred — `CampaignEditor.test.tsx` still uses it ✅
+
+## Non-Goals
+
+- Improving test coverage beyond the current test cases
+- Refactoring the components under test
+- Updating `reactRoot.ts` itself
+- Migrating integration tests
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/specs/rtl-migration/spec.md
+++ b/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/specs/rtl-migration/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED Component test infrastructure — 4 files use RTL (AC1)
+
+The system SHALL render all 4 migrated test components using RTL `render` from `@testing-library/react` with no manual container setup.
+
+#### Scenario: CombatStatsRow renders with RTL
+
+- **Given** `CombatStatsRow.test.tsx` is migrated
+- **When** the test suite runs
+- **Then** `render(<CombatStatsRow ... />)` is called with no `createReactRoot`, no `act` wrapper, and no manual container variable
+
+#### Scenario: CharacterMiniSummary renders with RTL
+
+- **Given** `CharacterMiniSummary.test.tsx` is migrated
+- **When** the test suite runs
+- **Then** `render(<CharacterMiniSummary ... />)` is called and RTL's automatic cleanup runs after each test
+
+#### Scenario: LairForm renders with RTL
+
+- **Given** `LairForm.test.tsx` is migrated
+- **When** the test suite runs
+- **Then** `render(<LairForm ... />)` is called synchronously with no `await act(async () => ...)` wrapper
+
+#### Scenario: LairActionsSlot renders with RTL
+
+- **Given** `LairActionsSlot.test.tsx` is migrated
+- **When** the test suite runs
+- **Then** `render(<LairActionsSlot ... />)` is called and `beforeEach`/`afterEach` setup blocks are removed
+
+---
+
+### Requirement: MODIFIED Component test assertions use semantic RTL queries (AC1, AC4)
+
+The system SHALL query rendered output using `screen.getByRole`, `screen.getByText`, `screen.getByTestId`, or equivalent RTL screen queries — not `container.textContent`, `container.querySelector`, or `container.querySelectorAll`.
+
+#### Scenario: Text-content assertions replaced
+
+- **Given** a migrated test previously asserting `container.textContent.toContain('X')`
+- **When** the assertion runs
+- **Then** it uses `screen.getByText(/X/)` + `toBeInTheDocument()` or `toHaveTextContent`
+
+#### Scenario: Button found by role, not text scan
+
+- **Given** `LairForm.test.tsx` migrated
+- **When** the test queries for the "Add Lair" button
+- **Then** it uses `screen.getByRole('button', { name: /Add Lair/i })` rather than `querySelectorAll('button').find(...)`
+
+#### Scenario: data-testid elements found via `getByTestId`
+
+- **Given** `LairActionsSlot.test.tsx` migrated
+- **When** a test queries an element by `data-testid`
+- **Then** it uses `screen.getByTestId('...')` rather than `container.querySelector('[data-testid="..."]')`
+
+---
+
+### Requirement: MODIFIED Click interactions use `userEvent.setup()` (AC4)
+
+The system SHALL simulate user interactions using `userEvent.setup()` instantiated per test, consistent with project convention.
+
+#### Scenario: Click interaction in LairForm
+
+- **Given** `LairForm.test.tsx` migrated
+- **When** a test clicks the "Add Lair" button
+- **Then** it calls `const user = userEvent.setup()` inside the test, then `await user.click(button)`, and the `onConfirm` mock receives exactly 1 call
+
+#### Scenario: Click interaction in LairActionsSlot
+
+- **Given** `LairActionsSlot.test.tsx` migrated
+- **When** a test clicks an action button
+- **Then** it calls `const user = userEvent.setup()` inside the test and `await user.click(el)`, with the mock receiving the expected arguments
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED No `createReactRoot` imports in the 4 migrated files (AC2)
+
+The system SHALL have zero imports from `@/tests/unit/helpers/reactRoot` in the 4 migrated test files.
+
+#### Scenario: Import removed post-migration
+
+- **Given** any of the 4 migrated test files
+- **When** `grep "reactRoot" tests/unit/LairForm.test.tsx tests/unit/CharacterMiniSummary.test.tsx tests/unit/LairActionsSlot.test.tsx tests/unit/CombatStatsRow.test.tsx` is run
+- **Then** the command returns no matches
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Manual DOM container lifecycle
+
+Reason for removal: `createReactRoot` setup (`let container`, `let root`, `beforeEach`, `afterEach` with `unmountReactRoot`) is replaced by RTL's automatic render and cleanup. This pattern is no longer required in the 4 migrated files.
+
+---
+
+## Traceability
+
+- Proposal element "Replace createReactRoot/act setup" → Requirement AC1 (RTL render)
+- Proposal element "Replace container.textContent assertions" → Requirement AC1/AC4 (semantic queries)
+- Proposal element "Replace querySelectorAll button find" → Requirement AC4 (getByRole)
+- Proposal element "Replace btn.click() interactions" → Requirement AC4 (userEvent.setup)
+- Proposal element "No reactRoot imports" → Requirement AC2
+- Design Decision 1 (semantic queries) → AC1, AC4
+- Design Decision 2 (userEvent.setup) → AC4
+- Design Decision 3 (drop async act) → AC1
+- Design Decision 4 (keep reactRoot.ts) → not a test requirement; enforced by scope boundary
+- AC1 → Task: migrate each file (4 tasks)
+- AC2 → Task: verify no reactRoot import (per-file + final grep)
+- AC3 → Task: run full unit test suite
+- AC4 → Task: code review against CombatantCard.callbacks.test.tsx pattern
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Maintainability
+
+#### Scenario: Pattern consistency
+
+- **Given** any of the 4 migrated files
+- **When** compared to `tests/unit/components/CombatantCard.callbacks.test.tsx`
+- **Then** the import style, query style, and interaction style are consistent (same RTL imports, `userEvent.setup()` per test, `screen.*` queries)
+
+### Requirement: Reliability
+
+#### Scenario: Zero regressions in unit test suite (AC3)
+
+- **Given** all 4 files are migrated
+- **When** `npm run test:unit` is executed
+- **Then** all tests pass with the same number of passing tests as before migration (no tests removed or newly skipped)

--- a/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/tasks.md
+++ b/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/tasks.md
@@ -77,14 +77,14 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before the final commit
-- [ ] Commit all changes to `test/rtl-migration-issue-355` and push to remote
-- [ ] Open PR from `test/rtl-migration-issue-355` to `main` with body including `Closes #355`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (never `--admin`)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
-- [ ] **Monitor PR comments** — poll autonomously; address, commit, validate locally, push, wait 180 seconds, repeat until no unresolved comments remain
-- [ ] **Monitor CI checks** — poll via `gh pr checks <PR-URL> --json isRequired,state`; for any required failing check: diagnose, fix, validate locally, push, wait 180 seconds, repeat
-- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+- [x] Ensure `openspec-review-code` sub-agent was run and all findings addressed before the final commit
+- [x] Commit all changes to `test/rtl-migration-issue-355` and push to remote
+- [x] Open PR from `test/rtl-migration-issue-355` to `main` with body including `Closes #355`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (never `--admin`)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [x] **Monitor PR comments** — poll autonomously; address, commit, validate locally, push, wait 180 seconds, repeat until no unresolved comments remain
+- [x] **Monitor CI checks** — poll via `gh pr checks <PR-URL> --json isRequired,state`; for any required failing check: diagnose, fix, validate locally, push, wait 180 seconds, repeat
+- [x] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
 
 Ownership metadata:
 
@@ -99,11 +99,11 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify merged changes appear on main
-- [ ] Mark all remaining tasks complete
-- [ ] No documentation updates required (test-only change)
-- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify merged changes appear on main
+- [x] Mark all remaining tasks complete
+- [x] No documentation updates required (test-only change)
+- [x] Sync approved spec deltas into `openspec/specs/` (global spec)
 - [ ] Archive the change: move `openspec/changes/migrate-createreactroot-to-rtl/` to `openspec/changes/archive/YYYY-MM-DD-migrate-createreactroot-to-rtl/` in a single commit (copy + delete staged together)
 - [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-migrate-createreactroot-to-rtl/` exists and `openspec/changes/migrate-createreactroot-to-rtl/` is gone
 - [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-migrate-createreactroot-to-rtl` then `git push -u origin doc/archive-YYYY-MM-DD-migrate-createreactroot-to-rtl`

--- a/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/tests.md
+++ b/openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/tests.md
@@ -1,0 +1,69 @@
+---
+name: tests
+description: Test verification plan for migrate-createreactroot-to-rtl
+---
+
+# Tests
+
+## Overview
+
+This document maps acceptance scenarios to the test commands that verify them. Because this change is a test migration (not a production code change), the TDD cycle is inverted: the existing tests ARE the specification. The workflow is:
+
+1. **Rewrite test file** to use RTL
+2. **Run the file** — must pass (the test is the failing/passing signal)
+3. **Refactor** if any tests needed loosening or tightening during migration
+
+## Testing Steps
+
+### File 1 — `tests/unit/CombatStatsRow.test.tsx`
+
+Spec reference: `specs/rtl-migration/spec.md` — AC1, AC2
+
+- [ ] **TDD step 1 (Red):** Before migrating, confirm tests pass with legacy pattern: `npx jest tests/unit/CombatStatsRow.test.tsx --no-coverage`
+- [ ] **TDD step 2 (Green):** Migrate file; run `npx jest tests/unit/CombatStatsRow.test.tsx --no-coverage` — all 3 tests must pass
+- [ ] **TDD step 3 (Verify AC2):** `grep "reactRoot" tests/unit/CombatStatsRow.test.tsx` — expect no output
+- [ ] **TDD step 3 (Verify AC1):** Confirm `render` from `@testing-library/react` is imported; confirm `screen.getByText` (or equivalent) is used in assertions
+
+### File 2 — `tests/unit/CharacterMiniSummary.test.tsx`
+
+Spec reference: `specs/rtl-migration/spec.md` — AC1, AC2
+
+- [ ] **TDD step 1 (Red):** Baseline: `npx jest tests/unit/CharacterMiniSummary.test.tsx --no-coverage` passes with legacy pattern
+- [ ] **TDD step 2 (Green):** Migrate file; run `npx jest tests/unit/CharacterMiniSummary.test.tsx --no-coverage` — all 8 tests must pass (including `global.fetch` spy test)
+- [ ] **TDD step 3 (Verify AC2):** `grep "reactRoot" tests/unit/CharacterMiniSummary.test.tsx` — expect no output
+- [ ] **TDD step 3 (Verify AC1):** Confirm `screen.getByText`, `toBeInTheDocument`, `not.toBeInTheDocument` used in assertions
+
+### File 3 — `tests/unit/LairForm.test.tsx`
+
+Spec reference: `specs/rtl-migration/spec.md` — AC1, AC2, AC4 (userEvent)
+
+- [ ] **TDD step 1 (Red):** Baseline: `npx jest tests/unit/LairForm.test.tsx --no-coverage` passes with legacy pattern
+- [ ] **TDD step 2 (Green):** Migrate file; run `npx jest tests/unit/LairForm.test.tsx --no-coverage` — all tests must pass
+- [ ] **TDD step 3 (Verify AC2):** `grep "reactRoot" tests/unit/LairForm.test.tsx` — expect no output
+- [ ] **TDD step 3 (Verify AC4):** Confirm `userEvent.setup()` used per-test for click interactions; confirm `screen.getByRole('button', { name: /Add Lair/i })` used (no `querySelectorAll`)
+- [ ] **TDD step 3 (Verify AC1):** Confirm `screen.getByTestId` used for `data-testid` queries
+
+### File 4 — `tests/unit/LairActionsSlot.test.tsx`
+
+Spec reference: `specs/rtl-migration/spec.md` — AC1, AC2, AC4 (userEvent)
+
+- [ ] **TDD step 1 (Red):** Baseline: `npx jest tests/unit/LairActionsSlot.test.tsx --no-coverage` passes with legacy pattern
+- [ ] **TDD step 2 (Green):** Migrate file; run `npx jest tests/unit/LairActionsSlot.test.tsx --no-coverage` — all tests must pass
+- [ ] **TDD step 3 (Verify AC2):** `grep "reactRoot" tests/unit/LairActionsSlot.test.tsx` — expect no output
+- [ ] **TDD step 3 (Verify AC4):** Confirm `userEvent.setup()` used per-test for click interactions
+- [ ] **TDD step 3 (Verify AC1):** Confirm `screen.getByTestId` used in place of `container.querySelector`
+
+### Full Suite — AC3 regression check
+
+Spec reference: `specs/rtl-migration/spec.md` — AC3
+
+- [ ] Run `npm run test:unit` — all tests pass, zero regressions
+- [ ] Confirm `tests/unit/helpers/reactRoot.ts` still exists: `ls tests/unit/helpers/reactRoot.ts`
+- [ ] Confirm `CampaignEditor.test.tsx` still imports `reactRoot`: `grep "reactRoot" tests/unit/components/CampaignEditor.test.tsx`
+- [ ] Run `npm run test:integration` — all integration tests pass
+
+### Maintainability check — AC4
+
+Spec reference: `specs/rtl-migration/spec.md` — Non-Functional: Maintainability
+
+- [ ] Compare any migrated file against `tests/unit/components/CombatantCard.callbacks.test.tsx` — import style, `userEvent.setup()` per test, `screen.*` queries are consistent

--- a/openspec/specs/rtl-migration/spec.md
+++ b/openspec/specs/rtl-migration/spec.md
@@ -134,3 +134,65 @@ Reason for removal: Replaced by `screen.getBy*` / `screen.queryBy*` queries, whi
 - **Given** the updated source files (`ui.tsx`, `CampaignEditor.tsx`, `CampaignEditor.test.tsx`)
 - **When** `tsc --noEmit` is run
 - **Then** zero TypeScript errors are reported
+
+---
+
+## ADDED Requirements — 4-file RTL migration (migrate-createreactroot-to-rtl)
+
+### Requirement: Component test infrastructure — 4 files use RTL
+
+The system SHALL render all 4 migrated test components using RTL `render` from `@testing-library/react` with no manual container setup.
+
+#### Scenario: CombatStatsRow, CharacterMiniSummary, LairForm, LairActionsSlot render with RTL
+
+- **Given** any of `CombatStatsRow.test.tsx`, `CharacterMiniSummary.test.tsx`, `LairForm.test.tsx`, `LairActionsSlot.test.tsx`
+- **When** the test suite runs
+- **Then** RTL `render(...)` is called with no `createReactRoot`, no `act` wrapper, and no manual `container`/`root` lifecycle
+
+---
+
+### Requirement: Component test assertions use semantic RTL queries
+
+The system SHALL query rendered output using `screen.getByRole`, `screen.getByText`, `screen.getByTestId`, `toHaveTextContent`, or equivalent RTL screen queries — not raw `container.textContent`, `container.querySelector`, or `container.querySelectorAll`.
+
+#### Scenario: Button found by role
+
+- **Given** `LairForm.test.tsx` migrated
+- **When** the test queries for the "Add Lair" button
+- **Then** it uses `screen.getByRole('button', { name: /Add Lair/i })`
+
+#### Scenario: data-testid elements found via `getByTestId`
+
+- **Given** `LairActionsSlot.test.tsx` migrated
+- **When** a test queries an element by `data-testid`
+- **Then** it uses `screen.getByTestId('...')`
+
+---
+
+### Requirement: Click interactions use `userEvent.setup()` per test
+
+The system SHALL simulate user interactions using `userEvent.setup()` instantiated per test (before render), consistent with project convention.
+
+#### Scenario: Click interaction in LairForm and LairActionsSlot
+
+- **Given** any migrated test that simulates a click
+- **When** the test runs
+- **Then** `const user = userEvent.setup()` is called before `render`, and `await user.click(el)` performs the interaction
+
+---
+
+### Requirement: No `createReactRoot` imports in the 4 migrated files
+
+The system SHALL have zero imports from `@/tests/unit/helpers/reactRoot` in the 4 migrated test files.
+
+#### Scenario: Import removed post-migration
+
+- **Given** any of the 4 migrated test files
+- **When** `grep "reactRoot" tests/unit/LairForm.test.tsx tests/unit/CharacterMiniSummary.test.tsx tests/unit/LairActionsSlot.test.tsx tests/unit/CombatStatsRow.test.tsx` is run
+- **Then** the command returns no matches
+
+---
+
+### Requirement: REMOVED Manual DOM container lifecycle (4 files)
+
+Reason for removal: `createReactRoot` setup (`let container`, `let root`, `beforeEach`, `afterEach` with `unmountReactRoot`) is replaced by RTL's automatic render and cleanup in the 4 migrated files.


### PR DESCRIPTION
Archives the completed `migrate-createreactroot-to-rtl` OpenSpec change and syncs spec deltas to the global rtl-migration spec.

- Moves `openspec/changes/migrate-createreactroot-to-rtl/` → `openspec/changes/archive/2026-06-05-migrate-createreactroot-to-rtl/`
- Appends 4-file RTL migration requirements to `openspec/specs/rtl-migration/spec.md`