### PR TITLE
feat: accept/decline campaign invitations + list pending invitations

### DIFF
--- a/app/api/campaigns/[id]/members/me/route.ts
+++ b/app/api/campaigns/[id]/members/me/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+
+type Params = { id: string };
+
+export const PATCH = withAuthAndParams<Params>(async (request: NextRequest, auth, { id: campaignId }) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'action must be "accept" or "decline"' }, { status: 400 });
+  }
+
+  const { action } = (body ?? {}) as Record<string, unknown>;
+  if (action !== 'accept' && action !== 'decline') {
+    return NextResponse.json({ error: 'action must be "accept" or "decline"' }, { status: 400 });
+  }
+
+  try {
+    const member = await storage.getMember(campaignId, auth.userId);
+    if (!member || member.status === 'removed') {
+      return NextResponse.json({ error: 'No invitation found' }, { status: 404 });
+    }
+
+    const { status } = member;
+
+    if (action === 'accept') {
+      if (status === 'active') return NextResponse.json({ status: 'active' }, { status: 200 });
+      if (status === 'declined') return NextResponse.json({ error: 'You have already declined this invitation' }, { status: 409 });
+      await storage.updateMemberStatus(campaignId, auth.userId, 'active', auth.userId);
+      return NextResponse.json({ status: 'active' }, { status: 200 });
+    }
+
+    // action === 'decline'
+    if (status === 'declined') return NextResponse.json({ status: 'declined' }, { status: 200 });
+    if (status === 'active') return NextResponse.json({ error: 'You have already accepted this invitation' }, { status: 409 });
+    await storage.updateMemberStatus(campaignId, auth.userId, 'declined', auth.userId);
+    return NextResponse.json({ status: 'declined' }, { status: 200 });
+  } catch (error) {
+    console.error('Error responding to invitation:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/api/campaigns/[id]/members/me/route.ts
+++ b/app/api/campaigns/[id]/members/me/route.ts
@@ -9,7 +9,7 @@ export const PATCH = withAuthAndParams<Params>(async (request: NextRequest, auth
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: 'action must be "accept" or "decline"' }, { status: 400 });
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
   }
 
   const { action } = (body ?? {}) as Record<string, unknown>;

--- a/app/api/me/invitations/route.ts
+++ b/app/api/me/invitations/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+import { getDatabase } from '@/lib/db';
+import { Campaign, MemberHistoryEntry } from '@/lib/types';
+
+function lastInvitedEntry(history: MemberHistoryEntry[]): MemberHistoryEntry | undefined {
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].action === 'invited') return history[i];
+  }
+  return undefined;
+}
+
+export const GET = withAuth(async (_request: NextRequest, auth) => {
+  try {
+    const invitations = await storage.listInvitationsForUser(auth.userId);
+    if (invitations.length === 0) {
+      return NextResponse.json({ invitations: [] }, { status: 200 });
+    }
+
+    const uniqueCampaignIds = [...new Set(invitations.map((m) => m.campaignId))];
+    const uniqueInviterIds = [
+      ...new Set(
+        invitations
+          .map((m) => lastInvitedEntry(m.history ?? [])?.by)
+          .filter((id): id is string => typeof id === 'string'),
+      ),
+    ];
+
+    const db = await getDatabase();
+    const [campaignDocs, usernameMap] = await Promise.all([
+      db
+        .collection<Campaign>('campaigns')
+        .find({ id: { $in: uniqueCampaignIds } }, { projection: { id: 1, name: 1 } })
+        .toArray(),
+      storage.getUsersByIds(uniqueInviterIds),
+    ]);
+
+    const campaignNameMap: Record<string, string> = {};
+    for (const c of campaignDocs) {
+      campaignNameMap[c.id] = c.name;
+    }
+
+    const result = invitations.map((m) => {
+      const entry = lastInvitedEntry(m.history ?? []);
+      const invitedBy = entry?.by ? (usernameMap[entry.by] ?? 'Unknown user') : 'Unknown user';
+      return {
+        id: m.id,
+        campaignId: m.campaignId,
+        campaignName: campaignNameMap[m.campaignId] ?? '',
+        invitedBy,
+        invitedAt: entry?.at ?? null,
+      };
+    });
+
+    return NextResponse.json({ invitations: result }, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching invitations:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/api/me/invitations/route.ts
+++ b/app/api/me/invitations/route.ts
@@ -42,7 +42,7 @@ export const GET = withAuth(async (_request: NextRequest, auth) => {
       return {
         id: m.id,
         campaignId: m.campaignId,
-        campaignName: campaignNameMap[m.campaignId] ?? '',
+        campaignName: campaignNameMap[m.campaignId] ?? 'Unknown campaign',
         invitedBy,
         invitedAt: entry?.at ?? null,
       };

--- a/app/api/me/invitations/route.ts
+++ b/app/api/me/invitations/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
-import { getDatabase } from '@/lib/db';
-import { Campaign, MemberHistoryEntry } from '@/lib/types';
+import type { MemberHistoryEntry } from '@/lib/types';
 
 function lastInvitedEntry(history: MemberHistoryEntry[]): MemberHistoryEntry | undefined {
   for (let i = history.length - 1; i >= 0; i--) {
@@ -27,12 +26,8 @@ export const GET = withAuth(async (_request: NextRequest, auth) => {
       ),
     ];
 
-    const db = await getDatabase();
     const [campaignDocs, usernameMap] = await Promise.all([
-      db
-        .collection<Campaign>('campaigns')
-        .find({ id: { $in: uniqueCampaignIds } }, { projection: { id: 1, name: 1 } })
-        .toArray(),
+      storage.getCampaignsByIds(uniqueCampaignIds),
       storage.getUsersByIds(uniqueInviterIds),
     ]);
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -19,9 +19,11 @@ import {
   MemberRole,
   MemberStatus,
   MemberHistoryEntry,
+  PublicUser,
 } from "./types";
 import { DuplicateMemberError } from "./errors";
 import { GLOBAL_USER_ID } from "./constants";
+import { InvalidUserIdError } from "./permissions";
 import { ObjectId, Filter, Document } from "mongodb";
 
 interface QueryableEntity {
@@ -942,6 +944,49 @@ export const storage = {
       console.error("Error listing campaigns for member:", error);
       return [];
     }
+  },
+
+  async getUserById(userId: string): Promise<PublicUser | null> {
+    if (!ObjectId.isValid(userId)) throw new InvalidUserIdError(userId);
+    const db = await getDatabase();
+    const doc = await db
+      .collection("users")
+      .findOne({ _id: { $eq: new ObjectId(userId) } }, { projection: { username: 1 } });
+    if (!doc || !doc['username']) return null;
+    return { id: userId, username: doc['username'] as string };
+  },
+
+  async getUsersByIds(userIds: string[]): Promise<Record<string, string>> {
+    if (userIds.length === 0) return {};
+    const validObjectIds = userIds
+      .filter((id) => ObjectId.isValid(id))
+      .map((id) => new ObjectId(id));
+    if (validObjectIds.length === 0) return {};
+    const db = await getDatabase();
+    const docs = await db
+      .collection("users")
+      .find({ _id: { $in: validObjectIds } }, { projection: { username: 1 } })
+      .toArray();
+    const result: Record<string, string> = {};
+    for (const doc of docs) {
+      if (doc['username']) {
+        result[doc._id.toString()] = doc['username'] as string;
+      }
+    }
+    return result;
+  },
+
+  async listInvitationsForUser(userId: string): Promise<CampaignMember[]> {
+    const db = await getDatabase();
+    const members = await db
+      .collection<CampaignMember>("campaignMembers")
+      .find({ userId, status: "invited" })
+      .toArray();
+    return members.map((m) => {
+      const normalized = normalizeStoredEntityId(m);
+      const { _id, ...rest } = normalized;
+      return rest as CampaignMember;
+    });
   },
 
   // Clear all data for a user

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -989,6 +989,16 @@ export const storage = {
     });
   },
 
+  async getCampaignsByIds(campaignIds: string[]): Promise<Pick<Campaign, "id" | "name">[]> {
+    if (campaignIds.length === 0) return [];
+    const db = await getDatabase();
+    const docs = await db
+      .collection<Campaign>("campaigns")
+      .find({ id: { $in: campaignIds } }, { projection: { id: 1, name: 1, _id: 0 } })
+      .toArray();
+    return docs as Pick<Campaign, "id" | "name">[];
+  },
+
   // Clear all data for a user
   async clear(userId: string): Promise<void> {
     try {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -243,9 +243,14 @@ export interface User {
   passwordHash: string;
   tokenVersion: number;
   isAdmin?: boolean; // Admin users can manage global monster templates
-  username?: string;
+  username: string;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface PublicUser {
+  id: string;
+  username: string;
 }
 
 export interface AuthPayload {

--- a/openspec/changes/accept-decline-api/.openspec.yaml
+++ b/openspec/changes/accept-decline-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-06

--- a/openspec/changes/accept-decline-api/design.md
+++ b/openspec/changes/accept-decline-api/design.md
@@ -1,0 +1,188 @@
+## Context
+
+- **Relevant architecture:** Next.js App Router API routes; MongoDB via `lib/storage.ts`; `withAuth`/`withAuthAndParams` middleware from `lib/middleware.ts`; `CampaignMember` documents with `history: MemberHistoryEntry[]`; existing `storage.getMember` and `storage.updateMemberStatus`.
+- **Dependencies:** Phase 1d (members storage) and Phase 2a (invite API, #305) — both merged. `CampaignMember.status` values `"invited"`, `"active"`, `"declined"`, `"removed"` are live.
+- **Interfaces/contracts touched:** `lib/types.ts` (`User`, new `PublicUser`); `lib/storage.ts` (3 new methods); 2 new API route files; no changes to existing routes.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Allow an invited player to accept or decline a campaign invitation via `PATCH /api/campaigns/[id]/members/me`
+- Allow a player to list their pending invitations via `GET /api/me/invitations`, with campaign name and inviter username
+- Make `User.username` required in the type system (data already backfilled)
+- Add typed, storage-layer user lookup methods (`getUserById`, `getUsersByIds`)
+
+### Non-Goals
+
+- UI for accepting/declining (issue #308)
+- Pagination on invitations list
+- Real-time / push notifications
+- DM-side invitation management UI (issue #307)
+
+## Decisions
+
+### Decision 1: PATCH `/api/campaigns/[id]/members/me` for respond action
+
+- **Chosen:** `PATCH /api/campaigns/[id]/members/me` with body `{ "action": "accept" | "decline" }`
+- **Alternatives considered:** `POST /api/campaigns/[id]/members/respond` (action-oriented RPC)
+- **Rationale:** REST standard — the player is mutating their own membership resource. `/me` scopes the resource to the caller without requiring a memberId in the URL. `action` vocabulary (`accept`/`decline`) is used in the body rather than internal status values to avoid leaking domain internals to the client.
+- **Trade-offs:** Slightly less discoverable than a named action endpoint, but more consistent with REST conventions used elsewhere.
+
+### Decision 2: Idempotency rule for PATCH
+
+- **Chosen:** Same action as current status → 200 (no DB write, no history entry). Conflicting action → 409 with message.
+- **Alternatives considered:** Always write, treating repeat as a new history entry; or 400 for any repeat.
+- **Rationale:** True idempotency for network retries (accept after transient failure returns 200, not 409). Conflicting requests indicate client confusion, not network retry — 409 is appropriate.
+- **Trade-offs:** Idempotent path skips history — acceptable since no state change occurred.
+
+### Decision 3: `getUsersByIds` batch lookup in storage
+
+- **Chosen:** `storage.getUsersByIds(userIds: string[]): Promise<Record<string, string>>` returning `{ [userId]: username }`.
+- **Alternatives considered:** N individual `getUserById` calls inside the route; a MongoDB `$lookup` aggregation in `listInvitationsForUser`.
+- **Rationale:** Batch query is O(1) round trips vs O(n). Keeping the join in the route (not storage) preserves storage-layer simplicity — storage returns domain objects, routes compose responses.
+- **Trade-offs:** Route is slightly more complex. Missing users (deleted accounts) silently return an empty entry; route falls back to `"Unknown user"` — acceptable edge case.
+
+### Decision 4: `getUserById` lives in `storage.ts`, not `permissions.ts`
+
+- **Chosen:** New typed `storage.getUserById(userId): Promise<PublicUser | null>` — projects only `id` and `username`. Existing `permissions.ts` `getUserById` (returns `Record<string, unknown>`) is left unchanged for auth use.
+- **Alternatives considered:** Enhance `permissions.ts` version; share one function.
+- **Rationale:** The permissions version is scoped to auth/admin checks and projects `email`, `tokenVersion`, `isAdmin`. Mixing concerns would require a broader projection or conditional logic. A clean typed method in storage is simpler and more maintainable.
+- **Trade-offs:** Two functions named similarly in different modules — mitigated by different import paths and return types.
+
+### Decision 5: `invitedAt` / `invitedBy` derived from last `action: "invited"` history entry
+
+- **Chosen:** Scan `history` array in reverse and return the first entry with `action: "invited"`.
+- **Alternatives considered:** Always use `history[0]`; store a denormalized field.
+- **Rationale:** A re-invite cycle appends a new `"invited"` entry — the last one is the most recent invitation, which is what the player sees.
+- **Trade-offs:** Requires a linear scan of history (small array in practice).
+
+### Decision 6: `User.username` made required
+
+- **Chosen:** Remove `?` from `User.username` in `lib/types.ts`. Add `PublicUser { id: string; username: string }` for route response shaping.
+- **Alternatives considered:** Keep optional, add runtime fallback everywhere.
+- **Rationale:** Backfill already run on all 4 users. Making it required eliminates defensive coding everywhere username is accessed. `PublicUser` provides a minimal public-safe interface that doesn't expose `passwordHash`, `tokenVersion`, etc.
+- **Trade-offs:** Any code constructing a `User` object without `username` will fail TypeScript compilation — these sites must be updated as part of this task.
+
+## Proposal to Design Mapping
+
+- Proposal element: `PATCH /api/campaigns/[id]/members/me`
+  - Design decision: Decision 1
+  - Validation approach: Unit tests for all state-machine paths; auth guard tests
+
+- Proposal element: Idempotency + 409 conflict rule
+  - Design decision: Decision 2
+  - Validation approach: Unit tests for same-action (idempotent) and conflicting-action (409) cases
+
+- Proposal element: `GET /api/me/invitations` with username in response
+  - Design decision: Decision 3
+  - Validation approach: Unit test mocking `listInvitationsForUser`, `getUsersByIds`, campaign lookup
+
+- Proposal element: `getUserById` and `getUsersByIds` in storage
+  - Design decision: Decisions 3 + 4
+  - Validation approach: Storage unit tests with real MongoDB test DB
+
+- Proposal element: `invitedBy` / `invitedAt` from history
+  - Design decision: Decision 5
+  - Validation approach: Unit test with re-invited member (multiple `"invited"` history entries)
+
+- Proposal element: `User.username` required + `PublicUser`
+  - Design decision: Decision 6
+  - Validation approach: TypeScript compilation; grep construction sites before merge
+
+## Functional Requirements Mapping
+
+- Requirement: Invited user can accept → status becomes `active`
+  - Design element: PATCH route; `updateMemberStatus(campaignId, userId, "active", callerId)`
+  - Acceptance criteria reference: specs/accept-decline-api/spec.md — PATCH accept scenario
+  - Testability notes: Mock `getMember` returning `invited`; assert `updateMemberStatus` called with `"active"`
+
+- Requirement: Invited user can decline → status becomes `declined`
+  - Design element: PATCH route; `updateMemberStatus(campaignId, userId, "declined", callerId)`
+  - Acceptance criteria reference: specs — PATCH decline scenario
+  - Testability notes: Mock `getMember` returning `invited`; assert `updateMemberStatus` called with `"declined"`
+
+- Requirement: Idempotent repeat of same action → 200, no DB write
+  - Design element: PATCH route status-machine logic; early return before `updateMemberStatus`
+  - Acceptance criteria reference: specs — idempotent scenarios
+  - Testability notes: Assert `updateMemberStatus` NOT called; response status 200
+
+- Requirement: Conflicting action → 409
+  - Design element: PATCH route conflict detection branch
+  - Acceptance criteria reference: specs — conflict scenarios
+  - Testability notes: Assert 409 with correct error message text
+
+- Requirement: Non-member / removed → 404
+  - Design element: PATCH route; null-membership and `removed` status checks
+  - Acceptance criteria reference: specs — not-found scenarios
+  - Testability notes: Mock `getMember` returning null or `{ status: "removed" }`
+
+- Requirement: Only caller can respond (not others)
+  - Design element: `getMember(campaignId, auth.userId)` — lookup uses authenticated userId, not a param
+  - Acceptance criteria reference: specs — authorization scenarios
+  - Testability notes: No userId in URL; auth middleware provides callerId
+
+- Requirement: GET returns pending invitations with campaign name + inviter username
+  - Design element: `listInvitationsForUser` + campaign lookup + `getUsersByIds`
+  - Acceptance criteria reference: specs — invitations list scenarios
+  - Testability notes: Mock all three data sources; assert response shape
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: security
+  - Requirement: Only authenticated users can call either endpoint
+  - Design element: `withAuth` / `withAuthAndParams` middleware
+  - Acceptance criteria reference: specs — unauthenticated → 401
+  - Testability notes: Omit auth token; assert 401
+
+- Requirement category: security
+  - Requirement: User can only respond to their own invitation
+  - Design element: Membership lookup uses `auth.userId` (not a URL param)
+  - Acceptance criteria reference: specs — no userId in PATCH URL
+  - Testability notes: Structural — no code path allows responding for another user
+
+- Requirement category: reliability
+  - Requirement: Concurrent accept/decline calls handled safely
+  - Design element: `updateMemberStatus` uses atomic `updateOne`; last write wins
+  - Acceptance criteria reference: proposal risk section
+  - Testability notes: Not unit-testable in isolation; acceptable given low concurrency risk
+
+- Requirement category: operability
+  - Requirement: Storage errors surface as 500, not leaked internals
+  - Design element: `try/catch` in both routes; `console.error` server-side only
+  - Acceptance criteria reference: specs — storage error scenarios
+  - Testability notes: Mock storage to throw; assert 500 with generic body
+
+- Requirement category: performance
+  - Requirement: Invitations list avoids N+1 user lookups
+  - Design element: `getUsersByIds` batch query
+  - Acceptance criteria reference: N/A (implementation detail)
+  - Testability notes: Assert single `getUsersByIds` call regardless of invitation count
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `username` required breaks construction sites that omit it
+  - Impact: TypeScript build failure
+  - Mitigation: Task includes explicit step to grep and fix all `User` construction sites
+
+- Risk/trade-off: Deleted user's username missing from batch lookup
+  - Impact: `invitedBy` shows `"Unknown user"` for that invitation
+  - Mitigation: Accepted; extremely unlikely in current usage; invitation still shown
+
+## Rollback / Mitigation
+
+- **Rollback trigger:** Critical bug in PATCH route causing incorrect status transitions.
+- **Rollback steps:** Revert the PR; no data migration required (DB writes use existing `updateMemberStatus` pattern).
+- **Data migration considerations:** Making `username` required is a type-system-only change — no DB schema migration. The backfill is already applied.
+- **Verification after rollback:** Confirm `GET /api/me/invitations` returns 404 (route removed) and existing invite flow still works.
+
+## Operational Blocking Policy
+
+- **If CI checks fail:** Do not merge. Fix the failing check. Do not use admin override.
+- **If security checks fail:** Do not merge. Investigate and remediate before proceeding.
+- **If required reviews are blocked/stale:** Ping reviewer after 24h. Escalate to team lead after 48h.
+- **Escalation path and timeout:** If blocked >48h with no response, raise in team standup.
+
+## Open Questions
+
+No open questions. All decisions made during exploration session prior to proposal creation.

--- a/openspec/changes/accept-decline-api/proposal.md
+++ b/openspec/changes/accept-decline-api/proposal.md
@@ -1,0 +1,93 @@
+## GitHub Issues
+
+- #306
+- #294 (parent epic — Phase 2 Invite & accept flow)
+
+## Why
+
+- **Problem statement:** Invited players have no way to accept or decline campaign invitations, and no way to see what invitations are pending. The invite API (2a / #305) can create `CampaignMember` records with `status: "invited"` but there is no endpoint for the invitee to respond.
+- **Why now:** 2a is merged. 2b is the direct unblocked dependency for the player-facing inbox UI (2d / #308) and the full invite flow cannot be tested end-to-end until it exists.
+- **Business/user impact:** Without this, the multi-user campaigns initiative stalls. Players cannot join campaigns they've been invited to.
+
+## Problem Space
+
+- **Current behavior:** A DM can invite a player via `POST /api/campaigns/[id]/members`. The `CampaignMember` document is created with `status: "invited"` and a history entry. The player has no API to respond, and no API to list their pending invites.
+- **Desired behavior:** An invited player can call `PATCH /api/campaigns/[id]/members/me` with `{ "action": "accept" | "decline" }`. Accepting transitions status to `active`; declining to `declined`. A separate `GET /api/me/invitations` lists all pending invitations for the caller, including campaign name and inviter username.
+- **Constraints:**
+  - Only the invited user may respond — not a DM, not another player.
+  - `username` is now required on all `User` documents (backfill already run).
+  - `CampaignMember` uses `history: MemberHistoryEntry[]` — no flat `respondedAt` field.
+  - Storage layer already has `updateMemberStatus` and `getMember`.
+- **Assumptions:**
+  - All 4 existing users have usernames after the backfill script was run.
+  - The `invitedAt` and `invitedBy` values are derived from the **last** history entry with `action: "invited"` (accounts for re-invite cycles).
+- **Edge cases considered:**
+  - Idempotent repeat requests (accept when already active, decline when already declined) → 200 with current status, no DB write.
+  - Conflicting repeat requests (accept when already declined, decline when already accepted) → 409 with descriptive message.
+  - No membership or `removed` status → 404.
+  - Unauthenticated → 401.
+  - Missing or invalid action field → 400.
+  - Invitations list with no pending invites → 200 with empty array.
+  - Batch user lookup for inviter usernames avoids N+1 queries.
+
+## Scope
+
+### In Scope
+
+- `PATCH /api/campaigns/[id]/members/me` — accept or decline an invitation
+- `GET /api/me/invitations` — list caller's pending invitations (with campaign name + inviter username)
+- `lib/types.ts`: make `User.username` required; add `PublicUser` interface
+- `lib/storage.ts`: add `getUserById`, `getUsersByIds`, `listInvitationsForUser`
+- Unit tests for all new storage methods and both routes
+
+### Out of Scope
+
+- Player invitations inbox UI (issue #308 — depends on this change)
+- Campaign member-management UI (issue #307)
+- Push notifications or real-time updates for new invitations
+- Pagination on `GET /api/me/invitations`
+
+## What Changes
+
+- `lib/types.ts`: `User.username` becomes required; new `PublicUser { id: string; username: string }` interface added
+- `lib/storage.ts`: three new methods — `getUserById`, `getUsersByIds`, `listInvitationsForUser`
+- `app/api/campaigns/[id]/members/me/route.ts`: new file — PATCH handler with full state-machine enforcement
+- `app/api/me/invitations/route.ts`: new file — GET handler, creates the `me/` route area
+- `tests/unit/storage/campaignMembers.test.ts`: new cases for `listInvitationsForUser`
+- `tests/unit/storage/users.test.ts`: new file — `getUserById` + `getUsersByIds` cases
+- `tests/unit/api/campaigns/[id]/members/me.test.ts`: new file — PATCH route unit tests
+- `tests/unit/api/me/invitations.test.ts`: new file — GET route unit tests
+
+## Risks
+
+- Risk: `username` required change breaks TypeScript compilation for code that constructs `User` objects without `username`.
+  - Impact: Build fails until all construction sites are updated.
+  - Mitigation: The backfill is already run; grep for `User` construction sites before merging.
+
+- Risk: Batch user lookup (`getUsersByIds`) fetches from `users` collection directly — if a user document is deleted, the inviter username is missing.
+  - Impact: `invitedBy` field would be undefined for that entry.
+  - Mitigation: Storage method returns `Record<string, string>` — route falls back to `"Unknown user"` for any missing entry (deleted accounts only).
+
+- Risk: Concurrent accept/decline calls for the same membership.
+  - Impact: Both could read `invited` status and both attempt to update.
+  - Mitigation: `updateMemberStatus` is a single `updateOne` call — last write wins, both callers get a 200. Acceptable for this use case (player clicking twice).
+
+## Open Questions
+
+No unresolved ambiguity. All design decisions were made during exploration:
+- PATCH shape uses `{ action: "accept" | "decline" }` (intent vocabulary, not internal status values)
+- Idempotency rule confirmed: same action = 200, conflicting action = 409
+- `invitedBy` returns username (not userId)
+- `getUserById` lives in `storage.ts` (typed); existing `permissions.ts` version stays for auth use
+
+## Non-Goals
+
+- Real-time invitation notifications
+- Email notifications on invite/accept/decline
+- Invitation expiry
+- DM visibility into whether a player has seen the invitation
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/accept-decline-api/specs/accept-decline-api/spec.md
+++ b/openspec/changes/accept-decline-api/specs/accept-decline-api/spec.md
@@ -1,0 +1,300 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+---
+
+### Requirement: MODIFIED `User.username` — now required
+
+The system SHALL define `User.username` as `string` (not `string | undefined`).
+
+#### Scenario: User construction requires username
+
+- **Given** `lib/types.ts` exports `User`
+- **When** a `User` object is constructed without a `username` field
+- **Then** TypeScript compilation fails with a type error
+
+---
+
+### Requirement: ADDED `PublicUser` interface
+
+The system SHALL export `PublicUser` with fields `id: string` and `username: string`.
+
+#### Scenario: PublicUser shape is correct
+
+- **Given** a `PublicUser` object
+- **When** both `id` and `username` are present as strings
+- **Then** TypeScript accepts the value without error
+
+---
+
+### Requirement: ADDED `storage.getUserById`
+
+The system SHALL return a `PublicUser` (id + username only) for a valid userId, or `null` if not found.
+
+#### Scenario: Found user returns PublicUser
+
+- **Given** a user document exists in the `users` collection with a `username`
+- **When** `storage.getUserById(userId)` is called with that user's id
+- **Then** the result is `{ id: userId, username: <username> }`
+
+#### Scenario: Unknown userId returns null
+
+- **Given** no user document exists for the given userId
+- **When** `storage.getUserById(userId)` is called
+- **Then** the result is `null`
+
+#### Scenario: Invalid ObjectId throws
+
+- **Given** a non-ObjectId string is passed
+- **When** `storage.getUserById("not-an-id")` is called
+- **Then** an `InvalidUserIdError` (or equivalent) is thrown
+
+---
+
+### Requirement: ADDED `storage.getUsersByIds`
+
+The system SHALL return a `Record<string, string>` mapping userId → username for a batch of userIds. UserIds with no matching document are omitted from the result.
+
+#### Scenario: All users found
+
+- **Given** three user documents exist for three userIds
+- **When** `storage.getUsersByIds([id1, id2, id3])` is called
+- **Then** the result is `{ [id1]: username1, [id2]: username2, [id3]: username3 }`
+
+#### Scenario: Some users missing
+
+- **Given** only two of three userIds have matching documents
+- **When** `storage.getUsersByIds([id1, id2, id3])` is called
+- **Then** the result contains only the two found users; the missing id is not present
+
+#### Scenario: Empty array input
+
+- **Given** an empty array is passed
+- **When** `storage.getUsersByIds([])` is called
+- **Then** the result is `{}`
+
+---
+
+### Requirement: ADDED `storage.listInvitationsForUser`
+
+The system SHALL return all `CampaignMember` documents for a given userId where `status` is `"invited"`.
+
+#### Scenario: Returns pending invitations
+
+- **Given** a user has two `CampaignMember` documents with `status: "invited"` and one with `status: "active"`
+- **When** `storage.listInvitationsForUser(userId)` is called
+- **Then** only the two `"invited"` documents are returned
+
+#### Scenario: Returns empty array when no invitations
+
+- **Given** a user has no `CampaignMember` documents with `status: "invited"`
+- **When** `storage.listInvitationsForUser(userId)` is called
+- **Then** the result is `[]`
+
+---
+
+### Requirement: ADDED `PATCH /api/campaigns/[id]/members/me` — accept invitation
+
+The system SHALL transition a `CampaignMember` from `"invited"` to `"active"` and append a history entry when the invited user sends `{ "action": "accept" }`.
+
+#### Scenario: Successful accept
+
+- **Given** an authenticated user with `status: "invited"` in campaign `[id]`
+- **When** they PATCH `{ "action": "accept" }`
+- **Then** the response is `200` with body `{ "status": "active" }`, and `updateMemberStatus` is called with `"active"`
+
+---
+
+### Requirement: ADDED `PATCH /api/campaigns/[id]/members/me` — decline invitation
+
+The system SHALL transition a `CampaignMember` from `"invited"` to `"declined"` and append a history entry when the invited user sends `{ "action": "decline" }`.
+
+#### Scenario: Successful decline
+
+- **Given** an authenticated user with `status: "invited"` in campaign `[id]`
+- **When** they PATCH `{ "action": "decline" }`
+- **Then** the response is `200` with body `{ "status": "declined" }`, and `updateMemberStatus` is called with `"declined"`
+
+---
+
+### Requirement: ADDED `PATCH /api/campaigns/[id]/members/me` — idempotent repeat
+
+The system SHALL return `200` with the current status and NOT call `updateMemberStatus` when the requested action matches the member's current status.
+
+#### Scenario: Accept when already active (idempotent)
+
+- **Given** an authenticated user with `status: "active"` in campaign `[id]`
+- **When** they PATCH `{ "action": "accept" }`
+- **Then** the response is `200` with body `{ "status": "active" }` and no DB write occurs
+
+#### Scenario: Decline when already declined (idempotent)
+
+- **Given** an authenticated user with `status: "declined"` in campaign `[id]`
+- **When** they PATCH `{ "action": "decline" }`
+- **Then** the response is `200` with body `{ "status": "declined" }` and no DB write occurs
+
+---
+
+### Requirement: ADDED `PATCH /api/campaigns/[id]/members/me` — conflict on mismatched action
+
+The system SHALL return `409 Conflict` with a descriptive error message when the requested action conflicts with the member's current resolved status.
+
+#### Scenario: Decline when already accepted
+
+- **Given** an authenticated user with `status: "active"` in campaign `[id]`
+- **When** they PATCH `{ "action": "decline" }`
+- **Then** the response is `409` with body `{ "error": "You have already accepted this invitation" }`
+
+#### Scenario: Accept when already declined
+
+- **Given** an authenticated user with `status: "declined"` in campaign `[id]`
+- **When** they PATCH `{ "action": "accept" }`
+- **Then** the response is `409` with body `{ "error": "You have already declined this invitation" }`
+
+---
+
+### Requirement: ADDED `PATCH /api/campaigns/[id]/members/me` — not found
+
+The system SHALL return `404` when the caller has no membership or has `status: "removed"` in the campaign.
+
+#### Scenario: No membership
+
+- **Given** an authenticated user with no `CampaignMember` document for campaign `[id]`
+- **When** they PATCH `{ "action": "accept" }`
+- **Then** the response is `404` with body `{ "error": "No invitation found" }`
+
+#### Scenario: Removed member
+
+- **Given** an authenticated user with `status: "removed"` in campaign `[id]`
+- **When** they PATCH `{ "action": "accept" }`
+- **Then** the response is `404` with body `{ "error": "No invitation found" }`
+
+---
+
+### Requirement: ADDED `PATCH /api/campaigns/[id]/members/me` — input validation
+
+The system SHALL return `400` when the request body is missing or contains an invalid `action` value.
+
+#### Scenario: Missing action field
+
+- **Given** an authenticated invited user
+- **When** they PATCH `{}` or an empty body
+- **Then** the response is `400` with body `{ "error": "action must be \"accept\" or \"decline\"" }`
+
+#### Scenario: Invalid action value
+
+- **Given** an authenticated invited user
+- **When** they PATCH `{ "action": "maybe" }`
+- **Then** the response is `400` with body `{ "error": "action must be \"accept\" or \"decline\"" }`
+
+---
+
+### Requirement: ADDED `GET /api/me/invitations` — list pending invitations
+
+The system SHALL return all pending (`"invited"`) campaign invitations for the authenticated caller, each including campaign name, inviter username, and invitation date.
+
+#### Scenario: Returns pending invitations
+
+- **Given** an authenticated user with two pending campaign invitations
+- **When** they GET `/api/me/invitations`
+- **Then** the response is `200` with body:
+  ```json
+  {
+    "invitations": [
+      {
+        "id": "<memberId>",
+        "campaignId": "<campaignId>",
+        "campaignName": "<name>",
+        "invitedBy": "<inviterUsername>",
+        "invitedAt": "<ISO date string>"
+      }
+    ]
+  }
+  ```
+
+#### Scenario: Returns empty array when no invitations
+
+- **Given** an authenticated user with no pending invitations
+- **When** they GET `/api/me/invitations`
+- **Then** the response is `200` with body `{ "invitations": [] }`
+
+#### Scenario: invitedBy and invitedAt use the last "invited" history entry
+
+- **Given** a member who was invited, declined, and re-invited (two `"invited"` history entries)
+- **When** they GET `/api/me/invitations`
+- **Then** `invitedBy` and `invitedAt` reflect the most recent invitation (last `action: "invited"` entry)
+
+#### Scenario: Missing inviter username falls back gracefully
+
+- **Given** an invitation where the inviter's user document has been deleted
+- **When** they GET `/api/me/invitations`
+- **Then** the invitation is still returned with `invitedBy: "Unknown user"`
+
+---
+
+## REMOVED Requirements
+
+None.
+
+---
+
+## Traceability
+
+- Proposal element: `User.username` required → Requirement: MODIFIED `User.username`
+- Proposal element: `PublicUser` interface → Requirement: ADDED `PublicUser`
+- Proposal element: `storage.getUserById` → Requirement: ADDED `storage.getUserById`; Design Decision 4
+- Proposal element: `storage.getUsersByIds` → Requirement: ADDED `storage.getUsersByIds`; Design Decision 3
+- Proposal element: `storage.listInvitationsForUser` → Requirement: ADDED `storage.listInvitationsForUser`
+- Proposal element: PATCH respond endpoint → Requirements: ADDED PATCH (accept, decline, idempotent, conflict, not-found, input validation); Design Decisions 1, 2
+- Proposal element: GET invitations endpoint → Requirement: ADDED GET invitations; Design Decisions 3, 5
+- Design Decision 5 (last history entry) → Requirement: GET invitations — re-invite scenario
+- All PATCH requirements → Task: Add PATCH `/api/campaigns/[id]/members/me` route
+- All GET requirements → Task: Add GET `/api/me/invitations` route
+- All storage requirements → Task: Add storage methods + type changes
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+#### Scenario: Unauthenticated PATCH rejected
+
+- **Given** no authentication token
+- **When** a PATCH is made to `/api/campaigns/[id]/members/me`
+- **Then** the response is `401 Unauthorized`
+
+#### Scenario: Unauthenticated GET rejected
+
+- **Given** no authentication token
+- **When** a GET is made to `/api/me/invitations`
+- **Then** the response is `401 Unauthorized`
+
+#### Scenario: Caller can only respond to their own invitation
+
+- **Given** an authenticated user who is not a member of campaign `[id]`
+- **When** they PATCH `{ "action": "accept" }`
+- **Then** the response is `404` (membership lookup uses `auth.userId`, not a URL param)
+
+### Requirement: Reliability
+
+#### Scenario: Storage error on PATCH surfaces as 500
+
+- **Given** an authenticated invited user
+- **When** `storage.getMember` throws an unexpected error
+- **Then** the response is `500`; no internal error details are in the response body; the error is logged server-side
+
+#### Scenario: Storage error on GET surfaces as 500
+
+- **Given** an authenticated user
+- **When** `storage.listInvitationsForUser` throws an unexpected error
+- **Then** the response is `500`; no internal error details are in the response body
+
+### Requirement: Performance
+
+#### Scenario: Invitations list uses batch user lookup
+
+- **Given** an authenticated user with N pending invitations
+- **When** they GET `/api/me/invitations`
+- **Then** exactly one `getUsersByIds` call is made (not N individual user lookups)

--- a/openspec/changes/accept-decline-api/tasks.md
+++ b/openspec/changes/accept-decline-api/tasks.md
@@ -1,0 +1,167 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/accept-decline-api` then immediately `git push -u origin feat/accept-decline-api`
+
+## Execution
+
+### Task 1 — Make `User.username` required + add `PublicUser`
+
+File: `lib/types.ts`
+
+- [x] Change `username?: string` to `username: string` on the `User` interface
+- [x] Add `PublicUser` interface: `export interface PublicUser { id: string; username: string; }`
+- [x] Grep for all `User` object construction sites and add `username` where missing: `grep -rn "passwordHash\|tokenVersion" --include="*.ts" .`
+- [x] Run `npm run build` to confirm no TypeScript errors
+
+### Task 2 — Add storage methods: `getUserById`, `getUsersByIds`, `listInvitationsForUser`
+
+File: `lib/storage.ts`
+
+- [x] Add `getUserById(userId: string): Promise<PublicUser | null>`
+  - Validate `userId` is a valid ObjectId (throw `InvalidUserIdError` from `lib/permissions.ts` if not)
+  - Query `users` collection with `{ _id: { $eq: new ObjectId(userId) } }`, project `{ username: 1 }`
+  - Return `{ id: userId, username: doc.username }` or `null`
+- [x] Add `getUsersByIds(userIds: string[]): Promise<Record<string, string>>`
+  - Return `{}` immediately for empty input
+  - Filter to valid ObjectIds; query `users` collection with `{ _id: { $in: objectIds } }`, project `{ username: 1 }`
+  - Return `{ [id.toString()]: doc.username }` map, omitting entries without username
+- [x] Add `listInvitationsForUser(userId: string): Promise<CampaignMember[]>`
+  - Query `campaignMembers` collection with `{ userId, status: "invited" }`
+  - Normalize and return as `CampaignMember[]` (follow same pattern as `listMembersForCampaign`)
+- [x] Verify TypeScript compiles: `npm run build`
+
+### Task 3 — Add `PATCH /api/campaigns/[id]/members/me` route
+
+File: `app/api/campaigns/[id]/members/me/route.ts` (new file)
+
+- [x] Use `withAuthAndParams<{ id: string }>` middleware
+- [x] Parse and validate body: `action` must be `"accept"` or `"decline"` → 400 if invalid
+- [x] Call `storage.getMember(campaignId, auth.userId)` → 404 if null or `status: "removed"`
+- [x] State machine:
+  - `invited` + `accept` → call `updateMemberStatus(..., "active", ...)` → 200 `{ status: "active" }`
+  - `invited` + `decline` → call `updateMemberStatus(..., "declined", ...)` → 200 `{ status: "declined" }`
+  - `active` + `accept` → 200 `{ status: "active" }` (no DB write)
+  - `declined` + `decline` → 200 `{ status: "declined" }` (no DB write)
+  - `active` + `decline` → 409 `{ error: "You have already accepted this invitation" }`
+  - `declined` + `accept` → 409 `{ error: "You have already declined this invitation" }`
+- [x] Catch unexpected storage errors → 500 with `console.error`, no internals in response body
+- [x] Verify TypeScript compiles: `npm run build`
+
+### Task 4 — Add `GET /api/me/invitations` route
+
+File: `app/api/me/invitations/route.ts` (new file — creates `me/` route area)
+
+- [x] Use `withAuth` middleware
+- [x] Call `storage.listInvitationsForUser(auth.userId)`
+- [x] If empty, return `200 { invitations: [] }` immediately
+- [x] Extract unique `campaignId` values; load campaign docs in parallel (query `campaigns` collection by `id`)
+- [x] Extract unique inviter userIds from each member's last `action: "invited"` history entry
+- [x] Call `storage.getUsersByIds(inviterUserIds)` for batch username lookup
+- [x] Build response array: for each invitation, compose `{ id, campaignId, campaignName, invitedBy, invitedAt }` — use `"Unknown user"` if inviter username missing
+- [x] Return `200 { invitations: [...] }`
+- [x] Catch unexpected storage errors → 500 with `console.error`, no internals in response body
+- [x] Verify TypeScript compiles: `npm run build`
+
+### Task 5 — Unit tests: storage methods
+
+Files:
+- `tests/unit/storage/users.test.ts` (new)
+- `tests/unit/storage/campaignMembers.test.ts` (add cases)
+
+`users.test.ts`:
+- [x] `getUserById` — found user returns `PublicUser`
+- [x] `getUserById` — unknown userId returns `null`
+- [x] `getUserById` — invalid ObjectId throws `InvalidUserIdError`
+- [x] `getUsersByIds` — all users found → full map returned
+- [x] `getUsersByIds` — some users missing → only found users in result
+- [x] `getUsersByIds` — empty array → `{}`
+
+`campaignMembers.test.ts`:
+- [x] `listInvitationsForUser` — returns only `"invited"` memberships
+- [x] `listInvitationsForUser` — returns `[]` when no pending invitations
+
+### Task 6 — Unit tests: PATCH `/api/campaigns/[id]/members/me`
+
+File: `tests/unit/api/campaigns/[id]/members/me.test.ts` (new)
+
+- [x] `invited` + `accept` → 200 `{ status: "active" }`, `updateMemberStatus` called with `"active"`
+- [x] `invited` + `decline` → 200 `{ status: "declined" }`, `updateMemberStatus` called with `"declined"`
+- [x] `active` + `accept` → 200 `{ status: "active" }`, `updateMemberStatus` NOT called
+- [x] `declined` + `decline` → 200 `{ status: "declined" }`, `updateMemberStatus` NOT called
+- [x] `active` + `decline` → 409 `"You have already accepted this invitation"`
+- [x] `declined` + `accept` → 409 `"You have already declined this invitation"`
+- [x] No membership → 404 `"No invitation found"`
+- [x] `removed` status → 404 `"No invitation found"`
+- [x] Missing `action` field → 400
+- [x] Invalid `action` value → 400
+- [x] Unauthenticated → 401
+- [x] Storage error → 500 with no internal details
+
+### Task 7 — Unit tests: GET `/api/me/invitations`
+
+File: `tests/unit/api/me/invitations.test.ts` (new)
+
+- [x] Pending invitations returned with correct shape (`id`, `campaignId`, `campaignName`, `invitedBy`, `invitedAt`)
+- [x] Empty array returned when no pending invitations
+- [x] Re-invited member: `invitedBy` and `invitedAt` use the last `action: "invited"` history entry
+- [x] Missing inviter username → `"Unknown user"` fallback
+- [x] Single `getUsersByIds` call regardless of invitation count (no N+1)
+- [x] Unauthenticated → 401
+- [x] Storage error → 500 with no internal details
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill on all modified files. The primary agent must automatically address all findings before committing.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — no TypeScript errors, clean build
+- [ ] Manually verify PATCH state machine against spec scenarios
+- [ ] All tasks above marked complete
+
+## Remote push validation
+
+All must pass before opening or updating the PR:
+
+- **Unit tests:** `npm run test:unit` — all pass
+- **Build:** `npm run build` — no errors
+
+If any fail, fix and iterate before pushing.
+
+## PR and Merge
+
+- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [ ] Commit all changes to `feat/accept-decline-api` and push
+- [ ] Open PR to `main`. PR body must include `Closes #306`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (never `--admin`)
+- [ ] Wait 180 seconds for CI and agentic reviewers
+- [ ] **Monitor PR comments** — address each, commit fixes, validate locally, push, wait 180s, repeat until none unresolved
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failures, push, wait 180s, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+- Implementer: assigned agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+- CI failure → fix → commit → `npm run test:unit && npm run build` → push → re-check
+- Review comment → address → commit → validate → push → confirm thread resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all tasks complete
+- [ ] Sync approved spec deltas: copy `openspec/changes/accept-decline-api/specs/accept-decline-api/spec.md` to `openspec/specs/accept-decline-api/spec.md`
+- [ ] Archive change: move `openspec/changes/accept-decline-api/` to `openspec/changes/archive/YYYY-MM-DD-accept-decline-api/` — stage copy + deletion in a **single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-accept-decline-api/` exists and `openspec/changes/accept-decline-api/` is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-accept-decline-api` then push
+- [ ] Open PR: title `docs: archive accept-decline-api (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same loop as implementation PR)
+- [ ] Prune: `git fetch --prune` and `git branch -d feat/accept-decline-api doc/archive-YYYY-MM-DD-accept-decline-api`

--- a/openspec/changes/accept-decline-api/tests.md
+++ b/openspec/changes/accept-decline-api/tests.md
@@ -1,0 +1,177 @@
+---
+name: tests
+description: Tests for the accept-decline-api change
+---
+
+# Tests
+
+## Overview
+
+Test cases for the `accept-decline-api` change. All implementation follows strict TDD: write a failing test first, then write the minimum code to pass, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — capture the requirement; run and confirm it fails.
+2. **Write code to pass** — minimum implementation to make it green.
+3. **Refactor** — improve quality while keeping tests green.
+
+## Task 2 — Storage methods (`lib/storage.ts`)
+
+File: `tests/unit/storage/users.test.ts`
+
+### `getUserById`
+
+- [ ] **Found user** — given a user document exists, returns `{ id, username }` as `PublicUser`
+  - Spec: ADDED `storage.getUserById` — Found user returns PublicUser
+
+- [ ] **Unknown userId** — given no matching document, returns `null`
+  - Spec: ADDED `storage.getUserById` — Unknown userId returns null
+
+- [ ] **Invalid ObjectId** — given a non-ObjectId string, throws `InvalidUserIdError`
+  - Spec: ADDED `storage.getUserById` — Invalid ObjectId throws
+
+### `getUsersByIds`
+
+- [ ] **All users found** — given N matching documents, returns map with all N entries
+  - Spec: ADDED `storage.getUsersByIds` — All users found
+
+- [ ] **Some users missing** — given 2 of 3 ids match, returns map with only 2 entries
+  - Spec: ADDED `storage.getUsersByIds` — Some users missing
+
+- [ ] **Empty input** — given `[]`, returns `{}` without querying the DB
+  - Spec: ADDED `storage.getUsersByIds` — Empty array input
+
+File: `tests/unit/storage/campaignMembers.test.ts`
+
+### `listInvitationsForUser`
+
+- [ ] **Has invitations** — given user has 2 `invited` + 1 `active` memberships, returns only the 2 `invited` ones
+  - Spec: ADDED `storage.listInvitationsForUser` — Returns pending invitations
+
+- [ ] **No invitations** — given user has no `invited` memberships, returns `[]`
+  - Spec: ADDED `storage.listInvitationsForUser` — Returns empty array when no invitations
+
+---
+
+## Task 3 — PATCH `/api/campaigns/[id]/members/me` route
+
+File: `tests/unit/api/campaigns/[id]/members/me.test.ts`
+
+### Happy path transitions
+
+- [ ] **Accept from invited** — `getMember` returns `invited`; `action: accept`; response is `200 { status: "active" }`; `updateMemberStatus` called with `"active"`
+  - Spec: ADDED PATCH accept invitation — Successful accept
+
+- [ ] **Decline from invited** — `getMember` returns `invited`; `action: decline`; response is `200 { status: "declined" }`; `updateMemberStatus` called with `"declined"`
+  - Spec: ADDED PATCH decline invitation — Successful decline
+
+### Idempotent paths (no DB write)
+
+- [ ] **Accept when already active** — `getMember` returns `active`; `action: accept`; response is `200 { status: "active" }`; `updateMemberStatus` NOT called
+  - Spec: ADDED PATCH idempotent — Accept when already active
+
+- [ ] **Decline when already declined** — `getMember` returns `declined`; `action: decline`; response is `200 { status: "declined" }`; `updateMemberStatus` NOT called
+  - Spec: ADDED PATCH idempotent — Decline when already declined
+
+### Conflict paths (409)
+
+- [ ] **Decline when already accepted** — `getMember` returns `active`; `action: decline`; response is `409 { error: "You have already accepted this invitation" }`
+  - Spec: ADDED PATCH conflict — Decline when already accepted
+
+- [ ] **Accept when already declined** — `getMember` returns `declined`; `action: accept`; response is `409 { error: "You have already declined this invitation" }`
+  - Spec: ADDED PATCH conflict — Accept when already declined
+
+### Not found (404)
+
+- [ ] **No membership** — `getMember` returns `null`; response is `404 { error: "No invitation found" }`
+  - Spec: ADDED PATCH not found — No membership
+
+- [ ] **Removed member** — `getMember` returns `{ status: "removed" }`; response is `404 { error: "No invitation found" }`
+  - Spec: ADDED PATCH not found — Removed member
+
+### Input validation (400)
+
+- [ ] **Missing action field** — body is `{}`; response is `400` with error message
+  - Spec: ADDED PATCH input validation — Missing action field
+
+- [ ] **Invalid action value** — body is `{ action: "maybe" }`; response is `400` with error message
+  - Spec: ADDED PATCH input validation — Invalid action value
+
+### Auth + error
+
+- [ ] **Unauthenticated** — no auth token; response is `401`
+  - Spec: Non-Functional — Unauthenticated PATCH rejected
+
+- [ ] **Storage error** — `getMember` throws; response is `500`; body contains no internal details
+  - Spec: Non-Functional — Storage error on PATCH surfaces as 500
+
+---
+
+## Task 4 — GET `/api/me/invitations` route
+
+File: `tests/unit/api/me/invitations.test.ts`
+
+### Happy path
+
+- [ ] **Pending invitations returned** — `listInvitationsForUser` returns 2 members; campaigns and usernames loaded; response is `200` with correctly shaped `invitations` array (`id`, `campaignId`, `campaignName`, `invitedBy`, `invitedAt`)
+  - Spec: ADDED GET invitations — Returns pending invitations
+
+- [ ] **Empty list** — `listInvitationsForUser` returns `[]`; response is `200 { invitations: [] }`
+  - Spec: ADDED GET invitations — Returns empty array when no invitations
+
+### History edge cases
+
+- [ ] **Re-invited member** — member has two `action: "invited"` history entries; `invitedBy` and `invitedAt` reflect the **last** one
+  - Spec: ADDED GET invitations — invitedBy and invitedAt use the last "invited" history entry
+
+- [ ] **Missing inviter username** — inviter userId not in `getUsersByIds` result; `invitedBy` is `"Unknown user"`
+  - Spec: ADDED GET invitations — Missing inviter username falls back gracefully
+
+### Performance
+
+- [ ] **Batch user lookup** — regardless of how many invitations are returned, `getUsersByIds` is called exactly once
+  - Spec: Non-Functional — Invitations list uses batch user lookup
+
+### Auth + error
+
+- [ ] **Unauthenticated** — no auth token; response is `401`
+  - Spec: Non-Functional — Unauthenticated GET rejected
+
+- [ ] **Storage error** — `listInvitationsForUser` throws; response is `500`; body contains no internal details
+  - Spec: Non-Functional — Storage error on GET surfaces as 500
+
+---
+
+## Acceptance Scenario Mapping
+
+| Test | Task | Spec Scenario |
+|------|------|---------------|
+| `getUserById` found | Task 2 | ADDED `storage.getUserById` — Found user |
+| `getUserById` null | Task 2 | ADDED `storage.getUserById` — Unknown userId |
+| `getUserById` invalid ID | Task 2 | ADDED `storage.getUserById` — Invalid ObjectId |
+| `getUsersByIds` all found | Task 2 | ADDED `storage.getUsersByIds` — All users found |
+| `getUsersByIds` some missing | Task 2 | ADDED `storage.getUsersByIds` — Some users missing |
+| `getUsersByIds` empty | Task 2 | ADDED `storage.getUsersByIds` — Empty array input |
+| `listInvitationsForUser` has invitations | Task 2 | ADDED `storage.listInvitationsForUser` — Returns pending |
+| `listInvitationsForUser` empty | Task 2 | ADDED `storage.listInvitationsForUser` — Returns empty |
+| PATCH accept from invited | Task 3 | ADDED PATCH accept — Successful accept |
+| PATCH decline from invited | Task 3 | ADDED PATCH decline — Successful decline |
+| PATCH accept idempotent | Task 3 | ADDED PATCH idempotent — Accept when already active |
+| PATCH decline idempotent | Task 3 | ADDED PATCH idempotent — Decline when already declined |
+| PATCH decline conflict | Task 3 | ADDED PATCH conflict — Decline when already accepted |
+| PATCH accept conflict | Task 3 | ADDED PATCH conflict — Accept when already declined |
+| PATCH no membership | Task 3 | ADDED PATCH not found — No membership |
+| PATCH removed | Task 3 | ADDED PATCH not found — Removed member |
+| PATCH missing action | Task 3 | ADDED PATCH input validation — Missing action |
+| PATCH invalid action | Task 3 | ADDED PATCH input validation — Invalid action |
+| PATCH unauthenticated | Task 3 | Non-Functional — Unauthenticated PATCH rejected |
+| PATCH storage error | Task 3 | Non-Functional — Storage error on PATCH |
+| GET pending invitations | Task 4 | ADDED GET invitations — Returns pending |
+| GET empty list | Task 4 | ADDED GET invitations — Returns empty array |
+| GET re-invited member | Task 4 | ADDED GET invitations — Last invited history entry |
+| GET missing username | Task 4 | ADDED GET invitations — Missing username fallback |
+| GET batch lookup | Task 4 | Non-Functional — Batch user lookup |
+| GET unauthenticated | Task 4 | Non-Functional — Unauthenticated GET rejected |
+| GET storage error | Task 4 | Non-Functional — Storage error on GET |

--- a/tests/unit/api/campaigns/[id]/members/me.test.ts
+++ b/tests/unit/api/campaigns/[id]/members/me.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment node
+ */
+import { PATCH } from "@/app/api/campaigns/[id]/members/me/route";
+import { requireAuth } from "@/lib/middleware";
+import { storage } from "@/lib/storage";
+import { MOCK_AUTH, makeRouteRequest } from "@/tests/unit/helpers/route.test.helpers";
+import { CampaignMember } from "@/lib/types";
+
+jest.mock("@/lib/middleware");
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+    updateMemberStatus: jest.fn(),
+  },
+}));
+
+const mockedRequireAuth = jest.mocked(requireAuth);
+const mockedStorage = jest.mocked(storage) as {
+  getMember: jest.MockedFunction<typeof storage.getMember>;
+  updateMemberStatus: jest.MockedFunction<typeof storage.updateMemberStatus>;
+};
+
+const CAMPAIGN_ID = "camp-1";
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
+
+const makePatchRequest = (body: unknown) =>
+  makeRouteRequest(`http://localhost/api/campaigns/${CAMPAIGN_ID}/members/me`, "PATCH", body);
+
+const makeInvitedMember = (overrides: Partial<CampaignMember> = {}): CampaignMember => ({
+  id: "mem-1",
+  campaignId: CAMPAIGN_ID,
+  userId: MOCK_AUTH.userId,
+  role: "player",
+  status: "invited",
+  history: [{ action: "invited", by: "dm-1", at: new Date() }],
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedStorage.updateMemberStatus.mockResolvedValue(undefined);
+});
+
+describe("PATCH /api/campaigns/[id]/members/me — unauthenticated", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockedRequireAuth.mockReturnValue({ status: 401 } as never);
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("PATCH /api/campaigns/[id]/members/me — input validation", () => {
+  beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+  it("returns 400 for missing action field", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember());
+    const response = await PATCH(makePatchRequest({}), { params: PARAMS });
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("accept");
+    expect(body.error).toContain("decline");
+  });
+
+  it("returns 400 for invalid action value", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember());
+    const response = await PATCH(makePatchRequest({ action: "maybe" }), { params: PARAMS });
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+    const req = new Request(
+      `http://localhost/api/campaigns/${CAMPAIGN_ID}/members/me`,
+      { method: "PATCH", headers: { "Content-Type": "application/json", cookie: "auth-token=t" }, body: "not-json" }
+    );
+    const response = await PATCH(req as never, { params: PARAMS });
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/campaigns/[id]/members/me — not found", () => {
+  beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+  it("returns 404 when no membership exists", async () => {
+    mockedStorage.getMember.mockResolvedValue(null);
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("No invitation found");
+  });
+
+  it("returns 404 for removed membership", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "removed" }));
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("No invitation found");
+  });
+});
+
+describe("PATCH /api/campaigns/[id]/members/me — accept", () => {
+  beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+  it("invited + accept → 200 { status: 'active' } and calls updateMemberStatus with 'active'", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "invited" }));
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("active");
+    expect(mockedStorage.updateMemberStatus).toHaveBeenCalledWith(
+      CAMPAIGN_ID, MOCK_AUTH.userId, "active", MOCK_AUTH.userId
+    );
+  });
+
+  it("active + accept → 200 { status: 'active' } and does NOT call updateMemberStatus", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "active" }));
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("active");
+    expect(mockedStorage.updateMemberStatus).not.toHaveBeenCalled();
+  });
+
+  it("declined + accept → 409 with conflict message", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "declined" }));
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("You have already declined this invitation");
+  });
+});
+
+describe("PATCH /api/campaigns/[id]/members/me — decline", () => {
+  beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+  it("invited + decline → 200 { status: 'declined' } and calls updateMemberStatus with 'declined'", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "invited" }));
+    const response = await PATCH(makePatchRequest({ action: "decline" }), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("declined");
+    expect(mockedStorage.updateMemberStatus).toHaveBeenCalledWith(
+      CAMPAIGN_ID, MOCK_AUTH.userId, "declined", MOCK_AUTH.userId
+    );
+  });
+
+  it("declined + decline → 200 { status: 'declined' } and does NOT call updateMemberStatus", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "declined" }));
+    const response = await PATCH(makePatchRequest({ action: "decline" }), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("declined");
+    expect(mockedStorage.updateMemberStatus).not.toHaveBeenCalled();
+  });
+
+  it("active + decline → 409 with conflict message", async () => {
+    mockedStorage.getMember.mockResolvedValue(makeInvitedMember({ status: "active" }));
+    const response = await PATCH(makePatchRequest({ action: "decline" }), { params: PARAMS });
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("You have already accepted this invitation");
+  });
+});
+
+describe("PATCH /api/campaigns/[id]/members/me — storage error", () => {
+  beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+  it("returns 500 with no internals when getMember throws", async () => {
+    mockedStorage.getMember.mockRejectedValue(new Error("DB down"));
+    const response = await PATCH(makePatchRequest({ action: "accept" }), { params: PARAMS });
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).not.toHaveProperty("stack");
+    expect(body.error).toBe("Internal server error");
+  });
+});

