### PR TITLE
docs: archive rtl-userevent-setup-migration (2026-06-06)

### DIFF
--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-06

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/design.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/design.md
@@ -1,0 +1,89 @@
+## Context
+
+- Relevant architecture: Unit tests live under `tests/unit/` and run with `npm run test:unit` (Jest + jsdom). RTL (`@testing-library/react`) and `@testing-library/user-event` v14 are already installed. 18 test files already use `userEvent.setup()` as the reference pattern.
+- Dependencies: No new dependencies. No production code touched.
+- Interfaces/contracts touched: Only the test interaction layer — how tests drive DOM events.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Replace all static `userEvent.*()` calls in 5 files with instance calls on a `user` obtained from `userEvent.setup()`
+- Choose the least-boilerplate scoping strategy per file (inline vs `beforeEach`)
+- Ensure `npm run test:unit` passes with no regressions after migration
+
+### Non-Goals
+
+- Changing assertions, test coverage, or component logic
+- Enforcing the pattern via lint rules
+- Migrating the 18 already-compliant files
+
+## Decisions
+
+### Decision 1: Inline `const user` vs `beforeEach` at describe scope
+
+- Chosen: Inline `const user = userEvent.setup()` for files where only one test needs user interaction; `beforeEach` describe-scope `let user` for files where multiple tests need it.
+- Alternatives considered: Always `beforeEach` (uniform but adds unnecessary describe-scope state to single-test cases); always inline (repetitive for CampaignsPage with 3 affected tests).
+- Rationale: Reduces duplication where it exists, keeps tests self-contained where it doesn't. Matches the goal of reducing boilerplate while meeting standards.
+- Trade-offs: Slight inconsistency across files, but the per-file choice is deterministic and documented.
+
+### Decision 2: File-by-file migration order
+
+- Chosen: Migrate each file independently and verify `npm run test:unit` passes before moving to the next.
+- Alternatives considered: All files in one commit (faster but harder to bisect if a test breaks).
+- Rationale: Isolates regressions to a single file. Given the mechanical nature of the change, a single PR with all 5 files is fine, but tasks are ordered sequentially.
+- Trade-offs: Slightly more verification steps, but each is cheap (unit tests are fast).
+
+## Proposal to Design Mapping
+
+- Proposal element: 5 files using static `userEvent` API
+  - Design decision: Decision 1 (inline vs beforeEach per file)
+  - Validation approach: `npm run test:unit` green after each file
+
+- Proposal element: Risk of async timing regressions
+  - Design decision: Decision 2 (sequential file migration with per-file test run)
+  - Validation approach: Full `npm run test:unit` after all 5 files done
+
+## Functional Requirements Mapping
+
+- Requirement: No static `userEvent.*()` calls remain in any test file
+  - Design element: Replace all 11 static calls across 5 files
+  - Acceptance criteria reference: specs/migration-pattern.md
+  - Testability notes: `grep -r "userEvent\." tests/ | grep -v "setup()"` should return empty
+
+- Requirement: All existing tests continue to pass
+  - Design element: Mechanical replacement only — no assertion changes
+  - Acceptance criteria reference: specs/migration-pattern.md
+  - Testability notes: `npm run test:unit` exit code 0
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: No flaky tests introduced by timing changes
+  - Design element: `userEvent.setup()` uses the same defaults as the static API; no config needed
+  - Acceptance criteria reference: specs/migration-pattern.md
+  - Testability notes: Run `npm run test:unit` twice; results must be stable
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `userEvent.setup()` instance behaves identically to static calls for these simple interactions (click, type, selectOptions), so timing regressions are very unlikely
+  - Impact: Low
+  - Mitigation: Per-file test verification
+
+## Rollback / Mitigation
+
+- Rollback trigger: `npm run test:unit` failures that cannot be resolved in the PR
+- Rollback steps: Revert the affected file(s) to the static API call; the change is a pure text substitution so revert is trivial
+- Data migration considerations: None — test-only change
+- Verification after rollback: `npm run test:unit` passes
+
+## Operational Blocking Policy
+
+- If CI checks fail: Fix failing tests before merging; do not merge with red CI
+- If security checks fail: N/A — no production code changed
+- If required reviews are blocked/stale: Ping reviewer; all PR review threads must be resolved before merge (project ruleset)
+- Escalation path and timeout: If blocked >2 days, re-raise in issue #369
+
+## Open Questions
+
+No open questions. All design decisions are resolved.

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/design.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/design.md
@@ -49,7 +49,7 @@
 - Requirement: No static `userEvent.*()` calls remain in any test file
   - Design element: Replace all 11 static calls across 5 files
   - Acceptance criteria reference: specs/migration-pattern.md
