### PR TITLE
test: migrate userEvent static calls to setup() instance pattern

### DIFF
--- a/tests/unit/components/AlignmentSelect.test.tsx
+++ b/tests/unit/components/AlignmentSelect.test.tsx
@@ -53,8 +53,9 @@ describe('AlignmentSelect', () => {
 
   test('calls onChange with the selected value when user changes the select', async () => {
     const onChange = jest.fn() as jest.MockedFunction<(v: string) => void>;
+    const user = userEvent.setup();
     renderSelect({ onChange });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Alignment' }), 'Chaotic Evil');
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Alignment' }), 'Chaotic Evil');
     expect(onChange).toHaveBeenCalledWith('Chaotic Evil');
   });
 

--- a/tests/unit/components/CampaignsPage.test.tsx
+++ b/tests/unit/components/CampaignsPage.test.tsx
@@ -68,6 +68,9 @@ function renderPage() {
 }
 
 describe('Campaign Catalog UI', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  beforeEach(() => { user = userEvent.setup(); });
+
   it('renders Campaign Catalog section heading', async () => {
     setupFetch([], [MOCK_TEMPLATE]);
     renderPage();
@@ -119,7 +122,7 @@ describe('Campaign Catalog UI', () => {
 
     const copyButton = await screen.findByRole('button', { name: /copy/i });
 
-    await userEvent.click(copyButton);
+    await user.click(copyButton);
 
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
     const copyCall = fetchMock.mock.calls.find(
@@ -147,7 +150,7 @@ describe('Campaign Catalog UI', () => {
 
     const copyButton = await screen.findByRole('button', { name: /copy/i });
 
-    await userEvent.click(copyButton);
+    await user.click(copyButton);
 
     const loadingButton = await screen.findByRole('button', { name: /copying/i });
     expect(loadingButton).toBeInTheDocument();
@@ -172,7 +175,7 @@ describe('Campaign Catalog UI', () => {
     renderPage();
 
     const copyButton = await screen.findByRole('button', { name: /copy/i });
-    await userEvent.click(copyButton);
+    await user.click(copyButton);
 
     expect(await screen.findByText('Server error')).toBeInTheDocument();
   });

--- a/tests/unit/components/NavBar.test.tsx
+++ b/tests/unit/components/NavBar.test.tsx
@@ -55,10 +55,11 @@ describe('NavBar', () => {
   });
 
   it('calls logout when logout button clicked', async () => {
+    const user = userEvent.setup();
     const logout = jest.fn() as any;
     mockAuth({ isAuthenticated: true, user: { userId: 'u1', email: 'u@test.com' }, logout });
     render(<NavBar />);
-    await userEvent.click(screen.getByTestId('logout-button'));
+    await user.click(screen.getByTestId('logout-button'));
     expect(logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/components/RegisterPage.test.tsx
+++ b/tests/unit/components/RegisterPage.test.tsx
@@ -41,18 +41,19 @@ async function renderAndSubmit(fields: {
   password?: string;
   confirmPassword?: string;
 }) {
+  const user = userEvent.setup();
   render(<RegisterPage />);
   if (fields.username !== undefined) {
-    await userEvent.type(screen.getByLabelText(/username/i), fields.username);
+    await user.type(screen.getByLabelText(/username/i), fields.username);
   }
   if (fields.email !== undefined) {
-    await userEvent.type(screen.getByLabelText(/email address/i), fields.email);
+    await user.type(screen.getByLabelText(/email address/i), fields.email);
   }
   if (fields.password !== undefined) {
-    await userEvent.type(screen.getByLabelText(/^password$/i), fields.password);
+    await user.type(screen.getByLabelText(/^password$/i), fields.password);
   }
   if (fields.confirmPassword !== undefined) {
-    await userEvent.type(screen.getByLabelText(/confirm password/i), fields.confirmPassword);
+    await user.type(screen.getByLabelText(/confirm password/i), fields.confirmPassword);
   }
   fireEvent.submit(document.querySelector('form')!);
 }

--- a/tests/unit/components/SessionsPage.test.tsx
+++ b/tests/unit/components/SessionsPage.test.tsx
@@ -76,6 +76,9 @@ async function renderWithData(logs: object[], parties: object[] = []) {
 }
 
 describe('SessionsPage — session log display', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  beforeEach(() => { user = userEvent.setup(); });
+
   test('renders session title and number', async () => {
     await renderWithData([MOCK_LOG]);
     expect(await screen.findByText('Into the Mines')).toBeInTheDocument();
@@ -106,7 +109,7 @@ describe('SessionsPage — session log display', () => {
   test('renders session form when button clicked', async () => {
     await renderWithData([]);
     const btn = await screen.findByRole('button', { name: /new session/i });
-    await userEvent.click(btn);
+    await user.click(btn);
     expect(await screen.findByText(/Session #/)).toBeInTheDocument();
     expect(screen.getByText('Date Played')).toBeInTheDocument();
   });
@@ -115,7 +118,7 @@ describe('SessionsPage — session log display', () => {
     // useCampaignContext mock returns no parties by default (context: null)
     await renderWithData([]);
     const btn = await screen.findByRole('button', { name: /new session/i });
-    await userEvent.click(btn);
+    await user.click(btn);
     expect(await screen.findByText(/No linked party found/)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Migrates 5 test files from static `userEvent.click/type/selectOptions` calls to the `userEvent.setup()` instance pattern required by `@testing-library/user-event` v14.

### Files changed

- `AlignmentSelect.test.tsx` — inline `const user = userEvent.setup()` (single interaction)
- `NavBar.test.tsx` — inline `const user = userEvent.setup()` (single interaction)
- `RegisterPage.test.tsx` — inline `const user` in shared `renderAndSubmit` helper
- `CampaignsPage.test.tsx` — `beforeEach` pattern (3 tests share a user instance)
- `SessionsPage.test.tsx` — `beforeEach` pattern (2 tests share a user instance)

### Verification

- `npm run test:unit` — 1949 tests pass ✓
- `npm run build` — succeeds ✓
- No static `userEvent.click/type/selectOptions` calls remain ✓

Closes #369