### PR TITLE
feat: add invite API — POST /api/campaigns/[id]/members

### DIFF
--- a/app/api/campaigns/[id]/members/route.ts
+++ b/app/api/campaigns/[id]/members/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+import { DuplicateMemberError } from '@/lib/errors';
+
+type Params = { id: string };
+
+export const POST = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
+  try {
+    const body = await request.json();
+    const { userId } = body;
+
+    if (typeof userId !== 'string' || userId.trim() === '') {
+      return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+    }
+
+    if (userId === auth.userId) {
+      return NextResponse.json({ error: 'Cannot invite yourself' }, { status: 400 });
+    }
+
+    const caller = await storage.getMember(campaignId, auth.userId);
+    if (!caller || caller.role !== 'dm' || caller.status !== 'active') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const target = await storage.getMember(campaignId, userId);
+
+    if (!target) {
+      const newId = crypto.randomUUID();
+      await storage.addMember({
+        id: newId,
+        campaignId,
+        userId,
+        role: 'player',
+        status: 'invited',
+        history: [{ action: 'invited', by: auth.userId, at: new Date() }],
+      });
+      return NextResponse.json({ id: newId, status: 'invited' }, { status: 201 });
+    }
+
+    if (target.status === 'active' || target.status === 'invited') {
+      return NextResponse.json({ error: 'Member already exists' }, { status: 409 });
+    }
+
+    await storage.updateMemberStatus(campaignId, userId, 'invited', auth.userId);
+    return NextResponse.json({ id: target.id, status: 'invited' }, { status: 201 });
+  } catch (error) {
+    if (error instanceof DuplicateMemberError) {
+      return NextResponse.json({ error: 'Member already exists' }, { status: 409 });
+    }
+    console.error('Error inviting member:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/api/campaigns/[id]/members/route.ts
+++ b/app/api/campaigns/[id]/members/route.ts
@@ -6,13 +6,21 @@ import { DuplicateMemberError } from '@/lib/errors';
 type Params = { id: string };
 
 export const POST = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
+  let body: unknown;
   try {
-    const body = await request.json();
-    const { userId } = body;
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
 
-    if (typeof userId !== 'string' || userId.trim() === '') {
+  try {
+    const { userId: rawUserId } = body as Record<string, unknown>;
+
+    if (typeof rawUserId !== 'string' || rawUserId.trim() === '') {
       return NextResponse.json({ error: 'userId is required' }, { status: 400 });
     }
+
+    const userId = rawUserId.trim();
 
     if (userId === auth.userId) {
       return NextResponse.json({ error: 'Cannot invite yourself' }, { status: 400 });
@@ -42,7 +50,7 @@ export const POST = withAuthAndParams<Params>(async (request, auth, { id: campai
       return NextResponse.json({ error: 'Member already exists' }, { status: 409 });
     }
 
-    await storage.updateMemberStatus(campaignId, userId, 'invited', auth.userId);
+    await storage.updateMemberStatus(campaignId, userId, 'invited', auth.userId, 'player');
     return NextResponse.json({ id: target.id, status: 'invited' }, { status: 201 });
   } catch (error) {
     if (error instanceof DuplicateMemberError) {

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -54,8 +54,7 @@ export const POST = withAuth(async (request, auth) => {
         userId: auth.userId,
         role: 'dm',
         status: 'active',
-        invitedBy: auth.userId,
-        invitedAt: new Date(),
+        history: [{ action: 'active' as const, by: auth.userId, at: new Date() }],
       });
     } catch (memberError) {
       try {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,6 +18,7 @@ import {
   CampaignMemberSummary,
   MemberRole,
   MemberStatus,
+  MemberHistoryEntry,
 } from "./types";
 import { DuplicateMemberError } from "./errors";
 import { GLOBAL_USER_ID } from "./constants";
@@ -848,25 +849,23 @@ export const storage = {
     }
   },
 
-  async updateMember(
+  async updateMemberStatus(
     campaignId: string,
     userId: string,
-    role?: MemberRole,
-    status?: MemberStatus,
+    status: MemberStatus,
+    actorId: string,
   ): Promise<void> {
     try {
       const db = await getDatabase();
-      const patch: Record<string, unknown> = {};
-      if (role !== undefined) patch.role = role;
-      if (status !== undefined) patch.status = status;
-      if (Object.keys(patch).length === 0) {
-        return;
-      }
+      const historyEntry: MemberHistoryEntry = { action: status, by: actorId, at: new Date() };
       await db
         .collection<CampaignMember>("campaignMembers")
-        .updateOne({ campaignId, userId }, { $set: patch });
+        .updateOne(
+          { campaignId, userId },
+          { $set: { status }, $push: { history: historyEntry } as never },
+        );
     } catch (error) {
-      console.error("Error updating campaign member:", error);
+      console.error("Error updating campaign member status:", error);
       throw error;
     }
   },

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -854,15 +854,17 @@ export const storage = {
     userId: string,
     status: MemberStatus,
     actorId: string,
+    role?: MemberRole,
   ): Promise<void> {
     try {
       const db = await getDatabase();
       const historyEntry: MemberHistoryEntry = { action: status, by: actorId, at: new Date() };
+      const setFields = role !== undefined ? { status, role } : { status };
       await db
         .collection<CampaignMember>("campaignMembers")
         .updateOne(
           { campaignId, userId },
-          { $set: { status }, $push: { history: historyEntry } as never },
+          { $set: setFields, $push: { history: historyEntry } as any },
         );
     } catch (error) {
       console.error("Error updating campaign member status:", error);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -716,7 +716,13 @@ export interface SpellTemplate {
 
 export const MEMBER_ROLES = ["dm", "player"] as const;
 export type MemberRole = (typeof MEMBER_ROLES)[number];
-export type MemberStatus = "active" | "pending" | "declined";
+export type MemberStatus = "active" | "invited" | "declined" | "removed";
+
+export interface MemberHistoryEntry {
+  action: MemberStatus;
+  by: string;
+  at: Date;
+}
 
 export interface CampaignMember {
   _id?: string;
@@ -725,9 +731,7 @@ export interface CampaignMember {
   userId: string;
   role: MemberRole;
   status: MemberStatus;
-  invitedBy: string;
-  invitedAt: Date;
-  respondedAt?: Date;
+  history: MemberHistoryEntry[];
 }
 
 export interface CampaignMemberSummary {

--- a/openspec/changes/invite-api/.openspec.yaml
+++ b/openspec/changes/invite-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-05

--- a/openspec/changes/invite-api/design.md
+++ b/openspec/changes/invite-api/design.md
@@ -1,0 +1,155 @@
+## Context
+
+- Relevant architecture: Next.js App Router API routes under `app/api/`; MongoDB via `lib/storage.ts`; auth via `withAuth` middleware; `lib/types.ts` as the shared type contract.
+- Dependencies: Phase 1 complete — `getMember`, `loadCampaignByIdAny`, `addMember`, user search API (`GET /api/users/search`) all exist.
+- Interfaces/contracts touched: `CampaignMember` (type), `MemberStatus` (type), `storage.addMember`, `storage.updateMember` (replaced), new `storage.updateMemberStatus`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add `POST /api/campaigns/[id]/members` with DM-only guard, self-invite guard, and upsert logic
+- Migrate `CampaignMember` schema from flat scalar fields to append-only `history` array
+- Replace `storage.updateMember` with `storage.updateMemberStatus` (atomic status + history push)
+- Keep `status` as a top-level field on `CampaignMember` for query efficiency
+
+### Non-Goals
+
+- Accept/decline, removal, UI, notifications (out of scope per proposal)
+
+## Decisions
+
+### Decision 1: `MemberStatus` uses `"invited"` (not `"pending"`) and adds `"removed"`
+
+- Chosen: `"active" | "invited" | "declined" | "removed"`
+- Alternatives considered: keep `"pending"` as an alias; separate enum for the invite flow
+- Rationale: Phase doc and issue spec use `"invited"` consistently. No existing data means no migration cost. `"removed"` is needed now so the re-invite upsert path (`removed → invited`) can pattern-match on it correctly — deferring it would leave a gap in the state machine.
+- Trade-offs: Future sub-issues (2b, 2c) must use the same type; acceptable since this is a shared contract they already depend on.
+
+### Decision 2: Append-only `history: MemberHistoryEntry[]` replaces flat scalar fields
+
+- Chosen: Remove `invitedBy`, `invitedAt`, `respondedAt` from `CampaignMember`; add `history: MemberHistoryEntry[]` where each entry is `{ action: MemberStatus; by: string; at: Date }`.
+- Alternatives considered: Keep flat fields and add history as an additive parallel field; derive `status` from last history entry (no separate `status` field).
+- Rationale: Flat fields cannot represent re-invite cycles (which DM invited, when). History as a list gives full audit trail at no query cost. `status` is kept as a top-level denormalized field so filter queries (`find({ campaignId, status: 'invited' })`) remain simple index-friendly operations without `$arrayElemAt`.
+- Trade-offs: `addMember` callers must now construct the initial history entry. Slightly more verbose at call sites, but structurally correct.
+
+### Decision 3: `action` field in `MemberHistoryEntry` mirrors `MemberStatus` (state transitioned to)
+
+- Chosen: `action: MemberStatus` — records the state the member moved *into*.
+- Alternatives considered: Separate verb vocabulary (`"invite"`, `"accept"`, `"decline"`, `"remove"`).
+- Rationale: A separate verb type would need to stay in sync with `MemberStatus` and adds surface area for divergence. Using `MemberStatus` directly means the history is self-describing: `{ action: 'invited' }` means "transitioned to invited". No additional type needed.
+- Trade-offs: The `history` array records state transitions, not free-form events. Sufficient for this domain.
+
+### Decision 4: Replace `updateMember` with `updateMemberStatus`
+
+- Chosen: `updateMemberStatus(campaignId, userId, status: MemberStatus, actorId: string): Promise<void>` — single MongoDB `updateOne` with `{ $set: { status }, $push: { history: { action: status, by: actorId, at: new Date() } } }`.
+- Alternatives considered: Extend existing `updateMember` with optional history params; add a separate `appendHistory` storage method.
+- Rationale: `updateMember` has zero application callers (verified by grep). A clean replacement is safer than extending with optional params that could be misused. Combining `$set` and `$push` in one `updateOne` is atomic at the document level in MongoDB — no transaction needed.
+- Trade-offs: Callers that previously set `role` independently via `updateMember` no longer have that path. Role changes are not in scope for Phase 2; a `updateMemberRole` can be added in 2c if needed.
+
+### Decision 5: Upsert via `getMember` + conditional `addMember`/`updateMemberStatus`
+
+- Chosen: Read-then-write pattern using existing `getMember`.
+  - No existing member → `addMember` with `status: 'invited'`, `history: [{ action: 'invited', by: dmId, at: now }]`
+  - Existing with `status: 'declined'` or `'removed'` → `updateMemberStatus('invited', dmId)` (clears nothing; history just grows)
+  - Existing with `status: 'active'` or `'invited'` → `409 Conflict`
+- Alternatives considered: MongoDB native upsert (`findOneAndUpdate` with `$setOnInsert`); separate invite/reinvite endpoints.
+- Rationale: The conditional branching (reject active/invited, allow declined/removed) cannot be expressed as a simple MongoDB filter-based upsert. Read-then-write is explicit and testable. The window for a race condition (two concurrent invites) is small and the unique index on `{campaignId, userId}` catches it — `addMember` will throw `DuplicateMemberError` which maps to 409.
+- Trade-offs: Two DB round trips on the re-invite path. Acceptable at this scale.
+
+### Decision 6: Response shape is `201 { id, status }`
+
+- Chosen: Return only `{ id: string; status: MemberStatus }` on success.
+- Alternatives considered: Return full `CampaignMember` document.
+- Rationale: The UI for 2c (member management) will use the member list endpoint to display state, not the invite response. A minimal response reduces payload and avoids exposing history to the caller unnecessarily.
+- Trade-offs: If future UIs need the full member immediately on invite, this can be changed without breaking existing callers.
+
+## Proposal to Design Mapping
+
+- Proposal element: `MemberStatus` updated, `"removed"` added now
+  - Design decision: Decision 1
+  - Validation approach: TypeScript compile-time; unit tests check all status values
+- Proposal element: `history: MemberHistoryEntry[]` replaces flat fields
+  - Design decision: Decisions 2 & 3
+  - Validation approach: Unit tests on `addMember` verify history array structure
+- Proposal element: `updateMember` → `updateMemberStatus`
+  - Design decision: Decision 4
+  - Validation approach: Unit tests on storage method; integration via route tests
+- Proposal element: Upsert logic (three branches)
+  - Design decision: Decision 5
+  - Validation approach: Route unit tests with one test per branch
+- Proposal element: Response `{ id, status }`
+  - Design decision: Decision 6
+  - Validation approach: Route unit test asserts response body shape
+
+## Functional Requirements Mapping
+
+- Requirement: DM can invite a user by userId
+  - Design element: POST handler, `addMember` branch
+  - Acceptance criteria reference: specs/invite-api/spec.md — Scenario: Successful invite
+  - Testability notes: Mock `getMember` returning null, assert `addMember` called and 201 returned
+
+- Requirement: Non-DM cannot invite
+  - Design element: Guard — `getMember(campaignId, callerId)` must return active DM
+  - Acceptance criteria reference: specs/invite-api/spec.md — Scenario: Non-DM invite rejected
+  - Testability notes: Mock `getMember` returning player or null; assert 403
+
+- Requirement: Self-invite rejected
+  - Design element: Guard — `userId === callerId` check before DB access
+  - Acceptance criteria reference: specs/invite-api/spec.md — Scenario: Self-invite rejected
+  - Testability notes: POST with userId === auth.userId; assert 400
+
+- Requirement: Active/invited duplicate rejected
+  - Design element: Upsert branch — `status: 'active'|'invited'` → 409
+  - Acceptance criteria reference: specs/invite-api/spec.md — Scenario: Duplicate rejected
+  - Testability notes: Mock `getMember` returning active/invited member; assert 409
+
+- Requirement: Re-invite declined/removed member succeeds
+  - Design element: Upsert branch — `updateMemberStatus('invited', dmId)`
+  - Acceptance criteria reference: specs/invite-api/spec.md — Scenario: Re-invite succeeds
+  - Testability notes: Mock `getMember` returning declined/removed; assert `updateMemberStatus` called, 201 returned
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Concurrent duplicate invites handled gracefully
+  - Design element: Unique index on `{campaignId, userId}` catches race; `DuplicateMemberError` → 409
+  - Testability notes: Unit test for `addMember` throwing `DuplicateMemberError`; route maps it to 409
+
+- Requirement category: security
+  - Requirement: Only authenticated DMs of a given campaign can invite
+  - Design element: `withAuth` + `getMember` DM check
+  - Testability notes: Unauthenticated request → 401 (withAuth); non-DM → 403
+
+- Requirement category: operability
+  - Requirement: Storage errors surface as 500 without leaking internals
+  - Design element: try/catch in route handler; generic error response
+  - Testability notes: Mock storage throwing; assert 500
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Read-then-write race for concurrent invites
+  - Impact: Low — unique index is the safety net; results in 409, not data corruption
+  - Mitigation: `DuplicateMemberError` from `addMember` mapped to 409 in route handler
+
+- Risk/trade-off: `updateMemberStatus` does not reset `respondedAt` (field no longer exists)
+  - Impact: None — `respondedAt` is removed from the schema; history entries have their own `at` timestamps
+  - Mitigation: N/A — schema change eliminates the issue
+
+## Rollback / Mitigation
+
+- Rollback trigger: Critical bug in invite route or type regression breaking existing campaign creation
+- Rollback steps: Revert the PR; no DB migration to undo (no data written to prod yet)
+- Data migration considerations: None — no existing `campaignMembers` documents
+- Verification after rollback: Campaign creation smoke test; existing unit tests pass
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check. No --no-verify bypasses.
+- If security checks fail: Treat as a blocker. Assess scope and fix before merge.
+- If required reviews are blocked/stale: Re-request after 24h; escalate to maintainer after 48h.
+- Escalation path and timeout: If blocked > 48h with no response, flag in the GitHub issue thread.
+
+## Open Questions
+
+No open questions. All design decisions resolved during exploration session prior to proposal creation.

--- a/openspec/changes/invite-api/proposal.md
+++ b/openspec/changes/invite-api/proposal.md
@@ -1,0 +1,85 @@
+## GitHub Issues
+
+- dougis-org/session-combat#305
+- dougis-org/session-combat#294 (parent epic)
+
+## Why
+
+- Problem statement: DMs cannot yet invite players to a campaign. The campaign exists but membership is restricted to the DM owner, making multi-user campaigns non-functional.
+- Why now: Phase 1 (1c user search, 1d members collection, 1e access guards) is complete. Issue #305 is the first deliverable of Phase 2 and unblocks 2b (accept/decline), 2c (member management UI), and 2d (player inbox UI).
+- Business/user impact: Without an invite API, the multi-user campaign feature cannot be used at all. This is the entry point for the entire invite/accept flow.
+
+## Problem Space
+
+- Current behavior: `POST /api/campaigns` creates a campaign and seeds the creator as an `active` DM member. No route exists to invite additional users. `CampaignMember` stores `invitedBy`, `invitedAt`, and `respondedAt` as flat scalar fields.
+- Desired behavior: A DM can POST a `userId` to `/api/campaigns/[id]/members` to invite a player. If the target user has a prior `declined` or `removed` membership, the invite resets their status (upsert). Active or already-invited members are rejected. All membership transitions are recorded in an append-only `history` array on `CampaignMember`.
+- Constraints: `userId` is resolved from username search (Phase 1c) before the POST; this endpoint accepts `userId` directly and does not perform username resolution itself. No email or push notification in this phase.
+- Assumptions: No existing data in `campaignMembers` collection — no DB migration required for schema changes. `getMember` and `loadCampaignByIdAny` storage methods already exist (Phase 1e).
+- Edge cases considered: self-invite; inviting an already-active member; inviting an already-invited member; re-inviting a declined member; re-inviting a removed member; non-DM attempting to invite; invalid `userId` (user does not exist).
+
+## Scope
+
+### In Scope
+
+- `MemberStatus` type updated to `"active" | "invited" | "declined" | "removed"` (drops `"pending"`, adds `"removed"`)
+- New `MemberHistoryEntry` interface: `{ action: MemberStatus; by: string; at: Date }`
+- `CampaignMember` interface updated: remove `invitedBy`, `invitedAt`, `respondedAt`; add `history: MemberHistoryEntry[]`
+- `storage.updateMember` replaced by `storage.updateMemberStatus(campaignId, userId, status, actorId)` — atomically `$set status` and `$push` a history entry
+- `storage.addMember` callers updated to pass `history: [...]` instead of flat fields
+- DM owner seed in `app/api/campaigns/route.ts` updated to match new schema
+- New route `app/api/campaigns/[id]/members/route.ts` — `POST` handler
+- Existing `addMember` unit tests updated for new schema
+- New unit tests for the POST route (all guard branches + all three upsert branches)
+
+### Out of Scope
+
+- Accept/decline endpoint (issue #306)
+- Member removal (issue #307)
+- Invitations inbox UI (issue #308)
+- Email or push notifications for invites
+- Username resolution (Phase 1c already handles this upstream of this endpoint)
+- Role changes (DM/player promotion/demotion)
+
+## What Changes
+
+- `lib/types.ts`: `MemberStatus`, new `MemberHistoryEntry` interface, `CampaignMember` shape
+- `lib/storage.ts`: replace `updateMember` with `updateMemberStatus`; no signature change to `addMember`
+- `app/api/campaigns/route.ts`: update DM owner seed (line ~51)
+- `app/api/campaigns/[id]/members/route.ts`: new file
+- `tests/unit/storage/campaignMembers.test.ts` (or equivalent): update for new schema
+- New test file: `tests/unit/api/campaigns/[id]/members/route.unit.test.ts`
+
+## Risks
+
+- Risk: `updateMember` replacement breaks consumers
+  - Impact: Low — `updateMember` has zero application call sites; only defined in storage.ts
+  - Mitigation: Verified via grep before design; safe to replace
+- Risk: Schema change affects other Phase 2 sub-issues (2b, 2c, 2d)
+  - Impact: Medium — those issues depend on `CampaignMember` shape
+  - Mitigation: History-list schema is strictly more capable; downstream issues benefit from it. Phase doc updated to reflect the design.
+- Risk: `$push` + `$set` not atomic in MongoDB without a transaction
+  - Impact: Low — a history entry missing the status update (or vice versa) would be inconsistent, but both ops are in a single `updateOne` with a combined update document (`{ $set: ..., $push: ... }`), which MongoDB applies atomically at the document level.
+  - Mitigation: Use a single `updateOne` call with both operators in one update document.
+
+## Open Questions
+
+No unresolved ambiguity. All design decisions were resolved during exploration:
+- `"invited"` chosen over `"pending"` (no existing data, spec uses `"invited"`)
+- `"removed"` added to `MemberStatus` now (needed for re-invite path; actual removal endpoint deferred to 2c)
+- `history: MemberHistoryEntry[]` replaces flat scalar fields
+- `action: MemberStatus` (state transitioned to) rather than a separate verb vocabulary
+- Response shape: `201 { id, status }` (not the full document)
+
+## Non-Goals
+
+- Bulk invite
+- Invite by email
+- Invite links / tokens
+- Rate limiting on invites (can be added later)
+- Notifications of any kind
+
+## Change Control
+
+If scope changes after proposal approval, update `openspec/changes/invite-api/proposal.md`,
+`openspec/changes/invite-api/design.md`, `openspec/changes/invite-api/specs/**/*.md`,
+and `openspec/changes/invite-api/tasks.md` before implementation starts.

--- a/openspec/changes/invite-api/specs/invite-api/spec.md
+++ b/openspec/changes/invite-api/specs/invite-api/spec.md
@@ -1,0 +1,234 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `MemberStatus` values `"invited"` and `"removed"`
+
+The system SHALL define `MemberStatus` as `"active" | "invited" | "declined" | "removed"`.
+
+#### Scenario: All status values are valid TypeScript
+
+- **Given** `lib/types.ts` exports `MemberStatus`
+- **When** a variable is assigned each of `"active"`, `"invited"`, `"declined"`, `"removed"`
+- **Then** TypeScript compilation succeeds with no type errors
+
+---
+
+### Requirement: ADDED `MemberHistoryEntry` interface
+
+The system SHALL export `MemberHistoryEntry` with fields `action: MemberStatus`, `by: string`, `at: Date`.
+
+#### Scenario: History entry shape is correct
+
+- **Given** a `MemberHistoryEntry` object
+- **When** all three fields are present with correct types
+- **Then** TypeScript accepts the value without error
+
+---
+
+### Requirement: MODIFIED `CampaignMember` — history replaces flat fields
+
+The system SHALL store membership transitions in `history: MemberHistoryEntry[]` and SHALL NOT include `invitedBy`, `invitedAt`, or `respondedAt` as top-level fields.
+
+#### Scenario: DM owner seed populates history
+
+- **Given** a new campaign is created
+- **When** `storage.addMember` is called for the DM owner
+- **Then** the stored document has `status: "active"` and `history` containing one entry `{ action: "active", by: <dmUserId>, at: <Date> }`, with no `invitedBy`, `invitedAt`, or `respondedAt` fields
+
+---
+
+### Requirement: ADDED `storage.updateMemberStatus`
+
+The system SHALL atomically update `status` and append a `MemberHistoryEntry` to `history` in a single `updateOne` call when `updateMemberStatus(campaignId, userId, status, actorId)` is invoked.
+
+#### Scenario: Status and history updated atomically
+
+- **Given** a `CampaignMember` document exists with `status: "declined"`
+- **When** `updateMemberStatus(campaignId, userId, "invited", dmId)` is called
+- **Then** the document's `status` field is `"invited"` and `history` has a new tail entry `{ action: "invited", by: dmId, at: <Date> }`, and the previous history entries are preserved
+
+#### Scenario: No-op if member not found
+
+- **Given** no `CampaignMember` exists for the given `campaignId` / `userId` pair
+- **When** `updateMemberStatus` is called
+- **Then** the call completes without error and no document is modified
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/members` — successful invite
+
+The system SHALL create a new `CampaignMember` with `status: "invited"` and a single history entry when a DM invites a valid, uninvited user.
+
+#### Scenario: Successful new invite
+
+- **Given** an authenticated user who is an `active` DM of campaign `[id]`
+- **When** they POST `{ userId: "<targetId>" }` where `targetId` ≠ callerId and target has no existing membership
+- **Then** the response is `201` with body `{ id: "<memberId>", status: "invited" }`, and a `CampaignMember` is persisted with `status: "invited"` and `history: [{ action: "invited", by: <callerId>, at: <Date> }]`
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/members` — re-invite (upsert)
+
+The system SHALL reset a `declined` or `removed` member back to `invited` status (appending a new history entry) when a DM re-invites them.
+
+#### Scenario: Re-invite a declined member
+
+- **Given** an authenticated DM and an existing member with `status: "declined"`
+- **When** the DM POSTs `{ userId: "<targetId>" }`
+- **Then** the response is `201` with `{ id, status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
+
+#### Scenario: Re-invite a removed member
+
+- **Given** an authenticated DM and an existing member with `status: "removed"`
+- **When** the DM POSTs `{ userId: "<targetId>" }`
+- **Then** the response is `201` with `{ id, status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/members` — guard: non-DM rejected
+
+The system SHALL reject invite attempts by users who are not an `active` DM of the campaign.
+
+#### Scenario: Caller is not a member of the campaign
+
+- **Given** an authenticated user with no membership in campaign `[id]`
+- **When** they POST `{ userId: "<targetId>" }`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Caller is a player (not DM)
+
+- **Given** an authenticated user who is an `active` member with `role: "player"`
+- **When** they POST `{ userId: "<targetId>" }`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Unauthenticated request
+
+- **Given** no authentication token
+- **When** a POST is made to the endpoint
+- **Then** the response is `401 Unauthorized`
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/members` — guard: self-invite rejected
+
+The system SHALL reject requests where the `userId` in the body matches the authenticated caller's userId.
+
+#### Scenario: Self-invite rejected
+
+- **Given** an authenticated DM
+- **When** they POST `{ userId: "<their own userId>" }`
+- **Then** the response is `400 Bad Request`
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/members` — guard: duplicate rejected
+
+The system SHALL reject invite attempts targeting a user who already has `active` or `invited` membership.
+
+#### Scenario: Already-active member rejected
+
+- **Given** an authenticated DM and a target user with `status: "active"` in the campaign
+- **When** the DM POSTs `{ userId: "<targetId>" }`
+- **Then** the response is `409 Conflict`
+
+#### Scenario: Already-invited member rejected
+
+- **Given** an authenticated DM and a target user with `status: "invited"` in the campaign
+- **When** the DM POSTs `{ userId: "<targetId>" }`
+- **Then** the response is `409 Conflict`
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/members` — guard: missing body field
+
+The system SHALL reject requests with a missing or non-string `userId` field.
+
+#### Scenario: Missing userId
+
+- **Given** an authenticated DM
+- **When** they POST `{}` or an empty body
+- **Then** the response is `400 Bad Request`
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `storage.addMember` — callers pass `history`
+
+The system SHALL require all `addMember` callers to supply a populated `history: MemberHistoryEntry[]` array. The `invitedBy`, `invitedAt`, and `respondedAt` fields SHALL NOT be passed.
+
+#### Scenario: Campaign creation seeds DM with history
+
+- **Given** the campaign creation handler at `app/api/campaigns/route.ts`
+- **When** a new campaign is created
+- **Then** `addMember` is called with `history: [{ action: "active", by: <userId>, at: <Date> }]` and no `invitedBy` / `invitedAt` fields
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED `storage.updateMember`
+
+Reason for removal: Replaced by `storage.updateMemberStatus` which atomically updates both `status` and `history`. The old method had no application call sites.
+
+### Requirement: REMOVED `CampaignMember.invitedBy`, `.invitedAt`, `.respondedAt`
+
+Reason for removal: Superseded by `history: MemberHistoryEntry[]`. These fields could not represent re-invite cycles.
+
+### Requirement: REMOVED `MemberStatus` value `"pending"`
+
+Reason for removal: Renamed to `"invited"` to match phase documentation. No existing data.
+
+---
+
+## Traceability
+
+- Proposal element: `MemberStatus` change → Requirement: ADDED `MemberStatus` values
+- Proposal element: `MemberHistoryEntry` interface → Requirement: ADDED `MemberHistoryEntry`
+- Proposal element: `CampaignMember` schema change → Requirement: MODIFIED `CampaignMember`
+- Proposal element: Replace `updateMember` → Requirements: ADDED `updateMemberStatus`, REMOVED `updateMember`
+- Proposal element: Update DM owner seed → Requirement: MODIFIED `storage.addMember` callers
+- Proposal element: New route POST `/api/campaigns/[id]/members` → Requirements: ADDED POST route (all scenarios)
+- Design Decision 1 → Requirement: ADDED `MemberStatus` values
+- Design Decision 2 → Requirement: MODIFIED `CampaignMember`
+- Design Decision 3 → Requirement: ADDED `MemberHistoryEntry`
+- Design Decision 4 → Requirements: ADDED `updateMemberStatus`, REMOVED `updateMember`
+- Design Decision 5 → Requirements: ADDED POST route (upsert scenarios)
+- Design Decision 6 → Requirement: ADDED POST route (response shape)
+- All ADDED POST route requirements → Task: Add POST `/api/campaigns/[id]/members` route
+- ADDED/MODIFIED storage requirements → Task: Update types and storage layer
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+#### Scenario: Access control — unauthenticated
+
+- **Given** no auth token
+- **When** POST is made to `/api/campaigns/[id]/members`
+- **Then** response is `401`; no DB access occurs
+
+#### Scenario: Access control — non-DM
+
+- **Given** a valid auth token for a user who is not an active DM of the campaign
+- **When** POST is made with a valid `userId` body
+- **Then** response is `403`; no `addMember` or `updateMemberStatus` call is made
+
+### Requirement: Reliability
+
+#### Scenario: Concurrent duplicate invite race
+
+- **Given** two simultaneous invite requests for the same `(campaignId, userId)` pair, neither member existing yet
+- **When** both reach `addMember` after `getMember` returned null
+- **Then** one succeeds with `201`; the other receives a `DuplicateMemberError` which the route maps to `409`; no data corruption occurs
+
+### Requirement: Operability
+
+#### Scenario: Storage error surfaces as 500
+
+- **Given** an authenticated DM with a valid request
+- **When** the storage layer throws an unexpected error
+- **Then** the response is `500`; the error is logged server-side; no internal details are leaked in the response body

--- a/openspec/changes/invite-api/tasks.md
+++ b/openspec/changes/invite-api/tasks.md
@@ -1,0 +1,134 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/invite-api` then immediately `git push -u origin feat/invite-api`
+
+## Execution
+
+### 1. Update `MemberStatus`, add `MemberHistoryEntry`, update `CampaignMember` — `lib/types.ts`
+
+- [x] Change `MemberStatus` to `"active" | "invited" | "declined" | "removed"` (remove `"pending"`, add `"removed"`)
+- [x] Add `export interface MemberHistoryEntry { action: MemberStatus; by: string; at: Date; }`
+- [x] Remove `invitedBy: string`, `invitedAt: Date`, `respondedAt?: Date` from `CampaignMember`
+- [x] Add `history: MemberHistoryEntry[]` to `CampaignMember`
+- [x] Verify: `npm run type-check` passes
+
+### 2. Replace `updateMember` with `updateMemberStatus` — `lib/storage.ts`
+
+- [x] Remove `updateMember` method
+- [x] Add `updateMemberStatus(campaignId: string, userId: string, status: MemberStatus, actorId: string): Promise<void>`
+  - Single `updateOne` with `{ $set: { status }, $push: { history: { action: status, by: actorId, at: new Date() } } }`
+- [x] Update import if needed (no new imports required)
+- [x] Verify: `npm run type-check` passes
+
+### 3. Update DM owner seed — `app/api/campaigns/route.ts`
+
+- [x] At the `addMember` call (line ~51), remove `invitedBy` and `invitedAt` fields
+- [x] Add `history: [{ action: 'active' as const, by: auth.userId, at: new Date() }]`
+- [x] Verify: `npm run type-check` passes
+
+### 4. Update existing `addMember` unit tests
+
+- [x] In `tests/unit/storage/campaignMembers.test.ts` (and `tests/unit/storage/campaigns.members.test.ts` if separate), replace `invitedBy`/`invitedAt` fields with `history: [{ action: 'active', by: <userId>, at: new Date() }]`
+- [x] Verify: `npm run test:unit -- --testPathPattern=campaignMembers` passes
+
+### 5. Add `updateMemberStatus` unit tests — `tests/unit/storage/campaignMembers.test.ts`
+
+- [x] Test: status field updated to new value
+- [x] Test: history entry appended with correct `action`, `by`, `at`
+- [x] Test: previous history entries preserved
+- [x] Test: member not found — no error thrown, no document modified
+- [x] Verify: `npm run test:unit -- --testPathPattern=campaignMembers` passes
+
+### 6. Add `POST /api/campaigns/[id]/members` route — `app/api/campaigns/[id]/members/route.ts`
+
+- [x] Create file `app/api/campaigns/[id]/members/route.ts`
+- [x] Implement `POST` handler with `withAuth`
+- [x] Parse and validate request body: `userId` must be a non-empty string; return `400` if missing/invalid
+- [x] Guard: self-invite check — `userId === auth.userId` → `400`
+- [x] Guard: DM check — `getMember(campaignId, auth.userId)` must return a member with `role: 'dm'` and `status: 'active'`; else `403`
+- [x] Upsert logic:
+  - Call `getMember(campaignId, userId)` for target
+  - No existing member → `addMember({ id: crypto.randomUUID(), campaignId, userId, role: 'player', status: 'invited', history: [{ action: 'invited', by: auth.userId, at: new Date() }] })` → `201 { id, status: 'invited' }`
+  - Existing with `status: 'declined'` or `'removed'` → `updateMemberStatus(campaignId, userId, 'invited', auth.userId)` → `201 { id: existingMember.id, status: 'invited' }`
+  - Existing with `status: 'active'` or `'invited'` → `409`
+- [x] `DuplicateMemberError` from `addMember` → `409` (race condition safety net)
+- [x] Unexpected errors → `500` (log server-side, no internals leaked)
+- [x] Verify: `npm run type-check` passes
+
+### 7. Add route unit tests — `tests/unit/api/campaigns/[id]/members/route.unit.test.ts`
+
+- [x] Setup: mock `storage.getMember`, `storage.addMember`, `storage.updateMemberStatus`, `withAuth`
+- [x] Test: successful new invite → `201 { id, status: 'invited' }`, `addMember` called with correct shape
+- [x] Test: re-invite declined member → `201`, `updateMemberStatus` called with `'invited'`
+- [x] Test: re-invite removed member → `201`, `updateMemberStatus` called with `'invited'`
+- [x] Test: target already active → `409`
+- [x] Test: target already invited → `409`
+- [x] Test: self-invite → `400`
+- [x] Test: missing `userId` in body → `400`
+- [x] Test: caller is not a member → `403`
+- [x] Test: caller is a player (not DM) → `403`
+- [x] Test: unauthenticated → `401`
+- [x] Test: `addMember` throws `DuplicateMemberError` → `409`
+- [x] Test: storage throws unexpected error → `500`
+- [x] Verify: `npm run test:unit -- --testPathPattern=members/route` passes
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn the `openspec-review-code` sub-agent. Automatically address all findings (complexity, duplication, quality) before committing.
+
+## Validation
+
+- [x] `npm run type-check` — no errors
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — build succeeds
+- [x] All execution tasks checked off
+- [x] All steps in Remote push validation passed
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit` — all tests must pass
+- **Type check** — `npm run type-check` — no errors
+- **Build** — `npm run build` — must succeed with no errors
+- If **ANY** of the above fail, iterate and fix before pushing
+
+## PR and Merge
+
+- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [ ] Commit all changes to `feat/invite-api` and push to remote
+- [ ] Open PR from `feat/invite-api` to `main`. PR body must include `Closes #305`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow Remote push validation, push; wait 180 seconds; repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, commit, follow Remote push validation, push; wait 180 seconds; repeat until all required checks pass
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user — never wait for a human to report the merge; never force-merge
+
+Ownership metadata:
+
+- Implementer: claude
+- Reviewer(s): agentic review + human
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → Remote push validation → push → re-run checks
+- Security finding → remediate → commit → Remote push validation → push → re-scan
+- Review comment → address → commit → Remote push validation → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/invite-api/spec.md`
+- [ ] Archive the change: move `openspec/changes/invite-api/` to `openspec/changes/archive/YYYY-MM-DD-invite-api/` **staging both new location and deletion in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-invite-api/` exists and `openspec/changes/invite-api/` is gone
+- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-invite-api` then `git push -u origin doc/archive-YYYY-MM-DD-invite-api`
+- [ ] Open PR with title `docs: archive invite-api (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same loop — address comments and CI failures, push to doc branch, repeat)
+- [ ] Prune: `git fetch --prune` and `git branch -d feat/invite-api doc/archive-YYYY-MM-DD-invite-api`

--- a/openspec/changes/invite-api/tasks.md
+++ b/openspec/changes/invite-api/tasks.md
@@ -13,7 +13,7 @@
 - [x] Add `export interface MemberHistoryEntry { action: MemberStatus; by: string; at: Date; }`
 - [x] Remove `invitedBy: string`, `invitedAt: Date`, `respondedAt?: Date` from `CampaignMember`
 - [x] Add `history: MemberHistoryEntry[]` to `CampaignMember`
-- [x] Verify: `npm run type-check` passes
+- [x] Verify: `npm run typecheck` passes
 
 ### 2. Replace `updateMember` with `updateMemberStatus` — `lib/storage.ts`
 
@@ -21,13 +21,13 @@
 - [x] Add `updateMemberStatus(campaignId: string, userId: string, status: MemberStatus, actorId: string): Promise<void>`
   - Single `updateOne` with `{ $set: { status }, $push: { history: { action: status, by: actorId, at: new Date() } } }`
 - [x] Update import if needed (no new imports required)
-- [x] Verify: `npm run type-check` passes
+- [x] Verify: `npm run typecheck` passes
 
 ### 3. Update DM owner seed — `app/api/campaigns/route.ts`
 
 - [x] At the `addMember` call (line ~51), remove `invitedBy` and `invitedAt` fields
 - [x] Add `history: [{ action: 'active' as const, by: auth.userId, at: new Date() }]`
-- [x] Verify: `npm run type-check` passes
+- [x] Verify: `npm run typecheck` passes
 
 ### 4. Update existing `addMember` unit tests
 
@@ -56,7 +56,7 @@
   - Existing with `status: 'active'` or `'invited'` → `409`
 - [x] `DuplicateMemberError` from `addMember` → `409` (race condition safety net)
 - [x] Unexpected errors → `500` (log server-side, no internals leaked)
-- [x] Verify: `npm run type-check` passes
+- [x] Verify: `npm run typecheck` passes
 
 ### 7. Add route unit tests — `tests/unit/api/campaigns/[id]/members/route.unit.test.ts`
 
@@ -81,7 +81,7 @@
 
 ## Validation
 
-- [x] `npm run type-check` — no errors
+- [x] `npm run typecheck` — no errors
 - [x] `npm run test:unit` — all tests pass
 - [x] `npm run build` — build succeeds
 - [x] All execution tasks checked off
@@ -92,16 +92,16 @@
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
 - **Unit tests** — `npm run test:unit` — all tests must pass
-- **Type check** — `npm run type-check` — no errors
+- **Type check** — `npm run typecheck` — no errors
 - **Build** — `npm run build` — must succeed with no errors
 - If **ANY** of the above fail, iterate and fix before pushing
 
 ## PR and Merge
 
-- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
-- [ ] Commit all changes to `feat/invite-api` and push to remote
-- [ ] Open PR from `feat/invite-api` to `main`. PR body must include `Closes #305`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [x] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [x] Commit all changes to `feat/invite-api` and push to remote
+- [x] Open PR from `feat/invite-api` to `main`. PR body must include `Closes #305`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
 - [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow Remote push validation, push; wait 180 seconds; repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, commit, follow Remote push validation, push; wait 180 seconds; repeat until all required checks pass

--- a/openspec/changes/invite-api/tests.md
+++ b/openspec/changes/invite-api/tests.md
@@ -23,7 +23,7 @@ For each task in `tasks.md`:
 
 ### Task 1 — Type changes (`lib/types.ts`)
 
-These are compile-time checks enforced by TypeScript. No runtime test file needed; verified by `npm run type-check` after edits.
+These are compile-time checks enforced by TypeScript. No runtime test file needed; verified by `npm run typecheck` after edits.
 
 - [ ] `MemberStatus` does not accept `"pending"` (type error if used)
 - [ ] `MemberStatus` accepts `"invited"` and `"removed"` without error
@@ -31,7 +31,7 @@ These are compile-time checks enforced by TypeScript. No runtime test file neede
 - [ ] `CampaignMember` rejects `invitedBy`, `invitedAt`, `respondedAt` (type error if passed)
 - [ ] `CampaignMember` requires `history: MemberHistoryEntry[]`
 
-**File:** `lib/types.ts` | **Verified by:** `npm run type-check`
+**File:** `lib/types.ts` | **Verified by:** `npm run typecheck`
 **Spec ref:** ADDED `MemberStatus` values; ADDED `MemberHistoryEntry`; MODIFIED `CampaignMember`
 
 ---
@@ -132,7 +132,7 @@ These are compile-time checks enforced by TypeScript. No runtime test file neede
 
 | Task | Test file |
 |------|-----------|
-| Types (compile-time) | `lib/types.ts` — verified by `npm run type-check` |
+| Types (compile-time) | `lib/types.ts` — verified by `npm run typecheck` |
 | `updateMemberStatus` storage | `tests/unit/storage/campaignMembers.test.ts` |
 | Campaign creation seed | `tests/unit/api/campaigns/route.unit.test.ts` |
 | POST route | `tests/unit/api/campaigns/[id]/members/route.unit.test.ts` |
@@ -140,7 +140,7 @@ These are compile-time checks enforced by TypeScript. No runtime test file neede
 ## Commands
 
 ```bash
-npm run type-check
+npm run typecheck
 npm run test:unit -- --testPathPattern=campaignMembers
 npm run test:unit -- --testPathPattern="campaigns/route"
 npm run test:unit -- --testPathPattern="members/route"

--- a/openspec/changes/invite-api/tests.md
+++ b/openspec/changes/invite-api/tests.md
@@ -1,0 +1,148 @@
+---
+name: tests
+description: Tests for the invite-api change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `invite-api` change. All work follows strict TDD: write a failing test, write the minimum code to pass it, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — before any implementation, write a test capturing the requirement. Run it and confirm it fails.
+2. **Write code to pass the test** — write the simplest code that makes the test pass.
+3. **Refactor** — improve code quality and structure while keeping the test green.
+
+---
+
+## Test Cases
+
+### Task 1 — Type changes (`lib/types.ts`)
+
+These are compile-time checks enforced by TypeScript. No runtime test file needed; verified by `npm run type-check` after edits.
+
+- [ ] `MemberStatus` does not accept `"pending"` (type error if used)
+- [ ] `MemberStatus` accepts `"invited"` and `"removed"` without error
+- [ ] `MemberHistoryEntry` requires `action`, `by`, and `at`; omitting any field is a type error
+- [ ] `CampaignMember` rejects `invitedBy`, `invitedAt`, `respondedAt` (type error if passed)
+- [ ] `CampaignMember` requires `history: MemberHistoryEntry[]`
+
+**File:** `lib/types.ts` | **Verified by:** `npm run type-check`
+**Spec ref:** ADDED `MemberStatus` values; ADDED `MemberHistoryEntry`; MODIFIED `CampaignMember`
+
+---
+
+### Task 2 — `storage.updateMemberStatus` unit tests
+
+**File:** `tests/unit/storage/campaignMembers.test.ts`
+**Spec ref:** ADDED `storage.updateMemberStatus`
+
+- [ ] **Happy path — status updated:** Given a member with `status: "declined"`, calling `updateMemberStatus(campaignId, userId, "invited", dmId)` results in `status: "invited"` on the document
+- [ ] **Happy path — history appended:** The same call appends `{ action: "invited", by: dmId, at: <Date> }` to `history`; prior history entries are preserved
+- [ ] **Happy path — `at` is a Date:** The appended history entry has an `at` field that is a `Date` instance
+- [ ] **Member not found:** Calling `updateMemberStatus` for a non-existent `(campaignId, userId)` completes without error and modifies no documents
+
+---
+
+### Task 3 — Updated `addMember` call in campaign creation
+
+**File:** `tests/unit/api/campaigns/route.unit.test.ts` (existing test file)
+**Spec ref:** MODIFIED `storage.addMember` callers; Scenario: Campaign creation seeds DM with history
+
+- [ ] **DM seed has history:** When `POST /api/campaigns` creates a campaign, `storage.addMember` is called with `history: [{ action: "active", by: <userId>, at: <Date> }]`
+- [ ] **DM seed has no flat fields:** `addMember` is NOT called with `invitedBy`, `invitedAt`, or `respondedAt`
+
+---
+
+### Task 4 — Updated existing `addMember` unit tests
+
+**File:** `tests/unit/storage/campaignMembers.test.ts`
+**Spec ref:** MODIFIED `storage.addMember` callers
+
+- [ ] Existing `addMember` happy-path test passes with `history: [{ action: "active", by: userId, at: new Date() }]` instead of `invitedBy`/`invitedAt`
+- [ ] `addMember` with `invitedBy` / `invitedAt` in the payload causes a TypeScript compile error (type-check only)
+
+---
+
+### Task 5 — `POST /api/campaigns/[id]/members` route unit tests
+
+**File:** `tests/unit/api/campaigns/[id]/members/route.unit.test.ts`
+**Spec ref:** All ADDED POST route scenarios
+
+#### Successful invite (new member)
+
+- [ ] Returns `201` with `{ id: <string>, status: "invited" }`
+- [ ] Calls `storage.addMember` with `status: "invited"`, `role: "player"`, and `history: [{ action: "invited", by: <callerId>, at: <Date> }]`
+- [ ] Does NOT call `storage.updateMemberStatus`
+
+#### Re-invite declined member
+
+- [ ] Given `getMember` returns a member with `status: "declined"`, returns `201` with `{ id: <existingId>, status: "invited" }`
+- [ ] Calls `storage.updateMemberStatus(campaignId, userId, "invited", callerId)`
+- [ ] Does NOT call `storage.addMember`
+
+#### Re-invite removed member
+
+- [ ] Given `getMember` returns a member with `status: "removed"`, returns `201` with `{ id: <existingId>, status: "invited" }`
+- [ ] Calls `storage.updateMemberStatus(campaignId, userId, "invited", callerId)`
+
+#### Duplicate rejection
+
+- [ ] Given `getMember` returns a member with `status: "active"`, returns `409`
+- [ ] Given `getMember` returns a member with `status: "invited"`, returns `409`
+- [ ] Neither `addMember` nor `updateMemberStatus` is called in either case
+
+#### Self-invite
+
+- [ ] Given `userId` in body equals `auth.userId`, returns `400`
+- [ ] No storage calls are made
+
+#### Missing / invalid body
+
+- [ ] Body `{}` (no `userId`) returns `400`
+- [ ] Body `{ userId: 123 }` (non-string) returns `400`
+
+#### Non-DM caller
+
+- [ ] Given `getMember(campaignId, callerId)` returns `null`, returns `403`
+- [ ] Given `getMember(campaignId, callerId)` returns a member with `role: "player"`, returns `403`
+- [ ] Given `getMember(campaignId, callerId)` returns a member with `status: "invited"` (not active DM), returns `403`
+
+#### Unauthenticated
+
+- [ ] Request without auth token returns `401`
+
+#### Race condition / duplicate insert
+
+- [ ] Given `getMember` returns null but `addMember` throws `DuplicateMemberError`, returns `409`
+
+#### Storage error
+
+- [ ] Given `addMember` throws an unexpected error, returns `500`
+- [ ] Given `updateMemberStatus` throws an unexpected error, returns `500`
+- [ ] Error details are not present in the response body
+
+---
+
+## Test file locations
+
+| Task | Test file |
+|------|-----------|
+| Types (compile-time) | `lib/types.ts` — verified by `npm run type-check` |
+| `updateMemberStatus` storage | `tests/unit/storage/campaignMembers.test.ts` |
+| Campaign creation seed | `tests/unit/api/campaigns/route.unit.test.ts` |
+| POST route | `tests/unit/api/campaigns/[id]/members/route.unit.test.ts` |
+
+## Commands
+
+```bash
+npm run type-check
+npm run test:unit -- --testPathPattern=campaignMembers
+npm run test:unit -- --testPathPattern="campaigns/route"
+npm run test:unit -- --testPathPattern="members/route"
+npm run test:unit   # full suite
+```

--- a/tests/integration/campaigns.members.integration.test.ts
+++ b/tests/integration/campaigns.members.integration.test.ts
@@ -42,9 +42,8 @@ describe("Campaign Members Integration Tests", () => {
         campaignId: "camp-123",
         userId: "user-456",
         role: "player",
-        status: "pending",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
+        status: "invited",
+        history: [{ action: "invited", by: "user-dm", at: new Date() }],
       };
 
       await storage.addMember(member);
@@ -54,7 +53,7 @@ describe("Campaign Members Integration Tests", () => {
       expect(list[0].id).toBe("mem-123");
       expect(list[0].userId).toBe("user-456");
       expect(list[0].role).toBe("player");
-      expect(list[0].status).toBe("pending");
+      expect(list[0].status).toBe("invited");
     });
 
     test("addMember — duplicate throws DuplicateMemberError", async () => {
@@ -64,8 +63,7 @@ describe("Campaign Members Integration Tests", () => {
         userId: "user-1",
         role: "dm",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
 
       await storage.addMember(member);
@@ -81,8 +79,7 @@ describe("Campaign Members Integration Tests", () => {
         userId: "user-1",
         role: "dm",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
 
       const member2: CampaignMember = {
@@ -90,9 +87,8 @@ describe("Campaign Members Integration Tests", () => {
         campaignId: "camp-2",
         userId: "user-1",
         role: "player",
-        status: "active",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
+        status: "invited",
+        history: [{ action: "invited", by: "user-dm", at: new Date() }],
       };
 
       await storage.addMember(member1);
@@ -104,46 +100,45 @@ describe("Campaign Members Integration Tests", () => {
       expect(list2).toHaveLength(1);
     });
 
-    test("updateMember — status update persisted", async () => {
+    test("updateMemberStatus — status update persisted", async () => {
       const member: CampaignMember = {
         id: "mem-1",
         campaignId: "camp-1",
         userId: "user-1",
         role: "player",
-        status: "pending",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
+        status: "invited",
+        history: [{ action: "invited", by: "user-dm", at: new Date() }],
       };
 
       await storage.addMember(member);
-      await storage.updateMember("camp-1", "user-1", undefined, "active");
+      await storage.updateMemberStatus("camp-1", "user-1", "active", "user-dm");
 
       const list = await storage.listMembersForCampaign("camp-1");
       expect(list[0].status).toBe("active");
       expect(list[0].role).toBe("player");
     });
 
-    test("updateMember — role update persisted", async () => {
+    test("updateMemberStatus — history entry appended", async () => {
       const member: CampaignMember = {
         id: "mem-1",
         campaignId: "camp-1",
         userId: "user-1",
         role: "player",
-        status: "active",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
+        status: "invited",
+        history: [{ action: "invited", by: "user-dm", at: new Date() }],
       };
 
       await storage.addMember(member);
-      await storage.updateMember("camp-1", "user-1", "dm", undefined);
+      await storage.updateMemberStatus("camp-1", "user-1", "active", "user-dm");
 
       const list = await storage.listMembersForCampaign("camp-1");
-      expect(list[0].role).toBe("dm");
-      expect(list[0].status).toBe("active");
+      expect(list[0].history).toHaveLength(2);
+      expect(list[0].history[1].action).toBe("active");
+      expect(list[0].history[1].by).toBe("user-dm");
     });
 
-    test("updateMember — non-existent member: no error, no record created", async () => {
-      await expect(storage.updateMember("camp-none", "user-none", "dm", "active")).resolves.not.toThrow();
+    test("updateMemberStatus — non-existent member: no error, no record created", async () => {
+      await expect(storage.updateMemberStatus("camp-none", "user-none", "invited", "user-dm")).resolves.not.toThrow();
       const list = await storage.listMembersForCampaign("camp-none");
       expect(list).toHaveLength(0);
     });
@@ -155,8 +150,7 @@ describe("Campaign Members Integration Tests", () => {
         userId: "user-1",
         role: "dm",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
 
       const member2: CampaignMember = {
@@ -165,8 +159,7 @@ describe("Campaign Members Integration Tests", () => {
         userId: "user-2",
         role: "player",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
 
       const member3: CampaignMember = {
@@ -175,8 +168,7 @@ describe("Campaign Members Integration Tests", () => {
         userId: "user-3",
         role: "player",
         status: "active",
-        invitedBy: "user-dm",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-dm", at: new Date() }],
       };
 
       await storage.addMember(member1);
@@ -250,8 +242,7 @@ describe("Campaign Members Integration Tests", () => {
           userId: "user-alice",
           role: "player",
           status: "active",
-          invitedBy: "user-dm",
-          invitedAt: new Date(),
+          history: [{ action: "active", by: "user-dm", at: new Date() }],
         };
 
         const member2: CampaignMember = {
@@ -259,9 +250,8 @@ describe("Campaign Members Integration Tests", () => {
           campaignId: "camp-3",
           userId: "user-alice",
           role: "player",
-          status: "pending",
-          invitedBy: "user-dm",
-          invitedAt: new Date(),
+          status: "invited",
+          history: [{ action: "invited", by: "user-dm", at: new Date() }],
         };
 
         await storage.addMember(member1);

--- a/tests/unit/api/campaigns/[id]/members/route.unit.test.ts
+++ b/tests/unit/api/campaigns/[id]/members/route.unit.test.ts
@@ -123,10 +123,10 @@ describe("POST /api/campaigns/[id]/members", () => {
       expect(body.status).toBe("invited");
     });
 
-    it("calls updateMemberStatus with 'invited'", async () => {
+    it("calls updateMemberStatus with 'invited' and role 'player'", async () => {
       await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
       expect(mockedStorage.updateMemberStatus).toHaveBeenCalledWith(
-        CAMPAIGN_ID, TARGET_USER_ID, "invited", MOCK_AUTH.userId
+        CAMPAIGN_ID, TARGET_USER_ID, "invited", MOCK_AUTH.userId, "player"
       );
     });
 
@@ -161,10 +161,10 @@ describe("POST /api/campaigns/[id]/members", () => {
       expect(body.status).toBe("invited");
     });
 
-    it("calls updateMemberStatus with 'invited'", async () => {
+    it("calls updateMemberStatus with 'invited' and role 'player'", async () => {
       await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
       expect(mockedStorage.updateMemberStatus).toHaveBeenCalledWith(
-        CAMPAIGN_ID, TARGET_USER_ID, "invited", MOCK_AUTH.userId
+        CAMPAIGN_ID, TARGET_USER_ID, "invited", MOCK_AUTH.userId, "player"
       );
     });
   });
@@ -235,6 +235,18 @@ describe("POST /api/campaigns/[id]/members", () => {
     it("returns 400 when userId is a number", async () => {
       const response = await POST(makePostRequest({ userId: 123 }), { params: PARAMS });
       expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when body is malformed JSON", async () => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      const req = new Request(
+        `http://localhost/api/campaigns/${CAMPAIGN_ID}/members`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "not-json" }
+      );
+      const response = await POST(req as never, { params: PARAMS });
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error).toBe("Invalid JSON");
     });
   });
 

--- a/tests/unit/api/campaigns/[id]/members/route.unit.test.ts
+++ b/tests/unit/api/campaigns/[id]/members/route.unit.test.ts
@@ -1,0 +1,327 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "@/app/api/campaigns/[id]/members/route";
+import { requireAuth } from "@/lib/middleware";
+import { storage } from "@/lib/storage";
+import { DuplicateMemberError } from "@/lib/errors";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+} from "@/tests/unit/helpers/route.test.helpers";
+import { CampaignMember } from "@/lib/types";
+
+jest.mock("@/lib/middleware");
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+    addMember: jest.fn(),
+    updateMemberStatus: jest.fn(),
+  },
+}));
+
+const mockedRequireAuth = jest.mocked(requireAuth);
+const mockedStorage = jest.mocked(storage) as {
+  getMember: jest.MockedFunction<typeof storage.getMember>;
+  addMember: jest.MockedFunction<typeof storage.addMember>;
+  updateMemberStatus: jest.MockedFunction<typeof storage.updateMemberStatus>;
+};
+
+const CAMPAIGN_ID = "camp-1";
+const TARGET_USER_ID = "target-user";
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
+
+const ACTIVE_DM: CampaignMember = {
+  id: "mem-dm",
+  campaignId: CAMPAIGN_ID,
+  userId: MOCK_AUTH.userId,
+  role: "dm",
+  status: "active",
+  history: [{ action: "active", by: MOCK_AUTH.userId, at: new Date() }],
+};
+
+const makePostRequest = (body: unknown) =>
+  makeRouteRequest(`http://localhost/api/campaigns/${CAMPAIGN_ID}/members`, "POST", body);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedStorage.addMember.mockResolvedValue(undefined);
+  mockedStorage.updateMemberStatus.mockResolvedValue(undefined);
+});
+
+describe("POST /api/campaigns/[id]/members", () => {
+  describe("unauthenticated", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockedRequireAuth.mockReturnValue(
+        { status: 401, json: async () => ({ error: "Unauthorized" }) } as never
+      );
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("successful new invite", () => {
+    beforeEach(() => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)   // caller check
+        .mockResolvedValueOnce(null);        // target check
+    });
+
+    it("returns 201 with { id, status: 'invited' }", async () => {
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(typeof body.id).toBe("string");
+      expect(body.status).toBe("invited");
+    });
+
+    it("calls addMember with correct shape", async () => {
+      await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(mockedStorage.addMember).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaignId: CAMPAIGN_ID,
+          userId: TARGET_USER_ID,
+          role: "player",
+          status: "invited",
+          history: expect.arrayContaining([
+            expect.objectContaining({ action: "invited", by: MOCK_AUTH.userId }),
+          ]),
+        })
+      );
+    });
+
+    it("does not call updateMemberStatus", async () => {
+      await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(mockedStorage.updateMemberStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("re-invite declined member", () => {
+    const DECLINED_MEMBER: CampaignMember = {
+      id: "mem-target",
+      campaignId: CAMPAIGN_ID,
+      userId: TARGET_USER_ID,
+      role: "player",
+      status: "declined",
+      history: [{ action: "declined", by: TARGET_USER_ID, at: new Date() }],
+    };
+
+    beforeEach(() => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(DECLINED_MEMBER);
+    });
+
+    it("returns 201 with existing id and status 'invited'", async () => {
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(body.id).toBe("mem-target");
+      expect(body.status).toBe("invited");
+    });
+
+    it("calls updateMemberStatus with 'invited'", async () => {
+      await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(mockedStorage.updateMemberStatus).toHaveBeenCalledWith(
+        CAMPAIGN_ID, TARGET_USER_ID, "invited", MOCK_AUTH.userId
+      );
+    });
+
+    it("does not call addMember", async () => {
+      await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(mockedStorage.addMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("re-invite removed member", () => {
+    const REMOVED_MEMBER: CampaignMember = {
+      id: "mem-target",
+      campaignId: CAMPAIGN_ID,
+      userId: TARGET_USER_ID,
+      role: "player",
+      status: "removed",
+      history: [{ action: "removed", by: MOCK_AUTH.userId, at: new Date() }],
+    };
+
+    beforeEach(() => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(REMOVED_MEMBER);
+    });
+
+    it("returns 201 with existing id and status 'invited'", async () => {
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(body.id).toBe("mem-target");
+      expect(body.status).toBe("invited");
+    });
+
+    it("calls updateMemberStatus with 'invited'", async () => {
+      await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(mockedStorage.updateMemberStatus).toHaveBeenCalledWith(
+        CAMPAIGN_ID, TARGET_USER_ID, "invited", MOCK_AUTH.userId
+      );
+    });
+  });
+
+  describe("duplicate rejection", () => {
+    const ACTIVE_TARGET: CampaignMember = {
+      id: "mem-target",
+      campaignId: CAMPAIGN_ID,
+      userId: TARGET_USER_ID,
+      role: "player",
+      status: "active",
+      history: [{ action: "active", by: TARGET_USER_ID, at: new Date() }],
+    };
+    const INVITED_TARGET: CampaignMember = {
+      id: "mem-target",
+      campaignId: CAMPAIGN_ID,
+      userId: TARGET_USER_ID,
+      role: "player",
+      status: "invited",
+      history: [{ action: "invited", by: MOCK_AUTH.userId, at: new Date() }],
+    };
+
+    beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+    it("returns 409 when target is already active", async () => {
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(ACTIVE_TARGET);
+
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(409);
+      expect(mockedStorage.addMember).not.toHaveBeenCalled();
+      expect(mockedStorage.updateMemberStatus).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 when target is already invited", async () => {
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(INVITED_TARGET);
+
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(409);
+      expect(mockedStorage.addMember).not.toHaveBeenCalled();
+      expect(mockedStorage.updateMemberStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("self-invite", () => {
+    it("returns 400 when userId equals auth.userId", async () => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      const response = await POST(
+        makePostRequest({ userId: MOCK_AUTH.userId }),
+        { params: PARAMS }
+      );
+      expect(response.status).toBe(400);
+      expect(mockedStorage.getMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("missing/invalid body", () => {
+    beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+    it("returns 400 when userId is missing", async () => {
+      const response = await POST(makePostRequest({}), { params: PARAMS });
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when userId is a number", async () => {
+      const response = await POST(makePostRequest({ userId: 123 }), { params: PARAMS });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("non-DM caller", () => {
+    beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+    it("returns 403 when caller is not a member", async () => {
+      mockedStorage.getMember.mockResolvedValueOnce(null);
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(403);
+    });
+
+    it("returns 403 when caller is a player", async () => {
+      const playerMember: CampaignMember = {
+        id: "mem-caller",
+        campaignId: CAMPAIGN_ID,
+        userId: MOCK_AUTH.userId,
+        role: "player",
+        status: "active",
+        history: [{ action: "active", by: MOCK_AUTH.userId, at: new Date() }],
+      };
+      mockedStorage.getMember.mockResolvedValueOnce(playerMember);
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(403);
+    });
+
+    it("returns 403 when caller is DM with 'invited' status (not active)", async () => {
+      const invitedDm: CampaignMember = {
+        id: "mem-caller",
+        campaignId: CAMPAIGN_ID,
+        userId: MOCK_AUTH.userId,
+        role: "dm",
+        status: "invited",
+        history: [{ action: "invited", by: "other", at: new Date() }],
+      };
+      mockedStorage.getMember.mockResolvedValueOnce(invitedDm);
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("race condition / DuplicateMemberError from addMember", () => {
+    it("returns 409 when addMember throws DuplicateMemberError", async () => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(null);
+      mockedStorage.addMember.mockRejectedValueOnce(
+        new DuplicateMemberError(CAMPAIGN_ID, TARGET_USER_ID)
+      );
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(409);
+    });
+  });
+
+  describe("storage error", () => {
+    it("returns 500 when addMember throws unexpected error", async () => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(null);
+      mockedStorage.addMember.mockRejectedValueOnce(new Error("DB failure"));
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body).not.toHaveProperty("stack");
+      expect(body.error).toBe("Internal server error");
+    });
+
+    it("returns 500 when updateMemberStatus throws unexpected error", async () => {
+      mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+      const declinedMember: CampaignMember = {
+        id: "mem-target",
+        campaignId: CAMPAIGN_ID,
+        userId: TARGET_USER_ID,
+        role: "player",
+        status: "declined",
+        history: [{ action: "declined", by: TARGET_USER_ID, at: new Date() }],
+      };
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(declinedMember);
+      mockedStorage.updateMemberStatus.mockRejectedValueOnce(new Error("DB failure"));
+      const response = await POST(makePostRequest({ userId: TARGET_USER_ID }), { params: PARAMS });
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body).not.toHaveProperty("stack");
+    });
+  });
+});

--- a/tests/unit/storage/campaignMembers.test.ts
+++ b/tests/unit/storage/campaignMembers.test.ts
@@ -27,8 +27,7 @@ const MOCK_MEMBER: CampaignMember = {
   userId: "user-1",
   role: "dm",
   status: "active",
-  invitedBy: "user-1",
-  invitedAt: new Date("2026-06-01T00:00:00Z"),
+  history: [{ action: "active", by: "user-1", at: new Date("2026-06-01T00:00:00Z") }],
 };
 
 describe("getMember", () => {

--- a/tests/unit/storage/campaigns.members.test.ts
+++ b/tests/unit/storage/campaigns.members.test.ts
@@ -153,6 +153,22 @@ describe("Campaign members storage and types", () => {
         storage.updateMemberStatus("camp-1", "nobody", "invited", "dm-user")
       ).resolves.not.toThrow();
     });
+
+    test("DB error — rethrows", async () => {
+      mockCollection.updateOne.mockRejectedValue(new Error("DB failure") as never);
+      await expect(
+        storage.updateMemberStatus("camp-1", "user-1", "invited", "dm-user")
+      ).rejects.toThrow("DB failure");
+    });
+
+    test("role reset — includes role in $set when provided", async () => {
+      mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
+      await storage.updateMemberStatus("camp-1", "user-1", "invited", "dm-user", "player");
+      expect(mockCollection.updateOne).toHaveBeenCalledWith(
+        { campaignId: "camp-1", userId: "user-1" },
+        expect.objectContaining({ $set: { status: "invited", role: "player" } })
+      );
+    });
   });
 
   describe("listMembersForCampaign (mocked DB)", () => {

--- a/tests/unit/storage/campaigns.members.test.ts
+++ b/tests/unit/storage/campaigns.members.test.ts
@@ -40,9 +40,8 @@ describe("Campaign members storage and types", () => {
         campaignId: "campaign-1",
         userId: "user-1",
         role: "player",
-        status: "pending",
-        invitedBy: "user-dm",
-        invitedAt: new Date("2026-05-30T12:00:00Z"),
+        status: "invited",
+        history: [{ action: "invited", by: "user-dm", at: new Date("2026-05-30T12:00:00Z") }],
       };
       expect(member.role).toBe("player");
     });
@@ -74,8 +73,7 @@ describe("Campaign members storage and types", () => {
         userId: "user-1",
         role: "dm",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
       await expect(storage.addMember(member)).resolves.not.toThrow();
       expect(mockDb.collection).toHaveBeenCalledWith("campaignMembers");
@@ -98,8 +96,7 @@ describe("Campaign members storage and types", () => {
         userId: "user-1",
         role: "dm",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
       await expect(storage.addMember(member)).rejects.toThrow(DuplicateMemberError);
     });
@@ -112,14 +109,13 @@ describe("Campaign members storage and types", () => {
         userId: "user-1",
         role: "dm",
         status: "active",
-        invitedBy: "user-1",
-        invitedAt: new Date(),
+        history: [{ action: "active", by: "user-1", at: new Date() }],
       };
       await expect(storage.addMember(member)).rejects.toThrow("DB failure");
     });
   });
 
-  describe("updateMember (mocked DB)", () => {
+  describe("updateMemberStatus (mocked DB)", () => {
     let mockCollection: ReturnType<typeof makeMockCollection>;
     let mockDb: { collection: ReturnType<typeof jest.fn> };
 
@@ -129,41 +125,33 @@ describe("Campaign members storage and types", () => {
       mockedGetDatabase.mockResolvedValue(mockDb as never);
     });
 
-    test("status only — set only status", async () => {
+    test("status field updated to new value", async () => {
       mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
-      await storage.updateMember("camp-1", "user-1", undefined, "active");
+      await storage.updateMemberStatus("camp-1", "user-1", "invited", "dm-user");
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         { campaignId: "camp-1", userId: "user-1" },
-        { $set: { status: "active" } }
+        expect.objectContaining({ $set: { status: "invited" } })
       );
     });
 
-    test("role only — set only role", async () => {
+    test("history entry appended with correct action, by, at", async () => {
       mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
-      await storage.updateMember("camp-1", "user-1", "dm", undefined);
+      await storage.updateMemberStatus("camp-1", "user-1", "invited", "dm-user");
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         { campaignId: "camp-1", userId: "user-1" },
-        { $set: { role: "dm" } }
+        expect.objectContaining({
+          $push: expect.objectContaining({
+            history: expect.objectContaining({ action: "invited", by: "dm-user", at: expect.any(Date) }),
+          }),
+        })
       );
     });
 
-    test("both fields — set both", async () => {
-      mockCollection.updateOne.mockResolvedValue({ matchedCount: 1 } as never);
-      await storage.updateMember("camp-1", "user-1", "player", "pending");
-      expect(mockCollection.updateOne).toHaveBeenCalledWith(
-        { campaignId: "camp-1", userId: "user-1" },
-        { $set: { role: "player", status: "pending" } }
-      );
-    });
-
-    test("no match — no error when matchedCount is 0", async () => {
+    test("member not found — no error thrown, no document modified", async () => {
       mockCollection.updateOne.mockResolvedValue({ matchedCount: 0 } as never);
-      await expect(storage.updateMember("camp-1", "user-1", "player", "active")).resolves.not.toThrow();
-    });
-
-    test("no-op — no updateOne called when both params are undefined", async () => {
-      await storage.updateMember("camp-1", "user-1", undefined, undefined);
-      expect(mockCollection.updateOne).not.toHaveBeenCalled();
+      await expect(
+        storage.updateMemberStatus("camp-1", "nobody", "invited", "dm-user")
+      ).resolves.not.toThrow();
     });
   });
 
@@ -180,7 +168,7 @@ describe("Campaign members storage and types", () => {
     test("returns normalized members for campaign", async () => {
       const rawDbMembers = [
         { _id: "obj-1", id: "mem-1", campaignId: "camp-1", userId: "user-1", role: "dm", status: "active" },
-        { _id: "obj-2", id: "mem-2", campaignId: "camp-1", userId: "user-2", role: "player", status: "pending" },
+        { _id: "obj-2", id: "mem-2", campaignId: "camp-1", userId: "user-2", role: "player", status: "invited" },
       ];
       mockCollection.toArray.mockResolvedValue(rawDbMembers);
 
@@ -272,7 +260,9 @@ describe("Route POST seeding (mocked storage)", () => {
         userId: "user-123",
         role: "dm",
         status: "active",
-        invitedBy: "user-123",
+        history: expect.arrayContaining([
+          expect.objectContaining({ action: "active", by: "user-123" }),
+        ]),
       })
     );
 

--- a/tests/unit/utils/assertCampaignAccess.test.ts
+++ b/tests/unit/utils/assertCampaignAccess.test.ts
@@ -21,6 +21,7 @@ const MOCK_CAMPAIGN = {
   id: "camp-1",
   userId: "owner-user",
   name: "Test Campaign",
+  moduleName: "",
   chapters: [],
   status: "active" as const,
   notes: "",
@@ -28,14 +29,13 @@ const MOCK_CAMPAIGN = {
   updatedAt: new Date("2026-01-01"),
 };
 
-const makeMember = (role: "dm" | "player", status: "active" | "pending" | "declined") => ({
+const makeMember = (role: "dm" | "player", status: "active" | "invited" | "declined" | "removed") => ({
   id: "mem-1",
   campaignId: "camp-1",
   userId: "user-1",
   role,
   status,
-  invitedBy: "owner-user",
-  invitedAt: new Date("2026-06-01"),
+  history: [{ action: status as "active" | "invited" | "declined" | "removed", by: "owner-user", at: new Date("2026-06-01") }],
 });
 
 beforeEach(() => {
@@ -78,8 +78,8 @@ describe("assertCampaignAccess", () => {
     expect(body).toEqual({ error: "Campaign not found" });
   });
 
-  it("returns 404 NextResponse when member status is 'pending'", async () => {
-    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "pending"));
+  it("returns 404 NextResponse when member status is 'invited'", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "invited"));
 
     const result = await assertCampaignAccess("camp-1", "user-1");
 
@@ -109,7 +109,7 @@ describe("assertCampaignAccess", () => {
   });
 
   it("does not call loadCampaignByIdAny when member is not active", async () => {
-    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "pending"));
+    mockedStorage.getMember.mockResolvedValue(makeMember("dm", "invited"));
 
     await assertCampaignAccess("camp-1", "user-1");
 


### PR DESCRIPTION
## Summary

Implements `POST /api/campaigns/[id]/members` — the DM invite endpoint for Phase 2 of multi-user campaigns.

## Changes

### Type Layer (`lib/types.ts`)
- `MemberStatus`: replaced `"pending"` with `"invited"`, added `"removed"`
- New `MemberHistoryEntry` interface: `{ action: MemberStatus; by: string; at: Date }`
- `CampaignMember`: removed `invitedBy`, `invitedAt`, `respondedAt`; added `history: MemberHistoryEntry[]`

### Storage Layer (`lib/storage.ts`)
- Replaced `updateMember` with `updateMemberStatus(campaignId, userId, status, actorId)` — single `updateOne` with `$set` + `$push` (atomic at document level)

### Route: Campaign Creation (`app/api/campaigns/route.ts`)
- Updated DM owner seed to pass `history: [{ action: 'active', by: userId, at: now }]`

### Route: Invite (`app/api/campaigns/[id]/members/route.ts`) — new file
- `POST` handler with `withAuthAndParams`
- Guards: unauthenticated → 401, missing/invalid `userId` → 400, self-invite → 400, non-active-DM caller → 403
- Upsert: new member → `addMember` → 201; declined/removed → `updateMemberStatus` → 201; active/invited → 409
- Race condition safety net: `DuplicateMemberError` from `addMember` → 409

### Tests
- Updated all existing unit/integration tests for new schema (no `invitedBy`/`invitedAt`)
- Added 20 new unit tests covering all invite route scenarios
- Added `updateMemberStatus` unit tests to `campaignMembers.test.ts`

Closes #305