--- a/tests/unit/api/campaigns/[id]/members/me.test.ts
+++ b/tests/unit/api/campaigns/[id]/members/me.test.ts
@@ -69,7 +69,7 @@ describe("PATCH /api/campaigns/[id]/members/me — input validation", () => {
     expect(response.status).toBe(400);
   });
 
-  it("returns 400 for malformed JSON", async () => {
+  it("returns 400 with 'Invalid JSON payload' for malformed JSON", async () => {
     mockedRequireAuth.mockReturnValue(MOCK_AUTH);
     const req = new Request(
       `http://localhost/api/campaigns/${CAMPAIGN_ID}/members/me`,
@@ -77,6 +77,8 @@ describe("PATCH /api/campaigns/[id]/members/me — input validation", () => {
     );
     const response = await PATCH(req as never, { params: PARAMS });
     expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid JSON payload");
   });
 });
 

--- a/tests/unit/api/me/invitations.test.ts
+++ b/tests/unit/api/me/invitations.test.ts
@@ -126,7 +126,7 @@ describe("GET /api/me/invitations — pending invitations", () => {
     expect(body.invitations[0].invitedBy).toBe("Unknown user");
   });
 
-  it("falls back to 'Unknown user' when history is empty", async () => {
+  it("falls back to 'Unknown user' and null invitedAt when history is empty", async () => {
     mockedStorage.listInvitationsForUser.mockResolvedValue([
       makeInvitation({ history: [] }),
     ]);
@@ -138,6 +138,19 @@ describe("GET /api/me/invitations — pending invitations", () => {
     const body = await response.json();
     expect(body.invitations[0].invitedBy).toBe("Unknown user");
     expect(body.invitations[0].invitedAt).toBeNull();
+  });
+
+  it("falls back to 'Unknown campaign' when campaign is not found", async () => {
+    mockedStorage.listInvitationsForUser.mockResolvedValue([
+      makeInvitation({ history: [{ action: "invited", by: DM_ID, at: new Date() }] }),
+    ]);
+    mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID]: "theDM" });
+    mockedStorage.getCampaignsByIds.mockResolvedValue([]);
+
+    const response = await GET(makeGetRequest());
+
+    const body = await response.json();
+    expect(body.invitations[0].campaignName).toBe("Unknown campaign");
   });
 
   it("makes exactly one getCampaignsByIds and getUsersByIds call regardless of invitation count", async () => {

--- a/tests/unit/api/me/invitations.test.ts
+++ b/tests/unit/api/me/invitations.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/me/invitations/route";
+import { requireAuth } from "@/lib/middleware";
+import { storage } from "@/lib/storage";
+import { getDatabase } from "@/lib/db";
+import { MOCK_AUTH, makeRouteRequest } from "@/tests/unit/helpers/route.test.helpers";
+import { CampaignMember } from "@/lib/types";
+
+jest.mock("@/lib/middleware");
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    listInvitationsForUser: jest.fn(),
+    getUsersByIds: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+const mockedRequireAuth = jest.mocked(requireAuth);
+const mockedStorage = jest.mocked(storage) as {
+  listInvitationsForUser: jest.MockedFunction<typeof storage.listInvitationsForUser>;
+  getUsersByIds: jest.MockedFunction<typeof storage.getUsersByIds>;
+};
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+const makeGetRequest = () =>
+  makeRouteRequest("http://localhost/api/me/invitations", "GET");
+
+const DM_ID = "507f1f77bcf86cd799439011";
+const DM_ID_2 = "507f1f77bcf86cd799439012";
+
+const makeInvitation = (overrides: Partial<CampaignMember> = {}): CampaignMember => ({
+  id: "mem-1",
+  campaignId: "camp-1",
+  userId: MOCK_AUTH.userId,
+  role: "player",
+  status: "invited",
+  history: [{ action: "invited", by: DM_ID, at: new Date("2026-06-01T10:00:00Z") }],
+  ...overrides,
+});
+
+function setupDb(campaignDocs: { id: string; name: string }[]) {
+  const toArray = jest.fn().mockResolvedValue(campaignDocs);
+  const find = jest.fn(() => ({ toArray }));
+  mockedGetDatabase.mockResolvedValue({ collection: jest.fn(() => ({ find })) } as never);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/me/invitations — unauthenticated", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockedRequireAuth.mockReturnValue({ status: 401 } as never);
+    const response = await GET(makeGetRequest());
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("GET /api/me/invitations — empty list", () => {
+  it("returns 200 with empty array when no pending invitations", async () => {
+    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+    mockedStorage.listInvitationsForUser.mockResolvedValue([]);
+
+    const response = await GET(makeGetRequest());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ invitations: [] });
+    expect(mockedGetDatabase).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/me/invitations — pending invitations", () => {
+  beforeEach(() => mockedRequireAuth.mockReturnValue(MOCK_AUTH));
+
+  it("returns correct shape for pending invitations", async () => {
+    const invAt = new Date("2026-06-01T10:00:00Z");
+    mockedStorage.listInvitationsForUser.mockResolvedValue([
+      makeInvitation({ history: [{ action: "invited", by: DM_ID, at: invAt }] }),
+    ]);
+    mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID]: "theDM" });
+    setupDb([{ id: "camp-1", name: "Dragon Campaign" }]);
+
+    const response = await GET(makeGetRequest());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.invitations).toHaveLength(1);
+    const inv = body.invitations[0];
+    expect(inv.id).toBe("mem-1");
+    expect(inv.campaignId).toBe("camp-1");
+    expect(inv.campaignName).toBe("Dragon Campaign");
+    expect(inv.invitedBy).toBe("theDM");
+    expect(inv.invitedAt).toBe(invAt.toISOString());
+  });
+
+  it("uses the last 'invited' history entry for re-invited member", async () => {
+    const firstAt = new Date("2026-05-01T10:00:00Z");
+    const lastAt = new Date("2026-06-01T10:00:00Z");
+    mockedStorage.listInvitationsForUser.mockResolvedValue([
+      makeInvitation({
+        history: [
+          { action: "invited", by: DM_ID, at: firstAt },
+          { action: "declined", by: MOCK_AUTH.userId, at: new Date("2026-05-15") },
+          { action: "invited", by: DM_ID_2, at: lastAt },
+        ],
+      }),
+    ]);
+    mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID_2]: "anotherDM" });
+    setupDb([{ id: "camp-1", name: "Dragon Campaign" }]);
+
+    const response = await GET(makeGetRequest());
+
+    const body = await response.json();
+    const inv = body.invitations[0];
+    expect(inv.invitedBy).toBe("anotherDM");
+    expect(inv.invitedAt).toBe(lastAt.toISOString());
+  });
+
+  it("falls back to 'Unknown user' when inviter username is missing", async () => {
+    mockedStorage.listInvitationsForUser.mockResolvedValue([
+      makeInvitation({ history: [{ action: "invited", by: DM_ID, at: new Date() }] }),
+    ]);
+    mockedStorage.getUsersByIds.mockResolvedValue({});
+    setupDb([{ id: "camp-1", name: "Dragon Campaign" }]);
+
+    const response = await GET(makeGetRequest());
+
+    const body = await response.json();
+    expect(body.invitations[0].invitedBy).toBe("Unknown user");
+  });
+
+  it("makes exactly one getUsersByIds call regardless of invitation count", async () => {
+    mockedStorage.listInvitationsForUser.mockResolvedValue([
+      makeInvitation({ id: "mem-1", campaignId: "camp-1", history: [{ action: "invited", by: DM_ID, at: new Date() }] }),
+      makeInvitation({ id: "mem-2", campaignId: "camp-2", history: [{ action: "invited", by: DM_ID_2, at: new Date() }] }),
+    ]);
+    mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID]: "dm1", [DM_ID_2]: "dm2" });
+    setupDb([
+      { id: "camp-1", name: "Campaign 1" },
+      { id: "camp-2", name: "Campaign 2" },
+    ]);
+
+    await GET(makeGetRequest());
+
+    expect(mockedStorage.getUsersByIds).toHaveBeenCalledTimes(1);
+    expect(mockedStorage.getUsersByIds).toHaveBeenCalledWith(
+      expect.arrayContaining([DM_ID, DM_ID_2])
+    );
+  });
+});
+
+describe("GET /api/me/invitations — storage error", () => {
+  it("returns 500 with no internals when listInvitationsForUser throws", async () => {
+    mockedRequireAuth.mockReturnValue(MOCK_AUTH);
+    mockedStorage.listInvitationsForUser.mockRejectedValue(new Error("DB down"));
+
+    const response = await GET(makeGetRequest());
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).not.toHaveProperty("stack");
+    expect(body.error).toBe("Internal server error");
+  });
+});

