### PR TITLE
docs: use consistent response body placeholder format in re-invite scenarios

### DIFF
--- a/openspec/changes/archive/2026-06-06-invite-api/specs/invite-api/spec.md
+++ b/openspec/changes/archive/2026-06-06-invite-api/specs/invite-api/spec.md
@@ -76,13 +76,13 @@ The system SHALL reset a `declined` or `removed` member back to `invited` status
 
 - **Given** an authenticated DM and an existing member with `status: "declined"`
 - **When** the DM POSTs `{ userId: "<targetId>" }`
-- **Then** the response is `201` with `{ id, status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
+- **Then** the response is `201` with body `{ id: "<memberId>", status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
 
 #### Scenario: Re-invite a removed member
 
 - **Given** an authenticated DM and an existing member with `status: "removed"`
 - **When** the DM POSTs `{ userId: "<targetId>" }`
-- **Then** the response is `201` with `{ id, status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
+- **Then** the response is `201` with body `{ id: "<memberId>", status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
 
 ---
 

--- a/openspec/changes/archive/2026-06-06-invite-api/tasks.md
+++ b/openspec/changes/archive/2026-06-06-invite-api/tasks.md
@@ -131,4 +131,4 @@ Blocking resolution flow:
 - [x] Open PR with title `docs: archive invite-api (2026-06-06)` — do NOT push directly to `main`
 - [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
 - [x] Monitor doc PR until merged (same loop — address comments and CI failures, push to doc branch, repeat)
-- [ ] Prune: `git fetch --prune` and `git branch -d feat/invite-api doc/archive-2026-06-06-invite-api`
+- [x] Prune: `git fetch --prune` and `git branch -d feat/invite-api doc/archive-2026-06-06-invite-api`

--- a/openspec/specs/invite-api/spec.md
+++ b/openspec/specs/invite-api/spec.md
@@ -76,13 +76,13 @@ The system SHALL reset a `declined` or `removed` member back to `invited` status
 
 - **Given** an authenticated DM and an existing member with `status: "declined"`
 - **When** the DM POSTs `{ userId: "<targetId>" }`
-- **Then** the response is `201` with `{ id, status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
+- **Then** the response is `201` with body `{ id: "<memberId>", status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
 
 #### Scenario: Re-invite a removed member
 
 - **Given** an authenticated DM and an existing member with `status: "removed"`
 - **When** the DM POSTs `{ userId: "<targetId>" }`
-- **Then** the response is `201` with `{ id, status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
+- **Then** the response is `201` with body `{ id: "<memberId>", status: "invited" }`, and the member document's `status` is `"invited"` with a new history entry appended
 
 ---
 


### PR DESCRIPTION
Fixes minor inconsistency in `openspec/specs/invite-api/spec.md` flagged by Codacy on PR #368.

The re-invite scenario **Then** clauses used `{ id, status: "invited" }` while the new invite scenario used `{ id: "<memberId>", status: "invited" }`. Both now use the explicit placeholder format for consistency.

Also applies the same fix to the archived copy.