-  - Testability notes: `grep -r "userEvent\." tests/ | grep -v "setup()"` should return empty
+  - Testability notes: `grep -r "userEvent\.\(click\|type\|selectOptions\)" tests/` should return empty
 
 - Requirement: All existing tests continue to pass
   - Design element: Mechanical replacement only — no assertion changes

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/proposal.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/proposal.md
@@ -1,0 +1,60 @@
+## GitHub Issues
+
+- #369
+
+## Why
+
+- Problem statement: 5 test files still use the deprecated static `userEvent` API (e.g. `userEvent.click(el)`) from `@testing-library/user-event` v14. The static API is an internal wrapper around `userEvent.setup()` that offers less control over timing and pointer/keyboard configuration, and is not the standard our other 18 RTL test files follow.
+- Why now: Standardizing now keeps the test suite internally consistent and avoids the static API being copy-pasted further as new tests are added. Issue #356 already established that new RTL migrations should use `setup()` from the start.
+- Business/user impact: No user-facing impact. Developer impact: consistent, maintainable test patterns across the full unit test suite.
+
+## Problem Space
+
+- Current behavior: 5 files call `userEvent.click(...)`, `userEvent.type(...)`, or `userEvent.selectOptions(...)` directly on the static import.
+- Desired behavior: All RTL tests obtain a `userEvent` instance via `userEvent.setup()` before interacting with the DOM.
+- Constraints: No logic changes — only the test interaction mechanism changes. All existing assertions remain untouched.
+- Assumptions: The 18 files already using `setup()` are the reference implementation; no changes needed there.
+- Edge cases considered: Files with multiple tests that each need a user instance should use `beforeEach` to avoid repetition; files with a single interacting test should use inline `const user` to stay self-contained.
+
+## Scope
+
+### In Scope
+
+- `tests/unit/components/AlignmentSelect.test.tsx` — 1 `selectOptions` call → inline `const user`
+- `tests/unit/components/NavBar.test.tsx` — 1 `click` call → inline `const user`
+- `tests/unit/components/RegisterPage.test.tsx` — 4 `type` calls in one test → inline `const user`
+- `tests/unit/components/CampaignsPage.test.tsx` — 3 `click` calls across 3 `it` blocks → `beforeEach` pattern
+- `tests/unit/components/SessionsPage.test.tsx` — 2 `click` calls across 2 `test` blocks → `beforeEach` pattern
+
+### Out of Scope
+
+- The 18 test files already using `setup()` — no changes needed
+- Any source/production code changes
+- Adding new test cases or changing assertions
+- ESLint rule enforcement (a follow-on could add a custom rule to ban the static API)
+
+## What Changes
+
+- 5 test files modified: static `userEvent.*()` calls replaced with instance calls on a `user` obtained from `userEvent.setup()`
+- Per-file strategy chosen to minimise boilerplate while avoiding unnecessary describe-scope mutation
+
+## Risks
+
+- Risk: A migrated test could become async-timing-sensitive in a new way
+  - Impact: Flaky test that was previously passing
+  - Mitigation: Run `npm run test:unit` in full after all 5 files are migrated; each file's tests must pass before moving to the next
+
+## Open Questions
+
+No unresolved ambiguity. The per-file strategy (inline vs `beforeEach`) was confirmed during exploration based on the number of tests that need user interaction per file.
+
+## Non-Goals
+
+- Migrating to a different testing library
+- Adding lint rules to enforce this pattern automatically
+- Changing any component behaviour or test coverage
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/specs/migration-pattern.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/specs/migration-pattern.md
@@ -89,12 +89,3 @@ Reason for removal: Deprecated in `@testing-library/user-event` v14. Replaced by
 - Design Decision 1 (inline vs beforeEach) → Modified requirement scenarios per file
 - Design Decision 2 (sequential migration) → Tasks: migrate one file at a time, verify after each
 