--- a/tests/unit/api/me/invitations.test.ts
+++ b/tests/unit/api/me/invitations.test.ts
@@ -4,7 +4,6 @@
 import { GET } from "@/app/api/me/invitations/route";
 import { requireAuth } from "@/lib/middleware";
 import { storage } from "@/lib/storage";
-import { getDatabase } from "@/lib/db";
 import { MOCK_AUTH, makeRouteRequest } from "@/tests/unit/helpers/route.test.helpers";
 import { CampaignMember } from "@/lib/types";
 
@@ -14,19 +13,16 @@ jest.mock("@/lib/storage", () => ({
   storage: {
     listInvitationsForUser: jest.fn(),
     getUsersByIds: jest.fn(),
+    getCampaignsByIds: jest.fn(),
   },
-}));
-
-jest.mock("@/lib/db", () => ({
-  getDatabase: jest.fn(),
 }));
 
 const mockedRequireAuth = jest.mocked(requireAuth);
 const mockedStorage = jest.mocked(storage) as {
   listInvitationsForUser: jest.MockedFunction<typeof storage.listInvitationsForUser>;
   getUsersByIds: jest.MockedFunction<typeof storage.getUsersByIds>;
+  getCampaignsByIds: jest.MockedFunction<typeof storage.getCampaignsByIds>;
 };
