### PR TITLE
docs: archive rtl-migration-campaign-editor (2026-06-06)

### DIFF
--- a/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-06

--- a/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/design.md
+++ b/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/design.md
@@ -1,0 +1,143 @@
+## Context
+
+- Relevant architecture: Component unit tests under `tests/unit/components/`. The legacy `createReactRoot` helper lives in `tests/unit/helpers/reactRoot.ts`. RTL (`@testing-library/react` v16, `@testing-library/user-event` v14, `@testing-library/jest-dom` v6) is already installed and configured in `jest.setup.ts`.
+- Dependencies: No production code changes. Test-only change against `tests/unit/components/CampaignEditor.test.tsx`.
+- Interfaces/contracts touched: The test file imports `CampaignEditor` from `app/campaigns/CampaignEditor.tsx`. The component's rendered structure (labels, roles, `data-testid` attributes, `aria-label` attributes) forms the implicit contract for RTL queries.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Replace all `createReactRoot` / `act` / `container.*` patterns with `render`, `screen`, and `userEvent.setup()`
+- Preserve all 25 existing test cases with identical assertions
+- Use accessible queries wherever the component provides them; fall back to `getByTestId` only where labels are not linked
+- Use shared local helpers (`renderEditor`, `openChapters`) to avoid repeated setup code
+
+### Non-Goals
+
+- Adding new test cases
+- Changing production code
+- Migrating the 5 static-API files from issue #369
+
+## Decisions
+
+### Decision 1: Query strategy per element
+
+- Chosen:
+  - Campaign Name input → `screen.getByLabelText('Campaign Name *')` (`TextInputField` uses `useId()` + `htmlFor`)
+  - Module/Adventure input → `screen.getByLabelText('Module / Adventure')`
+  - Status select → `screen.getByTestId('status-select')` (label not linked via `htmlFor`)
+  - Notes textarea → `screen.getByTestId('notes-textarea')` (label not linked via `htmlFor`)
+  - Chapter title inputs → `screen.getAllByTestId('chapter-title-input')` (have `aria-label` but `getByTestId` matches existing data attributes)
+  - Chapter move/remove buttons → `screen.getByTestId('move-up-N')`, `screen.getByTestId('remove-chapter-N')`
+  - Current chapter select → `screen.getByTestId('current-chapter-select')`
+  - Save/Cancel buttons → `screen.getByRole('button', { name: 'Save Campaign' })`, `screen.getByRole('button', { name: 'Cancel' })`
+  - Chapters accordion → `screen.getByRole('button', { name: /chapters/i })`
+- Alternatives considered: Using only `getByRole` or only `getByTestId` uniformly.
+- Rationale: Prioritise accessible queries (role, label) where the component already provides them; use `getByTestId` only for elements whose labels are not programmatically linked.
+- Trade-offs: Mixed query strategy requires slightly more knowledge of the component, but better reflects real accessibility of the component.
+
+### Decision 2: userEvent.setup() scoping
+
+- Chosen: Create one `user` instance per test via `const user = userEvent.setup()` at the top of each `it` block (not shared at describe scope).
+- Alternatives considered: Shared `user` via `beforeEach` at describe scope.
+- Rationale: Matches the existing pattern in the 18 files that already use `setup()`. Per-test instances avoid cross-test state bleed from pointer/keyboard simulation.
+- Trade-offs: Slightly more repetition per test, but each test is self-contained and easier to read in isolation.
+
+### Decision 3: Local helper strategy
+
+- Chosen: Two module-level helpers:
+  - `renderEditor(props)` — calls `render(<CampaignEditor .../>)` with defaults spread over BASE_CAMPAIGN, reducing per-test boilerplate.
+  - `openChapters()` — async helper that clicks the accordion only if `+ Add Chapter` is not already visible (guards against double-click when `chaptersExpanded` initialises `true`).
+- Alternatives considered: No helpers (inline render everywhere); a single unified render helper with userEvent baked in.
+- Rationale: Same thing done 8+ times warrants a helper. Keeping `renderEditor` and `openChapters` separate makes each composable and testable independently.
+- Trade-offs: Helpers must be maintained alongside the component; however they are small and obvious.
+
+### Decision 4: Chapter display assertion
+
+- Chosen: `screen.getByDisplayValue('Arrival')` (and similar) to verify chapter titles in the expanded chapters section.
+- Alternatives considered: `screen.getByText(/Arrival/)` (finds the option text in the select dropdown).
+- Rationale: `getByDisplayValue` directly asserts the input has the right value, which is the semantically correct assertion. The previous `container.textContent` approach incidentally found chapter titles in `<option>` elements, which is indirect.
+- Trade-offs: Requires chapters section to be expanded for the input to be in the DOM — `renderEditor` with `chapters` prop ensures `chaptersExpanded` starts `true`.
+
+### Decision 5: beforeEach / afterEach boilerplate
+
+- Chosen: Remove entirely. RTL registers its own `afterEach(cleanup)` automatically.
+- Alternatives considered: Keep `afterEach(() => jest.clearAllMocks())`.
+- Rationale: `jest.clearAllMocks()` is already in `jest.config.js`'s `clearMocks` setting (or called globally). Verify and remove redundant teardown.
+- Trade-offs: If global `clearMocks` is not set, mocks may leak. Mitigation: confirm `jest.config.js` setting; add `afterEach(() => jest.clearAllMocks())` only if needed.
+
+## Proposal to Design Mapping
+
+- Proposal element: Replace `findButton(text)` helper
+  - Design decision: Decision 1 (role-based button queries)
+  - Validation approach: Each test using `getByRole('button', ...)` is verified by the test passing
+
+- Proposal element: Replace `getInput(type, index)` helper
+  - Design decision: Decision 1 (`getByLabelText` for name/moduleName)
+  - Validation approach: `screen.getByLabelText('Campaign Name *')` must resolve without error
+
+- Proposal element: Replace `openChapters()` helper
+  - Design decision: Decision 3 (local `openChapters()` RTL version)
+  - Validation approach: All 8 tests that call `openChapters()` pass
+
+- Proposal element: Chapter display test using `container.textContent`
+  - Design decision: Decision 4 (`getByDisplayValue`)
+  - Validation approach: `screen.getByDisplayValue('Arrival')` resolves in expanded state
+
+- Proposal element: Use `userEvent.setup()` per #369
+  - Design decision: Decision 2 (per-test `user` instance)
+  - Validation approach: No static `userEvent.*` calls remain
+
+## Functional Requirements Mapping
+
+- Requirement: All 25 existing test cases preserved
+  - Design element: Direct 1:1 migration of each `it(...)` block
+  - Acceptance criteria reference: `npm test` passes with no failures or skips
+  - Testability notes: Run test suite before and after; diff test count
+
+- Requirement: No imports from `@/tests/unit/helpers/reactRoot`
+  - Design element: Decision 5 (remove boilerplate); Decision 1 (RTL queries replace DOM queries)
+  - Acceptance criteria reference: `grep -r 'reactRoot' tests/` returns no results in this file
+  - Testability notes: Static analysis / grep after migration
+
+- Requirement: Chapter display assertion uses input values not option text
+  - Design element: Decision 4
+  - Acceptance criteria reference: `getByDisplayValue` used in chapter display test
+  - Testability notes: Test passes and assertion is on input, not container.textContent
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: No flakiness introduced by event timing
+  - Design element: Decision 2 (per-test `userEvent.setup()` with proper async/await)
+  - Acceptance criteria reference: All async tests `await` every user interaction
+  - Testability notes: Run test suite 3× in CI to confirm consistent pass rate
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `getByRole('button', { name: /chapters/i })` matches emoji-prefixed button text `📖 Chapters (N)`
+  - Impact: Test throws if regex doesn't match computed accessible name
+  - Mitigation: Verified in explore — emoji is part of text content, `/chapters/i` matches the span text
+
+- Risk/trade-off: `jest.clearAllMocks()` teardown may be needed if global config doesn't cover it
+  - Impact: Mock state bleeds between tests
+  - Mitigation: Check `jest.config.js` for `clearMocks: true`; add `afterEach` if absent
+
+## Rollback / Mitigation
+
+- Rollback trigger: More than 1 test case fails after migration with no clear fix path
+- Rollback steps: Revert `tests/unit/components/CampaignEditor.test.tsx` to pre-migration state via `git checkout`
+- Data migration considerations: None (test-only change)
+- Verification after rollback: `npm test` passes with original file
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing test before opening PR.
+- If security checks fail: Not applicable (test-only change touches no production code).
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to repo maintainer after 48 hours.
+- Escalation path and timeout: Maintainer (@dougis) has final merge authority after 48 hours of stale review.
+
+## Open Questions
+
+No open questions. All design decisions were resolved during the explore session for issue #356.