-## Non-Functional Acceptance Criteria
-
-### Requirement: Reliability
-
-#### Scenario: No flakiness introduced
-
-- **Given** the 5 migrated test files
-- **When** `npm run test:unit` is executed twice in sequence
-- **Then** both runs produce identical results with exit code 0

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/specs/migration-pattern.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/specs/migration-pattern.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Use `userEvent.setup()` instance in all RTL tests
+
+All RTL test files SHALL obtain a `userEvent` instance via `userEvent.setup()` before calling any interaction methods. No static calls to `userEvent.click()`, `userEvent.type()`, or `userEvent.selectOptions()` shall remain.
+
+#### Scenario: Single-interaction test uses inline const
+
+- **Given** a test file where only one test function calls `userEvent` methods
+- **When** the test is written
+- **Then** it declares `const user = userEvent.setup()` inside that test function and calls methods on `user`
+
+#### Scenario: Multi-interaction tests use beforeEach
+
+- **Given** a describe block where multiple test functions each call `userEvent` methods
+- **When** the tests are written
+- **Then** a `let user: ReturnType<typeof userEvent.setup>` is declared at describe scope and assigned in `beforeEach(() => { user = userEvent.setup(); })`
+
+#### Scenario: No static calls remain
+
+- **Given** the full `tests/` directory
+- **When** `grep -r "userEvent\." tests/ | grep -v "setup()"` is run
+- **Then** the command returns no matches
+
+### Requirement: ADDED All migrated tests continue to pass
+
+The migrated test files SHALL produce the same pass/fail results as before migration.
+
+#### Scenario: All unit tests green after migration
+
+- **Given** all 5 files have been migrated
+- **When** `npm run test:unit` is executed
+- **Then** the command exits with code 0 and no test failures are reported
+
+#### Scenario: Migrated tests produce stable results
+
+- **Given** all 5 files have been migrated
+- **When** `npm run test:unit` is run twice consecutively
+- **Then** both runs exit 0 with identical pass counts (no flakiness)
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED RTL test interaction pattern
+
+The test suite SHALL use `userEvent.setup()` consistently across all files (previously 18/23 files; target: 23/23).
+
+#### Scenario: CampaignsPage — multiple tests share a user instance
+
+- **Given** `tests/unit/components/CampaignsPage.test.tsx` with 3 `it` blocks that click
+- **When** the file is migrated
+- **Then** a `beforeEach` assigns `user = userEvent.setup()` and each `it` block calls `await user.click(...)`
+
+#### Scenario: SessionsPage — multiple tests share a user instance
+
+- **Given** `tests/unit/components/SessionsPage.test.tsx` with 2 `test` blocks that click
+- **When** the file is migrated
+- **Then** a `beforeEach` assigns `user = userEvent.setup()` and each `test` block calls `await user.click(...)`
+
+#### Scenario: AlignmentSelect — single test uses inline const
+
+- **Given** `tests/unit/components/AlignmentSelect.test.tsx` with 1 test calling `selectOptions`
+- **When** the file is migrated
+- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.selectOptions(...)`
+
+#### Scenario: NavBar — single test uses inline const
+
+- **Given** `tests/unit/components/NavBar.test.tsx` with 1 test calling `click`
+- **When** the file is migrated
+- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.click(...)`
+
+#### Scenario: RegisterPage — single test with multiple type calls uses inline const
+
+- **Given** `tests/unit/components/RegisterPage.test.tsx` with 4 `type` calls in one test
+- **When** the file is migrated
+- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.type(...)` for each field
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Static userEvent API usage
+
+Reason for removal: Deprecated in `@testing-library/user-event` v14. Replaced by the `userEvent.setup()` instance pattern in all 5 affected files.
+
+## Traceability
+
+- Proposal: "5 files use static API" → Requirement: Use `userEvent.setup()` instance
+- Proposal: "Risk of timing regressions" → Requirement: All migrated tests continue to pass
+- Design Decision 1 (inline vs beforeEach) → Modified requirement scenarios per file
+- Design Decision 2 (sequential migration) → Tasks: migrate one file at a time, verify after each
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No flakiness introduced
+
+- **Given** the 5 migrated test files
+- **When** `npm run test:unit` is executed twice in sequence
+- **Then** both runs produce identical results with exit code 0

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tasks.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tasks.md
@@ -1,0 +1,107 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b test/rtl-userevent-setup-migration` then immediately `git push -u origin test/rtl-userevent-setup-migration`
+
+## Execution
+
+### AlignmentSelect.test.tsx (inline `const user`)
+
+- [x] In `tests/unit/components/AlignmentSelect.test.tsx`, find the test that calls `userEvent.selectOptions(...)` (line ~57)
+- [x] Add `const user = userEvent.setup();` at the top of that test function, before `render`
+- [x] Replace `await userEvent.selectOptions(...)` with `await user.selectOptions(...)`
+- [x] Verify: `npm run test:unit -- --testPathPattern=AlignmentSelect` passes
+
+### NavBar.test.tsx (inline `const user`)
+
+- [x] In `tests/unit/components/NavBar.test.tsx`, find the test that calls `userEvent.click(...)` (line ~61)
+- [x] Add `const user = userEvent.setup();` at the top of that test function, before `render`
+- [x] Replace `await userEvent.click(...)` with `await user.click(...)`
+- [x] Verify: `npm run test:unit -- --testPathPattern=NavBar` passes
+
+### RegisterPage.test.tsx (inline `const user`)
+
+- [x] In `tests/unit/components/RegisterPage.test.tsx`, find the test (or helper) containing the 4 `userEvent.type(...)` calls (lines ~46–55)
+- [x] Add `const user = userEvent.setup();` at the top of the enclosing test function
+- [x] Replace all 4 `await userEvent.type(...)` calls with `await user.type(...)`
+- [x] Verify: `npm run test:unit -- --testPathPattern=RegisterPage` passes
+
+### CampaignsPage.test.tsx (`beforeEach` pattern)
+
+- [x] In `tests/unit/components/CampaignsPage.test.tsx`, identify the describe block containing the 3 `it` blocks that call `userEvent.click(...)` (lines ~122, ~150, ~175)
+- [x] Add `let user: ReturnType<typeof userEvent.setup>;` at describe scope
+- [x] Add `beforeEach(() => { user = userEvent.setup(); });` inside that describe block
+- [x] Replace all 3 `await userEvent.click(...)` calls with `await user.click(...)`
+- [x] Verify: `npm run test:unit -- --testPathPattern=CampaignsPage` passes
+
+### SessionsPage.test.tsx (`beforeEach` pattern)
+
+- [x] In `tests/unit/components/SessionsPage.test.tsx`, identify the describe block containing the 2 `test` blocks that call `userEvent.click(...)` (lines ~109, ~118)
+- [x] Add `let user: ReturnType<typeof userEvent.setup>;` at describe scope
+- [x] Add `beforeEach(() => { user = userEvent.setup(); });` inside that describe block
+- [x] Replace both `await userEvent.click(...)` calls with `await user.click(...)`
+- [x] Verify: `npm run test:unit -- --testPathPattern=SessionsPage` passes
+
+### Final verification
+
+- [x] Confirm no static calls remain: `grep -r "userEvent\." tests/ | grep -v "setup()"` returns empty
+- [x] Run full suite: `npm run test:unit` exits 0
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings from the sub-agent's report, applying fixes for complexity, duplication, and quality issues before committing.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — build succeeds
+- [x] `grep -r "userEvent\." tests/ | grep -v "setup()"` — no output
+
+Note: No integration or E2E changes needed — this is a test-only migration.
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to the working branch and push to remote
+- [x] Open PR from `test/rtl-userevent-setup-migration` to `main`. **PR body MUST include `Closes #369`.**
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved to allow the process to progress. Follow all steps in Remote push validation then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [x] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in Remote push validation then push to the same working branch; wait 180 seconds then repeat until all required checks pass
+- [x] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): (auto-assigned by ruleset)
+- Required approvals: per repository ruleset
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on main (`git log --oneline -5`)
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] No documentation updates required — test-only change
+- [x] Sync approved spec deltas into `openspec/specs/` (global spec) if applicable
+- [x] Archive the change: move `openspec/changes/rtl-userevent-setup-migration/` to `openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/` **and stage both the new location and the deletion of the old location in a single commit**
+- [x] Confirm `openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/` exists and `openspec/changes/rtl-userevent-setup-migration/` is gone
+- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-2026-06-06-rtl-userevent-setup-migration` then `git push -u origin doc/archive-2026-06-06-rtl-userevent-setup-migration`
+- [x] Open a PR from `doc/archive-2026-06-06-rtl-userevent-setup-migration` to `main` with title `docs: archive rtl-userevent-setup-migration (2026-06-06)` — **do NOT push directly to main**
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [x] Monitor the doc PR until it merges
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d test/rtl-userevent-setup-migration doc/archive-2026-06-06-rtl-userevent-setup-migration`

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tasks.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tasks.md
@@ -46,7 +46,7 @@
 
 ### Final verification
 