-const mockedGetDatabase = jest.mocked(getDatabase);
 
 const makeGetRequest = () =>
   makeRouteRequest("http://localhost/api/me/invitations", "GET");
@@ -43,12 +39,6 @@ const makeInvitation = (overrides: Partial<CampaignMember> = {}): CampaignMember
   history: [{ action: "invited", by: DM_ID, at: new Date("2026-06-01T10:00:00Z") }],
   ...overrides,
 });
-
-function setupDb(campaignDocs: { id: string; name: string }[]) {
-  const toArray = jest.fn().mockResolvedValue(campaignDocs);
-  const find = jest.fn(() => ({ toArray }));
-  mockedGetDatabase.mockResolvedValue({ collection: jest.fn(() => ({ find })) } as never);
-}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -72,7 +62,7 @@ describe("GET /api/me/invitations — empty list", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toEqual({ invitations: [] });
-    expect(mockedGetDatabase).not.toHaveBeenCalled();
+    expect(mockedStorage.getCampaignsByIds).not.toHaveBeenCalled();
   });
 });
 
@@ -85,7 +75,7 @@ describe("GET /api/me/invitations — pending invitations", () => {
       makeInvitation({ history: [{ action: "invited", by: DM_ID, at: invAt }] }),
     ]);
     mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID]: "theDM" });
