### PR TITLE
fix: migrate test auth from auto-mock to withAuth factory pattern

### DIFF
--- a/openspec/changes/migrate-test-auth-to-withauth-factory/tasks.md
+++ b/openspec/changes/migrate-test-auth-to-withauth-factory/tasks.md
@@ -147,15 +147,15 @@ Verify: `npx jest tests/unit/import/ tests/unit/storage/ tests/unit/lib/api-help
 
 ## Pre-Commit Code Review
 
-- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
 
 ## Validation
 
-- [ ] Run unit tests: `npx jest --config jest.config.js tests/unit --no-coverage`
-- [ ] Run type check: `npx tsc --noEmit`
-- [ ] Run build: `npx next build` (or project build command)
-- [ ] All completed tasks marked as complete
-- [ ] All steps in [Remote push validation]
+- [x] Run unit tests: `npx jest --config jest.config.js tests/unit --no-coverage`
+- [x] Run type check: `npx tsc --noEmit`
+- [x] Run build: `npx next build` (or project build command)
+- [x] All completed tasks marked as complete
+- [x] All steps in [Remote push validation]
 
 ## Remote push validation
 
@@ -168,10 +168,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to the working branch and push to remote
-- [ ] Open PR from `fix/test-auth-factory-mock` to `main`. PR body **MUST** include `Closes #340`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to the working branch and push to remote
+- [x] Open PR from `fix/test-auth-factory-mock` to `main`. PR body **MUST** include `Closes #340` — PR #364
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
 - [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix, commit, follow all steps in [Remote push validation] then push; wait 180 seconds then repeat until all required checks pass

--- a/openspec/changes/migrate-test-auth-to-withauth-factory/tasks.md
+++ b/openspec/changes/migrate-test-auth-to-withauth-factory/tasks.md
@@ -1,0 +1,204 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b fix/test-auth-factory-mock` then immediately `git push -u origin fix/test-auth-factory-mock`
+
+## Execution
+
+### Task 1 — Update shared test helpers (`route.test.helpers.ts`)
+
+File: `tests/unit/helpers/route.test.helpers.ts`
+
+- [x] Delete `mockUnauthorized` function
+- [x] Delete `itReturns401` function
+- [x] Delete `itReturns401WithParams` function
+- [x] Remove `mockedRequireAuth: jest.Mock` param from `itReturns500` — delete the `mockedRequireAuth.mockReturnValue(MOCK_AUTH)` line inside it
+- [x] Remove `mockedRequireAuth: jest.Mock` param from `itReturns500WithParams` — delete the `mockedRequireAuth.mockReturnValue(MOCK_AUTH)` line inside it
+- [x] Remove `mockedRequireAuth: jest.Mock` param from `itReturns404WithParams` — delete the `mockedRequireAuth.mockReturnValue(MOCK_AUTH)` line inside it
+
+Verify: `npx tsc --noEmit` (expect only downstream call-site errors at this point — resolve in subsequent tasks)
+
+---
+
+### Task 2 — Migrate campaigns tests (5 files)
+
+Files:
+- `tests/unit/api/campaigns/route.test.ts`
+- `tests/unit/api/campaigns/sessions.route.test.ts`
+- `tests/unit/api/campaigns/sessions.id.route.test.ts`
+- `tests/unit/api/campaigns/global.id.copy.route.test.ts`
+- `tests/unit/api/campaigns/combat-events.route.test.ts`
+
+For each file:
+- [x] Replace `jest.mock("@/lib/middleware")` auto-mock with factory:
+  ```ts
+  jest.mock("@/lib/middleware", () => ({
+    withAuth: (handler: Function) => (req: NextRequest) =>
+      handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+    withAuthAndParams: (handler: Function) => (req: NextRequest, ctx: any) =>
+      handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, ctx.params),
+  }));
+  ```
+  (Include only `withAuth` or `withAuthAndParams` as needed by each file)
+- [x] Remove `import { requireAuth } from "@/lib/middleware"` line
+- [x] Remove `const mockedRequireAuth = jest.mocked(requireAuth)` line
+- [x] Delete any `itReturns401(...)` or `itReturns401WithParams(...)` call sites
+- [x] Drop the `mockedRequireAuth` last arg from any `itReturns500`, `itReturns500WithParams`, `itReturns404WithParams` calls
+
+Verify: `npx jest tests/unit/api/campaigns/ --no-coverage`
+
+---
+
+### Task 3 — Migrate characters tests (2 files)
+
+Files:
+- `tests/unit/api/characters/route.test.ts`
+- `tests/unit/api/characters/[id].route.test.ts`
+
+Apply same migration steps as Task 2.
+
+Verify: `npx jest tests/unit/api/characters/ --no-coverage`
+
+---
+
+### Task 4 — Migrate combat tests (2 files)
+
+Files:
+- `tests/unit/api/combat/route.test.ts`
+- `tests/unit/api/combat/id.test.ts`
+
+Apply same migration steps as Task 2.
+
+Verify: `npx jest tests/unit/api/combat/ --no-coverage`
+
+---
+
+### Task 5 — Migrate content tests (2 files)
+
+Files:
+- `tests/unit/api/content/route.test.ts`
+- `tests/unit/api/content/id.route.test.ts`
+
+Apply same migration steps as Task 2.
+
+Verify: `npx jest tests/unit/api/content/ --no-coverage`
+
+---
+
+### Task 6 — Migrate encounters tests (2 files)
+
+Files:
+- `tests/unit/api/encounters/route.test.ts`
+- `tests/unit/api/encounters/id.test.ts`
+
+Apply same migration steps as Task 2.
+
+Verify: `npx jest tests/unit/api/encounters/ --no-coverage`
+
+---
+
+### Task 7 — Migrate monsters tests (5 files)
+
+Files:
+- `tests/unit/api/monsters/route.test.ts`
+- `tests/unit/api/monsters/id.route.test.ts`
+- `tests/unit/api/monsters/global.route.test.ts`
+- `tests/unit/api/monsters/global.id.route.test.ts`
+- `tests/unit/api/monsters/duplicate.test.ts`
+- `tests/unit/api/monsters/upload.route.test.ts`
+
+Apply same migration steps as Task 2.
+
+Verify: `npx jest tests/unit/api/monsters/ --no-coverage`
+
+---
+
+### Task 8 — Migrate parties test (1 file)
+
+File: `tests/unit/api/parties/route.test.ts`
+
+Apply same migration steps as Task 2.
+
+Verify: `npx jest tests/unit/api/parties/ --no-coverage`
+
+---
+
+### Task 9 — Migrate miscellaneous tests (3 files)
+
+Files:
+- `tests/unit/import/characterImportRoute.test.ts` — already uses a hybrid pattern; remove the internal `requireAuth` from the factory, align to the clean pass-through shape
+- `tests/unit/storage/campaigns.members.test.ts`
+- `tests/unit/lib/api-helpers.test.ts`
+
+Apply same migration steps as Task 2. For `characterImportRoute.test.ts`, simplify the factory to remove the internal `requireAuth` reference.
+
+Verify: `npx jest tests/unit/import/ tests/unit/storage/ tests/unit/lib/api-helpers.test.ts --no-coverage`
+
+---
+
+### Task 10 — Final acceptance verification
+
+- [x] `grep -rn "requireAuth" tests/unit/ | grep -v middleware.test.ts` → **NOTE: 2 legitimate exceptions remain** — `api-helpers.test.ts` tests `requireAdmin` which calls `requireAuth` directly (not `withAuth`), and `global.route.test.ts` uses `requireAdmin` for the same reason. These are correct; the acceptance criterion is satisfied for all route handler tests.
+- [x] `grep -rn "itReturns401" tests/unit/` → zero output
+- [x] `npx tsc --noEmit` → clean
+- [x] `npx jest --config jest.config.js tests/unit --no-coverage` → all pass (1868 tests, 0 failures)
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [ ] Run unit tests: `npx jest --config jest.config.js tests/unit --no-coverage`
+- [ ] Run type check: `npx tsc --noEmit`
+- [ ] Run build: `npx next build` (or project build command)
+- [ ] All completed tasks marked as complete
+- [ ] All steps in [Remote push validation]
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npx jest --config jest.config.js tests/unit`; all tests must pass
+- **Integration tests** — `npx jest --config jest.integration.config.js`; all tests must pass
+- **Build** — `npx next build`; must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `fix/test-auth-factory-mock` to `main`. PR body **MUST** include `Closes #340`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix, commit, follow all steps in [Remote push validation] then push; wait 180 seconds then repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): —
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main: `grep -rn "requireAuth" tests/unit/ | grep -v middleware.test.ts` → zero output
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] No documentation updates required (test-only change)
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec)
+- [ ] Archive the change: move `openspec/changes/migrate-test-auth-to-withauth-factory/` to `openspec/changes/archive/YYYY-MM-DD-migrate-test-auth-to-withauth-factory/` **in a single atomic commit** — stage both the new location and the deletion of the old location together
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-migrate-test-auth-to-withauth-factory/` exists and `openspec/changes/migrate-test-auth-to-withauth-factory/` is gone
+- [ ] **Create a doc branch** for the archive: `git checkout -b doc/archive-YYYY-MM-DD-migrate-test-auth-to-withauth-factory` then `git push -u origin doc/archive-...`
+- [ ] Open a PR from the doc branch to `main` with title `docs: archive migrate-test-auth-to-withauth-factory (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until it merges
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d fix/test-auth-factory-mock doc/archive-YYYY-MM-DD-migrate-test-auth-to-withauth-factory`

--- a/tests/unit/api/campaigns/combat-events.route.test.ts
+++ b/tests/unit/api/campaigns/combat-events.route.test.ts
@@ -1,21 +1,21 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET } from "@/app/api/campaigns/[id]/combat-events/route";
-import { requireAuth } from "@/lib/middleware";
 import { getDatabase } from "@/lib/db";
 import {
-  MOCK_AUTH,
   mockDbCollection,
   makeRouteRequest,
-  itReturns401WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/db", () => ({ getDatabase: jest.fn() }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedGetDatabase = jest.mocked(getDatabase);
 
 const CAMPAIGN_ID = "camp-abc";
@@ -40,12 +40,9 @@ const MOCK_DOC = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
 });
 
 describe("GET /api/campaigns/[id]/combat-events", () => {
-  itReturns401WithParams(GET, makeGetReq, params, mockedRequireAuth);
-
   it("returns empty array when no documents match", async () => {
     mockDbCollection(mockedGetDatabase, { find: makeFind([]) });
 
@@ -131,6 +128,5 @@ describe("GET /api/campaigns/[id]/combat-events", () => {
           toArray: jest.fn().mockRejectedValue(new Error("DB error")),
         }),
       }),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/campaigns/global.id.copy.route.test.ts
+++ b/tests/unit/api/campaigns/global.id.copy.route.test.ts
@@ -1,16 +1,18 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { POST } from "@/app/api/campaigns/global/[id]/copy/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
   MOCK_AUTH,
   makeRouteRequest,
-  mockUnauthorized,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadGlobalCampaignTemplateById: jest.fn(),
@@ -23,7 +25,6 @@ jest.mock("crypto", () => ({
   randomUUID: jest.fn(() => `uuid-${++uuidCounter}`),
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const TEMPLATE_ID = "tpl-1";
@@ -47,16 +48,7 @@ const MOCK_TEMPLATE = {
 beforeEach(() => {
   jest.clearAllMocks();
   uuidCounter = 0;
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
   mockedStorage.saveCampaign.mockResolvedValue(undefined as any);
-});
-
-describe("POST /api/campaigns/global/[id]/copy — auth", () => {
-  it("returns 401 when not authenticated", async () => {
-    mockUnauthorized(mockedRequireAuth as jest.Mock);
-    const res = await POST(makeRouteRequest(BASE_URL, "POST"), { params: PARAMS });
-    expect(res.status).toBe(401);
-  });
 });
 
 describe("POST /api/campaigns/global/[id]/copy — not found", () => {

--- a/tests/unit/api/campaigns/route.test.ts
+++ b/tests/unit/api/campaigns/route.test.ts
@@ -1,21 +1,23 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/campaigns/route";
 import { GET as GET_ONE, PATCH, DELETE } from "@/app/api/campaigns/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 
 jest.mock("@/lib/storage", () => ({
   storage: {
@@ -27,7 +29,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const MOCK_CAMPAIGN = {
@@ -55,10 +56,7 @@ const PATCH_SINGLE_CHAPTER = [{ id: "ch-5", title: "New Chapter 5", order: 0 }];
 describe("GET /api/campaigns", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(GET, makeGetRequest, mockedRequireAuth);
-
   it("returns list of campaigns", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCampaigns.mockResolvedValue([MOCK_CAMPAIGN] as any);
 
     const response = await GET(makeGetRequest());
@@ -69,7 +67,6 @@ describe("GET /api/campaigns", () => {
   });
 
   it("returns empty array when no campaigns", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCampaigns.mockResolvedValue([]);
 
     const response = await GET(makeGetRequest());
@@ -81,7 +78,6 @@ describe("GET /api/campaigns", () => {
     GET,
     makeGetRequest,
     () => mockedStorage.loadCampaigns.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
@@ -93,28 +89,22 @@ describe("POST /api/campaigns", () => {
     mockedStorage.saveCampaign.mockResolvedValue(undefined as any);
   });
 
-  itReturns401(POST, () => makePostRequest({ name: "Test" }), mockedRequireAuth);
-
   it("returns 400 when name is missing", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ moduleName: "X" }));
     expect(response.status).toBe(400);
   });
 
   it("returns 400 when name is blank", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: "   " }));
     expect(response.status).toBe(400);
   });
 
   it("returns 400 when name is a non-string type", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: 123 }));
     expect(response.status).toBe(400);
   });
 
   it("creates campaign with required fields and returns 201", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: "  Dragon Heist  " }));
     expect(response.status).toBe(201);
     const body = await response.json();
@@ -129,7 +119,6 @@ describe("POST /api/campaigns", () => {
   });
 
   it("creates campaign with optional moduleName and explicit status", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(
       makePostRequest({
         name: "Dragon Heist",
@@ -145,32 +134,27 @@ describe("POST /api/campaigns", () => {
   });
 
   it("POST with no status defaults to active", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: "Test" }));
     expect(response.status).toBe(201);
     expect((await response.json()).status).toBe("active");
   });
 
   it("POST with no notes defaults to empty string", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: "Test" }));
     expect((await response.json()).notes).toBe("");
   });
 
   it("POST returns 400 when notes exceed 10000 chars", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: "Test", notes: "x".repeat(10001) }));
     expect(response.status).toBe(400);
   });
 
   it("POST returns 201 when notes are exactly 10000 chars", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makePostRequest({ name: "Test", notes: "x".repeat(10000) }));
     expect(response.status).toBe(201);
   });
 
   it("ignores non-string moduleName", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(
       makePostRequest({ name: "Test", moduleName: 42 })
     );
@@ -179,7 +163,6 @@ describe("POST /api/campaigns", () => {
   });
 
   it("creates campaign with chapters and valid currentChapterId", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(
       makePostRequest({
         name: "Lost Mine",
@@ -200,7 +183,6 @@ describe("POST /api/campaigns", () => {
   });
 
   it("clears currentChapterId if it does not exist in chapters", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(
       makePostRequest({
         name: "Lost Mine",
@@ -219,7 +201,6 @@ describe("POST /api/campaigns", () => {
     POST,
     () => makePostRequest({ name: "Doomed" }),
     () => mockedStorage.saveCampaign.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
@@ -228,10 +209,7 @@ describe("POST /api/campaigns", () => {
 describe("GET /api/campaigns/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(GET_ONE, () => makeIdRequest("GET"), PARAMS, mockedRequireAuth);
-
   it("returns campaign when found", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCampaignById.mockResolvedValue(MOCK_CAMPAIGN as any);
 
     const response = await GET_ONE(makeIdRequest("GET"), { params: PARAMS });
@@ -244,7 +222,6 @@ describe("GET /api/campaigns/[id]", () => {
     () => makeIdRequest("GET"),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockResolvedValue(null),
-    mockedRequireAuth
   );
 
   itReturns500WithParams(
@@ -252,7 +229,6 @@ describe("GET /api/campaigns/[id]", () => {
     () => makeIdRequest("GET"),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
@@ -261,12 +237,9 @@ describe("GET /api/campaigns/[id]", () => {
 describe("PATCH /api/campaigns/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCampaignById.mockResolvedValue({ ...MOCK_CAMPAIGN } as any);
     mockedStorage.saveCampaign.mockResolvedValue(undefined as any);
   });
-
-  itReturns401WithParams(PATCH, () => makeIdRequest("PATCH", {}), PARAMS, mockedRequireAuth);
 
   it("updates name and returns 200", async () => {
     const response = await PATCH(
@@ -424,7 +397,6 @@ describe("PATCH /api/campaigns/[id]", () => {
     () => makeIdRequest("PATCH", { name: "X" }),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockResolvedValue(null),
-    mockedRequireAuth
   );
 
   itReturns500WithParams(
@@ -432,7 +404,6 @@ describe("PATCH /api/campaigns/[id]", () => {
     () => makeIdRequest("PATCH", { name: "X" }),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
@@ -441,12 +412,9 @@ describe("PATCH /api/campaigns/[id]", () => {
 describe("DELETE /api/campaigns/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCampaignById.mockResolvedValue({ ...MOCK_CAMPAIGN } as any);
     mockedStorage.deleteCampaign.mockResolvedValue(undefined as any);
   });
-
-  itReturns401WithParams(DELETE, () => makeIdRequest("DELETE"), PARAMS, mockedRequireAuth);
 
   it("deletes campaign and returns 200", async () => {
     const response = await DELETE(makeIdRequest("DELETE"), { params: PARAMS });
@@ -459,7 +427,6 @@ describe("DELETE /api/campaigns/[id]", () => {
     () => makeIdRequest("DELETE"),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockResolvedValue(null),
-    mockedRequireAuth
   );
 
   itReturns500WithParams(
@@ -467,6 +434,5 @@ describe("DELETE /api/campaigns/[id]", () => {
     () => makeIdRequest("DELETE"),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/campaigns/sessions.id.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.id.route.test.ts
@@ -1,19 +1,20 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { PATCH, DELETE } from "@/app/api/campaigns/[id]/sessions/[sessionId]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   MOCK_SESSION_LOG,
   makeRouteRequest,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     updateSessionLog: jest.fn(),
@@ -21,7 +22,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const CAMPAIGN_ID = "campaign-1";
@@ -34,14 +34,11 @@ const makeDeleteReq = () => makeRouteRequest(BASE_URL, "DELETE");
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
 });
 
 // ─── PATCH /api/campaigns/[id]/sessions/[sessionId] ───────────────────────────
 
 describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
-  itReturns401WithParams(PATCH, () => makePatchReq({ title: "Updated" }), PARAMS, mockedRequireAuth);
-
   it("returns 200 with updated log", async () => {
     const updated = { ...MOCK_SESSION_LOG, title: "Updated Title" };
     mockedStorage.updateSessionLog.mockResolvedValue(updated as any);
@@ -66,7 +63,6 @@ describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
     () => makePatchReq({ title: "X" }),
     PARAMS,
     () => mockedStorage.updateSessionLog.mockResolvedValue(null),
-    mockedRequireAuth,
     "returns 404 when session log not found"
   );
 
@@ -75,15 +71,12 @@ describe("PATCH /api/campaigns/[id]/sessions/[sessionId]", () => {
     () => makePatchReq({ title: "X" }),
     PARAMS,
     () => mockedStorage.updateSessionLog.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
 // ─── DELETE /api/campaigns/[id]/sessions/[sessionId] ──────────────────────────
 
 describe("DELETE /api/campaigns/[id]/sessions/[sessionId]", () => {
-  itReturns401WithParams(DELETE, makeDeleteReq, PARAMS, mockedRequireAuth);
-
   it("returns 200 when deleted", async () => {
     mockedStorage.deleteSessionLog.mockResolvedValue(true as any);
     const res = await DELETE(makeDeleteReq(), { params: PARAMS });
@@ -96,7 +89,6 @@ describe("DELETE /api/campaigns/[id]/sessions/[sessionId]", () => {
     makeDeleteReq,
     PARAMS,
     () => mockedStorage.deleteSessionLog.mockResolvedValue(null as any),
-    mockedRequireAuth,
     "returns 404 when session log not found"
   );
 
@@ -105,6 +97,5 @@ describe("DELETE /api/campaigns/[id]/sessions/[sessionId]", () => {
     makeDeleteReq,
     PARAMS,
     () => mockedStorage.deleteSessionLog.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/campaigns/sessions.route.test.ts
+++ b/tests/unit/api/campaigns/sessions.route.test.ts
@@ -1,19 +1,20 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/campaigns/[id]/sessions/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   MOCK_SESSION_LOG,
   makeRouteRequest,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadCampaignById: jest.fn(),
@@ -24,7 +25,6 @@ jest.mock("@/lib/storage", () => ({
 }));
 jest.mock("crypto", () => ({ randomUUID: jest.fn(() => "test-uuid") }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const CAMPAIGN_ID = "campaign-1";
@@ -37,15 +37,12 @@ const MOCK_CAMPAIGN = { id: CAMPAIGN_ID, userId: "user-123", name: "Test Campaig
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
   mockedStorage.loadCampaignById.mockResolvedValue(MOCK_CAMPAIGN as any);
 });
 
 // ─── GET /api/campaigns/[id]/sessions ─────────────────────────────────────────
 
 describe("GET /api/campaigns/[id]/sessions", () => {
-  itReturns401WithParams(GET, makeGetReq, PARAMS, mockedRequireAuth);
-
   it("returns 200 with session logs", async () => {
     mockedStorage.loadSessionLogs.mockResolvedValue([MOCK_SESSION_LOG] as any);
     const res = await GET(makeGetReq(), { params: PARAMS });
@@ -67,7 +64,6 @@ describe("GET /api/campaigns/[id]/sessions", () => {
     makeGetReq,
     PARAMS,
     () => mockedStorage.loadCampaignById.mockResolvedValue(null as any),
-    mockedRequireAuth,
     "returns 404 when campaign not found"
   );
 
@@ -76,7 +72,6 @@ describe("GET /api/campaigns/[id]/sessions", () => {
     makeGetReq,
     PARAMS,
     () => mockedStorage.loadSessionLogs.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
@@ -87,8 +82,6 @@ describe("POST /api/campaigns/[id]/sessions", () => {
     mockedStorage.saveSessionLog.mockResolvedValue(undefined as any);
     mockedStorage.getNextSessionNumber.mockResolvedValue(2);
   });
-
-  itReturns401WithParams(POST, () => makePostReq({ datePlayed: "2026-05-01" }), PARAMS, mockedRequireAuth);
 
   it("returns 400 when datePlayed is missing", async () => {
     const res = await POST(makePostReq({ title: "Session 1" }), { params: PARAMS });
@@ -162,7 +155,6 @@ describe("POST /api/campaigns/[id]/sessions", () => {
     () => makePostReq({ datePlayed: "2026-05-01" }),
     PARAMS,
     () => mockedStorage.loadCampaignById.mockResolvedValue(null as any),
-    mockedRequireAuth,
     "returns 404 when campaign not found"
   );
 
@@ -171,6 +163,5 @@ describe("POST /api/campaigns/[id]/sessions", () => {
     () => makePostReq({ datePlayed: "2026-05-01" }),
     PARAMS,
     () => mockedStorage.saveSessionLog.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/characters/[id].route.test.ts
+++ b/tests/unit/api/characters/[id].route.test.ts
@@ -1,16 +1,18 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { PUT } from "@/app/api/characters/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
   itValidatesAlignmentFieldWithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadCharacters: jest.fn(),
@@ -18,7 +20,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const EXISTING_CHARACTER = {
@@ -55,7 +56,6 @@ const makeRequest = (body: unknown) =>
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
   mockedStorage.loadCharacters.mockResolvedValue([EXISTING_CHARACTER] as any);
   mockedStorage.saveCharacter.mockResolvedValue(undefined as any);
 });

--- a/tests/unit/api/characters/route.test.ts
+++ b/tests/unit/api/characters/route.test.ts
@@ -1,18 +1,19 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/characters/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
   itValidatesAlignmentField,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadCharacters: jest.fn(),
@@ -20,7 +21,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const MOCK_CHARACTERS = [{ id: "char-1", name: "Thorin", userId: "user-123" }];
@@ -32,10 +32,7 @@ const makeRequest = (body?: unknown) =>
 describe("GET /api/characters", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(GET, () => makeRequest(), mockedRequireAuth);
-
   it("returns list of characters", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCharacters.mockResolvedValue(MOCK_CHARACTERS as any);
 
     const response = await GET(makeRequest());
@@ -49,18 +46,14 @@ describe("GET /api/characters", () => {
     GET,
     () => makeRequest(),
     () => mockedStorage.loadCharacters.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });
 
 describe("POST /api/characters", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.saveCharacter.mockResolvedValue(undefined as any);
   });
-
-  itReturns401(POST, () => makeRequest({ name: "Hero" }), mockedRequireAuth);
 
   it("returns 400 when name is missing", async () => {
     const response = await POST(makeRequest({ hp: 10 }));
@@ -128,7 +121,6 @@ describe("POST /api/characters", () => {
     POST,
     () => makeRequest({ name: "Doomed Hero" }),
     () => mockedStorage.saveCharacter.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 
   itValidatesAlignmentField(
@@ -192,7 +184,6 @@ describe("GET /api/characters — characterType filter", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadCharacters.mockResolvedValue(MOCK_CHARS as any);
   });
 

--- a/tests/unit/api/combat/id.test.ts
+++ b/tests/unit/api/combat/id.test.ts
@@ -1,22 +1,22 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, PUT, DELETE } from "@/app/api/combat/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { getDatabase } from "@/lib/db";
 import {
-  MOCK_AUTH,
   mockDbCollection,
   makeRouteRequest,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/db", () => ({ getDatabase: jest.fn() }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedGetDatabase = jest.mocked(getDatabase);
 
 const COMBAT_ID = "cs-abc-123";
@@ -36,18 +36,14 @@ const makeRequest = (method: string, body?: unknown) =>
 describe("GET /api/combat/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(GET, () => makeRequest("GET"), params, mockedRequireAuth);
-
   itReturns404WithParams(
     GET,
     () => makeRequest("GET"),
     params,
     () => mockDbCollection(mockedGetDatabase, { findOne: jest.fn().mockResolvedValue(null) }),
-    mockedRequireAuth
   );
 
   it("returns combat state when found", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockDbCollection(mockedGetDatabase, { findOne: jest.fn().mockResolvedValue(MOCK_STATE) });
 
     const response = await GET(makeRequest("GET"), { params });
@@ -63,25 +59,20 @@ describe("GET /api/combat/[id]", () => {
     () => mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockRejectedValue(new Error("DB error")),
     }),
-    mockedRequireAuth
   );
 });
 
 describe("PUT /api/combat/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(PUT, () => makeRequest("PUT", {}), params, mockedRequireAuth);
-
   itReturns404WithParams(
     PUT,
     () => makeRequest("PUT", { currentRound: 2 }),
     params,
     () => mockDbCollection(mockedGetDatabase, { findOne: jest.fn().mockResolvedValue(null) }),
-    mockedRequireAuth
   );
 
   it("updates combat state and returns 200", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const updateOne = jest.fn().mockResolvedValue({});
     mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockResolvedValue(MOCK_STATE),
@@ -107,25 +98,20 @@ describe("PUT /api/combat/[id]", () => {
     () => mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockRejectedValue(new Error("DB error")),
     }),
-    mockedRequireAuth
   );
 });
 
 describe("DELETE /api/combat/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(DELETE, () => makeRequest("DELETE"), params, mockedRequireAuth);
-
   itReturns404WithParams(
     DELETE,
     () => makeRequest("DELETE"),
     params,
     () => mockDbCollection(mockedGetDatabase, { findOne: jest.fn().mockResolvedValue(null) }),
-    mockedRequireAuth
   );
 
   it("deletes combat state and returns 200", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const deleteOne = jest.fn().mockResolvedValue({});
     mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockResolvedValue(MOCK_STATE),
@@ -145,6 +131,5 @@ describe("DELETE /api/combat/[id]", () => {
     () => mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockRejectedValue(new Error("DB error")),
     }),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/combat/route.test.ts
+++ b/tests/unit/api/combat/route.test.ts
@@ -1,21 +1,21 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/combat/route";
-import { requireAuth } from "@/lib/middleware";
 import { getDatabase } from "@/lib/db";
 import {
-  MOCK_AUTH,
   mockDbCollection,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/db", () => ({ getDatabase: jest.fn() }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedGetDatabase = jest.mocked(getDatabase);
 
 const BASE_URL = "http://localhost/api/combat";
@@ -25,10 +25,7 @@ const makeRequest = (body?: unknown) =>
 describe("GET /api/combat", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(GET, () => makeRequest(), mockedRequireAuth);
-
   it("returns null when no combat state exists", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockDbCollection(mockedGetDatabase, { findOne: jest.fn().mockResolvedValue(null) });
 
     const response = await GET(makeRequest());
@@ -38,7 +35,6 @@ describe("GET /api/combat", () => {
   });
 
   it("returns existing combat state", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const state = { id: "cs-1", userId: "user-123", combatants: [] };
     mockDbCollection(mockedGetDatabase, { findOne: jest.fn().mockResolvedValue(state) });
 
@@ -49,7 +45,6 @@ describe("GET /api/combat", () => {
   });
 
   it("filters by campaignId when provided as query param", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const findOne = jest.fn().mockResolvedValue(null);
     mockDbCollection(mockedGetDatabase, { findOne });
 
@@ -67,17 +62,13 @@ describe("GET /api/combat", () => {
     () => mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockRejectedValue(new Error("DB error")),
     }),
-    mockedRequireAuth
   );
 });
 
 describe("POST /api/combat", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(POST, () => makeRequest({ combatants: [] }), mockedRequireAuth);
-
   it("creates new combat state without campaignId and returns 201", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const insertOne = jest.fn().mockResolvedValue({});
     mockDbCollection(mockedGetDatabase, { insertOne });
 
@@ -91,7 +82,6 @@ describe("POST /api/combat", () => {
   });
 
   it("creates new combat state with campaignId and returns 201", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const insertOne = jest.fn().mockResolvedValue({});
     mockDbCollection(mockedGetDatabase, { insertOne });
 
@@ -115,6 +105,5 @@ describe("POST /api/combat", () => {
     () => mockDbCollection(mockedGetDatabase, {
       insertOne: jest.fn().mockRejectedValue(new Error("DB error")),
     }),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/content/id.route.test.ts
+++ b/tests/unit/api/content/id.route.test.ts
@@ -1,18 +1,19 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { PUT, DELETE } from "@/app/api/content/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     savedContent: {
@@ -22,7 +23,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedUpdate = jest.mocked(storage.savedContent.update);
 const mockedRemove = jest.mocked(storage.savedContent.remove);
 
@@ -35,14 +35,11 @@ const makeDeleteReq = () => makeRouteRequest(BASE_URL, "DELETE");
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
 });
 
 // ─── PUT /api/content/[id] ────────────────────────────────────────────────────
 
 describe("PUT /api/content/[id]", () => {
-  itReturns401WithParams(PUT, () => makePutReq({ result: "text" }), PARAMS, mockedRequireAuth);
-
   it("returns 400 when result is not a string", async () => {
     const res = await PUT(makePutReq({ result: 42 }), { params: PARAMS });
     expect(res.status).toBe(400);
@@ -86,7 +83,6 @@ describe("PUT /api/content/[id]", () => {
     () => makePutReq({ result: "text" }),
     PARAMS,
     () => mockedUpdate.mockResolvedValue(false),
-    mockedRequireAuth,
     "returns 404 when item not found"
   );
 
@@ -95,15 +91,12 @@ describe("PUT /api/content/[id]", () => {
     () => makePutReq({ result: "text" }),
     PARAMS,
     () => mockedUpdate.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
 // ─── DELETE /api/content/[id] ─────────────────────────────────────────────────
 
 describe("DELETE /api/content/[id]", () => {
-  itReturns401WithParams(DELETE, makeDeleteReq, PARAMS, mockedRequireAuth);
-
   it("returns 204 on successful delete", async () => {
     mockedRemove.mockResolvedValue(true);
     const res = await DELETE(makeDeleteReq(), { params: PARAMS });
@@ -116,7 +109,6 @@ describe("DELETE /api/content/[id]", () => {
     makeDeleteReq,
     PARAMS,
     () => mockedRemove.mockResolvedValue(false),
-    mockedRequireAuth,
     "returns 404 when item not found"
   );
 
@@ -125,6 +117,5 @@ describe("DELETE /api/content/[id]", () => {
     makeDeleteReq,
     PARAMS,
     () => mockedRemove.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/content/route.test.ts
+++ b/tests/unit/api/content/route.test.ts
@@ -1,18 +1,19 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/content/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
 } from "@/tests/unit/helpers/route.test.helpers";
 import type { SavedContent } from "@/lib/types";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     savedContent: {
@@ -22,7 +23,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedList = jest.mocked(storage.savedContent.list);
 const mockedCreate = jest.mocked(storage.savedContent.create);
 
@@ -60,14 +60,11 @@ const MOCK_ITEM: SavedContent = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
 });
 
 // ─── GET /api/content ─────────────────────────────────────────────────────────
 
 describe("GET /api/content", () => {
-  itReturns401(GET, () => makeGetReq(CAMPAIGN_ID), mockedRequireAuth);
-
   it("returns 400 when campaignId is missing", async () => {
     const res = await GET(makeGetReq());
     expect(res.status).toBe(400);
@@ -89,15 +86,12 @@ describe("GET /api/content", () => {
     GET,
     () => makeGetReq(CAMPAIGN_ID),
     () => mockedList.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
 // ─── POST /api/content ────────────────────────────────────────────────────────
 
 describe("POST /api/content", () => {
-  itReturns401(POST, () => makePostReq(VALID_BODY), mockedRequireAuth);
-
   it("returns 400 when required fields are missing", async () => {
     const res = await POST(makePostReq({ campaignId: CAMPAIGN_ID }));
     expect(res.status).toBe(400);
@@ -150,6 +144,5 @@ describe("POST /api/content", () => {
     POST,
     () => makePostReq(VALID_BODY),
     () => mockedCreate.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/encounters/id.test.ts
+++ b/tests/unit/api/encounters/id.test.ts
@@ -1,18 +1,19 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, PUT, DELETE } from "@/app/api/encounters/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadEncounters: jest.fn(),
@@ -21,7 +22,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const ENC_ID = "enc-abc";
@@ -40,18 +40,14 @@ const makeRequest = (method: string, body?: unknown) =>
 describe("GET /api/encounters/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(GET, () => makeRequest("GET"), params, mockedRequireAuth);
-
   itReturns404WithParams(
     GET,
     () => makeRequest("GET"),
     params,
     () => mockedStorage.loadEncounters.mockResolvedValue([]),
-    mockedRequireAuth
   );
 
   it("returns encounter when found", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadEncounters.mockResolvedValue([MOCK_ENCOUNTER] as any);
 
     const response = await GET(makeRequest("GET"), { params });
@@ -65,25 +61,20 @@ describe("GET /api/encounters/[id]", () => {
     () => makeRequest("GET"),
     params,
     () => mockedStorage.loadEncounters.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });
 
 describe("PUT /api/encounters/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(PUT, () => makeRequest("PUT", {}), params, mockedRequireAuth);
-
   itReturns404WithParams(
     PUT,
     () => makeRequest("PUT", { name: "New Name" }),
     params,
     () => mockedStorage.loadEncounters.mockResolvedValue([]),
-    mockedRequireAuth
   );
 
   it("returns 400 when name is empty after update", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadEncounters.mockResolvedValue([MOCK_ENCOUNTER] as any);
 
     const response = await PUT(makeRequest("PUT", { name: "  " }), { params });
@@ -91,7 +82,6 @@ describe("PUT /api/encounters/[id]", () => {
   });
 
   it("updates encounter and returns 200", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadEncounters.mockResolvedValue([MOCK_ENCOUNTER] as any);
     mockedStorage.saveEncounter.mockResolvedValue(undefined as any);
 
@@ -112,25 +102,20 @@ describe("PUT /api/encounters/[id]", () => {
     () => makeRequest("PUT", { name: "Valid" }),
     params,
     () => mockedStorage.loadEncounters.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });
 
 describe("DELETE /api/encounters/[id]", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401WithParams(DELETE, () => makeRequest("DELETE"), params, mockedRequireAuth);
-
   itReturns404WithParams(
     DELETE,
     () => makeRequest("DELETE"),
     params,
     () => mockedStorage.loadEncounters.mockResolvedValue([]),
-    mockedRequireAuth
   );
 
   it("deletes encounter and returns 200", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadEncounters.mockResolvedValue([MOCK_ENCOUNTER] as any);
     mockedStorage.deleteEncounter.mockResolvedValue(undefined as any);
 
@@ -148,6 +133,5 @@ describe("DELETE /api/encounters/[id]", () => {
     () => makeRequest("DELETE"),
     params,
     () => mockedStorage.loadEncounters.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/encounters/route.test.ts
+++ b/tests/unit/api/encounters/route.test.ts
@@ -1,17 +1,18 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/encounters/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadEncounters: jest.fn(),
@@ -19,7 +20,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const MOCK_ENCOUNTERS = [
@@ -33,10 +33,7 @@ const makeRequest = (body?: unknown) =>
 describe("GET /api/encounters", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(GET, () => makeRequest(), mockedRequireAuth);
-
   it("returns list of encounters", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadEncounters.mockResolvedValue(MOCK_ENCOUNTERS as any);
 
     const response = await GET(makeRequest());
@@ -50,29 +47,23 @@ describe("GET /api/encounters", () => {
     GET,
     () => makeRequest(),
     () => mockedStorage.loadEncounters.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });
 
 describe("POST /api/encounters", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(POST, () => makeRequest({ name: "Test" }), mockedRequireAuth);
-
   it("returns 400 when name is missing", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makeRequest({ monsters: [] }));
     expect(response.status).toBe(400);
   });
 
   it("returns 400 when name is empty string", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makeRequest({ name: "   " }));
     expect(response.status).toBe(400);
   });
 
   it("creates encounter and returns 201", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.saveEncounter.mockResolvedValue(undefined as any);
 
     const response = await POST(
@@ -91,6 +82,5 @@ describe("POST /api/encounters", () => {
     POST,
     () => makeRequest({ name: "Valid Name" }),
     () => mockedStorage.saveEncounter.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/monsters/duplicate.test.ts
+++ b/tests/unit/api/monsters/duplicate.test.ts
@@ -4,7 +4,10 @@
 const mockLoadAll = jest.fn();
 const mockSave = jest.fn();
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: any, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadAllMonsterTemplates: (...args: any[]) => mockLoadAll(...args),
@@ -13,15 +16,11 @@ jest.mock("@/lib/storage", () => ({
 }));
 
 import { POST } from "@/app/api/monsters/[id]/duplicate/route";
-import { requireAuth } from "@/lib/middleware";
-
-const mockedRequireAuth = jest.mocked(requireAuth);
 
 describe("POST /api/monsters/[id]/duplicate", () => {
   beforeEach(() => {
     mockLoadAll.mockReset();
     mockSave.mockReset();
-    mockedRequireAuth.mockReturnValue({ userId: "user-1", email: "user@example.com", tokenVersion: 0 });
   });
 
   it("duplicates an existing template into the user library", async () => {
@@ -55,7 +54,7 @@ describe("POST /api/monsters/[id]/duplicate", () => {
 
     expect(mockSave).toHaveBeenCalledTimes(1);
     const saved = mockSave.mock.calls[0][0];
-    expect(saved.userId).toBe("user-1");
+    expect(saved.userId).toBe("user-123");
     expect(saved.id).not.toBe("orig-1");
     expect(saved.name).toMatch(/Goblin/);
     expect(res && (res as any).status).toBe(201);

--- a/tests/unit/api/monsters/global.id.route.test.ts
+++ b/tests/unit/api/monsters/global.id.route.test.ts
@@ -1,19 +1,21 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { PUT, DELETE } from "@/app/api/monsters/global/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import { getDatabase } from "@/lib/db";
 import {
-  ADMIN_AUTH,
   makeRouteRequest,
   mockDbCollection,
   itValidatesAlignmentFieldWithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 import { EXISTING_GLOBAL_MONSTER } from "./fixtures";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadGlobalMonsterTemplates: jest.fn(),
@@ -27,7 +29,6 @@ jest.mock("mongodb", () => {
   return { ObjectId };
 });
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 const mockedGetDatabase = jest.mocked(getDatabase);
 
@@ -43,7 +44,6 @@ const makeReqWith = (alignment: string | undefined) =>
 describe("PUT /api/monsters/global/[id] — alignment validation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedStorage.loadGlobalMonsterTemplates.mockResolvedValue([EXISTING_GLOBAL_MONSTER] as any);
     mockedStorage.saveMonsterTemplate.mockResolvedValue(undefined as any);
     mockDbCollection(mockedGetDatabase, {
@@ -57,7 +57,6 @@ describe("PUT /api/monsters/global/[id] — alignment validation", () => {
 describe("PUT /api/monsters/global/[id] — DB error during admin check", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
   });
 
@@ -77,7 +76,6 @@ describe("PUT /api/monsters/global/[id] — DB error during admin check", () => 
 describe("DELETE /api/monsters/global/[id] — DB error during admin check", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
   });
 

--- a/tests/unit/api/monsters/global.route.test.ts
+++ b/tests/unit/api/monsters/global.route.test.ts
@@ -1,18 +1,21 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { POST, PUT } from "@/app/api/monsters/global/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import { getDatabase } from "@/lib/db";
 import {
-  ADMIN_AUTH,
   makeRouteRequest,
   mockDbCollection,
   itValidatesAlignmentField,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+  requireAuth: () => ({ userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadGlobalMonsterTemplates: jest.fn(),
@@ -36,7 +39,6 @@ jest.mock("mongodb", () => {
   return { ObjectId };
 });
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 const mockedGetDatabase = jest.mocked(getDatabase);
 
@@ -50,7 +52,6 @@ const makeReqWith = (alignment: string | undefined) =>
 describe("POST /api/monsters/global — alignment validation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedStorage.saveMonsterTemplate.mockResolvedValue(undefined as any);
     mockDbCollection(mockedGetDatabase, {
       findOne: jest.fn().mockResolvedValue({ tokenVersion: 0, isAdmin: true }),
@@ -63,7 +64,6 @@ describe("POST /api/monsters/global — alignment validation", () => {
 describe("POST /api/monsters/global — DB error during admin check", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
   });
 
@@ -79,7 +79,6 @@ describe("POST /api/monsters/global — DB error during admin check", () => {
 describe("PUT /api/monsters/global — DB error during admin check", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetDatabase.mockRejectedValue(new Error("connection refused"));
   });
 

--- a/tests/unit/api/monsters/global.route.test.ts
+++ b/tests/unit/api/monsters/global.route.test.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment node
  */
-import { NextRequest } from "next/server";
 import { POST, PUT } from "@/app/api/monsters/global/route";
 import { storage } from "@/lib/storage";
 import { getDatabase } from "@/lib/db";
@@ -12,8 +11,6 @@ import {
 } from "@/tests/unit/helpers/route.test.helpers";
 
 jest.mock("@/lib/middleware", () => ({
-  withAuth: (handler: Function) => (req: NextRequest) =>
-    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
   requireAuth: () => ({ userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
 }));
 jest.mock("@/lib/storage", () => ({

--- a/tests/unit/api/monsters/id.route.test.ts
+++ b/tests/unit/api/monsters/id.route.test.ts
@@ -1,17 +1,19 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { PUT } from "@/app/api/monsters/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
   itValidatesAlignmentFieldWithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 import { EXISTING_MONSTER } from "./fixtures";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadMonsterTemplates: jest.fn(),
@@ -19,7 +21,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const PARAMS = Promise.resolve({ id: "monster-1" });
@@ -34,7 +35,6 @@ const makeReqWith = (alignment: string | undefined) =>
 describe("PUT /api/monsters/[id] — alignment validation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadMonsterTemplates.mockResolvedValue([EXISTING_MONSTER] as any);
     mockedStorage.saveMonsterTemplate.mockResolvedValue(undefined as any);
   });

--- a/tests/unit/api/monsters/route.test.ts
+++ b/tests/unit/api/monsters/route.test.ts
@@ -1,16 +1,18 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { POST } from "@/app/api/monsters/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
   itValidatesAlignmentField,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadAllMonsterTemplates: jest.fn(),
@@ -19,7 +21,6 @@ jest.mock("@/lib/storage", () => ({
 }));
 jest.mock("@/lib/db", () => ({ getDatabase: jest.fn() }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const BASE_BODY = { name: "Goblin", maxHp: 10, hp: 10 };
@@ -32,7 +33,6 @@ const makeReqWith = (alignment: string | undefined) =>
 describe("POST /api/monsters — alignment validation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.saveMonsterTemplate.mockResolvedValue(undefined as any);
   });
 

--- a/tests/unit/api/monsters/upload.route.test.ts
+++ b/tests/unit/api/monsters/upload.route.test.ts
@@ -3,21 +3,20 @@
  */
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/monsters/upload/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: { saveMonsterTemplate: jest.fn() },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedSave = jest.mocked(storage.saveMonsterTemplate);
 
 const BASE_URL = "http://localhost/api/monsters/upload";
@@ -29,13 +28,6 @@ const makeValidReq = () => makeReq({ monsters: [{ name: "G", maxHp: 7 }] });
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedRequireAuth.mockReturnValue(MOCK_AUTH);
-});
-
-// ─── Auth ────────────────────────────────────────────────────────────────────
-
-describe("POST /api/monsters/upload — auth", () => {
-  itReturns401(POST, makeValidReq, mockedRequireAuth);
 });
 
 // ─── Request parsing ──────────────────────────────────────────────────────────
@@ -128,6 +120,5 @@ describe("POST /api/monsters/upload — partial and total failure", () => {
     POST,
     makeValidReq,
     () => mockedSave.mockRejectedValue(new Error("DB")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/parties/route.test.ts
+++ b/tests/unit/api/parties/route.test.ts
@@ -1,21 +1,23 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/parties/route";
 import { GET as GET_ONE, PUT, DELETE } from "@/app/api/parties/[id]/route";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import {
-  MOCK_AUTH,
   makeRouteRequest,
-  itReturns401,
   itReturns500,
-  itReturns401WithParams,
   itReturns404WithParams,
   itReturns500WithParams,
 } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 jest.mock("@/lib/storage", () => ({
   storage: {
     loadParties: jest.fn(),
@@ -24,7 +26,6 @@ jest.mock("@/lib/storage", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage);
 
 const MOCK_PARTIES = [
@@ -38,10 +39,7 @@ const makeRequest = (body?: unknown) =>
 describe("GET /api/parties", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(GET, () => makeRequest(), mockedRequireAuth);
-
   it("returns list of parties", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadParties.mockResolvedValue(MOCK_PARTIES as any);
 
     const response = await GET(makeRequest());
@@ -55,35 +53,28 @@ describe("GET /api/parties", () => {
     GET,
     () => makeRequest(),
     () => mockedStorage.loadParties.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });
 
 describe("POST /api/parties", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  itReturns401(POST, () => makeRequest({ name: "Crew" }), mockedRequireAuth);
-
   it("returns 400 when name is missing", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makeRequest({ characterIds: [] }));
     expect(response.status).toBe(400);
   });
 
   it("returns 400 when name is empty string", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makeRequest({ name: "  " }));
     expect(response.status).toBe(400);
   });
 
   it("returns 400 when name is a non-string type", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const response = await POST(makeRequest({ name: 123 }));
     expect(response.status).toBe(400);
   });
 
   it("creates party and returns 201", async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.saveParty.mockResolvedValue(undefined as any);
 
     const response = await POST(
@@ -110,7 +101,6 @@ describe("POST /api/parties", () => {
     POST,
     () => makeRequest({ name: "Doomed Party" }),
     () => mockedStorage.saveParty.mockRejectedValue(new Error("Storage error")),
-    mockedRequireAuth
   );
 });
 
@@ -127,7 +117,6 @@ describe("PUT /api/parties/[id]", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadParties.mockResolvedValue([EXISTING_PARTY] as any);
     mockedStorage.saveParty.mockResolvedValue(undefined as any);
   });
@@ -221,13 +210,10 @@ describe("GET /api/parties/[id]", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadParties.mockResolvedValue([
       { id: "party-123", userId: "user-123", name: "Fellowship", members: [] },
     ] as any);
   });
-
-  itReturns401WithParams(GET_ONE, makeReq, PARAMS, mockedRequireAuth);
 
   it("returns party when found", async () => {
     const response = await GET_ONE(makeReq(), { params: PARAMS });
@@ -240,7 +226,6 @@ describe("GET /api/parties/[id]", () => {
     makeReq,
     PARAMS,
     () => mockedStorage.loadParties.mockResolvedValue([]),
-    mockedRequireAuth
   );
 
   itReturns500WithParams(
@@ -248,7 +233,6 @@ describe("GET /api/parties/[id]", () => {
     makeReq,
     PARAMS,
     () => mockedStorage.loadParties.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });
 
@@ -258,14 +242,11 @@ describe("DELETE /api/parties/[id]", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedStorage.loadParties.mockResolvedValue([
       { id: "party-123", userId: "user-123", name: "Fellowship", members: [] },
     ] as any);
     mockedStorage.deleteParty.mockResolvedValue(undefined as any);
   });
-
-  itReturns401WithParams(DELETE, makeReq, PARAMS, mockedRequireAuth);
 
   it("deletes party and returns 200", async () => {
     const response = await DELETE(makeReq(), { params: PARAMS });
@@ -278,7 +259,6 @@ describe("DELETE /api/parties/[id]", () => {
     makeReq,
     PARAMS,
     () => mockedStorage.loadParties.mockResolvedValue([]),
-    mockedRequireAuth
   );
 
   itReturns500WithParams(
@@ -286,6 +266,5 @@ describe("DELETE /api/parties/[id]", () => {
     makeReq,
     PARAMS,
     () => mockedStorage.loadParties.mockRejectedValue(new Error("DB error")),
-    mockedRequireAuth
   );
 });

--- a/tests/unit/api/spells/route.test.ts
+++ b/tests/unit/api/spells/route.test.ts
@@ -5,7 +5,7 @@ import { GET, POST } from "@/app/api/spells/route";
 import { storage } from "@/lib/storage";
 import { requireAdmin } from "@/lib/api-helpers";
 import { SpellTemplate } from "@/lib/types";
-import { makeRouteRequest, mockUnauthorized } from "@/tests/unit/helpers/route.test.helpers";
+import { makeRouteRequest, mockAdminDenied } from "@/tests/unit/helpers/route.test.helpers";
 
 jest.mock("@/lib/storage", () => ({
   storage: {
@@ -172,7 +172,7 @@ describe("POST /api/spells", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    mockUnauthorized(mockedRequireAdmin);
+    mockAdminDenied(mockedRequireAdmin, 401);
 
     const req = makeRouteRequest("http://localhost/api/spells", "POST", BASE_BODY);
     const res = await POST(req);

--- a/tests/unit/helpers/route.test.helpers.ts
+++ b/tests/unit/helpers/route.test.helpers.ts
@@ -15,13 +15,6 @@ export const ADMIN_AUTH: AuthPayload = {
   tokenVersion: 0,
 };
 
-/** Configure a mocked requireAuth/verifyAuth to return a 401 Unauthorized response */
-export function mockUnauthorized(mockedFn: jest.Mock): void {
-  mockedFn.mockReturnValue(
-    NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  );
-}
-
 /** Configure a mocked requireAdmin (async) to return a 401 or 403 response */
 export function mockAdminDenied(mockedFn: jest.Mock, status: 401 | 403): void {
   const message = status === 401 ? "Unauthorized" : "Only administrators can perform this action";
@@ -87,46 +80,17 @@ type ContextHandler<P extends Record<string, string> = { id: string }> = (
   ctx: { params: Promise<P> }
 ) => Promise<Response>;
 
-/** Register: returns 401 when requireAuth returns Unauthorized (no route params) */
-export function itReturns401(
-  handler: RouteHandler,
-  makeReq: () => NextRequest,
-  mockedRequireAuth: jest.Mock
-): void {
-  it("returns 401 when not authenticated", async () => {
-    mockUnauthorized(mockedRequireAuth);
-    const response = await handler(makeReq());
-    expect(response.status).toBe(401);
-  });
-}
-
 /** Register: returns 500 when setupError configures the mock to throw (no route params) */
 export function itReturns500(
   handler: RouteHandler,
   makeReq: () => NextRequest,
   setupError: () => void,
-  mockedRequireAuth: jest.Mock,
   description = "returns 500 on error"
 ): void {
   it(description, async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     setupError();
     const response = await handler(makeReq());
     expect(response.status).toBe(500);
-  });
-}
-
-/** Register: returns 401 when requireAuth returns Unauthorized (with route params) */
-export function itReturns401WithParams<P extends Record<string, string>>(
-  handler: ContextHandler<P>,
-  makeReq: () => NextRequest,
-  params: Promise<P>,
-  mockedRequireAuth: jest.Mock
-): void {
-  it("returns 401 when not authenticated", async () => {
-    mockUnauthorized(mockedRequireAuth);
-    const response = await handler(makeReq(), { params });
-    expect(response.status).toBe(401);
   });
 }
 
@@ -136,11 +100,9 @@ export function itReturns404WithParams<P extends Record<string, string>>(
   makeReq: () => NextRequest,
   params: Promise<P>,
   setupNotFound: () => void,
-  mockedRequireAuth: jest.Mock,
   description = "returns 404 when not found"
 ): void {
   it(description, async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     setupNotFound();
     const response = await handler(makeReq(), { params });
     expect(response.status).toBe(404);
@@ -153,11 +115,9 @@ export function itReturns500WithParams<P extends Record<string, string>>(
   makeReq: () => NextRequest,
   params: Promise<P>,
   setupError: () => void,
-  mockedRequireAuth: jest.Mock,
   description = "returns 500 on error"
 ): void {
   it(description, async () => {
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     setupError();
     const response = await handler(makeReq(), { params });
     expect(response.status).toBe(500);

--- a/tests/unit/import/characterImportRoute.test.ts
+++ b/tests/unit/import/characterImportRoute.test.ts
@@ -1,10 +1,9 @@
 /**
  * @jest-environment node
  */
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { POST } from "@/app/api/characters/import/route";
 import { DndBeyondImportError } from "@/lib/dndBeyondCharacterImport";
-import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
 import { importDndBeyondCharacter } from "@/lib/server/dndBeyondCharacterImport";
 import {
@@ -14,24 +13,13 @@ import {
   EXISTING_IMPORTED_CHARACTER_ID,
   IMPORT_WARNING,
 } from "@/tests/helpers/dndBeyondImport";
-import { MOCK_AUTH } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware", () => {
-  const requireAuth = jest.fn();
-  return {
-    requireAuth,
-    withAuth: (handler: any) => async (request: any) => {
-      const auth = requireAuth(request);
-      if (auth && 'status' in auth) return auth;
-      return handler(request, auth);
-    },
-    withAuthAndParams: (handler: any) => async (request: any, { params }: any) => {
-      const auth = requireAuth(request);
-      if (auth && 'status' in auth) return auth;
-      return handler(request, auth, await params);
-    },
-  };
-});
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (request: any) =>
+    handler(request, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+  withAuthAndParams: (handler: Function) => async (request: any, ctx: any) =>
+    handler(request, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 
 jest.mock("@/lib/storage", () => ({
   storage: {
@@ -44,7 +32,6 @@ jest.mock("@/lib/server/dndBeyondCharacterImport", () => ({
   importDndBeyondCharacter: jest.fn(),
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedLoadCharacters = jest.mocked(storage.loadCharacters);
 const mockedSaveCharacter = jest.mocked(storage.saveCharacter);
 const mockedImportCharacter = jest.mocked(importDndBeyondCharacter);
@@ -61,25 +48,13 @@ function createRequest(body: unknown): NextRequest {
 
 describe("character import route", () => {
   beforeEach(() => {
-    mockedRequireAuth.mockReset();
     mockedLoadCharacters.mockReset();
     mockedSaveCharacter.mockReset();
     mockedImportCharacter.mockReset();
 
-    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     mockedLoadCharacters.mockResolvedValue([]);
     mockedSaveCharacter.mockResolvedValue(undefined);
     mockedImportCharacter.mockResolvedValue(createNormalizedImportResult());
-  });
-
-  test("returns auth response when the user is not authenticated", async () => {
-    mockedRequireAuth.mockReturnValue(
-      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
-    );
-
-    const response = await POST(createRequest({ url: "https://example.com" }));
-
-    expect(response.status).toBe(401);
   });
 
   test("returns 400 when the import URL is blank", async () => {

--- a/tests/unit/lib/api-helpers.test.ts
+++ b/tests/unit/lib/api-helpers.test.ts
@@ -2,12 +2,15 @@
  * @jest-environment node
  */
 import { requireAdmin } from "@/lib/api-helpers";
-import { requireAuth } from "@/lib/middleware";
 import { getUserById, InvalidUserIdError } from "@/lib/permissions";
 import { NextResponse } from "next/server";
 import { makeRouteRequest, ADMIN_AUTH } from "@/tests/unit/helpers/route.test.helpers";
 
-jest.mock("@/lib/middleware", () => ({ requireAuth: jest.fn() }));
+const mockRequireAuth = jest.fn();
+
+jest.mock("@/lib/middleware", () => ({
+  requireAuth: (...args: any[]) => mockRequireAuth(...args),
+}));
 jest.mock("@/lib/permissions", () => ({
   getUserById: jest.fn(),
   InvalidUserIdError: class InvalidUserIdError extends Error {
@@ -18,7 +21,6 @@ jest.mock("@/lib/permissions", () => ({
   },
 }));
 
-const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedGetUserById = jest.mocked(getUserById);
 
 describe("requireAdmin", () => {
@@ -27,20 +29,20 @@ describe("requireAdmin", () => {
   });
 
   it("returns null when user is authenticated and is an admin", async () => {
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetUserById.mockResolvedValue({ tokenVersion: ADMIN_AUTH.tokenVersion, isAdmin: true });
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});
     const result = await requireAdmin(req);
 
     expect(result).toBeNull();
-    expect(mockedRequireAuth).toHaveBeenCalledWith(req);
+    expect(mockRequireAuth).toHaveBeenCalledWith(req);
     expect(mockedGetUserById).toHaveBeenCalledWith(ADMIN_AUTH.userId);
   });
 
-  it("returns 401 when requireAuth returns a response", async () => {
+  it("returns 401 when auth middleware rejects the request", async () => {
     const authResponse = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    mockedRequireAuth.mockReturnValue(authResponse);
+    mockRequireAuth.mockReturnValue(authResponse);
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});
     const result = await requireAdmin(req);
@@ -50,7 +52,7 @@ describe("requireAdmin", () => {
   });
 
   it("returns 401 when tokenVersion does not match DB", async () => {
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetUserById.mockResolvedValue({ tokenVersion: 99, isAdmin: true });
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});
@@ -61,7 +63,7 @@ describe("requireAdmin", () => {
 
   it("allows legacy user with no tokenVersion in DB when JWT tokenVersion is 0", async () => {
     const legacyAuth = { ...ADMIN_AUTH, tokenVersion: 0 };
-    mockedRequireAuth.mockReturnValue(legacyAuth);
+    mockRequireAuth.mockReturnValue(legacyAuth);
     mockedGetUserById.mockResolvedValue({ isAdmin: true });
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});
@@ -72,7 +74,7 @@ describe("requireAdmin", () => {
 
   it("allows pre-rollout JWT with no tokenVersion field when DB tokenVersion is also 0", async () => {
     const preRolloutAuth = { userId: ADMIN_AUTH.userId, email: ADMIN_AUTH.email, tokenVersion: undefined as unknown as number };
-    mockedRequireAuth.mockReturnValue(preRolloutAuth);
+    mockRequireAuth.mockReturnValue(preRolloutAuth);
     mockedGetUserById.mockResolvedValue({ isAdmin: true });
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});
@@ -82,7 +84,7 @@ describe("requireAdmin", () => {
   });
 
   it("returns 401 when userId is invalid", async () => {
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockRequireAuth.mockReturnValue(ADMIN_AUTH);
     const { InvalidUserIdError: MockInvalidUserIdError } = jest.requireMock("@/lib/permissions");
     mockedGetUserById.mockRejectedValue(new MockInvalidUserIdError(ADMIN_AUTH.userId));
 
@@ -93,7 +95,7 @@ describe("requireAdmin", () => {
   });
 
   it("returns 500 when getUserById throws a DB error", async () => {
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetUserById.mockRejectedValue(new Error("DB connection failed"));
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});
@@ -105,7 +107,7 @@ describe("requireAdmin", () => {
   });
 
   it("returns 403 when user is not an admin", async () => {
-    mockedRequireAuth.mockReturnValue(ADMIN_AUTH);
+    mockRequireAuth.mockReturnValue(ADMIN_AUTH);
     mockedGetUserById.mockResolvedValue({ tokenVersion: ADMIN_AUTH.tokenVersion, isAdmin: false });
 
     const req = makeRouteRequest("http://localhost/api/test", "POST", {});

--- a/tests/unit/lib/api-helpers.test.ts
+++ b/tests/unit/lib/api-helpers.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import { requireAdmin } from "@/lib/api-helpers";
-import { getUserById, InvalidUserIdError } from "@/lib/permissions";
+import { getUserById } from "@/lib/permissions";
 import { NextResponse } from "next/server";
 import { makeRouteRequest, ADMIN_AUTH } from "@/tests/unit/helpers/route.test.helpers";
 

--- a/tests/unit/storage/campaigns.members.test.ts
+++ b/tests/unit/storage/campaigns.members.test.ts
@@ -1,22 +1,26 @@
 /**
  * @jest-environment node
  */
+import { NextRequest } from "next/server";
 import { storage } from "@/lib/storage";
 import { getDatabase } from "@/lib/db";
 import { DuplicateMemberError } from "@/lib/errors";
 import { MEMBER_ROLES, MemberRole, CampaignMember } from "@/lib/types";
 import { POST } from "@/app/api/campaigns/route";
-import { requireAuth } from "@/lib/middleware";
 import { makeRouteRequest } from "@/tests/unit/helpers/route.test.helpers";
 
 jest.mock("@/lib/db", () => ({
   getDatabase: jest.fn(),
 }));
 
-jest.mock("@/lib/middleware");
+jest.mock("@/lib/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }),
+  withAuthAndParams: (handler: Function) => async (req: NextRequest, ctx: any) =>
+    handler(req, { userId: "user-123", email: "user@example.com", tokenVersion: 0 }, await ctx.params),
+}));
 
 const mockedGetDatabase = jest.mocked(getDatabase);
-const mockedRequireAuth = jest.mocked(requireAuth);
 
 function makeMockCollection() {
   const toArray = jest.fn<Promise<unknown[]>, []>();
@@ -255,7 +259,6 @@ describe("Route POST seeding (mocked storage)", () => {
   });
 
   test("POST campaign — 201 returned and addMember called with correct DM payload", async () => {
-    mockedRequireAuth.mockReturnValue({ userId: "user-123", email: "user@test.com", tokenVersion: 1 });
     const saveCampaignSpy = jest.spyOn(storage, "saveCampaign").mockResolvedValue(undefined as any);
     const addMemberSpy = jest.spyOn(storage, "addMember").mockResolvedValue(undefined as any);
     const req = makeRouteRequest("http://localhost/api/campaigns", "POST", { name: "New Epic Campaign" });
@@ -281,8 +284,6 @@ describe("Route POST seeding (mocked storage)", () => {
   });
 
   test("POST campaign — deleteCampaign called and 500 returned when addMember throws", async () => {
-    mockedRequireAuth.mockReturnValue({ userId: "user-123", email: "user@test.com", tokenVersion: 1 });
-
     const saveCampaignSpy = jest.spyOn(storage, "saveCampaign").mockResolvedValue(undefined as any);
     const addMemberSpy = jest.spyOn(storage, "addMember").mockRejectedValue(new Error("DB failure") as never);
     const deleteCampaignSpy = jest.spyOn(storage, "deleteCampaign").mockResolvedValue(undefined as any);

--- a/tests/unit/utils/assertCampaignAccess.test.ts
+++ b/tests/unit/utils/assertCampaignAccess.test.ts
@@ -21,6 +21,7 @@ const MOCK_CAMPAIGN = {
   id: "camp-1",
   userId: "owner-user",
   name: "Test Campaign",
+  moduleName: "",
   chapters: [],
   status: "active" as const,
   notes: "",


### PR DESCRIPTION
Replaces `jest.mock("@/lib/middleware")` auto-mock with explicit factory mocks that stub `withAuth`/`withAuthAndParams` as pass-throughs injecting a fixed auth payload. Removes the redundant 401 route-level tests (auth is covered by `middleware.test.ts`) and cleans up shared helper signatures.

## Changes

- `tests/unit/helpers/route.test.helpers.ts`: deleted `mockUnauthorized`, `itReturns401`, `itReturns401WithParams`; removed `mockedRequireAuth` param from `itReturns500`, `itReturns500WithParams`, `itReturns404WithParams`
- 23 route test files: replaced auto-mock with factory, removed `requireAuth` import and `jest.mocked` reference, dropped 401 call sites
- `tests/unit/api/monsters/global.route.test.ts` and `tests/unit/lib/api-helpers.test.ts`: retain `requireAuth` in factory because these test `requireAdmin` which calls `requireAuth` directly (not via `withAuth`)

## Verification

- `npx tsc --noEmit` — clean
- `npx jest --config jest.config.js tests/unit --no-coverage` — 1868 pass, 0 fail
- `INTEGRATION_WORKERS=4 npx jest --config jest.integration.config.js --no-coverage --forceExit` — 229 pass, 0 fail
- `npx next build` — no errors

Closes #340