-- [x] Confirm no static calls remain: `grep -r "userEvent\." tests/ | grep -v "setup()"` returns empty
+- [x] Confirm no static calls remain: `grep -r "userEvent\.\(click\|type\|selectOptions\)" tests/` returns empty
 - [x] Run full suite: `npm run test:unit` exits 0
 
 ## Pre-Commit Code Review
@@ -57,7 +57,7 @@
 
 - [x] `npm run test:unit` — all tests pass
 - [x] `npm run build` — build succeeds
-- [x] `grep -r "userEvent\." tests/ | grep -v "setup()"` — no output
+- [x] `grep -r "userEvent\.\(click\|type\|selectOptions\)" tests/` — no output
 
 Note: No integration or E2E changes needed — this is a test-only migration.
 

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tests.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tests.md
@@ -1,0 +1,52 @@
+---
+name: tests
+description: Tests for the rtl-userevent-setup-migration change
+---
+
+# Tests
+
+## Overview
+
+This change is a mechanical migration of existing tests — no new production code is written. The verification strategy is therefore: run the existing tests after each file migration and confirm they still pass. The "test" for correctness of the migration _is_ the existing test suite.
+
+## Testing Steps
+
+For each file migration task in `tasks.md`:
+
+1. **Before migrating:** run the file's tests to confirm they pass as a baseline
+2. **Migrate:** replace static `userEvent.*()` calls with instance calls
+3. **After migrating:** run the file's tests again — they must still pass (same pass count, no new failures)
+4. **After all 5 files:** run the full suite and confirm no regressions
+
+## Test Cases
+
+### AlignmentSelect.test.tsx
+
+- [ ] Baseline: `npm run test:unit -- --testPathPattern=AlignmentSelect` passes before migration
+- [ ] After migration: same command passes; `userEvent.selectOptions` static call no longer present
+
+### NavBar.test.tsx
+
+- [ ] Baseline: `npm run test:unit -- --testPathPattern=NavBar` passes before migration
+- [ ] After migration: same command passes; `userEvent.click` static call no longer present
+
+### RegisterPage.test.tsx
+
+- [ ] Baseline: `npm run test:unit -- --testPathPattern=RegisterPage` passes before migration
+- [ ] After migration: same command passes; all 4 `userEvent.type` static calls replaced
+
+### CampaignsPage.test.tsx
+
+- [ ] Baseline: `npm run test:unit -- --testPathPattern=CampaignsPage` passes before migration
+- [ ] After migration: same command passes; all 3 `userEvent.click` static calls replaced with instance calls via `beforeEach`
+
+### SessionsPage.test.tsx
+
+- [ ] Baseline: `npm run test:unit -- --testPathPattern=SessionsPage` passes before migration
+- [ ] After migration: same command passes; both `userEvent.click` static calls replaced with instance calls via `beforeEach`
+
+### Full suite regression check
+
+- [ ] `npm run test:unit` exits 0 with no failures after all 5 files are migrated
+- [ ] `grep -r "userEvent\." tests/ | grep -v "setup()"` returns no output
+- [ ] `npm run build` exits 0