--- a/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/proposal.md
+++ b/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/proposal.md
@@ -1,0 +1,71 @@
+## GitHub Issues
+
+- #356
+
+## Why
+
+- Problem statement: `tests/unit/components/CampaignEditor.test.tsx` (387 lines) uses the legacy `createReactRoot` / `act` / `container.querySelectorAll` pattern that predates React Testing Library. The helper `@/tests/unit/helpers/reactRoot` is the last remaining consumer of this pattern.
+- Why now: Issue #356 was filed to complete the RTL migration started in #254 and tracked through the archived `rtl-migration-issue-260` change. All other component test files have been migrated; `CampaignEditor.test.tsx` is the last holdout.
+- Business/user impact: Consistent test infrastructure across all component tests. Removes the legacy `reactRoot` helper entirely once done.
+
+## Problem Space
+
+- Current behavior: Tests use `createReactRoot` to mount, `act()` to interact, `container.querySelector*` for all DOM queries, and `dispatchEvent` to fire change events on selects and inputs.
+- Desired behavior: Tests use `render` + `screen` from `@testing-library/react` and `userEvent.setup()` from `@testing-library/user-event`. DOM queries use accessible roles, labels, and `data-testid` attributes. Event interactions use `user.click()`, `user.selectOptions()`, `user.type()`.
+- Constraints:
+  - All 25 existing test cases must be preserved — no cases added or removed.
+  - Must use `userEvent.setup()` per the standard set in #369 (not the deprecated static API).
+  - The `TextInputField` components for Campaign Name and Module/Adventure use `useId()` + `htmlFor`, so `getByLabelText` works without component changes.
+  - The status `<select>` and notes `<textarea>` use `data-testid` but their labels are not linked via `htmlFor`, so `getByTestId` is the correct query.
+  - Chapter title inputs have `aria-label="Chapter N title"` attributes — `getByLabelText` or `getByTestId` both work.
+- Assumptions:
+  - No changes to `CampaignEditor.tsx` or `ui.tsx` are needed.
+  - `@testing-library/react`, `@testing-library/user-event` v14, and `@testing-library/jest-dom` are already installed and configured.
+- Edge cases considered:
+  - `chaptersExpanded` initialises to `true` when a campaign already has chapters. The `openChapters()` helper guards against double-clicking the accordion.
+  - The "chapter display" test currently checks `container.textContent` for chapter titles, which finds them via `<option>` text. Migrating to `screen.getByDisplayValue()` checks the input values directly — more semantically correct.
+
+## Scope
+
+### In Scope
+
+- Full rewrite of `tests/unit/components/CampaignEditor.test.tsx` to RTL
+- Deletion of the `createReactRoot` / `unmountReactRoot` import and all `container`/`root` boilerplate
+- Addition of a local `renderEditor()` helper and an `openChapters()` helper to reduce duplication
+- Use `userEvent.setup()` per #369 standard
+
+### Out of Scope
+
+- Migration of the other 5 static-API files from #369 (separate issue)
+- Deletion of `tests/unit/helpers/reactRoot.ts` itself — only done once confirmed no other consumers remain (verify separately)
+- Changes to `CampaignEditor.tsx`, `ui.tsx`, or any production code
+- Adding new test cases beyond the existing 25
+
+## What Changes
+
+- `tests/unit/components/CampaignEditor.test.tsx`: full migration to RTL
+
+## Risks
+
+- Risk: A test that passed with `act()` + `dispatchEvent` behaves differently with `userEvent` (timing, synthetic vs. real events).
+  - Impact: Test failure or false negative.
+  - Mitigation: Run `npm test` after each describe-block migration and fix immediately.
+
+- Risk: `getByLabelText('Campaign Name *')` fails if the label text is rendered differently (e.g. trailing whitespace or asterisk stripped).
+  - Impact: Test throws `TestingLibraryElementError`.
+  - Mitigation: Verified in explore — `TextInputField` renders `<label htmlFor={id}>Campaign Name *</label>` exactly.
+
+## Open Questions
+
+No unresolved ambiguity exists. All query strategies, helpers, and event patterns were resolved during the explore session for this issue.
+
+## Non-Goals
+
+- Increasing test coverage beyond the existing 25 cases
+- Refactoring `CampaignEditor.tsx` for testability
+- Standardising the static-API files (tracked in #369)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/specs/rtl-migration/spec.md
+++ b/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/specs/rtl-migration/spec.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED RTL render pattern
+
+The system SHALL render `CampaignEditor` in tests using `render` from `@testing-library/react` via a local `renderEditor(overrides?)` helper, with no `createReactRoot`, `container`, or `root` variables.
+
+#### Scenario: Render with defaults
+
+- **Given** `BASE_CAMPAIGN` and stub callbacks
+- **When** `renderEditor()` is called with no overrides
+- **Then** the component is mounted with no `document.body` container manipulation required by the test
+
+#### Scenario: Render with overrides
+
+- **Given** a partial campaign object (e.g. `{ name: '' }`)
+- **When** `renderEditor({ campaign: { ...BASE_CAMPAIGN, name: '' } })` is called
+- **Then** the component renders with the overridden props
+
+---
+
+### Requirement: ADDED Accessible button queries
+
+The system SHALL locate buttons using `screen.getByRole('button', { name: ... })`.
+
+#### Scenario: Save Campaign button found by name
+
+- **Given** the component is rendered with `canSave=true`
+- **When** `screen.getByRole('button', { name: 'Save Campaign' })` is called
+- **Then** the element is found and not disabled
+
+#### Scenario: Save Campaign button is disabled when name is empty
+
+- **Given** the component is rendered with `campaign.name = ''`
+- **When** `screen.getByRole('button', { name: 'Save Campaign' })` is queried
+- **Then** `expect(button).toBeDisabled()` passes
+
+#### Scenario: Chapters accordion button matched by regex
+
+- **Given** the component is rendered (button text is `📖 Chapters (N) ▼`)
+- **When** `screen.getByRole('button', { name: /chapters/i })` is called
+- **Then** the accordion toggle button is found
+
+---
+
+### Requirement: ADDED Label-based input queries
+
+The system SHALL locate Campaign Name and Module/Adventure inputs using `screen.getByLabelText(...)`.
+
+#### Scenario: Campaign Name input found by label
+
+- **Given** `TextInputField` renders `<label htmlFor={id}>Campaign Name *</label>` and `<input id={id} />`
+- **When** `screen.getByLabelText('Campaign Name *')` is called
+- **Then** the correct input element is returned
+
+#### Scenario: Module/Adventure input found by label
+
+- **Given** `TextInputField` renders `<label htmlFor={id}>Module / Adventure</label>` and `<input id={id} />`
+- **When** `screen.getByLabelText('Module / Adventure')` is called
+- **Then** the correct input element is returned
+
+---
+
+### Requirement: ADDED testId-based queries for unlabelled controls
+
+The system SHALL locate status select, notes textarea, chapter controls, and current-chapter select using `screen.getByTestId(...)` / `screen.getAllByTestId(...)`.
+
+#### Scenario: Status select found by testId
+
+- **Given** the component is rendered
+- **When** `screen.getByTestId('status-select')` is called
+- **Then** the `<select>` element is returned
+
+#### Scenario: Notes textarea found by testId
+
+- **Given** the component is rendered
+- **When** `screen.getByTestId('notes-textarea')` is called
+- **Then** the `<textarea>` element is returned
+
+#### Scenario: Chapter title inputs found by testId (plural)
+
+- **Given** the component is rendered with `chapters` having N items and the accordion is expanded
+- **When** `screen.getAllByTestId('chapter-title-input')` is called
+- **Then** an array of N input elements is returned
+
+---
+
+### Requirement: ADDED userEvent.setup() interaction pattern
+
+The system SHALL drive all user interactions via a `userEvent.setup()` instance created per test.
+
+#### Scenario: Button click via user.click
+
+- **Given** a `user` instance from `userEvent.setup()`
+- **When** `await user.click(screen.getByRole('button', { name: 'Save Campaign' }))` is called
+- **Then** `onSave` is called once with the current campaign state
+
+#### Scenario: Select change via user.selectOptions
+
+- **Given** a `user` instance and the status select is in the DOM
+- **When** `await user.selectOptions(screen.getByTestId('status-select'), 'completed')` is called
+- **Then** the select reflects the new value and `onSave` includes `status: 'completed'` when Save is clicked
+
+#### Scenario: Text input change via user.type
+
+- **Given** a `user` instance and a chapter title input is in the DOM
+- **When** `await user.clear(input); await user.type(input, 'New Arrival')` is called
+- **Then** `expect(input).toHaveValue('New Arrival')`
+
+---
+
+### Requirement: ADDED openChapters helper
+
+The system SHALL provide an `openChapters()` async helper that expands the chapters accordion only when it is currently collapsed.
+
+#### Scenario: Chapters collapsed on empty campaign
+
+- **Given** `BASE_CAMPAIGN` with `chapters: []` (accordion starts collapsed)
+- **When** `await openChapters()` is called
+- **Then** `screen.queryByText('+ Add Chapter')` returns a DOM element
+
+#### Scenario: Chapters already open when campaign has chapters
+
+- **Given** a campaign with existing chapters (accordion starts expanded due to `chaptersExpanded = true`)
+- **When** `await openChapters()` is called
+- **Then** the accordion is not clicked a second time (no double-toggle)
+
+---
+
+### Requirement: ADDED Chapter display assertion uses input values
+
+The system SHALL assert chapter titles via `screen.getByDisplayValue(title)` rather than `container.textContent`.
+
+#### Scenario: Chapter title visible in input
+
+- **Given** a campaign with `chapters: [{ title: 'Arrival', ... }, ...]` (accordion auto-expanded)
+- **When** `screen.getByDisplayValue('Arrival')` is called
+- **Then** the chapter title input with value `'Arrival'` is found
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CampaignEditor test setup/teardown
+
+The system SHALL NOT use `beforeEach` / `afterEach` blocks for mounting or unmounting. RTL handles cleanup automatically via its own `afterEach(cleanup)`.
+
+#### Scenario: No manual DOM teardown
+
+- **Given** a test that renders `CampaignEditor`
+- **When** the test completes
+- **Then** RTL's automatic cleanup unmounts the component without explicit `unmountReactRoot` calls
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED createReactRoot / unmountReactRoot usage
+
+Reason for removal: Replaced by RTL's `render` and automatic `cleanup`. The `@/tests/unit/helpers/reactRoot` import is no longer needed in this file.
+
+### Requirement: REMOVED container / root module-level variables
+
+Reason for removal: RTL exposes `screen` as a global query surface; no container reference is needed.
+
+### Requirement: REMOVED findButton / getInput local helpers
+
+Reason for removal: Replaced by `screen.getByRole`, `screen.getByLabelText`, and `screen.getByTestId`.
+
+### Requirement: REMOVED raw act() / dispatchEvent interactions
+
+Reason for removal: Replaced by `userEvent.setup()` instance methods (`click`, `selectOptions`, `type`, `clear`).
+
+---
+
+## Traceability
+
+- Proposal: replace `findButton` → Requirement: ADDED Accessible button queries → Task: Migrate button interactions
+- Proposal: replace `getInput` → Requirement: ADDED Label-based input queries → Task: Migrate input queries
+- Proposal: use `userEvent.setup()` → Requirement: ADDED userEvent.setup() pattern → Task: Add user instance per test
+- Proposal: keep `openChapters()` helper → Requirement: ADDED openChapters helper → Task: Write openChapters RTL helper
+- Proposal: shift chapter display to `getByDisplayValue` → Requirement: ADDED Chapter display assertion → Task: Migrate chapters display test
+- Design Decision 1 (query strategy) → Requirement: ADDED Accessible button/label/testId queries
+- Design Decision 2 (userEvent.setup scoping) → Requirement: ADDED userEvent.setup() pattern
+- Design Decision 3 (local helpers) → Requirements: ADDED renderEditor + openChapters helpers
+- Design Decision 4 (getByDisplayValue) → Requirement: ADDED Chapter display assertion
+- Design Decision 5 (remove boilerplate) → Requirement: MODIFIED setup/teardown
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Test suite passes consistently
+
+- **Given** the migrated test file
+- **When** `npm test -- --testPathPattern=CampaignEditor` is run three times in succession
+- **Then** all 25 test cases pass each time with no flakiness
+
+### Requirement: No legacy imports
+
+#### Scenario: reactRoot import absent
+
+- **Given** the migrated file
+- **When** `grep "reactRoot" tests/unit/components/CampaignEditor.test.tsx` is run
+- **Then** the command returns no output (exit code 1)

--- a/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/tasks.md
+++ b/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/tasks.md
@@ -1,0 +1,165 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b test/rtl-migration-campaign-editor` then immediately `git push -u origin test/rtl-migration-campaign-editor`
+
+## Execution
+
+- [x] **1. Add imports and remove legacy boilerplate**
+  - Remove imports: `Root` from `react-dom/client`, `act` from `react`, `createReactRoot`/`unmountReactRoot` from `@/tests/unit/helpers/reactRoot`
+  - Add imports: `render`, `screen` from `@testing-library/react`; `userEvent` from `@testing-library/user-event`
+  - Remove module-level `container: HTMLDivElement` and `root: Root` variables
+  - Remove `beforeEach` and `afterEach` blocks entirely
+  - Verify: `grep 'reactRoot\|createReactRoot\|unmountReactRoot' tests/unit/components/CampaignEditor.test.tsx` returns no output
+
+- [x] **2. Write `renderEditor` helper**
+  - Add above the test suite:
+    ```ts
+    function renderEditor(props: Partial<Parameters<typeof CampaignEditor>[0]> = {}) {
+      return render(
+        <CampaignEditor
+          campaign={BASE_CAMPAIGN}
+          onSave={jest.fn()}
+          onCancel={jest.fn()}
+          isNew={false}
+          {...props}
+        />
+      );
+    }
+    ```
+  - Verify: calling `renderEditor()` in a quick smoke test renders without error
+
+- [x] **3. Write `openChapters` helper**
+  - Add below `renderEditor`:
+    ```ts
+    async function openChapters() {
+      if (!screen.queryByText('+ Add Chapter')) {
+        await userEvent.setup().click(
+          screen.getByRole('button', { name: /chapters/i }),
+        );
+      }
+    }
+    ```
+  - Note: each call to `userEvent.setup()` here is a one-off for the accordion click; individual tests create their own `user` instances for subsequent interactions.
+
+- [x] **4. Migrate `rendering` describe block** (7 tests)
+  - Replace each `render({ ... })` call with `renderEditor({ ... })` (or `renderEditor({ campaign: { ...BASE_CAMPAIGN, ... } })`)
+  - `container.querySelector('h2')?.textContent` → `screen.getByRole('heading', { level: 2 }).textContent`
+  - `container.querySelectorAll('input[type="text"]')[0].value` → `(screen.getByLabelText('Campaign Name *') as HTMLInputElement).value`
+  - `container.querySelectorAll('input[type="text"]')[1].value` → `(screen.getByLabelText('Module / Adventure') as HTMLInputElement).value`
+  - `container.querySelector('select[data-testid="status-select"]')?.value` → `(screen.getByTestId('status-select') as HTMLSelectElement).value`
+  - `container.querySelector('textarea[data-testid="notes-textarea"]')?.value` → `(screen.getByTestId('notes-textarea') as HTMLTextAreaElement).value`
+  - `container.querySelector('textarea[data-testid="notes-textarea"]')?.maxLength` → `(screen.getByTestId('notes-textarea') as HTMLTextAreaElement).maxLength`
+  - `container.textContent?.toContain('5/10000')` → `expect(screen.getByText('5/10000')).toBeInTheDocument()`
+  - Run: `npm test -- --testPathPattern=CampaignEditor`; all 7 rendering tests must pass
+
+- [x] **5. Migrate `validation` describe block** (2 tests)
+  - Replace render calls with `renderEditor({ campaign: { ...BASE_CAMPAIGN, name: '' } })`
+  - `findButton('Save Campaign').disabled` → `expect(screen.getByRole('button', { name: 'Save Campaign' })).toBeDisabled()`
+  - `findButton('Save Campaign').disabled === false` → `expect(screen.getByRole('button', { name: 'Save Campaign' })).not.toBeDisabled()`
+  - Run tests; both validation tests must pass
+
+- [x] **6. Migrate `saving` describe block** (4 tests)
+  - Add `const user = userEvent.setup()` at top of each `it` block
+  - `await act(async () => { findButton('Save Campaign').click(); })` → `await user.click(screen.getByRole('button', { name: 'Save Campaign' }))`
+  - Status dropdown interaction: `select.value = X; select.dispatchEvent(...)` → `await user.selectOptions(screen.getByTestId('status-select'), X)`
+  - Remove all `act()` wrappers and raw `dispatchEvent` calls
+  - Run tests; all 4 saving tests must pass
+
+- [x] **7. Migrate `cancel` describe block** (1 test)
+  - `act(() => { findButton('Cancel').click(); })` → `await user.click(screen.getByRole('button', { name: 'Cancel' }))`
+  - Make `it` callback `async`
+  - Run test; must pass
+
+- [x] **8. Migrate `legacy fields removed` describe block** (2 tests)
+  - `Array.from(container.querySelectorAll('label')).map(l => l.textContent)` → `screen.queryByText(/Current Chapter/)`, `screen.queryByText(/Chapter Order/)`
+  - `expect(labels.some(l => l?.includes(...))).toBe(false)` → `expect(screen.queryByText(/Current Chapter/)).not.toBeInTheDocument()`
+  - Run tests; both must pass
+
+- [x] **9. Migrate `chapters display` describe block** (2 tests)
+  - "renders chapter list when chapters present": replace `container.textContent.toContain('Arrival')` etc. with `expect(screen.getByDisplayValue('Arrival')).toBeInTheDocument()` (chapters auto-expand since `chapters.length > 0`)
+  - "save with no chapters": replace `render({ ... })` → `renderEditor()`; button click via `user.click`
+  - Run tests; both must pass
+
+- [x] **10. Migrate `chapters editing` describe block** (6 tests)
+  - Each test: add `const user = userEvent.setup()`
+  - `await openChapters()` — keep using the RTL helper from step 3
+  - `accordionBtn.click()` → `await user.click(screen.getByRole('button', { name: /chapters/i }))`
+  - `addBtn.click()` → `await user.click(screen.getByText('+ Add Chapter'))`
+  - `removeBtn.click()` → `await user.click(screen.getByTestId('remove-chapter-1'))`
+  - `moveUpBtn.click()` → `await user.click(screen.getByTestId('move-up-1'))`
+  - `moveDownBtn.click()` → `await user.click(screen.getByTestId('move-down-0'))`
+  - `select.value = X; dispatchEvent(...)` → `await user.selectOptions(screen.getByTestId('current-chapter-select'), X)`
+  - `input.value = X; dispatchEvent(...)` → `await user.clear(input); await user.type(input, 'New Arrival')`; assert with `expect(input).toHaveValue('New Arrival')`
+  - `container.querySelectorAll('input[data-testid="chapter-title-input"]')` → `screen.getAllByTestId('chapter-title-input')`
+  - `container.querySelector('button[data-testid="..."]')` → `screen.getByTestId('...')`
+  - `container.querySelector('select[data-testid="current-chapter-select"]')` → `screen.getByTestId('current-chapter-select')`
+  - `container.textContent.includes('+ Add Chapter')` checks → `screen.queryByText('+ Add Chapter')` null checks
+  - Run tests; all 6 must pass
+
+- [x] **11. Remove unused `findButton`, `getInput`, and legacy `render` function**
+  - Delete the three local helper functions that are no longer called
+  - Verify no references remain: `grep 'findButton\|getInput\|function render' tests/unit/components/CampaignEditor.test.tsx`
+  - Run full test suite: `npm test -- --testPathPattern=CampaignEditor`; all 25 tests must pass
+
+- [x] **12. Verify no legacy imports remain**
+  - `grep 'reactRoot\|createReactRoot\|unmountReactRoot\|from.*react.*act\b' tests/unit/components/CampaignEditor.test.tsx` → no output
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn the `openspec-review-code` sub-agent. The primary agent must automatically address all findings (complexity, duplication, quality) before committing.
+
+## Validation
+
+- [x] `npm test -- --testPathPattern=CampaignEditor` — all 25 tests pass
+- [x] `npm test` — full suite passes with zero regressions
+- [x] `npx tsc --noEmit` — no type errors
+- [x] `grep 'reactRoot' tests/unit/components/CampaignEditor.test.tsx` — no output
+- [x] `grep 'userEvent\.[a-z]' tests/unit/components/CampaignEditor.test.tsx | grep -v 'setup'` — no static API calls remain
+- [x] All tasks above marked `[x]`
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [x] Run `openspec-review-code` sub-agent; address all findings before final commit
+- [x] Commit: `git add tests/unit/components/CampaignEditor.test.tsx && git commit -m "test: migrate CampaignEditor.test.tsx to RTL (closes #356)"`
+- [x] Push: `git push`
+- [x] Open PR from `test/rtl-migration-campaign-editor` to `main` with body: `Closes #356`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (never `--admin`)
+- [x] Wait 180 seconds for CI and agentic reviewers
+- [x] **Monitor PR comments** — address each, commit fixes, validate locally, push, wait 180 seconds, repeat until no unresolved comments
+- [x] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, commit, validate locally, push, wait 180 seconds, repeat
+- [x] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed; if `CLOSED` notify user
+
+Ownership metadata:
+- Implementer: AI agent
+- Reviewer(s): @dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+- CI failure → fix → commit → `npm test && npm run build` → push → re-check
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify `CampaignEditor.test.tsx` on `main` has no `reactRoot` imports
+- [x] Mark all tasks `[x]`
+- [x] No documentation updates needed (test-only change)
+- [ ] Sync approved spec delta: copy `openspec/changes/rtl-migration-campaign-editor/specs/rtl-migration/spec.md` → `openspec/specs/rtl-migration/campaign-editor.md` (or merge into existing `openspec/specs/` RTL spec if present)
+- [ ] Archive: move `openspec/changes/rtl-migration-campaign-editor/` to `openspec/changes/archive/YYYY-MM-DD-rtl-migration-campaign-editor/` — stage both copy and deletion in **one commit**
+- [ ] Confirm archive exists and original path is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-rtl-migration-campaign-editor` → push
+- [ ] Open PR from doc branch to `main` with title `docs: archive rtl-migration-campaign-editor (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR
+- [ ] Monitor doc PR until merged (same loop as implementation PR)
+- [ ] Prune: `git fetch --prune && git branch -d test/rtl-migration-campaign-editor doc/archive-YYYY-MM-DD-rtl-migration-campaign-editor`

--- a/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/tests.md
+++ b/openspec/changes/archive/2026-06-06-rtl-migration-campaign-editor/tests.md
@@ -1,0 +1,102 @@
+---
+name: tests
+description: Tests for rtl-migration-campaign-editor
+---
+
+# Tests
+
+## Overview
+
+This migration is a test-file-only change: the deliverable IS the test file. The TDD workflow here is inverted — the existing 25 test cases are the specification. Each migration step below involves:
+
+1. **Red** — Confirm the test fails (or errors) after removing the legacy pattern
+2. **Green** — Apply the RTL equivalent; confirm the test passes
+3. **Refactor** — Clean up any duplication before moving to the next block
+
+Run `npm test -- --testPathPattern=CampaignEditor` after each step.
+
+## Test Cases
+
+### Task 1 — Imports and boilerplate removal
+
+- [ ] After removing `createReactRoot` import, `npm test -- --testPathPattern=CampaignEditor` fails with a compile/import error (red)
+- [ ] After adding `render`/`screen` imports, the file compiles (green)
+- [ ] No `container` or `root` variable references remain in the file (refactor verification)
+  - Spec: REMOVED createReactRoot / unmountReactRoot usage
+
+### Task 2 — `renderEditor` helper
+
+- [ ] `renderEditor()` with no arguments renders `<CampaignEditor>` with `BASE_CAMPAIGN` defaults without throwing
+- [ ] `renderEditor({ campaign: { ...BASE_CAMPAIGN, name: '' } })` renders with empty name (canSave=false path)
+  - Spec: ADDED RTL render pattern
+
+### Task 3 — `openChapters` helper
+
+- [ ] When called on an empty-chapters campaign (accordion collapsed), `openChapters()` expands the section so `screen.queryByText('+ Add Chapter')` returns a non-null element
+- [ ] When called on a campaign with existing chapters (accordion already expanded), `openChapters()` does not double-click and the section remains expanded
+  - Spec: ADDED openChapters helper
+
+### Task 4 — `rendering` describe block (7 tests)
+
+- [ ] `shows "Create Campaign" title when isNew` — `screen.getByRole('heading', { level: 2 })` returns element with text `Create Campaign`
+- [ ] `shows "Edit Campaign" title when not isNew` — heading text is `Edit Campaign`
+- [ ] `populates name input from campaign` — `screen.getByLabelText('Campaign Name *')` has value `'Test Campaign'`
+- [ ] `populates moduleName input from campaign` — `screen.getByLabelText('Module / Adventure')` has value `'LMoP'`
+- [ ] `renders status dropdown with current value selected` — `screen.getByTestId('status-select')` has value `'on-hold'`
+- [ ] `renders notes textarea with current value` — `screen.getByTestId('notes-textarea')` has value `'Party at level 5'`
+- [ ] `notes textarea has maxLength of 10000` — `(screen.getByTestId('notes-textarea') as HTMLTextAreaElement).maxLength === 10000`
+- [ ] `renders character counter showing length/10000` — `screen.getByText('5/10000')` is in the document
+  - Spec: ADDED Accessible button queries; ADDED Label-based input queries; ADDED testId-based queries
+
+### Task 5 — `validation` describe block (2 tests)
+
+- [ ] `save button is disabled when name is empty` — `expect(screen.getByRole('button', { name: 'Save Campaign' })).toBeDisabled()`
+- [ ] `save button is enabled when name has content` — `expect(...).not.toBeDisabled()`
+  - Spec: ADDED Accessible button queries
+
+### Task 6 — `saving` describe block (4 tests)
+
+- [ ] `calls onSave with trimmed name` — `user.click` triggers `onSave`; `mock.calls[0][0].name === 'Test Campaign'`
+- [ ] `calls onSave with trimmed moduleName` — `mock.calls[0][0].moduleName === 'DH'`
+- [ ] `calls onSave with updated status when dropdown changes` — `user.selectOptions` then save; `mock.calls[0][0].status === 'completed'`
+- [ ] `calls onSave with on-hold status when dropdown changes to on-hold` — status `'on-hold'` propagated
+  - Spec: ADDED userEvent.setup() interaction pattern
+
+### Task 7 — `cancel` describe block (1 test)
+
+- [ ] `calls onCancel when Cancel button clicked` — `user.click(screen.getByRole('button', { name: 'Cancel' }))` triggers `onCancel` once
+  - Spec: ADDED userEvent.setup() interaction pattern
+
+### Task 8 — `legacy fields removed` describe block (2 tests)
+
+- [ ] `does not render currentChapter input` — `screen.queryByText(/Current Chapter/)` returns `null`
+- [ ] `does not render currentChapterOrder input` — `screen.queryByText(/Chapter Order/)` returns `null`
+  - Spec: REMOVED createReactRoot / container usage
+
+### Task 9 — `chapters display` describe block (2 tests)
+
+- [ ] `renders chapter list when chapters present` — `screen.getByDisplayValue('Arrival')`, `screen.getByDisplayValue('The Inn')`, `screen.getByDisplayValue('The Dungeon')` all found in expanded section
+- [ ] `save with no chapters calls onSave with chapters: []` — `user.click` save; `mock.calls[0][0].chapters` deep-equals `[]`
+  - Spec: ADDED Chapter display assertion uses input values
+
+### Task 10 — `chapters editing` describe block (6 tests)
+
+- [ ] `toggles chapters editing section when accordion button is clicked` — accordion expands/collapses via `user.click(screen.getByRole('button', { name: /chapters/i }))`
+- [ ] `adds a new chapter row when "+ Add Chapter" is clicked` — `user.click(screen.getByText('+ Add Chapter'))`; `screen.getAllByTestId('chapter-title-input')` has length 1
+- [ ] `removes a chapter, shifts subsequent ones, and clears active chapter if deleted` — `user.click(screen.getByTestId('remove-chapter-1'))`; remaining inputs correct; `savedCampaign.currentChapterId` undefined
+- [ ] `reorders chapters with move buttons and updates order index` — move-up/down via testId buttons; saved chapters in correct order
+- [ ] `updates currentChapterId when a chapter is selected in active chapter select` — `user.selectOptions(screen.getByTestId('current-chapter-select'), 'ch-2')`; saved `currentChapterId === 'ch-2'`
+- [ ] `updates chapter title correctly when typing in the input field` — `user.clear` + `user.type`; `expect(input).toHaveValue('New Arrival')`
+- [ ] `sets currentChapterId to undefined when active chapter is removed` — remove active chapter; saved `currentChapterId` undefined
+  - Spec: ADDED openChapters helper; ADDED testId-based queries; ADDED userEvent.setup() pattern
+
+### Task 11 — Remove unused helpers
+
+- [ ] `grep 'findButton\|getInput\|function render' tests/unit/components/CampaignEditor.test.tsx` returns no output
+- [ ] Full suite of 25 tests still passes after deletion
+
+### Task 12 — No legacy imports remain
+
+- [ ] `grep 'reactRoot\|createReactRoot\|unmountReactRoot' tests/unit/components/CampaignEditor.test.tsx` returns no output
+- [ ] `grep 'userEvent\.[a-z]' tests/unit/components/CampaignEditor.test.tsx | grep -v setup` returns no output (no static API calls)
+  - Spec: REMOVED createReactRoot / unmountReactRoot usage; ADDED userEvent.setup() pattern

--- a/openspec/specs/rtl-migration/campaign-editor.md
+++ b/openspec/specs/rtl-migration/campaign-editor.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED RTL render pattern
+
+The system SHALL render `CampaignEditor` in tests using `render` from `@testing-library/react` via a local `renderEditor(overrides?)` helper, with no `createReactRoot`, `container`, or `root` variables.
+
+#### Scenario: Render with defaults
+
+- **Given** `BASE_CAMPAIGN` and stub callbacks
+- **When** `renderEditor()` is called with no overrides
+- **Then** the component is mounted with no `document.body` container manipulation required by the test
+
+#### Scenario: Render with overrides
+
+- **Given** a partial campaign object (e.g. `{ name: '' }`)
+- **When** `renderEditor({ campaign: { ...BASE_CAMPAIGN, name: '' } })` is called
+- **Then** the component renders with the overridden props
+
+---
+
+### Requirement: ADDED Accessible button queries
+
+The system SHALL locate buttons using `screen.getByRole('button', { name: ... })`.
+
+#### Scenario: Save Campaign button found by name
+
+- **Given** the component is rendered with `canSave=true`
+- **When** `screen.getByRole('button', { name: 'Save Campaign' })` is called
+- **Then** the element is found and not disabled
+
+#### Scenario: Save Campaign button is disabled when name is empty
+
+- **Given** the component is rendered with `campaign.name = ''`
+- **When** `screen.getByRole('button', { name: 'Save Campaign' })` is queried
+- **Then** `expect(button).toBeDisabled()` passes
+
+#### Scenario: Chapters accordion button matched by regex
+
+- **Given** the component is rendered (button text is `📖 Chapters (N) ▼`)
+- **When** `screen.getByRole('button', { name: /chapters/i })` is called
+- **Then** the accordion toggle button is found
+
+---
+
+### Requirement: ADDED Label-based input queries
+
+The system SHALL locate Campaign Name and Module/Adventure inputs using `screen.getByLabelText(...)`.
+
+#### Scenario: Campaign Name input found by label
+
+- **Given** `TextInputField` renders `<label htmlFor={id}>Campaign Name *</label>` and `<input id={id} />`
+- **When** `screen.getByLabelText('Campaign Name *')` is called
+- **Then** the correct input element is returned
+
+#### Scenario: Module/Adventure input found by label
+
+- **Given** `TextInputField` renders `<label htmlFor={id}>Module / Adventure</label>` and `<input id={id} />`
+- **When** `screen.getByLabelText('Module / Adventure')` is called
+- **Then** the correct input element is returned
+
+---
+
+### Requirement: ADDED testId-based queries for unlabelled controls
+
+The system SHALL locate status select, notes textarea, chapter controls, and current-chapter select using `screen.getByTestId(...)` / `screen.getAllByTestId(...)`.
+
+#### Scenario: Status select found by testId
+
+- **Given** the component is rendered
+- **When** `screen.getByTestId('status-select')` is called
+- **Then** the `<select>` element is returned
+
+#### Scenario: Notes textarea found by testId
+
+- **Given** the component is rendered
+- **When** `screen.getByTestId('notes-textarea')` is called
+- **Then** the `<textarea>` element is returned
+
+#### Scenario: Chapter title inputs found by testId (plural)
+
+- **Given** the component is rendered with `chapters` having N items and the accordion is expanded
+- **When** `screen.getAllByTestId('chapter-title-input')` is called
+- **Then** an array of N input elements is returned
+
+---
+
+### Requirement: ADDED userEvent.setup() interaction pattern
+
+The system SHALL drive all user interactions via a `userEvent.setup()` instance created per test.
+
+#### Scenario: Button click via user.click
+
+- **Given** a `user` instance from `userEvent.setup()`
+- **When** `await user.click(screen.getByRole('button', { name: 'Save Campaign' }))` is called
+- **Then** `onSave` is called once with the current campaign state
+
+#### Scenario: Select change via user.selectOptions
+
+- **Given** a `user` instance and the status select is in the DOM
+- **When** `await user.selectOptions(screen.getByTestId('status-select'), 'completed')` is called
+- **Then** the select reflects the new value and `onSave` includes `status: 'completed'` when Save is clicked
+
+#### Scenario: Text input change via user.type
+
+- **Given** a `user` instance and a chapter title input is in the DOM
+- **When** `await user.clear(input); await user.type(input, 'New Arrival')` is called
+- **Then** `expect(input).toHaveValue('New Arrival')`
+
+---
+
+### Requirement: ADDED openChapters helper
+
+The system SHALL provide an `openChapters()` async helper that expands the chapters accordion only when it is currently collapsed.
+
+#### Scenario: Chapters collapsed on empty campaign
+
+- **Given** `BASE_CAMPAIGN` with `chapters: []` (accordion starts collapsed)
+- **When** `await openChapters()` is called
+- **Then** `screen.queryByText('+ Add Chapter')` returns a DOM element
+
+#### Scenario: Chapters already open when campaign has chapters
+
+- **Given** a campaign with existing chapters (accordion starts expanded due to `chaptersExpanded = true`)
+- **When** `await openChapters()` is called
+- **Then** the accordion is not clicked a second time (no double-toggle)
+
+---
+
+### Requirement: ADDED Chapter display assertion uses input values
+
+The system SHALL assert chapter titles via `screen.getByDisplayValue(title)` rather than `container.textContent`.
+
+#### Scenario: Chapter title visible in input
+
+- **Given** a campaign with `chapters: [{ title: 'Arrival', ... }, ...]` (accordion auto-expanded)
+- **When** `screen.getByDisplayValue('Arrival')` is called
+- **Then** the chapter title input with value `'Arrival'` is found
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CampaignEditor test setup/teardown
+
+The system SHALL NOT use `beforeEach` / `afterEach` blocks for mounting or unmounting. RTL handles cleanup automatically via its own `afterEach(cleanup)`.
+
+#### Scenario: No manual DOM teardown
+
+- **Given** a test that renders `CampaignEditor`
+- **When** the test completes
+- **Then** RTL's automatic cleanup unmounts the component without explicit `unmountReactRoot` calls
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED createReactRoot / unmountReactRoot usage
+
+Reason for removal: Replaced by RTL's `render` and automatic `cleanup`. The `@/tests/unit/helpers/reactRoot` import is no longer needed in this file.
+
+### Requirement: REMOVED container / root module-level variables
+
+Reason for removal: RTL exposes `screen` as a global query surface; no container reference is needed.
+
+### Requirement: REMOVED findButton / getInput local helpers
+
+Reason for removal: Replaced by `screen.getByRole`, `screen.getByLabelText`, and `screen.getByTestId`.
+
+### Requirement: REMOVED raw act() / dispatchEvent interactions
+
+Reason for removal: Replaced by `userEvent.setup()` instance methods (`click`, `selectOptions`, `type`, `clear`).
+
+---
+
+## Traceability
+
+- Proposal: replace `findButton` → Requirement: ADDED Accessible button queries → Task: Migrate button interactions
+- Proposal: replace `getInput` → Requirement: ADDED Label-based input queries → Task: Migrate input queries
+- Proposal: use `userEvent.setup()` → Requirement: ADDED userEvent.setup() pattern → Task: Add user instance per test
+- Proposal: keep `openChapters()` helper → Requirement: ADDED openChapters helper → Task: Write openChapters RTL helper
+- Proposal: shift chapter display to `getByDisplayValue` → Requirement: ADDED Chapter display assertion → Task: Migrate chapters display test
+- Design Decision 1 (query strategy) → Requirement: ADDED Accessible button/label/testId queries
+- Design Decision 2 (userEvent.setup scoping) → Requirement: ADDED userEvent.setup() pattern
+- Design Decision 3 (local helpers) → Requirements: ADDED renderEditor + openChapters helpers
+- Design Decision 4 (getByDisplayValue) → Requirement: ADDED Chapter display assertion
+- Design Decision 5 (remove boilerplate) → Requirement: MODIFIED setup/teardown
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Test suite passes consistently
+
+- **Given** the migrated test file
+- **When** `npm test -- --testPathPattern=CampaignEditor` is run three times in succession
+- **Then** all 25 test cases pass each time with no flakiness
+
+### Requirement: No legacy imports
+
+#### Scenario: reactRoot import absent
+
+- **Given** the migrated file
+- **When** `grep "reactRoot" tests/unit/components/CampaignEditor.test.tsx` is run
+- **Then** the command returns no output (exit code 1)


### PR DESCRIPTION
Archives the rtl-migration-campaign-editor OpenSpec change after successful merge of #371. Syncs approved spec to openspec/specs/rtl-migration/campaign-editor.md.