-    setupDb([{ id: "camp-1", name: "Dragon Campaign" }]);
+    mockedStorage.getCampaignsByIds.mockResolvedValue([{ id: "camp-1", name: "Dragon Campaign" }]);
 
     const response = await GET(makeGetRequest());
 
@@ -113,7 +103,7 @@ describe("GET /api/me/invitations — pending invitations", () => {
       }),
     ]);
     mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID_2]: "anotherDM" });
-    setupDb([{ id: "camp-1", name: "Dragon Campaign" }]);
+    mockedStorage.getCampaignsByIds.mockResolvedValue([{ id: "camp-1", name: "Dragon Campaign" }]);
 
     const response = await GET(makeGetRequest());
 
@@ -128,7 +118,7 @@ describe("GET /api/me/invitations — pending invitations", () => {
       makeInvitation({ history: [{ action: "invited", by: DM_ID, at: new Date() }] }),
     ]);
     mockedStorage.getUsersByIds.mockResolvedValue({});
-    setupDb([{ id: "camp-1", name: "Dragon Campaign" }]);
+    mockedStorage.getCampaignsByIds.mockResolvedValue([{ id: "camp-1", name: "Dragon Campaign" }]);
 
     const response = await GET(makeGetRequest());
 
@@ -136,13 +126,27 @@ describe("GET /api/me/invitations — pending invitations", () => {
     expect(body.invitations[0].invitedBy).toBe("Unknown user");
   });
 