--- a/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tests.md
+++ b/openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/tests.md
@@ -22,31 +22,31 @@ For each file migration task in `tasks.md`:
 
 ### AlignmentSelect.test.tsx
 
-- [ ] Baseline: `npm run test:unit -- --testPathPattern=AlignmentSelect` passes before migration
-- [ ] After migration: same command passes; `userEvent.selectOptions` static call no longer present
+- [x] Baseline: `npm run test:unit -- --testPathPattern=AlignmentSelect` passes before migration
+- [x] After migration: same command passes; `userEvent.selectOptions` static call no longer present
 
 ### NavBar.test.tsx
 
-- [ ] Baseline: `npm run test:unit -- --testPathPattern=NavBar` passes before migration
-- [ ] After migration: same command passes; `userEvent.click` static call no longer present
+- [x] Baseline: `npm run test:unit -- --testPathPattern=NavBar` passes before migration
+- [x] After migration: same command passes; `userEvent.click` static call no longer present
 
 ### RegisterPage.test.tsx
 
-- [ ] Baseline: `npm run test:unit -- --testPathPattern=RegisterPage` passes before migration
-- [ ] After migration: same command passes; all 4 `userEvent.type` static calls replaced
+- [x] Baseline: `npm run test:unit -- --testPathPattern=RegisterPage` passes before migration
+- [x] After migration: same command passes; all 4 `userEvent.type` static calls replaced
 
 ### CampaignsPage.test.tsx
 