-  it("makes exactly one getUsersByIds call regardless of invitation count", async () => {
+  it("falls back to 'Unknown user' when history is empty", async () => {
+    mockedStorage.listInvitationsForUser.mockResolvedValue([
+      makeInvitation({ history: [] }),
+    ]);
+    mockedStorage.getUsersByIds.mockResolvedValue({});
+    mockedStorage.getCampaignsByIds.mockResolvedValue([{ id: "camp-1", name: "Dragon Campaign" }]);
+
+    const response = await GET(makeGetRequest());
+
+    const body = await response.json();
+    expect(body.invitations[0].invitedBy).toBe("Unknown user");
+    expect(body.invitations[0].invitedAt).toBeNull();
+  });
+
+  it("makes exactly one getCampaignsByIds and getUsersByIds call regardless of invitation count", async () => {
     mockedStorage.listInvitationsForUser.mockResolvedValue([
       makeInvitation({ id: "mem-1", campaignId: "camp-1", history: [{ action: "invited", by: DM_ID, at: new Date() }] }),
       makeInvitation({ id: "mem-2", campaignId: "camp-2", history: [{ action: "invited", by: DM_ID_2, at: new Date() }] }),
     ]);
     mockedStorage.getUsersByIds.mockResolvedValue({ [DM_ID]: "dm1", [DM_ID_2]: "dm2" });
-    setupDb([
+    mockedStorage.getCampaignsByIds.mockResolvedValue([
       { id: "camp-1", name: "Campaign 1" },
       { id: "camp-2", name: "Campaign 2" },
     ]);
@@ -150,6 +154,7 @@ describe("GET /api/me/invitations — pending invitations", () => {
     await GET(makeGetRequest());
 
     expect(mockedStorage.getUsersByIds).toHaveBeenCalledTimes(1);
+    expect(mockedStorage.getCampaignsByIds).toHaveBeenCalledTimes(1);
     expect(mockedStorage.getUsersByIds).toHaveBeenCalledWith(
       expect.arrayContaining([DM_ID, DM_ID_2])
     );

--- a/tests/unit/storage/campaignMembers.test.ts
+++ b/tests/unit/storage/campaignMembers.test.ts
@@ -71,6 +71,60 @@ describe("getMember", () => {
   });
 });
 
+describe("listInvitationsForUser", () => {
+  let mockCollection: ReturnType<typeof makeMockCollection>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection = makeMockCollection();
+    mockDb = { collection: jest.fn(() => mockCollection) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  const INVITED_1: CampaignMember = {
+    id: "mem-inv-1",
+    campaignId: "camp-1",
+    userId: "user-1",
+    role: "player",
+    status: "invited",
+    history: [{ action: "invited", by: "dm-1", at: new Date("2026-06-01") }],
+  };
+
+  const INVITED_2: CampaignMember = {
+    id: "mem-inv-2",
+    campaignId: "camp-2",
+    userId: "user-1",
+    role: "player",
+    status: "invited",
+    history: [{ action: "invited", by: "dm-2", at: new Date("2026-06-02") }],
+  };
+
+  it("returns only 'invited' memberships for the user", async () => {
+    mockCollection.toArray.mockResolvedValue([
+      { _id: "oid-1", ...INVITED_1 },
+      { _id: "oid-2", ...INVITED_2 },
+    ] as never);
+
+    const result = await storage.listInvitationsForUser("user-1");
+
+    expect(mockDb.collection).toHaveBeenCalledWith("campaignMembers");
+    expect(mockCollection.find).toHaveBeenCalledWith({ userId: "user-1", status: "invited" });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("mem-inv-1");
+    expect(result[1].id).toBe("mem-inv-2");
+    expect(result[0]).not.toHaveProperty("_id");
+  });
+
+  it("returns empty array when no pending invitations", async () => {
+    mockCollection.toArray.mockResolvedValue([] as never);
+
+    const result = await storage.listInvitationsForUser("user-1");
+
+    expect(result).toEqual([]);
+  });
+});
+
 describe("loadCampaignByIdAny", () => {
   let mockCollection: ReturnType<typeof makeMockCollection>;
   let mockDb: { collection: jest.Mock };

--- a/tests/unit/storage/users.test.ts
+++ b/tests/unit/storage/users.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment node
+ */
+import { ObjectId } from "mongodb";
+import { storage } from "@/lib/storage";
+import { getDatabase } from "@/lib/db";
+import { InvalidUserIdError } from "@/lib/permissions";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+const VALID_USER_ID = "507f1f77bcf86cd799439011";
+const VALID_USER_ID_2 = "507f1f77bcf86cd799439012";
+const VALID_USER_ID_3 = "507f1f77bcf86cd799439013";
+
+function makeMockFindOne() {
+  const findOne = jest.fn<Promise<unknown>, []>();
+  return { findOne };
+}
+
+function makeMockFind() {
+  const toArray = jest.fn<Promise<unknown[]>, []>();
+  const find = jest.fn(() => ({ toArray }));
+  return { find, toArray };
+}
+
+describe("getUserById", () => {
+  let findOne: jest.MockedFunction<() => Promise<unknown>>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const col = makeMockFindOne();
+    findOne = col.findOne as jest.MockedFunction<() => Promise<unknown>>;
+    mockDb = { collection: jest.fn(() => col) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  it("returns PublicUser when user exists", async () => {
+    findOne.mockResolvedValue({ _id: new ObjectId(VALID_USER_ID), username: "alice" });
+
+    const result = await storage.getUserById(VALID_USER_ID);
+
+    expect(mockDb.collection).toHaveBeenCalledWith("users");
+    expect(result).toEqual({ id: VALID_USER_ID, username: "alice" });
+  });
+
+  it("returns null when user does not exist", async () => {
+    findOne.mockResolvedValue(null);
+
+    const result = await storage.getUserById(VALID_USER_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it("throws InvalidUserIdError for invalid ObjectId", async () => {
+    await expect(storage.getUserById("not-an-id")).rejects.toThrow(InvalidUserIdError);
+    expect(mockedGetDatabase).not.toHaveBeenCalled();
+  });
+});
+
+describe("getUsersByIds", () => {
+  let toArray: jest.MockedFunction<() => Promise<unknown[]>>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const col = makeMockFind();
+    toArray = col.toArray as jest.MockedFunction<() => Promise<unknown[]>>;
+    mockDb = { collection: jest.fn(() => col) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  it("returns empty object for empty input without querying DB", async () => {
+    const result = await storage.getUsersByIds([]);
+
+    expect(result).toEqual({});
+    expect(mockedGetDatabase).not.toHaveBeenCalled();
+  });
+
+  it("returns full map when all users found", async () => {
+    toArray.mockResolvedValue([
+      { _id: new ObjectId(VALID_USER_ID), username: "alice" },
+      { _id: new ObjectId(VALID_USER_ID_2), username: "bob" },
+      { _id: new ObjectId(VALID_USER_ID_3), username: "carol" },
+    ]);
+
+    const result = await storage.getUsersByIds([VALID_USER_ID, VALID_USER_ID_2, VALID_USER_ID_3]);
+
+    expect(result).toEqual({
+      [VALID_USER_ID]: "alice",
+      [VALID_USER_ID_2]: "bob",
+      [VALID_USER_ID_3]: "carol",
+    });
+  });
+
+  it("returns only found users when some are missing", async () => {
+    toArray.mockResolvedValue([
+      { _id: new ObjectId(VALID_USER_ID), username: "alice" },
+      { _id: new ObjectId(VALID_USER_ID_2), username: "bob" },
+    ]);
+
+    const result = await storage.getUsersByIds([VALID_USER_ID, VALID_USER_ID_2, VALID_USER_ID_3]);
+
+    expect(result).toEqual({
+      [VALID_USER_ID]: "alice",
+      [VALID_USER_ID_2]: "bob",
+    });
+    expect(result).not.toHaveProperty(VALID_USER_ID_3);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 2b of the invite & accept flow (epic #294).

- **PATCH /api/campaigns/[id]/members/me** — accept or decline an invitation with full state-machine enforcement (idempotent repeat → 200, conflict → 409, not found → 404, invalid input → 400)
- **GET /api/me/invitations** — list pending invitations with campaign name and inviter username (batch user lookup, no N+1)
- **lib/types.ts** — `User.username` made required; new `PublicUser` interface added
- **lib/storage.ts** — three new methods: `getUserById`, `getUsersByIds`, `listInvitationsForUser`
- Unit tests for all new code (1940 tests pass, clean build)

Closes #306