-- [ ] Baseline: `npm run test:unit -- --testPathPattern=CampaignsPage` passes before migration
-- [ ] After migration: same command passes; all 3 `userEvent.click` static calls replaced with instance calls via `beforeEach`
+- [x] Baseline: `npm run test:unit -- --testPathPattern=CampaignsPage` passes before migration
+- [x] After migration: same command passes; all 3 `userEvent.click` static calls replaced with instance calls via `beforeEach`
 
 ### SessionsPage.test.tsx
 
-- [ ] Baseline: `npm run test:unit -- --testPathPattern=SessionsPage` passes before migration
-- [ ] After migration: same command passes; both `userEvent.click` static calls replaced with instance calls via `beforeEach`
+- [x] Baseline: `npm run test:unit -- --testPathPattern=SessionsPage` passes before migration
+- [x] After migration: same command passes; both `userEvent.click` static calls replaced with instance calls via `beforeEach`
 
 ### Full suite regression check
 
-- [ ] `npm run test:unit` exits 0 with no failures after all 5 files are migrated
-- [ ] `grep -r "userEvent\." tests/ | grep -v "setup()"` returns no output
-- [ ] `npm run build` exits 0
+- [x] `npm run test:unit` exits 0 with no failures after all 5 files are migrated
+- [x] `grep -r "userEvent\.\(click\|type\|selectOptions\)" tests/` returns no output
+- [x] `npm run build` exits 0

--- a/openspec/specs/rtl-migration/userevent-setup.md
+++ b/openspec/specs/rtl-migration/userevent-setup.md
@@ -1,100 +1,35 @@
-## ADDED Requirements
+# userEvent.setup() Instance Pattern
 
-This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+Specification for consistent use of `@testing-library/user-event` v14 in RTL unit tests.
 
-### Requirement: ADDED Use `userEvent.setup()` instance in all RTL tests
+## Requirement: Use `userEvent.setup()` instance for all interactions
 
 All RTL test files SHALL obtain a `userEvent` instance via `userEvent.setup()` before calling any interaction methods. No static calls to `userEvent.click()`, `userEvent.type()`, or `userEvent.selectOptions()` shall remain.
 
-#### Scenario: Single-interaction test uses inline const
+### Scenario: Single-interaction test uses inline const
 
 - **Given** a test file where only one test function calls `userEvent` methods
 - **When** the test is written
 - **Then** it declares `const user = userEvent.setup()` inside that test function and calls methods on `user`
 
-#### Scenario: Multi-interaction tests use beforeEach
+### Scenario: Multi-interaction tests use beforeEach
 
 - **Given** a describe block where multiple test functions each call `userEvent` methods
 - **When** the tests are written
 - **Then** a `let user: ReturnType<typeof userEvent.setup>` is declared at describe scope and assigned in `beforeEach(() => { user = userEvent.setup(); })`
 
-#### Scenario: No static calls remain
+### Scenario: No static calls remain
 
 - **Given** the full `tests/` directory
-- **When** `grep -r "userEvent\." tests/ | grep -v "setup()"` is run
+- **When** `grep -r "userEvent\.\(click\|type\|selectOptions\)" tests/` is run
 - **Then** the command returns no matches
 
-### Requirement: ADDED All migrated tests continue to pass
+## Requirement: All tests continue to pass after migration
 
-The migrated test files SHALL produce the same pass/fail results as before migration.
+Migrated test files SHALL produce the same pass/fail results as before migration.
 
-#### Scenario: All unit tests green after migration
+### Scenario: All unit tests green after migration
 
-- **Given** all 5 files have been migrated
+- **Given** all affected files have been migrated
 - **When** `npm run test:unit` is executed
-- **Then** the command exits with code 0 and no test failures are reported
-
-#### Scenario: Migrated tests produce stable results
-
-- **Given** all 5 files have been migrated
-- **When** `npm run test:unit` is run twice consecutively
-- **Then** both runs exit 0 with identical pass counts (no flakiness)
-
-## MODIFIED Requirements
-
-### Requirement: MODIFIED RTL test interaction pattern
-
-The test suite SHALL use `userEvent.setup()` consistently across all files (previously 18/23 files; target: 23/23).
-
-#### Scenario: CampaignsPage — multiple tests share a user instance
-
-- **Given** `tests/unit/components/CampaignsPage.test.tsx` with 3 `it` blocks that click
-- **When** the file is migrated
-- **Then** a `beforeEach` assigns `user = userEvent.setup()` and each `it` block calls `await user.click(...)`
-
-#### Scenario: SessionsPage — multiple tests share a user instance
-
-- **Given** `tests/unit/components/SessionsPage.test.tsx` with 2 `test` blocks that click
-- **When** the file is migrated
-- **Then** a `beforeEach` assigns `user = userEvent.setup()` and each `test` block calls `await user.click(...)`
-
-#### Scenario: AlignmentSelect — single test uses inline const
-
-- **Given** `tests/unit/components/AlignmentSelect.test.tsx` with 1 test calling `selectOptions`
-- **When** the file is migrated
-- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.selectOptions(...)`
-
-#### Scenario: NavBar — single test uses inline const
-
-- **Given** `tests/unit/components/NavBar.test.tsx` with 1 test calling `click`
-- **When** the file is migrated
-- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.click(...)`
-
-#### Scenario: RegisterPage — single test with multiple type calls uses inline const
-
-- **Given** `tests/unit/components/RegisterPage.test.tsx` with 4 `type` calls in one test
-- **When** the file is migrated
-- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.type(...)` for each field
-
-## REMOVED Requirements
-
-### Requirement: REMOVED Static userEvent API usage
-
-Reason for removal: Deprecated in `@testing-library/user-event` v14. Replaced by the `userEvent.setup()` instance pattern in all 5 affected files.
-
-## Traceability
-
-- Proposal: "5 files use static API" → Requirement: Use `userEvent.setup()` instance
-- Proposal: "Risk of timing regressions" → Requirement: All migrated tests continue to pass
-- Design Decision 1 (inline vs beforeEach) → Modified requirement scenarios per file
-- Design Decision 2 (sequential migration) → Tasks: migrate one file at a time, verify after each
-
-## Non-Functional Acceptance Criteria
-
-### Requirement: Reliability
-
-#### Scenario: No flakiness introduced
-
-- **Given** the 5 migrated test files
-- **When** `npm run test:unit` is executed twice in sequence
-- **Then** both runs produce identical results with exit code 0
+- **Then** the command exits with code 0 and no test failures are reported with identical pass counts (no flakiness)

--- a/openspec/specs/rtl-migration/userevent-setup.md
+++ b/openspec/specs/rtl-migration/userevent-setup.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED Use `userEvent.setup()` instance in all RTL tests
+
+All RTL test files SHALL obtain a `userEvent` instance via `userEvent.setup()` before calling any interaction methods. No static calls to `userEvent.click()`, `userEvent.type()`, or `userEvent.selectOptions()` shall remain.
+
+#### Scenario: Single-interaction test uses inline const
+
+- **Given** a test file where only one test function calls `userEvent` methods
+- **When** the test is written
+- **Then** it declares `const user = userEvent.setup()` inside that test function and calls methods on `user`
+
+#### Scenario: Multi-interaction tests use beforeEach
+
+- **Given** a describe block where multiple test functions each call `userEvent` methods
+- **When** the tests are written
+- **Then** a `let user: ReturnType<typeof userEvent.setup>` is declared at describe scope and assigned in `beforeEach(() => { user = userEvent.setup(); })`
+
+#### Scenario: No static calls remain
+
+- **Given** the full `tests/` directory
+- **When** `grep -r "userEvent\." tests/ | grep -v "setup()"` is run
+- **Then** the command returns no matches
+
+### Requirement: ADDED All migrated tests continue to pass
+
+The migrated test files SHALL produce the same pass/fail results as before migration.
+
+#### Scenario: All unit tests green after migration
+
+- **Given** all 5 files have been migrated
+- **When** `npm run test:unit` is executed
+- **Then** the command exits with code 0 and no test failures are reported
+
+#### Scenario: Migrated tests produce stable results
+
+- **Given** all 5 files have been migrated
+- **When** `npm run test:unit` is run twice consecutively
+- **Then** both runs exit 0 with identical pass counts (no flakiness)
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED RTL test interaction pattern
+
+The test suite SHALL use `userEvent.setup()` consistently across all files (previously 18/23 files; target: 23/23).
+
+#### Scenario: CampaignsPage — multiple tests share a user instance
+
+- **Given** `tests/unit/components/CampaignsPage.test.tsx` with 3 `it` blocks that click
+- **When** the file is migrated
+- **Then** a `beforeEach` assigns `user = userEvent.setup()` and each `it` block calls `await user.click(...)`
+
+#### Scenario: SessionsPage — multiple tests share a user instance
+
+- **Given** `tests/unit/components/SessionsPage.test.tsx` with 2 `test` blocks that click
+- **When** the file is migrated
+- **Then** a `beforeEach` assigns `user = userEvent.setup()` and each `test` block calls `await user.click(...)`
+
+#### Scenario: AlignmentSelect — single test uses inline const
+
+- **Given** `tests/unit/components/AlignmentSelect.test.tsx` with 1 test calling `selectOptions`
+- **When** the file is migrated
+- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.selectOptions(...)`
+
+#### Scenario: NavBar — single test uses inline const
+
+- **Given** `tests/unit/components/NavBar.test.tsx` with 1 test calling `click`
+- **When** the file is migrated
+- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.click(...)`
+
+#### Scenario: RegisterPage — single test with multiple type calls uses inline const
+
+- **Given** `tests/unit/components/RegisterPage.test.tsx` with 4 `type` calls in one test
+- **When** the file is migrated
+- **Then** that test declares `const user = userEvent.setup()` inline and calls `await user.type(...)` for each field
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Static userEvent API usage
+
+Reason for removal: Deprecated in `@testing-library/user-event` v14. Replaced by the `userEvent.setup()` instance pattern in all 5 affected files.
+
+## Traceability
+
+- Proposal: "5 files use static API" → Requirement: Use `userEvent.setup()` instance
+- Proposal: "Risk of timing regressions" → Requirement: All migrated tests continue to pass
+- Design Decision 1 (inline vs beforeEach) → Modified requirement scenarios per file
+- Design Decision 2 (sequential migration) → Tasks: migrate one file at a time, verify after each
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No flakiness introduced
+
+- **Given** the 5 migrated test files
+- **When** `npm run test:unit` is executed twice in sequence
+- **Then** both runs produce identical results with exit code 0


### PR DESCRIPTION
Archives the rtl-userevent-setup-migration change after PR #375 merged.

- Moves `openspec/changes/rtl-userevent-setup-migration/` to `openspec/changes/archive/2026-06-06-rtl-userevent-setup-migration/`
- Syncs `migration-pattern.md` spec delta to `openspec/specs/rtl-migration/userevent-setup.md`