### PR TITLE
feat: campaign character sharing (3a)

### DIFF
--- a/app/api/campaigns/[id]/characters/[cid]/route.ts
+++ b/app/api/campaigns/[id]/characters/[cid]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+
+type Params = { id: string; cid: string };
+
+export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: campaignId, cid: characterId }) => {
+  try {
+    const member = await storage.getMember(campaignId, auth.userId);
+    if (!member || member.status !== 'active') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const character = await storage.loadCharacterById(characterId);
+    if (!character) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    if (character.userId !== auth.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const deleted = await storage.removeShare(campaignId, characterId, auth.userId);
+    if (!deleted) {
+      return NextResponse.json({ error: 'Share not found' }, { status: 404 });
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Error unsharing character:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/api/campaigns/[id]/characters/[cid]/route.ts
+++ b/app/api/campaigns/[id]/characters/[cid]/route.ts
@@ -7,7 +7,7 @@ type Params = { id: string; cid: string };
 export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: campaignId, cid: characterId }) => {
   try {
     const member = await storage.getMember(campaignId, auth.userId);
-    if (!member || member.status !== 'active') {
+    if (!member || member.status !== 'active' || member.role !== 'player') {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 

--- a/app/api/campaigns/[id]/characters/route.ts
+++ b/app/api/campaigns/[id]/characters/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+import { DuplicateShareError } from '@/lib/errors';
+
+type Params = { id: string };
+
+export const POST = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { characterId: rawCharacterId } = body as Record<string, unknown>;
+  if (typeof rawCharacterId !== 'string' || rawCharacterId.trim() === '') {
+    return NextResponse.json({ error: 'characterId is required' }, { status: 400 });
+  }
+  const characterId = rawCharacterId.trim();
+
+  try {
+    const member = await storage.getMember(campaignId, auth.userId);
+    if (!member || member.status !== 'active' || member.role !== 'player') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const character = await storage.loadCharacterById(characterId);
+    if (!character) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    if (character.userId !== auth.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const id = crypto.randomUUID();
+    await storage.addShare({
+      id,
+      campaignId,
+      characterId,
+      userId: auth.userId,
+      sharedAt: new Date(),
+    });
+
+    return NextResponse.json({ id, characterId }, { status: 201 });
+  } catch (error) {
+    if (error instanceof DuplicateShareError) {
+      return NextResponse.json({ error: 'Character already shared' }, { status: 409 });
+    }
+    console.error('Error sharing character:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});
+
+export const GET = withAuthAndParams<Params>(async (_request, auth, { id: campaignId }) => {
+  try {
+    const member = await storage.getMember(campaignId, auth.userId);
+    if (!member || member.status !== 'active') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const shares = await storage.listSharesForCampaign(campaignId, auth.userId);
+    return NextResponse.json(shares);
+  } catch (error) {
+    console.error('Error listing character shares:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/api/campaigns/[id]/characters/route.ts
+++ b/app/api/campaigns/[id]/characters/route.ts
@@ -13,7 +13,8 @@ export const POST = withAuthAndParams<Params>(async (request, auth, { id: campai
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { characterId: rawCharacterId } = body as Record<string, unknown>;
+  const bodyObj = body !== null && typeof body === 'object' ? body as Record<string, unknown> : {};
+  const { characterId: rawCharacterId } = bodyObj;
   if (typeof rawCharacterId !== 'string' || rawCharacterId.trim() === '') {
     return NextResponse.json({ error: 'characterId is required' }, { status: 400 });
   }

--- a/app/api/campaigns/[id]/members/me/route.ts
+++ b/app/api/campaigns/[id]/members/me/route.ts
@@ -2,6 +2,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
 
+export const GET = withAuthAndParams<{ id: string }>(async (_request, auth, { id: campaignId }) => {
+  try {
+    const member = await storage.getMember(campaignId, auth.userId);
+    if (!member) {
+      return NextResponse.json({ error: 'Not a member' }, { status: 404 });
+    }
+    return NextResponse.json(member);
+  } catch (error) {
+    console.error('Error fetching member:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});
+
 type Params = { id: string };
 
 export const PATCH = withAuthAndParams<Params>(async (request: NextRequest, auth, { id: campaignId }) => {

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -8,7 +8,6 @@ import { Campaign, CampaignTemplate, Party, Character, SessionLog, getCharacterT
 import { CampaignEditor } from './CampaignEditor';
 import { CharacterRosterCard } from '@/lib/components/CharacterRosterCard';
 import { CampaignChapterInfo } from '@/lib/components/CampaignChapterInfo';
-import { SharedCharactersPanel } from '@/lib/components/SharedCharactersPanel';
 
 function ManagementChapterInfo({ campaign }: { campaign: Campaign }) {
   const currentCh = campaign.currentChapterId
@@ -381,10 +380,6 @@ export function CampaignsContent() {
                         })}
                       </div>
                     )}
-                    <SharedCharactersPanel
-                      campaignId={campaign.id}
-                      characters={characters}
-                    />
                   </div>
                 );
               })}

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -133,7 +133,6 @@ export function CampaignsContent() {
   }, [campaigns]);
 
   useEffect(() => {
-    if (campaigns.length === 0) return;
     const controller = new AbortController();
     const fetchMemberships = async () => {
       const results = await Promise.all(

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState } from '@/lib/components/ui';
-import { Campaign, CampaignTemplate, Party, Character, SessionLog, CampaignMember, getCharacterType } from '@/lib/types';
+import { Campaign, CampaignTemplate, Party, Character, SessionLog, getCharacterType } from '@/lib/types';
 import { CampaignEditor } from './CampaignEditor';
 import { CharacterRosterCard } from '@/lib/components/CharacterRosterCard';
 import { CampaignChapterInfo } from '@/lib/components/CampaignChapterInfo';
@@ -65,7 +65,6 @@ export function CampaignsContent() {
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [copyingIds, setCopyingIds] = useState<Set<string>>(new Set());
   const [copyError, setCopyError] = useState<Record<string, string>>({});
-  const [membershipsByCampaign, setMembershipsByCampaign] = useState<Record<string, CampaignMember | null>>({});
 
   const loadAll = async () => {
     try {
@@ -129,29 +128,6 @@ export function CampaignsContent() {
     };
 
     fetchSessions();
-    return () => controller.abort();
-  }, [campaigns]);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const fetchMemberships = async () => {
-      const results = await Promise.all(
-        campaigns.map(async (campaign) => {
-          try {
-            const res = await fetch(`/api/campaigns/${campaign.id}/members/me`, { signal: controller.signal });
-            if (!res.ok) return [campaign.id, null] as const;
-            const member: CampaignMember = await res.json();
-            return [campaign.id, member] as const;
-          } catch {
-            return [campaign.id, null] as const;
-          }
-        })
-      );
-      if (!controller.signal.aborted) {
-        setMembershipsByCampaign(Object.fromEntries(results));
-      }
-    };
-    fetchMemberships();
     return () => controller.abort();
   }, [campaigns]);
 
@@ -254,7 +230,6 @@ export function CampaignsContent() {
               {activeCampaigns.map(campaign => {
                 const linkedParties = parties.filter(p => p.campaignId === campaign.id);
                 const lastSession = sessionsByCampaign[campaign.id];
-                const currentUserMember = membershipsByCampaign[campaign.id] ?? null;
 
                 return (
                   <div key={campaign.id} className="bg-gray-800 rounded-lg p-6">
@@ -408,7 +383,7 @@ export function CampaignsContent() {
                     )}
                     <SharedCharactersPanel
                       campaignId={campaign.id}
-                      currentUserMember={currentUserMember}
+                      characters={characters}
                     />
                   </div>
                 );

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -4,10 +4,11 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState } from '@/lib/components/ui';
-import { Campaign, CampaignTemplate, Party, Character, SessionLog, getCharacterType } from '@/lib/types';
+import { Campaign, CampaignTemplate, Party, Character, SessionLog, CampaignMember, getCharacterType } from '@/lib/types';
 import { CampaignEditor } from './CampaignEditor';
 import { CharacterRosterCard } from '@/lib/components/CharacterRosterCard';
 import { CampaignChapterInfo } from '@/lib/components/CampaignChapterInfo';
+import { SharedCharactersPanel } from '@/lib/components/SharedCharactersPanel';
 
 function ManagementChapterInfo({ campaign }: { campaign: Campaign }) {
   const currentCh = campaign.currentChapterId
@@ -64,6 +65,7 @@ export function CampaignsContent() {
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [copyingIds, setCopyingIds] = useState<Set<string>>(new Set());
   const [copyError, setCopyError] = useState<Record<string, string>>({});
+  const [membershipsByCampaign, setMembershipsByCampaign] = useState<Record<string, CampaignMember | null>>({});
 
   const loadAll = async () => {
     try {
@@ -127,6 +129,30 @@ export function CampaignsContent() {
     };
 
     fetchSessions();
+    return () => controller.abort();
+  }, [campaigns]);
+
+  useEffect(() => {
+    if (campaigns.length === 0) return;
+    const controller = new AbortController();
+    const fetchMemberships = async () => {
+      const results = await Promise.all(
+        campaigns.map(async (campaign) => {
+          try {
+            const res = await fetch(`/api/campaigns/${campaign.id}/members/me`, { signal: controller.signal });
+            if (!res.ok) return [campaign.id, null] as const;
+            const member: CampaignMember = await res.json();
+            return [campaign.id, member] as const;
+          } catch {
+            return [campaign.id, null] as const;
+          }
+        })
+      );
+      if (!controller.signal.aborted) {
+        setMembershipsByCampaign(Object.fromEntries(results));
+      }
+    };
+    fetchMemberships();
     return () => controller.abort();
   }, [campaigns]);
 
@@ -229,6 +255,7 @@ export function CampaignsContent() {
               {activeCampaigns.map(campaign => {
                 const linkedParties = parties.filter(p => p.campaignId === campaign.id);
                 const lastSession = sessionsByCampaign[campaign.id];
+                const currentUserMember = membershipsByCampaign[campaign.id] ?? null;
 
                 return (
                   <div key={campaign.id} className="bg-gray-800 rounded-lg p-6">
@@ -380,6 +407,10 @@ export function CampaignsContent() {
                         })}
                       </div>
                     )}
+                    <SharedCharactersPanel
+                      campaignId={campaign.id}
+                      currentUserMember={currentUserMember}
+                    />
                   </div>
                 );
               })}

--- a/lib/components/SharedCharactersPanel.tsx
+++ b/lib/components/SharedCharactersPanel.tsx
@@ -41,19 +41,27 @@ export function SharedCharactersPanel({ campaignId, characters }: Props) {
   const handleToggle = async (character: Character) => {
     const id = character.id;
     const wasShared = sharedIds.has(id);
+    const prevIds = sharedIds;
+
     setToggling((prev) => new Set(prev).add(id));
+    const nextIds = new Set(sharedIds);
+    if (wasShared) { nextIds.delete(id); } else { nextIds.add(id); }
+    setSharedIds(nextIds);
+
     try {
       if (wasShared) {
         const res = await fetch(`/api/campaigns/${campaignId}/characters/${id}`, { method: 'DELETE' });
-        if (res.ok) setSharedIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+        if (!res.ok) throw new Error('delete failed');
       } else {
         const res = await fetch(`/api/campaigns/${campaignId}/characters`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ characterId: id }),
         });
-        if (res.ok) setSharedIds((prev) => { const next = new Set(prev); next.add(id); return next; });
+        if (!res.ok) throw new Error('share failed');
       }
+    } catch {
+      setSharedIds(prevIds);
     } finally {
       setToggling((prev) => { const next = new Set(prev); next.delete(id); return next; });
     }

--- a/lib/components/SharedCharactersPanel.tsx
+++ b/lib/components/SharedCharactersPanel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CampaignMember, Character, CampaignCharacterShare } from '@/lib/types';
+
+interface Props {
+  campaignId: string;
+  currentUserMember: CampaignMember | null | undefined;
+}
+
+export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) {
+  const [characters, setCharacters] = useState<Character[]>([]);
+  const [sharedIds, setSharedIds] = useState<Set<string>>(new Set());
+  const [toggling, setToggling] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState(true);
+
+  const isActivePlayer =
+    currentUserMember?.role === 'player' && currentUserMember?.status === 'active';
+
+  useEffect(() => {
+    if (!isActivePlayer) return;
+
+    const fetchData = async () => {
+      const [charRes, shareRes] = await Promise.all([
+        fetch('/api/characters'),
+        fetch(`/api/campaigns/${campaignId}/characters`),
+      ]);
+      if (charRes.ok) {
+        const chars: Character[] = await charRes.json();
+        setCharacters(chars);
+      }
+      if (shareRes.ok) {
+        const shares: CampaignCharacterShare[] = await shareRes.json();
+        setSharedIds(new Set(shares.map((s) => s.characterId)));
+      }
+    };
+
+    fetchData();
+  }, [campaignId, isActivePlayer]);
+
+  if (!isActivePlayer) return null;
+
+  const handleToggle = async (character: Character) => {
+    const id = character.id;
+    if (toggling.has(id)) return;
+
+    const wasShared = sharedIds.has(id);
+    setToggling((prev) => new Set(prev).add(id));
+    setSharedIds((prev) => {
+      const next = new Set(prev);
+      if (wasShared) { next.delete(id); } else { next.add(id); }
+      return next;
+    });
+
+    try {
+      if (wasShared) {
+        const res = await fetch(`/api/campaigns/${campaignId}/characters/${id}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error('delete failed');
+      } else {
+        const res = await fetch(`/api/campaigns/${campaignId}/characters`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ characterId: id }),
+        });
+        if (!res.ok) throw new Error('share failed');
+      }
+    } catch {
+      setSharedIds((prev) => {
+        const next = new Set(prev);
+        if (wasShared) { next.add(id); } else { next.delete(id); }
+        return next;
+      });
+    } finally {
+      setToggling((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div className="mt-4 bg-gray-700 rounded-lg p-4">
+      <button
+        onClick={() => setExpanded((e) => !e)}
+        className="flex items-center gap-2 w-full text-left font-semibold text-sm text-gray-200"
+        aria-expanded={expanded}
+      >
+        <span>{expanded ? '▾' : '▸'}</span>
+        <span>Shared Characters</span>
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-2">
+          {characters.length === 0 ? (
+            <p className="text-gray-400 text-sm">No characters to share.</p>
+          ) : (
+            characters.map((character) => {
+              const isShared = sharedIds.has(character.id);
+              return (
+                <label
+                  key={character.id}
+                  className="flex items-center gap-3 cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={character.name}
+                    checked={isShared}
+                    disabled={toggling.has(character.id)}
+                    onChange={() => handleToggle(character)}
+                    className="w-4 h-4"
+                  />
+                  <span className="text-sm text-gray-200">{character.name}</span>
+                </label>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/components/SharedCharactersPanel.tsx
+++ b/lib/components/SharedCharactersPanel.tsx
@@ -1,32 +1,29 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { CampaignMember, Character, CampaignCharacterShare } from '@/lib/types';
+import { Character, CampaignCharacterShare, CampaignMember } from '@/lib/types';
 
 interface Props {
   campaignId: string;
-  currentUserMember: CampaignMember | null | undefined;
+  characters: Character[];
 }
 
-export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) {
-  const [characters, setCharacters] = useState<Character[]>([]);
+export function SharedCharactersPanel({ campaignId, characters }: Props) {
+  const [member, setMember] = useState<CampaignMember | null>(null);
   const [sharedIds, setSharedIds] = useState<Set<string>>(new Set());
   const [toggling, setToggling] = useState<Set<string>>(new Set());
   const [expanded, setExpanded] = useState(true);
 
-  const isActivePlayer =
-    currentUserMember?.role === 'player' && currentUserMember?.status === 'active';
-
   useEffect(() => {
-    if (!isActivePlayer) return;
+    const controller = new AbortController();
 
     const fetchData = async () => {
-      const [charRes, shareRes] = await Promise.all([
-        fetch('/api/characters'),
-        fetch(`/api/campaigns/${campaignId}/characters`),
+      const [memberRes, shareRes] = await Promise.all([
+        fetch(`/api/campaigns/${campaignId}/members/me`, { signal: controller.signal }),
+        fetch(`/api/campaigns/${campaignId}/characters`, { signal: controller.signal }),
       ]);
-      if (charRes.ok) {
-        setCharacters(await charRes.json());
+      if (memberRes.ok) {
+        setMember(await memberRes.json());
       }
       if (shareRes.ok) {
         const shares: CampaignCharacterShare[] = await shareRes.json();
@@ -34,9 +31,11 @@ export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) 
       }
     };
 
-    fetchData();
-  }, [campaignId, isActivePlayer]);
+    fetchData().catch(() => {});
+    return () => controller.abort();
+  }, [campaignId]);
 
+  const isActivePlayer = member?.role === 'player' && member?.status === 'active';
   if (!isActivePlayer) return null;
 
   const handleToggle = async (character: Character) => {

--- a/lib/components/SharedCharactersPanel.tsx
+++ b/lib/components/SharedCharactersPanel.tsx
@@ -26,8 +26,7 @@ export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) 
         fetch(`/api/campaigns/${campaignId}/characters`),
       ]);
       if (charRes.ok) {
-        const chars: Character[] = await charRes.json();
-        setCharacters(chars);
+        setCharacters(await charRes.json());
       }
       if (shareRes.ok) {
         const shares: CampaignCharacterShare[] = await shareRes.json();
@@ -42,15 +41,14 @@ export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) 
 
   const handleToggle = async (character: Character) => {
     const id = character.id;
-    if (toggling.has(id)) return;
-
     const wasShared = sharedIds.has(id);
+    const prevIds = sharedIds;
+
     setToggling((prev) => new Set(prev).add(id));
-    setSharedIds((prev) => {
-      const next = new Set(prev);
-      if (wasShared) { next.delete(id); } else { next.add(id); }
-      return next;
-    });
+
+    const nextIds = new Set(sharedIds);
+    if (wasShared) { nextIds.delete(id); } else { nextIds.add(id); }
+    setSharedIds(nextIds);
 
     try {
       if (wasShared) {
@@ -65,11 +63,7 @@ export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) 
         if (!res.ok) throw new Error('share failed');
       }
     } catch {
-      setSharedIds((prev) => {
-        const next = new Set(prev);
-        if (wasShared) { next.add(id); } else { next.delete(id); }
-        return next;
-      });
+      setSharedIds(prevIds);
     } finally {
       setToggling((prev) => {
         const next = new Set(prev);
@@ -95,25 +89,22 @@ export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) 
           {characters.length === 0 ? (
             <p className="text-gray-400 text-sm">No characters to share.</p>
           ) : (
-            characters.map((character) => {
-              const isShared = sharedIds.has(character.id);
-              return (
-                <label
-                  key={character.id}
-                  className="flex items-center gap-3 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    aria-label={character.name}
-                    checked={isShared}
-                    disabled={toggling.has(character.id)}
-                    onChange={() => handleToggle(character)}
-                    className="w-4 h-4"
-                  />
-                  <span className="text-sm text-gray-200">{character.name}</span>
-                </label>
-              );
-            })
+            characters.map((character) => (
+              <label
+                key={character.id}
+                className="flex items-center gap-3 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  aria-label={character.name}
+                  checked={sharedIds.has(character.id)}
+                  disabled={toggling.has(character.id)}
+                  onChange={() => handleToggle(character)}
+                  className="w-4 h-4"
+                />
+                <span className="text-sm text-gray-200">{character.name}</span>
+              </label>
+            ))
           )}
         </div>
       )}

--- a/lib/components/SharedCharactersPanel.tsx
+++ b/lib/components/SharedCharactersPanel.tsx
@@ -42,34 +42,21 @@ export function SharedCharactersPanel({ campaignId, currentUserMember }: Props) 
   const handleToggle = async (character: Character) => {
     const id = character.id;
     const wasShared = sharedIds.has(id);
-    const prevIds = sharedIds;
-
     setToggling((prev) => new Set(prev).add(id));
-
-    const nextIds = new Set(sharedIds);
-    if (wasShared) { nextIds.delete(id); } else { nextIds.add(id); }
-    setSharedIds(nextIds);
-
     try {
       if (wasShared) {
         const res = await fetch(`/api/campaigns/${campaignId}/characters/${id}`, { method: 'DELETE' });
-        if (!res.ok) throw new Error('delete failed');
+        if (res.ok) setSharedIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
       } else {
         const res = await fetch(`/api/campaigns/${campaignId}/characters`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ characterId: id }),
         });
-        if (!res.ok) throw new Error('share failed');
+        if (res.ok) setSharedIds((prev) => { const next = new Set(prev); next.add(id); return next; });
       }
-    } catch {
-      setSharedIds(prevIds);
     } finally {
-      setToggling((prev) => {
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
+      setToggling((prev) => { const next = new Set(prev); next.delete(id); return next; });
     }
   };
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -80,6 +80,17 @@ async function initializeDatabase(db: Db): Promise<void> {
       }
     }
 
+    try {
+      await db
+        .collection("campaignCharacterShares")
+        .createIndex({ campaignId: 1, characterId: 1 }, { unique: true });
+      console.log("Created index on campaignCharacterShares.{campaignId, characterId}");
+    } catch (indexError) {
+      if (indexError instanceof Error && !indexError.message.includes("already exists")) {
+        console.warn("Warning creating campaignCharacterShares.{campaignId, characterId} index:", indexError.message);
+      }
+    }
+
     // Check if characters_active already exists as a view; only drop views,
     // never a real collection, to avoid accidental data loss during re-initialization.
     const existing = await db

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -91,6 +91,17 @@ async function initializeDatabase(db: Db): Promise<void> {
       }
     }
 
+    try {
+      await db
+        .collection("campaignCharacterShares")
+        .createIndex({ campaignId: 1, userId: 1 });
+      console.log("Created index on campaignCharacterShares.{campaignId, userId}");
+    } catch (indexError) {
+      if (indexError instanceof Error && !indexError.message.includes("already exists")) {
+        console.warn("Warning creating campaignCharacterShares.{campaignId, userId} index:", indexError.message);
+      }
+    }
+
     // Check if characters_active already exists as a view; only drop views,
     // never a real collection, to avoid accidental data loss during re-initialization.
     const existing = await db

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,7 +1,7 @@
 export class DuplicateShareError extends Error {
   constructor(campaignId: string, characterId: string) {
     super(`Character "${characterId}" is already shared into campaign "${campaignId}".`);
-    this.name = 'DuplicateShareError';
+    this.name = "DuplicateShareError";
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, DuplicateShareError);
     }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,3 +1,13 @@
+export class DuplicateShareError extends Error {
+  constructor(campaignId: string, characterId: string) {
+    super(`Character "${characterId}" is already shared into campaign "${campaignId}".`);
+    this.name = 'DuplicateShareError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DuplicateShareError);
+    }
+  }
+}
+
 export class DuplicateMemberError extends Error {
   constructor(campaignId: string, userId: string) {
     super(`User "${userId}" is already a member of campaign "${campaignId}".`);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1050,10 +1050,17 @@ export const storage = {
   async loadCharacterById(id: string): Promise<Character | null> {
     try {
       const db = await getDatabase();
-      const character = await db
-        .collection<Character>("characters")
-        .findOne({ id, deletedAt: null as unknown as Date });
-      return character ? normalizeStoredEntityId(character) : null;
+      try {
+        const character = await db
+          .collection<Character>("characters_active")
+          .findOne({ id });
+        return character ? normalizeStoredEntityId(character) : null;
+      } catch {
+        const character = await db
+          .collection<Character>("characters")
+          .findOne({ id, deletedAt: null as unknown as Date });
+        return character ? normalizeStoredEntityId(character) : null;
+      }
     } catch (error) {
       console.error("Error loading character by ID:", error);
       throw error;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1050,17 +1050,10 @@ export const storage = {
   async loadCharacterById(id: string): Promise<Character | null> {
     try {
       const db = await getDatabase();
-      try {
-        const character = await db
-          .collection<Character>("characters_active")
-          .findOne({ id });
-        return character ? normalizeStoredEntityId(character) : null;
-      } catch {
-        const character = await db
-          .collection<Character>("characters")
-          .findOne({ id, deletedAt: null as unknown as Date });
-        return character ? normalizeStoredEntityId(character) : null;
-      }
+      const character = await db
+        .collection<Character>("characters")
+        .findOne({ id, deletedAt: null as unknown as Date });
+      return character ? normalizeStoredEntityId(character) : null;
     } catch (error) {
       console.error("Error loading character by ID:", error);
       throw error;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -16,12 +16,13 @@ import {
   SavedContent,
   CampaignMember,
   CampaignMemberSummary,
+  CampaignCharacterShare,
   MemberRole,
   MemberStatus,
   MemberHistoryEntry,
   PublicUser,
 } from "./types";
-import { DuplicateMemberError } from "./errors";
+import { DuplicateMemberError, DuplicateShareError } from "./errors";
 import { GLOBAL_USER_ID } from "./constants";
 import { InvalidUserIdError } from "./permissions";
 import { ObjectId, Filter, Document } from "mongodb";
@@ -999,6 +1000,73 @@ export const storage = {
     return docs as Pick<Campaign, "id" | "name">[];
   },
 
+  async addShare(share: CampaignCharacterShare): Promise<void> {
+    try {
+      const db = await getDatabase();
+      const { _id, ...insertData } = share;
+      await db
+        .collection<CampaignCharacterShare>("campaignCharacterShares")
+        .insertOne(insertData as CampaignCharacterShare);
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === 11000) {
+        throw new DuplicateShareError(share.campaignId, share.characterId);
+      }
+      console.error("Error adding campaign character share:", error);
+      throw error;
+    }
+  },
+
+  async removeShare(campaignId: string, characterId: string, userId: string): Promise<boolean> {
+    try {
+      const db = await getDatabase();
+      const result = await db
+        .collection<CampaignCharacterShare>("campaignCharacterShares")
+        .deleteOne({ campaignId, characterId, userId });
+      return result.deletedCount > 0;
+    } catch (error) {
+      console.error("Error removing campaign character share:", error);
+      throw error;
+    }
+  },
+
+  async listSharesForCampaign(campaignId: string, userId: string): Promise<CampaignCharacterShare[]> {
+    try {
+      const db = await getDatabase();
+      const shares = await db
+        .collection<CampaignCharacterShare>("campaignCharacterShares")
+        .find({ campaignId, userId })
+        .toArray();
+      return shares.map((s) => {
+        const normalized = normalizeStoredEntityId(s);
+        const { _id, ...rest } = normalized;
+        return rest as CampaignCharacterShare;
+      });
+    } catch (error) {
+      console.error("Error listing campaign character shares:", error);
+      return [];
+    }
+  },
+
+  async loadCharacterById(id: string): Promise<Character | null> {
+    try {
+      const db = await getDatabase();
+      try {
+        const character = await db
+          .collection<Character>("characters_active")
+          .findOne({ id });
+        return character ? normalizeStoredEntityId(character) : null;
+      } catch {
+        const character = await db
+          .collection<Character>("characters")
+          .findOne({ id, deletedAt: null as unknown as Date });
+        return character ? normalizeStoredEntityId(character) : null;
+      }
+    } catch (error) {
+      console.error("Error loading character by ID:", error);
+      throw error;
+    }
+  },
+
   // Clear all data for a user
   async clear(userId: string): Promise<void> {
     try {
@@ -1010,6 +1078,7 @@ export const storage = {
         db.collection<CombatState>("combatStates").deleteMany({ userId }),
         db.collection<SavedContent>("savedContent").deleteMany({ userId }),
         db.collection("campaignMembers").deleteMany({ userId }),
+        db.collection("campaignCharacterShares").deleteMany({ userId }),
       ]);
     } catch (error) {
       console.error("Error clearing data:", error);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -744,3 +744,12 @@ export interface CampaignMemberSummary {
   name: string;
 }
 
+export interface CampaignCharacterShare {
+  _id?: string;
+  id: string;
+  campaignId: string;
+  characterId: string;
+  userId: string;
+  sharedAt: Date;
+}
+

--- a/openspec/changes/campaign-character-sharing/.openspec.yaml
+++ b/openspec/changes/campaign-character-sharing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-06

--- a/openspec/changes/campaign-character-sharing/design.md
+++ b/openspec/changes/campaign-character-sharing/design.md
@@ -47,7 +47,7 @@
 
 - **Chosen:**
   - `addShare(share: CampaignCharacterShare): Promise<void>` — throws `DuplicateShareError` on code 11000
-  - `removeShare(campaignId: string, characterId: string): Promise<boolean>` — returns false if no record found (mirrors `savedContent.remove`)
+  - `removeShare(campaignId: string, characterId: string, userId: string): Promise<boolean>` — deletes by `{campaignId, characterId, userId}` for defense-in-depth; returns false if no record found
   - `listSharesForCampaign(campaignId: string, userId: string): Promise<CampaignCharacterShare[]>` — filtered by both campaignId and userId (caller's shares only)
 - **Alternatives considered:** `listSharesForCampaign(campaignId)` without userId filter (would require route-layer filtering).
 - **Rationale:** Storage-layer filtering is more efficient and prevents accidental leakage. The `userId` param is explicit and auditable.
@@ -72,7 +72,7 @@
 
 ### Decision 7: `initializeDatabase` registers the new collection
 
-- **Chosen:** Add `campaignCharacterShares` unique index creation to `initializeDatabase()` in `lib/storage.ts`, following the `campaignMembers` pattern.
+- **Chosen:** Add `campaignCharacterShares` unique index creation to `initializeDatabase()` in `lib/db.ts`, following the `campaignMembers` pattern. Also adds a non-unique `{campaignId, userId}` index for efficient `listSharesForCampaign` queries.
 - **Rationale:** Consistent with how all collections are initialized in this project.
 - **Trade-offs:** None.
 

--- a/openspec/changes/campaign-character-sharing/design.md
+++ b/openspec/changes/campaign-character-sharing/design.md
@@ -1,0 +1,174 @@
+## Context
+
+- **Relevant architecture:** Next.js App Router API routes; MongoDB via `lib/storage.ts`; `withAuthAndParams` middleware for authenticated route handlers; `lib/errors.ts` for typed domain errors; `lib/types.ts` for shared types.
+- **Dependencies:** Phase 1 (1e) fully merged — `campaignMembers` collection, `getMember`, `addMember`, `updateMemberStatus`, `listMembersForCampaign`, and `DuplicateMemberError` all exist. Character ownership check follows the pattern in `app/api/characters/[id]/route.ts` (DELETE handler).
+- **Interfaces/contracts touched:** `lib/types.ts`, `lib/errors.ts`, `lib/storage.ts`, new API routes under `app/api/campaigns/[id]/characters/`, campaign view UI component.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add `CampaignCharacterShare` data type and `campaignCharacterShares` collection with uniqueness enforced by MongoDB index.
+- Add `DuplicateShareError` following the exact pattern of `DuplicateMemberError`.
+- Add `addShare`, `removeShare`, `listSharesForCampaign` to `storage` following the existing member method patterns.
+- Expose share/unshare/list via three REST endpoints under `/api/campaigns/[id]/characters/`.
+- Render a share-management panel on the campaign view for players (hidden from DMs).
+
+### Non-Goals
+
+- Party builder integration (3b).
+- Cleanup of party entries when a share is removed (3b).
+- DM-side visibility of shared characters (3b).
+
+## Decisions
+
+### Decision 1: `CampaignCharacterShare` type shape
+
+- **Chosen:** `{ id: string; campaignId: string; characterId: string; userId: string; sharedAt: Date }`
+- **Alternatives considered:** Omitting `userId` (derivable via character lookup), omitting `sharedAt` (no audit trail).
+- **Rationale:** `userId` is stored denormalized for efficient `listSharesForCampaign(campaignId, userId)` queries without a join. `sharedAt` provides a lightweight audit trail and orders the list naturally. Mirrors `CampaignMember` field conventions.
+- **Trade-offs:** Minor denormalization; acceptable since character ownership is immutable.
+
+### Decision 2: Unique index on `{campaignId, characterId}` only
+
+- **Chosen:** Unique compound index `{ campaignId: 1, characterId: 1 }`.
+- **Alternatives considered:** Including `userId` in the index (would allow the same character under different users — impossible since ownership is immutable).
+- **Rationale:** A character can appear in a campaign at most once. Since there is no ownership transfer, `userId` is redundant in the uniqueness constraint. Keeps the index semantically clean.
+- **Trade-offs:** None. Simpler index, enforces the invariant correctly.
+
+### Decision 3: `DuplicateShareError` in `lib/errors.ts`
+
+- **Chosen:** Add `DuplicateShareError extends Error` to `lib/errors.ts`, following the exact `DuplicateMemberError` pattern (name, message, `captureStackTrace`).
+- **Alternatives considered:** Reusing a generic error or raw 409 in the route handler.
+- **Rationale:** Typed errors decouple storage from HTTP semantics; consistent with existing pattern.
+- **Trade-offs:** None.
+
+### Decision 4: Storage method signatures
+
+- **Chosen:**
+  - `addShare(share: CampaignCharacterShare): Promise<void>` — throws `DuplicateShareError` on code 11000
+  - `removeShare(campaignId: string, characterId: string): Promise<boolean>` — returns false if no record found (mirrors `savedContent.remove`)
+  - `listSharesForCampaign(campaignId: string, userId: string): Promise<CampaignCharacterShare[]>` — filtered by both campaignId and userId (caller's shares only)
+- **Alternatives considered:** `listSharesForCampaign(campaignId)` without userId filter (would require route-layer filtering).
+- **Rationale:** Storage-layer filtering is more efficient and prevents accidental leakage. The `userId` param is explicit and auditable.
+- **Trade-offs:** The GET route always passes `auth.userId`; there is no admin/DM "list all shares" method in 3a (added in 3b if needed).
+
+### Decision 5: Route layout follows `/members` pattern
+
+- **Chosen:**
+  - `POST   /api/campaigns/[id]/characters`        — `app/api/campaigns/[id]/characters/route.ts`
+  - `GET    /api/campaigns/[id]/characters`        — same file
+  - `DELETE /api/campaigns/[id]/characters/[cid]`  — `app/api/campaigns/[id]/characters/[cid]/route.ts`
+- **Alternatives considered:** Routes under `/members/me/characters` (more REST-precise but adds nesting depth); character-centric routes `/api/characters/[cid]/campaigns/[id]` (unusual traversal direction for this app).
+- **Rationale:** Mirrors the existing `members/` and `members/me/` file structure. Consistent with how the codebase organizes campaign-scoped resources.
+- **Trade-offs:** The `[cid]` segment is a `characterId`, not a share `id`. This is intentional — the unique `{campaignId, characterId}` constraint means `characterId` is a sufficient natural key for DELETE.
+
+### Decision 6: Player-only UI panel on campaign view
+
+- **Chosen:** Add a "Shared Characters" collapsible panel to the campaign view, rendered only when `currentUserMember?.role === 'player' && currentUserMember?.status === 'active'`. Lists the player's own characters with a per-character share toggle.
+- **Alternatives considered:** Separate page/modal; character-page integration.
+- **Rationale:** Campaign context is primary for the player deciding what to share. Collapsible keeps the DM view uncluttered without conditional rendering logic in the layout.
+- **Trade-offs:** Requires fetching the player's characters and their existing shares on the campaign page. Two additional API calls on page load for players.
+
+### Decision 7: `initializeDatabase` registers the new collection
+
+- **Chosen:** Add `campaignCharacterShares` unique index creation to `initializeDatabase()` in `lib/storage.ts`, following the `campaignMembers` pattern.
+- **Rationale:** Consistent with how all collections are initialized in this project.
+- **Trade-offs:** None.
+
+## Proposal to Design Mapping
+
+- Proposal: `CampaignCharacterShare` type → Decision 1 (type shape)
+- Proposal: Unique `{campaignId, characterId}` index → Decision 2 (index)
+- Proposal: `DuplicateShareError` → Decision 3 (error class)
+- Proposal: Storage methods → Decision 4 (signatures)
+- Proposal: API routes (Option A) → Decision 5 (route layout)
+- Proposal: Player UI on campaign view → Decision 6 (UI panel)
+- Proposal: `initializeDatabase` registration → Decision 7
+
+## Functional Requirements Mapping
+
+- **Requirement:** Player can share their own character into a campaign they're an active member of
+  - **Design element:** POST handler verifies `getMember` returns active player + character `userId === auth.userId`
+  - **Acceptance criteria reference:** specs/campaign-character-shares.md — share accepted scenario
+  - **Testability notes:** Unit test with mocked storage; integration test with real MongoDB
+
+- **Requirement:** Player cannot share a character they don't own
+  - **Design element:** POST handler loads character, checks `character.userId === auth.userId`, returns 403 if not
+  - **Acceptance criteria reference:** specs — unowned character rejected scenario
+  - **Testability notes:** Unit test with mocked storage returning character owned by different userId
+
+- **Requirement:** Player cannot share into a campaign where they are not an active member
+  - **Design element:** POST/DELETE handler calls `getMember`, checks `status === 'active'`
+  - **Acceptance criteria reference:** specs — non-member / non-active member rejected scenario
+  - **Testability notes:** Unit test with getMember returning null, invited, declined, removed
+
+- **Requirement:** Duplicate share rejected
+  - **Design element:** `addShare` catches code 11000, throws `DuplicateShareError`; route returns 409
+  - **Acceptance criteria reference:** specs — duplicate share scenario
+  - **Testability notes:** Unit test; integration test with real MongoDB index
+
+- **Requirement:** Player can list only their own shares for a campaign
+  - **Design element:** `listSharesForCampaign(campaignId, auth.userId)` filters at storage layer
+  - **Acceptance criteria reference:** specs — list shares scenario
+  - **Testability notes:** Unit test confirming userId filter applied; integration test
+
+- **Requirement:** Player can unshare a character they previously shared
+  - **Design element:** DELETE handler verifies ownership then calls `removeShare(campaignId, characterId)`
+  - **Acceptance criteria reference:** specs — unshare scenario
+  - **Testability notes:** Unit test; verify 204 on success, 404 if not found, 403 if unowned
+
+## Non-Functional Requirements Mapping
+
+- **Requirement category:** Security
+  - **Requirement:** A player cannot unshare another player's character
+  - **Design element:** DELETE handler loads character, checks `character.userId === auth.userId` before `removeShare`
+  - **Acceptance criteria reference:** specs — unshare unowned character rejected
+  - **Testability notes:** Unit test with character owned by different user
+
+- **Requirement category:** Security
+  - **Requirement:** GET returns only the caller's shares, never other players'
+  - **Design element:** `listSharesForCampaign` receives `auth.userId` as required parameter
+  - **Acceptance criteria reference:** specs — list isolation scenario
+  - **Testability notes:** Integration test with two players sharing into same campaign; verify each sees only their own
+
+- **Requirement category:** Reliability
+  - **Requirement:** No phantom shares (share record for non-existent character)
+  - **Design element:** POST handler loads character from storage before calling `addShare`; returns 404 if not found
+  - **Testability notes:** Unit test with storage returning null for character
+
+- **Requirement category:** Performance
+  - **Requirement:** No N+1 queries on the share list
+  - **Design element:** `listSharesForCampaign` issues a single `find` with compound filter
+  - **Testability notes:** Code review; integration test count
+
+## Risks / Trade-offs
+
+- **Risk/trade-off:** Stale share records when a character is soft-deleted
+  - **Impact:** `listSharesForCampaign` may return shares for inactive characters; minor UI noise
+  - **Mitigation:** Deferred to 3b. Acceptable for 3a since the party builder (3b) will add reactive filtering.
+
+- **Risk/trade-off:** Two additional API calls on campaign page load for players
+  - **Impact:** Slight increase in page load time
+  - **Mitigation:** Both calls are cheap (indexed queries). Acceptable.
+
+## Rollback / Mitigation
+
+- **Rollback trigger:** P0 bug in share/unshare routes affecting production campaign data.
+- **Rollback steps:**
+  1. Revert the PR.
+  2. Drop the `campaignCharacterShares` collection (data is ephemeral — no shares existed before this feature).
+  3. Redeploy.
+- **Data migration considerations:** None. The collection is new; rollback simply drops it.
+- **Verification after rollback:** Confirm campaigns page loads without error for all member roles; confirm no 500s in logs.
+
+## Operational Blocking Policy
+
+- **If CI checks fail:** Do not merge. Fix the failing check. No `--no-verify` bypasses.
+- **If security checks fail:** Do not merge. Treat as a blocker regardless of perceived severity.
+- **If required reviews are blocked/stale:** Ping reviewer after 24h. Escalate to maintainer after 48h.
+- **Escalation path and timeout:** After 72h without resolution, open a discussion issue linking the blocked PR.
+
+## Open Questions
+
+No open questions. All design decisions were resolved before artifact creation.

--- a/openspec/changes/campaign-character-sharing/proposal.md
+++ b/openspec/changes/campaign-character-sharing/proposal.md
@@ -1,0 +1,94 @@
+## GitHub Issues
+
+- #309
+- #295 (parent epic)
+
+## Why
+
+- **Problem statement:** Players in a multi-user campaign have no way to make their own characters available to the DM for party building. The DM can only add characters they personally own to a party.
+- **Why now:** Phase 1 (campaign members collection, issue 1e) is complete. The `campaignMembers` collection and active-member concept are in place, giving us the guard condition (active membership) that character sharing requires.
+- **Business/user impact:** Without character sharing, multiplayer campaigns are blocked — the DM cannot build parties that include player characters.
+
+## Problem Space
+
+- **Current behavior:** A DM can only add characters they own to a party. No mechanism exists for a player to contribute their characters to a campaign.
+- **Desired behavior:** A player who is an active member of a campaign can opt specific characters in or out of that campaign. Shared characters become available to the DM for party building (handled in 3b).
+- **Constraints:**
+  - Character ownership is immutable — there is no transfer mechanism. A `CampaignCharacterShare` record always belongs to the character's owner.
+  - The unique index on `{campaignId, characterId}` enforces that a character can appear in a campaign at most once, regardless of who shared it.
+  - Only active members may share; invited/declined/removed members cannot.
+- **Assumptions:**
+  - `1e` is fully merged: `campaignMembers` collection, `getMember`, `addMember`, `updateMemberStatus`, `listMembersForCampaign` are all available in `storage`.
+  - Characters are soft-deleted via `characters_active` — the share API does not need to validate liveness (that is a 3b concern for the party builder).
+- **Edge cases considered:**
+  - Player tries to share a character they don't own → 403.
+  - Player tries to share into a campaign where they are not an active member → 403.
+  - Player shares the same character twice → 409 (duplicate).
+  - Player unshares a character that was already added to a party by the DM → cleanup is out of scope for 3a; handled reactively in 3b.
+
+## Scope
+
+### In Scope
+
+- `CampaignCharacterShare` type in `lib/types.ts`
+- `campaignCharacterShares` MongoDB collection with unique index on `{campaignId, characterId}`
+- `DuplicateShareError` in `lib/errors.ts`
+- Storage methods: `addShare`, `removeShare`, `listSharesForCampaign`
+- API routes under `app/api/campaigns/[id]/characters/`:
+  - `POST /api/campaigns/[id]/characters` — share a character
+  - `GET /api/campaigns/[id]/characters` — list caller's shares in this campaign
+  - `DELETE /api/campaigns/[id]/characters/[cid]` — unshare a character
+- Player UI on the campaign view: a panel showing the player's own characters with share toggles (visible only to players, not DMs)
+- Unit tests (RTL for UI, Jest for routes and storage methods)
+
+### Out of Scope
+
+- Party builder changes (3b)
+- Cleanup of party entries on unshare (3b)
+- DM visibility of shared characters (3b)
+- Character ownership transfer
+- Sharing characters across multiple campaigns in a single action
+
+## What Changes
+
+- `lib/types.ts` — add `CampaignCharacterShare` interface
+- `lib/errors.ts` — add `DuplicateShareError`
+- `lib/storage.ts` — add `addShare`, `removeShare`, `listSharesForCampaign` to the storage interface and MongoDB implementation; register `campaignCharacterShares` collection in `initializeDatabase()`
+- `app/api/campaigns/[id]/characters/route.ts` — POST and GET handlers
+- `app/api/campaigns/[id]/characters/[cid]/route.ts` — DELETE handler
+- `app/campaigns/` UI — add character-sharing panel to campaign view (player-only)
+- Tests for all of the above
+
+## Risks
+
+- **Risk:** `listSharesForCampaign` leaks shares from other users if the GET route does not filter by `auth.userId`
+  - **Impact:** Player A sees Player B's shared characters
+  - **Mitigation:** GET filters by `{ campaignId, userId: auth.userId }` — list endpoint returns only the caller's own shares
+
+- **Risk:** DELETE route could allow a player to unshare another player's character by guessing the `characterId`
+  - **Impact:** Denial of service against another player's campaign participation
+  - **Mitigation:** DELETE handler verifies `character.userId === auth.userId` before calling `removeShare`
+
+- **Risk:** Share record persists after the character is deleted (soft or hard)
+  - **Impact:** Stale share in `listSharesForCampaign`; minor UI noise in 3a, more significant in 3b
+  - **Mitigation:** Out of scope for 3a; 3b adds reactive filtering. Acceptable for now.
+
+## Open Questions
+
+No unresolved ambiguity remains. All design questions were resolved during exploration:
+- Route shape: Option A (`/api/campaigns/[id]/characters`) — confirmed
+- Uniqueness constraint: `{campaignId, characterId}` (no ownership transfer) — confirmed
+- UI placement: campaign view — confirmed
+- Unshare mechanism: `DELETE /api/campaigns/[id]/characters/[cid]` by characterId — confirmed
+
+## Non-Goals
+
+- Notifying the DM when a player shares a character
+- Bulk share/unshare operations
+- Share expiry or time-limited sharing
+- Sharing characters into campaigns the player is not a member of
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/campaign-character-sharing/specs/campaign-character-shares.md
+++ b/openspec/changes/campaign-character-sharing/specs/campaign-character-shares.md
@@ -70,18 +70,18 @@ The system SHALL provide `addShare(share: CampaignCharacterShare): Promise<void>
 
 ### Requirement: ADDED `storage.removeShare`
 
-The system SHALL provide `removeShare(campaignId: string, characterId: string): Promise<boolean>` that deletes the share record matching `{campaignId, characterId}`. Returns `true` if a record was deleted, `false` if no record was found.
+The system SHALL provide `removeShare(campaignId: string, characterId: string, userId: string): Promise<boolean>` that deletes the share record matching `{campaignId, characterId, userId}` (scoped by owner for defense-in-depth). Returns `true` if a record was deleted, `false` if no record was found.
 
 #### Scenario: Successful removal
 
-- **Given** character X is shared into campaign C
-- **When** `removeShare(C, X)` is called
-- **Then** the record is deleted and `listSharesForCampaign(C, userId)` no longer includes it; return value is `true`
+- **Given** character X is shared into campaign C by user U
+- **When** `removeShare(C, X, U)` is called
+- **Then** the record is deleted and `listSharesForCampaign(C, U)` no longer includes it; return value is `true`
 
 #### Scenario: Remove non-existent share returns false
 
 - **Given** character X is not shared into campaign C
-- **When** `removeShare(C, X)` is called
+- **When** `removeShare(C, X, U)` is called
 - **Then** no error is thrown and the return value is `false`
 
 ---

--- a/openspec/changes/campaign-character-sharing/specs/campaign-character-shares.md
+++ b/openspec/changes/campaign-character-sharing/specs/campaign-character-shares.md
@@ -1,0 +1,306 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `CampaignCharacterShare` type
+
+The system SHALL define a `CampaignCharacterShare` interface with fields `id`, `campaignId`, `characterId`, `userId`, and `sharedAt`.
+
+#### Scenario: Type shape is correct
+
+- **Given** the `CampaignCharacterShare` interface in `lib/types.ts`
+- **When** a value is typed as `CampaignCharacterShare`
+- **Then** it must have `id: string`, `campaignId: string`, `characterId: string`, `userId: string`, `sharedAt: Date`; any other shape is a TypeScript type error
+
+---
+
+### Requirement: ADDED `campaignCharacterShares` unique compound index
+
+The system SHALL create a unique index on `{ campaignId: 1, characterId: 1 }` in the `campaignCharacterShares` MongoDB collection during `initializeDatabase()`.
+
+#### Scenario: Index enforces uniqueness
+
+- **Given** a `campaignCharacterShares` record exists for `(campaignId=C, characterId=X)`
+- **When** a second insert is attempted with the same `(campaignId=C, characterId=X)` by any user
+- **Then** MongoDB rejects the insert with a duplicate key error (code 11000)
+
+#### Scenario: Index allows same character in different campaigns
+
+- **Given** a share record for `(campaignId=C1, characterId=X)`
+- **When** a record is inserted for `(campaignId=C2, characterId=X)`
+- **Then** the insert succeeds
+
+#### Scenario: Index allows different characters in the same campaign
+
+- **Given** a share record for `(campaignId=C, characterId=X)`
+- **When** a record is inserted for `(campaignId=C, characterId=Y)`
+- **Then** the insert succeeds
+
+---
+
+### Requirement: ADDED `DuplicateShareError`
+
+The system SHALL throw a `DuplicateShareError` (extending `Error`, `name = 'DuplicateShareError'`) when `addShare` is called with a `{campaignId, characterId}` pair that already exists. The error message SHALL include both `campaignId` and `characterId`.
+
+#### Scenario: Typed error on duplicate
+
+- **Given** character X is already shared into campaign C
+- **When** `storage.addShare({ campaignId: C, characterId: X, ... })` is called
+- **Then** a `DuplicateShareError` is thrown (not a raw MongoError)
+
+---
+
+### Requirement: ADDED `storage.addShare`
+
+The system SHALL provide `addShare(share: CampaignCharacterShare): Promise<void>` that inserts a new share record into `campaignCharacterShares`.
+
+#### Scenario: Successful share
+
+- **Given** character X is not yet shared into campaign C
+- **When** `addShare` is called with a valid `CampaignCharacterShare`
+- **Then** the record is persisted and `listSharesForCampaign(C, userId)` includes it
+
+#### Scenario: Duplicate rejected
+
+- **Given** character X is already shared into campaign C
+- **When** `addShare` is called with the same `{campaignId, characterId}`
+- **Then** `DuplicateShareError` is thrown
+
+---
+
+### Requirement: ADDED `storage.removeShare`
+
+The system SHALL provide `removeShare(campaignId: string, characterId: string): Promise<boolean>` that deletes the share record matching `{campaignId, characterId}`. Returns `true` if a record was deleted, `false` if no record was found.
+
+#### Scenario: Successful removal
+
+- **Given** character X is shared into campaign C
+- **When** `removeShare(C, X)` is called
+- **Then** the record is deleted and `listSharesForCampaign(C, userId)` no longer includes it; return value is `true`
+
+#### Scenario: Remove non-existent share returns false
+
+- **Given** character X is not shared into campaign C
+- **When** `removeShare(C, X)` is called
+- **Then** no error is thrown and the return value is `false`
+
+---
+
+### Requirement: ADDED `storage.listSharesForCampaign`
+
+The system SHALL provide `listSharesForCampaign(campaignId: string, userId: string): Promise<CampaignCharacterShare[]>` that returns only the share records matching both `campaignId` and `userId`.
+
+#### Scenario: Returns caller's shares only
+
+- **Given** campaign C has shares from player P1 (characters X, Y) and player P2 (character Z)
+- **When** `listSharesForCampaign(C, P1)` is called
+- **Then** returns exactly the two records for P1; the record for P2 is not included
+
+#### Scenario: Returns empty array for campaign with no shares by this user
+
+- **Given** campaign C exists but user U has no shares in it
+- **When** `listSharesForCampaign(C, U)` is called
+- **Then** an empty array is returned
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/[id]/characters` — share a character
+
+The system SHALL allow an authenticated active player-member to share one of their own characters into a campaign by `POST`ing `{ characterId }` to `/api/campaigns/[id]/characters`.
+
+#### Scenario: Successful share
+
+- **Given** user U is an active player-member of campaign C and owns character X
+- **When** `POST /api/campaigns/C/characters` with body `{ characterId: X }` is called
+- **Then** response is `201` with `{ id: <shareId>, characterId: X }` and `listSharesForCampaign(C, U)` includes the new record
+
+#### Scenario: Non-member rejected
+
+- **Given** user U is not a member of campaign C
+- **When** `POST /api/campaigns/C/characters` with body `{ characterId: X }` is called
+- **Then** response is `403 Forbidden`
+
+#### Scenario: Non-active member rejected
+
+- **Given** user U is an `invited` or `declined` or `removed` member of campaign C
+- **When** `POST /api/campaigns/C/characters` with any `characterId` is called
+- **Then** response is `403 Forbidden`
+
+#### Scenario: DM cannot share via this endpoint
+
+- **Given** user U is an active `dm` member of campaign C and owns character X
+- **When** `POST /api/campaigns/C/characters` with body `{ characterId: X }` is called
+- **Then** response is `403 Forbidden` (endpoint is player-only)
+
+#### Scenario: Unowned character rejected
+
+- **Given** user U is an active player-member of campaign C; character X exists but is owned by user V
+- **When** `POST /api/campaigns/C/characters` with body `{ characterId: X }` is called
+- **Then** response is `403 Forbidden`
+
+#### Scenario: Character not found
+
+- **Given** user U is an active player-member of campaign C; character Z does not exist
+- **When** `POST /api/campaigns/C/characters` with body `{ characterId: Z }` is called
+- **Then** response is `404 Not Found`
+
+#### Scenario: Duplicate share rejected
+
+- **Given** character X is already shared into campaign C by user U
+- **When** `POST /api/campaigns/C/characters` with body `{ characterId: X }` is called again
+- **Then** response is `409 Conflict`
+
+#### Scenario: Missing characterId rejected
+
+- **Given** user U is an active player-member of campaign C
+- **When** `POST /api/campaigns/C/characters` with body `{}` or missing `characterId` is called
+- **Then** response is `400 Bad Request`
+
+---
+
+### Requirement: ADDED `GET /api/campaigns/[id]/characters` — list caller's shares
+
+The system SHALL allow an authenticated active member to list the characters they have shared into a campaign by `GET /api/campaigns/[id]/characters`.
+
+#### Scenario: Player retrieves their shares
+
+- **Given** user U (active player) has shared characters X and Y into campaign C
+- **When** `GET /api/campaigns/C/characters` is called by U
+- **Then** response is `200` with an array containing exactly the two share records for U; no other player's shares appear
+
+#### Scenario: Non-member cannot list
+
+- **Given** user U is not a member of campaign C
+- **When** `GET /api/campaigns/C/characters` is called by U
+- **Then** response is `403 Forbidden`
+
+#### Scenario: Empty list for player with no shares
+
+- **Given** user U is an active player-member of campaign C but has not shared any characters
+- **When** `GET /api/campaigns/C/characters` is called by U
+- **Then** response is `200` with an empty array
+
+---
+
+### Requirement: ADDED `DELETE /api/campaigns/[id]/characters/[cid]` — unshare a character
+
+The system SHALL allow an authenticated active player-member to remove their own character share from a campaign.
+
+#### Scenario: Successful unshare
+
+- **Given** user U (active player) has shared character X into campaign C
+- **When** `DELETE /api/campaigns/C/characters/X` is called by U
+- **Then** response is `204 No Content` and `listSharesForCampaign(C, U)` no longer includes character X
+
+#### Scenario: Unshare non-existent share returns 404
+
+- **Given** character X is not currently shared into campaign C
+- **When** `DELETE /api/campaigns/C/characters/X` is called
+- **Then** response is `404 Not Found`
+
+#### Scenario: Cannot unshare another player's character
+
+- **Given** character X is shared into campaign C by player P2; user U (different player) attempts deletion
+- **When** `DELETE /api/campaigns/C/characters/X` is called by U
+- **Then** response is `403 Forbidden`
+
+#### Scenario: Non-member cannot unshare
+
+- **Given** user U is not a member of campaign C
+- **When** `DELETE /api/campaigns/C/characters/X` is called by U
+- **Then** response is `403 Forbidden`
+
+---
+
+### Requirement: ADDED Player character-sharing UI on campaign view
+
+The system SHALL render a "Shared Characters" panel on the campaign view, visible only to the authenticated user when they are an active player-member of that campaign. The panel SHALL list the player's own characters with a toggle (share/unshare) per character.
+
+#### Scenario: Panel is visible to active player
+
+- **Given** user U is an active player-member of campaign C
+- **When** U views the campaign page
+- **Then** a "Shared Characters" section is visible showing U's characters with share toggles
+
+#### Scenario: Panel is hidden from DM
+
+- **Given** user U is the DM of campaign C
+- **When** U views the campaign page
+- **Then** no "Shared Characters" section is rendered
+
+#### Scenario: Panel is hidden from non-members
+
+- **Given** user U is not a member of campaign C
+- **When** U views the campaign page (if accessible)
+- **Then** no "Shared Characters" section is rendered
+
+#### Scenario: Toggle shares a character
+
+- **Given** character X is not yet shared; the player clicks the toggle for X
+- **When** the toggle action completes
+- **Then** character X shows as shared in the panel; a POST to `/api/campaigns/C/characters` was made
+
+#### Scenario: Toggle unshares a character
+
+- **Given** character X is shared; the player clicks the toggle for X
+- **When** the toggle action completes
+- **Then** character X shows as unshared; a DELETE to `/api/campaigns/C/characters/X` was made
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal: `CampaignCharacterShare` type → Requirement: ADDED `CampaignCharacterShare` type
+- Proposal: Unique `{campaignId, characterId}` index → Requirement: ADDED `campaignCharacterShares` unique compound index
+- Proposal: `DuplicateShareError` → Requirement: ADDED `DuplicateShareError`
+- Proposal: `addShare` storage method → Requirement: ADDED `storage.addShare`
+- Proposal: `removeShare` storage method → Requirement: ADDED `storage.removeShare`
+- Proposal: `listSharesForCampaign` storage method → Requirement: ADDED `storage.listSharesForCampaign`
+- Proposal: POST route → Requirement: ADDED `POST /api/campaigns/[id]/characters`
+- Proposal: GET route → Requirement: ADDED `GET /api/campaigns/[id]/characters`
+- Proposal: DELETE route → Requirement: ADDED `DELETE /api/campaigns/[id]/characters/[cid]`
+- Proposal: Player UI on campaign view → Requirement: ADDED Player character-sharing UI
+- Design Decision 1 (type shape) → `CampaignCharacterShare` type requirement
+- Design Decision 2 (index) → `campaignCharacterShares` index requirement
+- Design Decision 3 (error class) → `DuplicateShareError` requirement
+- Design Decision 4 (storage signatures) → `addShare`, `removeShare`, `listSharesForCampaign` requirements
+- Design Decision 5 (route layout) → POST, GET, DELETE route requirements
+- Design Decision 6 (UI panel) → Player UI requirement
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+#### Scenario: Player cannot see other players' shares
+
+- **Given** players P1 and P2 are both active members of campaign C; each has shared characters
+- **When** P1 calls `GET /api/campaigns/C/characters`
+- **Then** only P1's shares are returned; P2's shares are absent
+
+#### Scenario: Player cannot delete another player's share by guessing characterId
+
+- **Given** character X is owned by P2 and shared into campaign C
+- **When** P1 (different active player) calls `DELETE /api/campaigns/C/characters/X`
+- **Then** response is `403 Forbidden`; the share record is unchanged
+
+### Requirement: Reliability
+
+#### Scenario: No phantom share records
+
+- **Given** a POST request body contains a `characterId` that does not exist in `characters`
+- **When** the POST handler processes the request
+- **Then** a `404` is returned and no record is inserted into `campaignCharacterShares`
+
+### Requirement: Performance
+
+#### Scenario: List query is bounded
+
+- **Given** a player has N shared characters in a campaign (N < 1000)
+- **When** `listSharesForCampaign` is called
+- **Then** exactly one DB query is issued (no N+1 pattern)

--- a/openspec/changes/campaign-character-sharing/tasks.md
+++ b/openspec/changes/campaign-character-sharing/tasks.md
@@ -39,12 +39,12 @@
 ### 3. Storage — `lib/storage.ts`
 
 - [x] Import `CampaignCharacterShare` and `DuplicateShareError` at the top of `lib/storage.ts`
-- [x] In `initializeDatabase()`, register the `campaignCharacterShares` unique index on `{ campaignId: 1, characterId: 1 }` (follow the `campaignMembers` index creation pattern)
+- [x] In `initializeDatabase()` in `lib/db.ts`, register the `campaignCharacterShares` unique index on `{ campaignId: 1, characterId: 1 }` and a non-unique index on `{ campaignId: 1, userId: 1 }` for list queries
 - [x] Add `addShare(share: CampaignCharacterShare): Promise<void>`:
   - Insert into `campaignCharacterShares` (strip `_id` before insert)
   - Catch code 11000 → throw `DuplicateShareError`
-- [x] Add `removeShare(campaignId: string, characterId: string): Promise<boolean>`:
-  - `deleteOne({ campaignId, characterId })`
+- [x] Add `removeShare(campaignId: string, characterId: string, userId: string): Promise<boolean>`:
+  - `deleteOne({ campaignId, characterId, userId })` — scoped by userId for defense-in-depth
   - Return `deletedCount > 0`
 - [x] Add `listSharesForCampaign(campaignId: string, userId: string): Promise<CampaignCharacterShare[]>`:
   - `find({ campaignId, userId }).toArray()`
@@ -77,7 +77,7 @@
   1. Load `getMember(campaignId, auth.userId)`; return 403 if null or not `active`
   2. Load character by `cid`; return 404 if not found
   3. Return 403 if `character.userId !== auth.userId`
-  4. Call `removeShare(campaignId, cid)`; return 404 if returns `false`
+  4. Call `removeShare(campaignId, cid, auth.userId)`; return 404 if returns `false`
   5. Return 204
 
 **TDD:** Write unit tests in `tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts` before implementing. Run `npm run test:unit`.

--- a/openspec/changes/campaign-character-sharing/tasks.md
+++ b/openspec/changes/campaign-character-sharing/tasks.md
@@ -127,10 +127,10 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings addressed before final commit
-- [ ] Commit all changes and push to `feat/campaign-character-sharing`
-- [ ] Open PR to `main`. PR body must include `Closes #309`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (never `--admin`)
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [x] Commit all changes and push to `feat/campaign-character-sharing`
+- [x] Open PR to `main`. PR body must include `Closes #309`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (never `--admin`)
 - [ ] Wait 180 seconds for CI and agentic reviewers
 - [ ] **Monitor PR comments** — address each, commit fixes, run remote push validation, push, wait 180s, repeat until no unresolved threads remain
 - [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required check, run remote push validation, push, wait 180s, repeat

--- a/openspec/changes/campaign-character-sharing/tasks.md
+++ b/openspec/changes/campaign-character-sharing/tasks.md
@@ -1,0 +1,163 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/campaign-character-sharing` then immediately `git push -u origin feat/campaign-character-sharing`
+
+## Execution
+
+### 1. Types — `lib/types.ts`
+
+- [x] Add `CampaignCharacterShare` interface after the `CampaignMemberSummary` block:
+  ```ts
+  export interface CampaignCharacterShare {
+    _id?: string;
+    id: string;
+    campaignId: string;
+    characterId: string;
+    userId: string;
+    sharedAt: Date;
+  }
+  ```
+
+### 2. Errors — `lib/errors.ts`
+
+- [x] Add `DuplicateShareError` following the exact `DuplicateMemberError` pattern:
+  ```ts
+  export class DuplicateShareError extends Error {
+    constructor(campaignId: string, characterId: string) {
+      super(`Character "${characterId}" is already shared into campaign "${campaignId}".`);
+      this.name = 'DuplicateShareError';
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, DuplicateShareError);
+      }
+    }
+  }
+  ```
+
+### 3. Storage — `lib/storage.ts`
+
+- [x] Import `CampaignCharacterShare` and `DuplicateShareError` at the top of `lib/storage.ts`
+- [x] In `initializeDatabase()`, register the `campaignCharacterShares` unique index on `{ campaignId: 1, characterId: 1 }` (follow the `campaignMembers` index creation pattern)
+- [x] Add `addShare(share: CampaignCharacterShare): Promise<void>`:
+  - Insert into `campaignCharacterShares` (strip `_id` before insert)
+  - Catch code 11000 → throw `DuplicateShareError`
+- [x] Add `removeShare(campaignId: string, characterId: string): Promise<boolean>`:
+  - `deleteOne({ campaignId, characterId })`
+  - Return `deletedCount > 0`
+- [x] Add `listSharesForCampaign(campaignId: string, userId: string): Promise<CampaignCharacterShare[]>`:
+  - `find({ campaignId, userId }).toArray()`
+  - Normalize `_id` via `normalizeStoredEntityId`, strip `_id` from result
+
+**TDD:** Write unit tests in `tests/unit/lib/storage-shares.test.ts` (mock the DB) before implementing. Run `npm run test:unit` to confirm they pass.
+
+### 4. API — POST and GET — `app/api/campaigns/[id]/characters/route.ts`
+
+- [x] Create `app/api/campaigns/[id]/characters/route.ts`
+- [x] **POST handler** (`withAuthAndParams<{ id: string }>`):
+  1. Parse body; return 400 if `characterId` is missing or not a non-empty string
+  2. Load `getMember(campaignId, auth.userId)`; return 403 if null, not `active`, or role is not `player`
+  3. Load character via `storage.loadCharacter(characterId, auth.userId)` (or equivalent); return 404 if not found
+  4. Return 403 if `character.userId !== auth.userId`
+  5. Call `addShare({ id: crypto.randomUUID(), campaignId, characterId, userId: auth.userId, sharedAt: new Date() })`
+  6. Catch `DuplicateShareError` → return 409
+  7. Return 201 with `{ id, characterId }`
+- [x] **GET handler** (`withAuthAndParams<{ id: string }>`):
+  1. Load `getMember(campaignId, auth.userId)`; return 403 if null or not `active`
+  2. Call `listSharesForCampaign(campaignId, auth.userId)`
+  3. Return 200 with the array
+
+**TDD:** Write unit tests in `tests/unit/api/campaigns/[id]/characters/route.test.ts` before implementing. Run `npm run test:unit`.
+
+### 5. API — DELETE — `app/api/campaigns/[id]/characters/[cid]/route.ts`
+
+- [x] Create `app/api/campaigns/[id]/characters/[cid]/route.ts`
+- [x] **DELETE handler** (`withAuthAndParams<{ id: string; cid: string }>`):
+  1. Load `getMember(campaignId, auth.userId)`; return 403 if null or not `active`
+  2. Load character by `cid`; return 404 if not found
+  3. Return 403 if `character.userId !== auth.userId`
+  4. Call `removeShare(campaignId, cid)`; return 404 if returns `false`
+  5. Return 204
+
+**TDD:** Write unit tests in `tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts` before implementing. Run `npm run test:unit`.
+
+### 6. Player UI — campaign view character-sharing panel
+
+- [x] Identify where the campaign detail is rendered in `app/campaigns/` (likely `CampaignEditor` or the campaign page component)
+- [x] Add a `SharedCharactersPanel` component (inline or separate file):
+  - Rendered only when `currentUserMember?.role === 'player' && currentUserMember?.status === 'active'`
+  - Fetches `GET /api/campaigns/[id]/characters` on mount to get current shares
+  - Fetches player's own characters from `GET /api/characters` (or existing character list)
+  - Renders each character with a toggle (checked = shared)
+  - On toggle on: `POST /api/campaigns/[id]/characters` with `{ characterId }`
+  - On toggle off: `DELETE /api/campaigns/[id]/characters/[cid]`
+  - Optimistic UI update; revert on error
+
+**TDD:** Write RTL unit tests in `tests/unit/components/SharedCharactersPanel.test.tsx`. Run `npm run test:unit`.
+
+### 7. Integration tests
+
+- [x] Write integration tests in `tests/integration/campaigns/characterSharing.integration.test.ts`:
+  - `addShare` inserts and `listSharesForCampaign` returns it
+  - Duplicate insert throws `DuplicateShareError`
+  - `removeShare` returns true on success, false on non-existent
+  - Same character can appear in two different campaigns
+  - Run with `npm run test:integration`
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically address all findings before committing.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run test:integration` — all tests pass
+- [x] `npm run build` — no type errors, clean build
+- [x] All execution tasks above are checked off
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit` — all must pass
+- **Integration tests** — `npm run test:integration` — all must pass
+- **Build** — `npm run build` — must succeed with no errors
+- If **ANY** of the above fail, iterate and fix before pushing
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [ ] Commit all changes and push to `feat/campaign-character-sharing`
+- [ ] Open PR to `main`. PR body must include `Closes #309`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (never `--admin`)
+- [ ] Wait 180 seconds for CI and agentic reviewers
+- [ ] **Monitor PR comments** — address each, commit fixes, run remote push validation, push, wait 180s, repeat until no unresolved threads remain
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required check, run remote push validation, push, wait 180s, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: (assigned)
+- Reviewer(s): (assigned)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → run remote push validation → push → re-run checks
+- Security finding → remediate → commit → run remote push validation → push → re-scan
+- Review comment → address → commit → run remote push validation → push → resolve thread
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on main
+- [ ] Mark all remaining tasks complete
+- [ ] Sync `openspec/changes/campaign-character-sharing/specs/campaign-character-shares.md` → `openspec/specs/campaign-character-shares/campaign-character-shares.md`
+- [ ] Archive the change: move `openspec/changes/campaign-character-sharing/` → `openspec/changes/archive/YYYY-MM-DD-campaign-character-sharing/` — stage both the copy and deletion in a **single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-character-sharing/` exists and `openspec/changes/campaign-character-sharing/` is gone
+- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-character-sharing` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-character-sharing`
+- [ ] Open PR from doc branch to `main` with title `docs: archive campaign-character-sharing (YYYY-MM-DD)` — do **not** push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same comment/CI loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -D feat/campaign-character-sharing doc/archive-YYYY-MM-DD-campaign-character-sharing`

--- a/openspec/changes/campaign-character-sharing/tests.md
+++ b/openspec/changes/campaign-character-sharing/tests.md
@@ -13,8 +13,9 @@ Test files:
 - `tests/unit/lib/storage-shares.test.ts` — storage methods (mocked DB)
 - `tests/unit/api/campaigns/[id]/characters/route.test.ts` — POST and GET handlers
 - `tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts` — DELETE handler
+- `tests/unit/api/campaigns/[id]/members/me.get.test.ts` — GET members/me handler
 - `tests/unit/components/SharedCharactersPanel.test.tsx` — player UI panel (RTL)
-- `tests/integration/campaigns/characterSharing.integration.test.ts` — real MongoDB
+- `tests/integration/campaigns.character-sharing.integration.test.ts` — real MongoDB
 
 Run unit tests: `npm run test:unit`
 Run integration tests: `npm run test:integration`
@@ -67,8 +68,8 @@ File: `tests/unit/lib/storage-shares.test.ts`
 - [ ] **T3-4** Returns `true` when a record is deleted
   - Spec: `storage.removeShare` — Successful removal
   - Given: `deleteOne` returns `{ deletedCount: 1 }`
-  - When: `removeShare('c1', 'ch1')`
-  - Then: returns `true`
+  - When: `removeShare('c1', 'ch1', 'u1')`
+  - Then: returns `true`; `deleteOne` called with `{ campaignId: 'c1', characterId: 'ch1', userId: 'u1' }`
 
 - [ ] **T3-5** Returns `false` when no record found
   - Spec: `storage.removeShare` — Remove non-existent share returns false

--- a/openspec/changes/campaign-character-sharing/tests.md
+++ b/openspec/changes/campaign-character-sharing/tests.md
@@ -1,0 +1,252 @@
+---
+name: tests
+description: Tests for the campaign-character-sharing change
+---
+
+# Tests
+
+## Overview
+
+All work follows strict TDD: write a failing test → write minimal code to pass → refactor.
+
+Test files:
+- `tests/unit/lib/storage-shares.test.ts` — storage methods (mocked DB)
+- `tests/unit/api/campaigns/[id]/characters/route.test.ts` — POST and GET handlers
+- `tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts` — DELETE handler
+- `tests/unit/components/SharedCharactersPanel.test.tsx` — player UI panel (RTL)
+- `tests/integration/campaigns/characterSharing.integration.test.ts` — real MongoDB
+
+Run unit tests: `npm run test:unit`
+Run integration tests: `npm run test:integration`
+
+---
+
+## Task 1 — Types (`lib/types.ts`)
+
+No runtime test needed; covered by TypeScript compilation in `npm run build`.
+
+---
+
+## Task 2 — `DuplicateShareError` (`lib/errors.ts`)
+
+### `tests/unit/lib/storage-shares.test.ts` (or dedicated errors test)
+
+- [ ] **T2-1** `DuplicateShareError` has `name === 'DuplicateShareError'`
+  - Spec: ADDED `DuplicateShareError`
+  - Given: `new DuplicateShareError('c1', 'ch1')`
+  - Then: `err.name === 'DuplicateShareError'` and message includes `'ch1'` and `'c1'`
+
+- [ ] **T2-2** `DuplicateShareError` is an instance of `Error`
+  - Then: `err instanceof Error === true`
+
+---
+
+## Task 3 — Storage methods (`lib/storage.ts`)
+
+File: `tests/unit/lib/storage-shares.test.ts`
+
+### `addShare`
+
+- [ ] **T3-1** Successfully inserts a share
+  - Spec: `storage.addShare` — Successful share
+  - Given: DB mock returns success on `insertOne`
+  - When: `addShare({ id, campaignId: 'c1', characterId: 'ch1', userId: 'u1', sharedAt: new Date() })`
+  - Then: resolves without error; `insertOne` called once with correct fields (no `_id`)
+
+- [ ] **T3-2** Throws `DuplicateShareError` on MongoDB code 11000
+  - Spec: `storage.addShare` — Duplicate rejected
+  - Given: DB mock throws `{ code: 11000 }` on `insertOne`
+  - Then: `addShare` throws `DuplicateShareError`
+
+- [ ] **T3-3** Re-throws non-11000 errors
+  - Given: DB mock throws a generic Error
+  - Then: `addShare` re-throws the original error (not `DuplicateShareError`)
+
+### `removeShare`
+
+- [ ] **T3-4** Returns `true` when a record is deleted
+  - Spec: `storage.removeShare` — Successful removal
+  - Given: `deleteOne` returns `{ deletedCount: 1 }`
+  - When: `removeShare('c1', 'ch1')`
+  - Then: returns `true`
+
+- [ ] **T3-5** Returns `false` when no record found
+  - Spec: `storage.removeShare` — Remove non-existent share returns false
+  - Given: `deleteOne` returns `{ deletedCount: 0 }`
+  - Then: returns `false`
+
+### `listSharesForCampaign`
+
+- [ ] **T3-6** Returns only the caller's shares
+  - Spec: `storage.listSharesForCampaign` — Returns caller's shares only
+  - Given: `find` returns two documents matching `{ campaignId: 'c1', userId: 'u1' }`
+  - When: `listSharesForCampaign('c1', 'u1')`
+  - Then: returns array of two normalized `CampaignCharacterShare` objects (no `_id`)
+
+- [ ] **T3-7** Returns empty array when no shares match
+  - Spec: `storage.listSharesForCampaign` — Returns empty array
+  - Given: `find` returns empty array
+  - Then: returns `[]`
+
+- [ ] **T3-8** Query includes both `campaignId` and `userId` filters
+  - When: `listSharesForCampaign('c1', 'u1')` is called
+  - Then: `find` called with `{ campaignId: 'c1', userId: 'u1' }` (not just `campaignId`)
+
+---
+
+## Task 4 — POST and GET routes (`app/api/campaigns/[id]/characters/route.ts`)
+
+File: `tests/unit/api/campaigns/[id]/characters/route.test.ts`
+
+### POST
+
+- [ ] **T4-1** Returns 400 when `characterId` is missing
+  - Spec: Missing characterId rejected
+  - Given: body `{}`
+  - Then: 400
+
+- [ ] **T4-2** Returns 400 when `characterId` is empty string
+  - Given: body `{ characterId: '' }`
+  - Then: 400
+
+- [ ] **T4-3** Returns 403 when caller is not a member
+  - Spec: Non-member rejected
+  - Given: `getMember` returns `null`
+  - Then: 403
+
+- [ ] **T4-4** Returns 403 when caller is `invited`
+  - Spec: Non-active member rejected
+  - Given: `getMember` returns `{ status: 'invited', role: 'player' }`
+  - Then: 403
+
+- [ ] **T4-5** Returns 403 when caller is active `dm`
+  - Spec: DM cannot share via this endpoint
+  - Given: `getMember` returns `{ status: 'active', role: 'dm' }`
+  - Then: 403
+
+- [ ] **T4-6** Returns 404 when character not found
+  - Spec: Character not found
+  - Given: caller is active player; `loadCharacter` returns null
+  - Then: 404
+
+- [ ] **T4-7** Returns 403 when character is owned by someone else
+  - Spec: Unowned character rejected
+  - Given: caller is active player; character exists with `userId !== auth.userId`
+  - Then: 403
+
+- [ ] **T4-8** Returns 409 on duplicate share
+  - Spec: Duplicate share rejected
+  - Given: caller owns character; `addShare` throws `DuplicateShareError`
+  - Then: 409
+
+- [ ] **T4-9** Returns 201 with `{ id, characterId }` on success
+  - Spec: Successful share
+  - Given: all guards pass; `addShare` resolves
+  - Then: 201 with `{ id: string, characterId: 'ch1' }`
+
+### GET
+
+- [ ] **T4-10** Returns 403 when caller is not a member
+  - Spec: Non-member cannot list
+  - Given: `getMember` returns `null`
+  - Then: 403
+
+- [ ] **T4-11** Returns 403 when caller is not active
+  - Given: `getMember` returns `{ status: 'removed' }`
+  - Then: 403
+
+- [ ] **T4-12** Returns 200 with shares array
+  - Spec: Player retrieves their shares
+  - Given: active member; `listSharesForCampaign` returns two records
+  - Then: 200 with the array
+
+- [ ] **T4-13** Returns 200 with empty array when no shares
+  - Spec: Empty list for player with no shares
+  - Given: `listSharesForCampaign` returns `[]`
+  - Then: 200 with `[]`
+
+---
+
+## Task 5 — DELETE route (`app/api/campaigns/[id]/characters/[cid]/route.ts`)
+
+File: `tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts`
+
+- [ ] **T5-1** Returns 403 when caller is not a member
+  - Spec: Non-member cannot unshare
+  - Given: `getMember` returns `null`
+  - Then: 403
+
+- [ ] **T5-2** Returns 404 when character not found
+  - Given: caller is active member; character lookup returns null
+  - Then: 404
+
+- [ ] **T5-3** Returns 403 when character is owned by someone else
+  - Spec: Cannot unshare another player's character
+  - Given: active member; character exists with `userId !== auth.userId`
+  - Then: 403
+
+- [ ] **T5-4** Returns 404 when `removeShare` returns false
+  - Spec: Unshare non-existent share returns 404
+  - Given: ownership check passes; `removeShare` returns `false`
+  - Then: 404
+
+- [ ] **T5-5** Returns 204 on successful unshare
+  - Spec: Successful unshare
+  - Given: all guards pass; `removeShare` returns `true`
+  - Then: 204
+
+---
+
+## Task 6 — `SharedCharactersPanel` UI (RTL)
+
+File: `tests/unit/components/SharedCharactersPanel.test.tsx`
+
+- [ ] **T6-1** Panel is NOT rendered when `currentUserMember` is null
+  - Spec: Panel hidden from non-members
+  - Then: no "Shared Characters" heading in document
+
+- [ ] **T6-2** Panel is NOT rendered when member is active `dm`
+  - Spec: Panel hidden from DM
+  - Given: `currentUserMember = { role: 'dm', status: 'active' }`
+  - Then: no "Shared Characters" heading
+
+- [ ] **T6-3** Panel IS rendered when member is active `player`
+  - Spec: Panel visible to active player
+  - Given: `currentUserMember = { role: 'player', status: 'active' }`
+  - Then: "Shared Characters" heading visible
+
+- [ ] **T6-4** Panel lists player's characters with share toggle
+  - Given: API returns characters [X, Y]; character X is already shared
+  - Then: character X toggle is checked; character Y toggle is unchecked
+
+- [ ] **T6-5** Clicking unchecked toggle calls POST
+  - When: user clicks toggle for unshared character Y
+  - Then: `POST /api/campaigns/[id]/characters` called with `{ characterId: Y }`
+
+- [ ] **T6-6** Clicking checked toggle calls DELETE
+  - When: user clicks toggle for shared character X
+  - Then: `DELETE /api/campaigns/[id]/characters/X` called
+
+---
+
+## Task 7 — Integration tests
+
+File: `tests/integration/campaigns/characterSharing.integration.test.ts`
+
+- [ ] **T7-1** `addShare` inserts and `listSharesForCampaign` returns it
+  - Spec: `storage.addShare` — Successful share; `listSharesForCampaign` — Returns caller's shares only
+
+- [ ] **T7-2** Duplicate insert throws `DuplicateShareError`
+  - Spec: `campaignCharacterShares` unique index; `DuplicateShareError`
+
+- [ ] **T7-3** `removeShare` returns `true` on success
+  - Spec: `storage.removeShare` — Successful removal
+
+- [ ] **T7-4** `removeShare` returns `false` on non-existent record
+  - Spec: `storage.removeShare` — Remove non-existent share
+
+- [ ] **T7-5** `listSharesForCampaign` does not return other users' shares
+  - Spec: Non-Functional — Security — Player cannot see other players' shares
+
+- [ ] **T7-6** Same character can be shared into two different campaigns
+  - Spec: `campaignCharacterShares` index — allows same character in different campaigns

--- a/tests/integration/campaigns.character-sharing.integration.test.ts
+++ b/tests/integration/campaigns.character-sharing.integration.test.ts
@@ -1,0 +1,90 @@
+import { storage } from "@/lib/storage";
+import { connectToDatabase, closeDatabase, getDatabase } from "@/lib/db";
+import { DuplicateShareError } from "@/lib/errors";
+import { CampaignCharacterShare } from "@/lib/types";
+
+describe("Campaign Character Sharing Integration Tests", () => {
+  beforeAll(async () => {
+    if (!process.env.MONGODB_URI) throw new Error("MONGODB_URI not set");
+    await connectToDatabase();
+  }, 30000);
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    const db = await getDatabase();
+    await db.collection("campaignCharacterShares").deleteMany({ campaignId: { $regex: "^int-camp-" } });
+  });
+
+  const makeShare = (overrides: Partial<CampaignCharacterShare> = {}): CampaignCharacterShare => ({
+    id: crypto.randomUUID(),
+    campaignId: "int-camp-1",
+    characterId: "int-char-1",
+    userId: "int-user-1",
+    sharedAt: new Date(),
+    ...overrides,
+  });
+
+  test("T7-1: addShare inserts and listSharesForCampaign returns it", async () => {
+    const share = makeShare();
+    await storage.addShare(share);
+
+    const list = await storage.listSharesForCampaign("int-camp-1", "int-user-1");
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(share.id);
+    expect(list[0].characterId).toBe("int-char-1");
+    expect(list[0].userId).toBe("int-user-1");
+    expect(list[0]).not.toHaveProperty("_id");
+  });
+
+  test("T7-2: duplicate insert throws DuplicateShareError", async () => {
+    const share = makeShare();
+    await storage.addShare(share);
+
+    const duplicate = makeShare({ id: crypto.randomUUID() });
+    await expect(storage.addShare(duplicate)).rejects.toThrow(DuplicateShareError);
+  });
+
+  test("T7-3: removeShare returns true on success", async () => {
+    const share = makeShare();
+    await storage.addShare(share);
+
+    const result = await storage.removeShare("int-camp-1", "int-char-1", "int-user-1");
+    expect(result).toBe(true);
+
+    const list = await storage.listSharesForCampaign("int-camp-1", "int-user-1");
+    expect(list).toHaveLength(0);
+  });
+
+  test("T7-4: removeShare returns false on non-existent record", async () => {
+    const result = await storage.removeShare("int-camp-1", "int-char-nonexistent", "int-user-1");
+    expect(result).toBe(false);
+  });
+
+  test("T7-5: listSharesForCampaign does not return other users' shares", async () => {
+    await storage.addShare(makeShare({ id: crypto.randomUUID(), characterId: "int-char-x", userId: "int-user-1" }));
+    await storage.addShare(makeShare({ id: crypto.randomUUID(), characterId: "int-char-z", userId: "int-user-2" }));
+
+    const p1List = await storage.listSharesForCampaign("int-camp-1", "int-user-1");
+    const p2List = await storage.listSharesForCampaign("int-camp-1", "int-user-2");
+
+    expect(p1List).toHaveLength(1);
+    expect(p1List[0].characterId).toBe("int-char-x");
+
+    expect(p2List).toHaveLength(1);
+    expect(p2List[0].characterId).toBe("int-char-z");
+  });
+
+  test("T7-6: same character can be shared into two different campaigns", async () => {
+    await storage.addShare(makeShare({ id: crypto.randomUUID(), campaignId: "int-camp-1", characterId: "int-char-1" }));
+    await storage.addShare(makeShare({ id: crypto.randomUUID(), campaignId: "int-camp-2", characterId: "int-char-1" }));
+
+    const camp1List = await storage.listSharesForCampaign("int-camp-1", "int-user-1");
+    const camp2List = await storage.listSharesForCampaign("int-camp-2", "int-user-1");
+
+    expect(camp1List).toHaveLength(1);
+    expect(camp2List).toHaveLength(1);
+  });
+});

--- a/tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts
@@ -70,6 +70,12 @@ describe("DELETE /api/campaigns/[id]/characters/[cid]", () => {
     expect(response.status).toBe(403);
   });
 
+  it("T5-1b: returns 403 when caller is an active dm", async () => {
+    mockedStorage.getMember.mockResolvedValue({ ...ACTIVE_PLAYER, role: "dm" });
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
   it("T5-2: returns 404 when character not found", async () => {
     mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
     mockedStorage.loadCharacterById.mockResolvedValue(null);

--- a/tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+import { DELETE } from "@/app/api/campaigns/[id]/characters/[cid]/route";
+import { storage } from "@/lib/storage";
+import { CampaignMember, Character } from "@/lib/types";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  mockAuthState,
+  itReturns401WithParams,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () =>
+  require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware()
+);
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+    removeShare: jest.fn(),
+    loadCharacterById: jest.fn(),
+  },
+}));
+
+const mockedStorage = jest.mocked(storage) as {
+  getMember: jest.MockedFunction<typeof storage.getMember>;
+  removeShare: jest.MockedFunction<typeof storage.removeShare>;
+  loadCharacterById: jest.MockedFunction<typeof storage.loadCharacterById>;
+};
+
+const CAMPAIGN_ID = "camp-1";
+const CHARACTER_ID = "char-1";
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID, cid: CHARACTER_ID });
+
+const ACTIVE_PLAYER: CampaignMember = {
+  id: "mem-1",
+  campaignId: CAMPAIGN_ID,
+  userId: MOCK_AUTH.userId,
+  role: "player",
+  status: "active",
+  history: [],
+};
+
+const OWN_CHARACTER = {
+  id: CHARACTER_ID,
+  userId: MOCK_AUTH.userId,
+  name: "Hero",
+} as unknown as Character;
+
+const makeDeleteRequest = () =>
+  makeRouteRequest(
+    `http://localhost/api/campaigns/${CAMPAIGN_ID}/characters/${CHARACTER_ID}`,
+    "DELETE"
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthState.payload = MOCK_AUTH;
+});
+
+describe("DELETE /api/campaigns/[id]/characters/[cid]", () => {
+  describe("unauthenticated", () => {
+    itReturns401WithParams(DELETE, makeDeleteRequest, PARAMS);
+  });
+
+  it("T5-1: returns 403 when caller is not a member", async () => {
+    mockedStorage.getMember.mockResolvedValue(null);
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T5-2: returns 404 when character not found", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(null);
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(404);
+  });
+
+  it("T5-3: returns 403 when character is owned by someone else", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue({
+      ...OWN_CHARACTER,
+      userId: "other-user",
+    });
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T5-4: returns 404 when removeShare returns false", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
+    mockedStorage.removeShare.mockResolvedValue(false);
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(404);
+  });
+
+  it("T5-5: returns 204 on successful unshare", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
+    mockedStorage.removeShare.mockResolvedValue(true);
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(204);
+  });
+});

--- a/tests/unit/api/campaigns/[id]/characters/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/characters/route.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment node
+ */
+import { POST, GET } from "@/app/api/campaigns/[id]/characters/route";
+import { storage } from "@/lib/storage";
+import { DuplicateShareError } from "@/lib/errors";
+import { CampaignMember, CampaignCharacterShare, Character } from "@/lib/types";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  mockAuthState,
+  itReturns401WithParams,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () =>
+  require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware()
+);
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+    addShare: jest.fn(),
+    listSharesForCampaign: jest.fn(),
+    loadCharacterById: jest.fn(),
+  },
+}));
+
+const mockedStorage = jest.mocked(storage) as {
+  getMember: jest.MockedFunction<typeof storage.getMember>;
+  addShare: jest.MockedFunction<typeof storage.addShare>;
+  listSharesForCampaign: jest.MockedFunction<typeof storage.listSharesForCampaign>;
+  loadCharacterById: jest.MockedFunction<typeof storage.loadCharacterById>;
+};
+
+const CAMPAIGN_ID = "camp-1";
+const CHARACTER_ID = "char-1";
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
+
+const ACTIVE_PLAYER: CampaignMember = {
+  id: "mem-1",
+  campaignId: CAMPAIGN_ID,
+  userId: MOCK_AUTH.userId,
+  role: "player",
+  status: "active",
+  history: [],
+};
+
+const OWN_CHARACTER = {
+  id: CHARACTER_ID,
+  userId: MOCK_AUTH.userId,
+  name: "Hero",
+} as unknown as Character;
+
+const makePostRequest = (body: unknown) =>
+  makeRouteRequest(
+    `http://localhost/api/campaigns/${CAMPAIGN_ID}/characters`,
+    "POST",
+    body
+  );
+
+const makeGetRequest = () =>
+  makeRouteRequest(
+    `http://localhost/api/campaigns/${CAMPAIGN_ID}/characters`,
+    "GET"
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthState.payload = MOCK_AUTH;
+});
+
+describe("POST /api/campaigns/[id]/characters", () => {
+  describe("unauthenticated", () => {
+    itReturns401WithParams(POST, () => makePostRequest({ characterId: CHARACTER_ID }), PARAMS);
+  });
+
+  it("T4-1: returns 400 when characterId is missing", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    const response = await POST(makePostRequest({}), { params: PARAMS });
+    expect(response.status).toBe(400);
+  });
+
+  it("T4-2: returns 400 when characterId is empty string", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    const response = await POST(makePostRequest({ characterId: "" }), { params: PARAMS });
+    expect(response.status).toBe(400);
+  });
+
+  it("T4-3: returns 403 when caller is not a member", async () => {
+    mockedStorage.getMember.mockResolvedValue(null);
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T4-4: returns 403 when caller is invited", async () => {
+    mockedStorage.getMember.mockResolvedValue({
+      ...ACTIVE_PLAYER,
+      status: "invited",
+    });
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T4-5: returns 403 when caller is active dm", async () => {
+    mockedStorage.getMember.mockResolvedValue({
+      ...ACTIVE_PLAYER,
+      role: "dm",
+    });
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T4-6: returns 404 when character not found", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(null);
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(404);
+  });
+
+  it("T4-7: returns 403 when character is owned by someone else", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue({
+      ...OWN_CHARACTER,
+      userId: "other-user",
+    });
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T4-8: returns 409 on duplicate share", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
+    mockedStorage.addShare.mockRejectedValue(
+      new DuplicateShareError(CAMPAIGN_ID, CHARACTER_ID)
+    );
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(409);
+  });
+
+  it("T4-9: returns 201 with { id, characterId } on success", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
+    mockedStorage.addShare.mockResolvedValue(undefined);
+    const response = await POST(makePostRequest({ characterId: CHARACTER_ID }), { params: PARAMS });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(typeof body.id).toBe("string");
+    expect(body.characterId).toBe(CHARACTER_ID);
+  });
+});
+
+describe("GET /api/campaigns/[id]/characters", () => {
+  describe("unauthenticated", () => {
+    itReturns401WithParams(GET, makeGetRequest, PARAMS);
+  });
+
+  it("T4-10: returns 403 when caller is not a member", async () => {
+    mockedStorage.getMember.mockResolvedValue(null);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T4-11: returns 403 when caller is not active", async () => {
+    mockedStorage.getMember.mockResolvedValue({
+      ...ACTIVE_PLAYER,
+      status: "removed",
+    });
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("T4-12: returns 200 with shares array", async () => {
+    const shares: CampaignCharacterShare[] = [
+      { id: "s1", campaignId: CAMPAIGN_ID, characterId: "ch1", userId: MOCK_AUTH.userId, sharedAt: new Date() },
+      { id: "s2", campaignId: CAMPAIGN_ID, characterId: "ch2", userId: MOCK_AUTH.userId, sharedAt: new Date() },
+    ];
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.listSharesForCampaign.mockResolvedValue(shares);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(2);
+  });
+
+  it("T4-13: returns 200 with empty array when no shares", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.listSharesForCampaign.mockResolvedValue([]);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/campaigns/[id]/members/me.get.test.ts
+++ b/tests/unit/api/campaigns/[id]/members/me.get.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/campaigns/[id]/members/me/route";
+import { storage } from "@/lib/storage";
+import { CampaignMember } from "@/lib/types";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  mockAuthState,
+  itReturns401WithParams,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () =>
+  require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware()
+);
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+  },
+}));
+
+const mockedStorage = jest.mocked(storage) as {
+  getMember: jest.MockedFunction<typeof storage.getMember>;
+};
+
+const CAMPAIGN_ID = "camp-1";
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
+
+const ACTIVE_PLAYER: CampaignMember = {
+  id: "mem-1",
+  campaignId: CAMPAIGN_ID,
+  userId: MOCK_AUTH.userId,
+  role: "player",
+  status: "active",
+  history: [],
+};
+
+const makeGetRequest = () =>
+  makeRouteRequest(`http://localhost/api/campaigns/${CAMPAIGN_ID}/members/me`, "GET");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthState.payload = MOCK_AUTH;
+});
+
+describe("GET /api/campaigns/[id]/members/me", () => {
+  describe("unauthenticated", () => {
+    itReturns401WithParams(GET, makeGetRequest, PARAMS);
+  });
+
+  it("returns 404 when caller is not a member", async () => {
+    mockedStorage.getMember.mockResolvedValue(null);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 200 with the member record", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.role).toBe("player");
+    expect(body.status).toBe("active");
+  });
+});

--- a/tests/unit/components/CampaignsPage.test.tsx
+++ b/tests/unit/components/CampaignsPage.test.tsx
@@ -236,3 +236,42 @@ describe('Campaign Catalog UI', () => {
     });
   });
 });
+
+describe('Campaign membership panel', () => {
+  const ACTIVE_CAMPAIGN = { ...MOCK_CAMPAIGN, status: 'active' };
+
+  it('renders SharedCharactersPanel for active player member', async () => {
+    const activeMember = {
+      id: 'mem-1', campaignId: MOCK_CAMPAIGN.id, userId: 'user-1',
+      role: 'player', status: 'active', history: [],
+    };
+
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/campaigns') return jsonResponse([ACTIVE_CAMPAIGN]);
+      if (url === '/api/campaigns/global') return jsonResponse([]);
+      if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/members/me`) return jsonResponse(activeMember);
+      if (url === '/api/characters') return jsonResponse([]);
+      if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/characters`) return jsonResponse([]);
+      return jsonResponse({ error: 'not found' }, 404);
+    }) as typeof fetch;
+
+    renderPage();
+
+    expect(await screen.findByText(/Shared Characters/i)).toBeInTheDocument();
+  });
+
+  it('does not render SharedCharactersPanel when membership fetch returns 404', async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/campaigns') return jsonResponse([ACTIVE_CAMPAIGN]);
+      if (url === '/api/campaigns/global') return jsonResponse([]);
+      return jsonResponse({ error: 'not found' }, 404);
+    }) as typeof fetch;
+
+    renderPage();
+    await screen.findByText('Active Campaigns');
+
+    expect(screen.queryByText(/Shared Characters/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/CampaignsPage.test.tsx
+++ b/tests/unit/components/CampaignsPage.test.tsx
@@ -239,19 +239,14 @@ describe('Campaign Catalog UI', () => {
 
 describe('Campaign membership panel', () => {
   const ACTIVE_CAMPAIGN = { ...MOCK_CAMPAIGN, status: 'active' };
+  const ACTIVE_MEMBER = { id: 'mem-1', campaignId: MOCK_CAMPAIGN.id, userId: 'user-1', role: 'player', status: 'active', history: [] };
 
   it('renders SharedCharactersPanel for active player member', async () => {
-    const activeMember = {
-      id: 'mem-1', campaignId: MOCK_CAMPAIGN.id, userId: 'user-1',
-      role: 'player', status: 'active', history: [],
-    };
-
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === '/api/campaigns') return jsonResponse([ACTIVE_CAMPAIGN]);
       if (url === '/api/campaigns/global') return jsonResponse([]);
-      if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/members/me`) return jsonResponse(activeMember);
-      if (url === '/api/characters') return jsonResponse([]);
+      if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/members/me`) return jsonResponse(ACTIVE_MEMBER);
       if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/characters`) return jsonResponse([]);
       return jsonResponse({ error: 'not found' }, 404);
     }) as typeof fetch;

--- a/tests/unit/components/CampaignsPage.test.tsx
+++ b/tests/unit/components/CampaignsPage.test.tsx
@@ -237,36 +237,3 @@ describe('Campaign Catalog UI', () => {
   });
 });
 
-describe('Campaign membership panel', () => {
-  const ACTIVE_CAMPAIGN = { ...MOCK_CAMPAIGN, status: 'active' };
-  const ACTIVE_MEMBER = { id: 'mem-1', campaignId: MOCK_CAMPAIGN.id, userId: 'user-1', role: 'player', status: 'active', history: [] };
-
-  it('renders SharedCharactersPanel for active player member', async () => {
-    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
-      const url = input.toString();
-      if (url === '/api/campaigns') return jsonResponse([ACTIVE_CAMPAIGN]);
-      if (url === '/api/campaigns/global') return jsonResponse([]);
-      if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/members/me`) return jsonResponse(ACTIVE_MEMBER);
-      if (url === `/api/campaigns/${MOCK_CAMPAIGN.id}/characters`) return jsonResponse([]);
-      return jsonResponse({ error: 'not found' }, 404);
-    }) as typeof fetch;
-
-    renderPage();
-
-    expect(await screen.findByText(/Shared Characters/i)).toBeInTheDocument();
-  });
-
-  it('does not render SharedCharactersPanel when membership fetch returns 404', async () => {
-    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
-      const url = input.toString();
-      if (url === '/api/campaigns') return jsonResponse([ACTIVE_CAMPAIGN]);
-      if (url === '/api/campaigns/global') return jsonResponse([]);
-      return jsonResponse({ error: 'not found' }, 404);
-    }) as typeof fetch;
-
-    renderPage();
-    await screen.findByText('Active Campaigns');
-
-    expect(screen.queryByText(/Shared Characters/i)).not.toBeInTheDocument();
-  });
-});

--- a/tests/unit/components/SharedCharactersPanel.test.tsx
+++ b/tests/unit/components/SharedCharactersPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Response as FetchResponse } from 'node-fetch';
 import { SharedCharactersPanel } from '@/lib/components/SharedCharactersPanel';
-import { CampaignMember, Character, CampaignCharacterShare } from '@/lib/types';
+import { Character, CampaignCharacterShare, CampaignMember } from '@/lib/types';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -24,6 +24,15 @@ const ACTIVE_PLAYER: CampaignMember = {
   campaignId: CAMPAIGN_ID,
   userId: 'user-1',
   role: 'player',
+  status: 'active',
+  history: [],
+};
+
+const ACTIVE_DM: CampaignMember = {
+  id: 'mem-2',
+  campaignId: CAMPAIGN_ID,
+  userId: 'user-2',
+  role: 'dm',
   status: 'active',
   history: [],
 };
@@ -69,42 +78,43 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-function setupFetch(characters: unknown[] = [], shares: unknown[] = []) {
+function setupFetch(member: CampaignMember | null, shares: CampaignCharacterShare[] = []) {
   global.fetch = jest.fn(async (input: RequestInfo | URL) => {
     const url = input.toString();
-    if (url === '/api/characters') return jsonResponse(characters);
+    if (url === `/api/campaigns/${CAMPAIGN_ID}/members/me`) {
+      return member ? jsonResponse(member) : jsonResponse({ error: 'Not a member' }, 404);
+    }
     if (url === `/api/campaigns/${CAMPAIGN_ID}/characters`) return jsonResponse(shares);
     return jsonResponse({ error: 'Not found' }, 404);
   });
 }
 
 describe('SharedCharactersPanel', () => {
-  it('T6-1: panel is NOT rendered when currentUserMember is null', () => {
-    setupFetch();
-    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={null} />);
+  it('T6-1: panel is NOT rendered when member fetch returns 404 (non-member)', async () => {
+    setupFetch(null);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_X]} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     expect(screen.queryByText(/Shared Characters/i)).not.toBeInTheDocument();
   });
 
-  it('T6-2: panel is NOT rendered when member is active dm', () => {
-    setupFetch();
-    render(
-      <SharedCharactersPanel
-        campaignId={CAMPAIGN_ID}
-        currentUserMember={{ ...ACTIVE_PLAYER, role: 'dm' }}
-      />
-    );
+  it('T6-2: panel is NOT rendered when member is active dm', async () => {
+    setupFetch(ACTIVE_DM);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_X]} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     expect(screen.queryByText(/Shared Characters/i)).not.toBeInTheDocument();
   });
 
   it('T6-3: panel IS rendered when member is active player', async () => {
-    setupFetch([], []);
-    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
-    expect(screen.getByText(/Shared Characters/i)).toBeInTheDocument();
+    setupFetch(ACTIVE_PLAYER);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[]} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Shared Characters/i)).toBeInTheDocument();
+    });
   });
 
   it('T6-4: panel lists characters with correct toggle states', async () => {
-    setupFetch([CHAR_X, CHAR_Y], [SHARE_X]);
-    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+    setupFetch(ACTIVE_PLAYER, [SHARE_X]);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_X, CHAR_Y]} />);
 
     await waitFor(() => {
       expect(screen.getByText('Aragorn')).toBeInTheDocument();
@@ -121,10 +131,8 @@ describe('SharedCharactersPanel', () => {
     const user = userEvent.setup();
     const mockFetch = jest.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
       const url = input.toString();
-      if (url === '/api/characters') return jsonResponse([CHAR_X, CHAR_Y]);
-      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && (!options || options.method !== 'POST')) {
-        return jsonResponse([SHARE_X]);
-      }
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/members/me`) return jsonResponse(ACTIVE_PLAYER);
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && !options?.method) return jsonResponse([SHARE_X]);
       if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && options?.method === 'POST') {
         return jsonResponse({ id: 'share-y', characterId: 'char-y' }, 201);
       }
@@ -132,14 +140,11 @@ describe('SharedCharactersPanel', () => {
     });
     global.fetch = mockFetch;
 
-    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_X, CHAR_Y]} />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Legolas')).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByText('Legolas')).toBeInTheDocument());
 
-    const legolasToggle = screen.getByRole('checkbox', { name: /Legolas/i });
-    await user.click(legolasToggle);
+    await user.click(screen.getByRole('checkbox', { name: /Legolas/i }));
 
     await waitFor(() => {
       const postCall = mockFetch.mock.calls.find(
@@ -148,8 +153,7 @@ describe('SharedCharactersPanel', () => {
           opts?.method === 'POST'
       );
       expect(postCall).toBeDefined();
-      const body = JSON.parse(postCall![1]!.body as string);
-      expect(body.characterId).toBe('char-y');
+      expect(JSON.parse(postCall![1]!.body as string).characterId).toBe('char-y');
     });
   });
 
@@ -157,10 +161,8 @@ describe('SharedCharactersPanel', () => {
     const user = userEvent.setup();
     const mockFetch = jest.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
       const url = input.toString();
-      if (url === '/api/characters') return jsonResponse([CHAR_X, CHAR_Y]);
-      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && !options?.method) {
-        return jsonResponse([SHARE_X]);
-      }
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/members/me`) return jsonResponse(ACTIVE_PLAYER);
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && !options?.method) return jsonResponse([SHARE_X]);
       if (url === `/api/campaigns/${CAMPAIGN_ID}/characters/char-x` && options?.method === 'DELETE') {
         return new FetchResponse(null, { status: 204 }) as unknown as Response;
       }
@@ -168,22 +170,36 @@ describe('SharedCharactersPanel', () => {
     });
     global.fetch = mockFetch;
 
-    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_X, CHAR_Y]} />);
+
+    await waitFor(() => expect(screen.getByText('Aragorn')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Aragorn')).toBeInTheDocument();
-    });
-
-    const aragornToggle = screen.getByRole('checkbox', { name: /Aragorn/i });
-    await user.click(aragornToggle);
-
-    await waitFor(() => {
-      const deleteCall = mockFetch.mock.calls.find(
+      expect(mockFetch.mock.calls.find(
         ([url, opts]) =>
           url.toString() === `/api/campaigns/${CAMPAIGN_ID}/characters/char-x` &&
           opts?.method === 'DELETE'
-      );
-      expect(deleteCall).toBeDefined();
+      )).toBeDefined();
     });
+  });
+
+  it('panel collapses and expands on button click', async () => {
+    const user = userEvent.setup();
+    setupFetch(ACTIVE_PLAYER);
+
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_X]} />);
+
+    await waitFor(() => expect(screen.getByText(/Shared Characters/i)).toBeInTheDocument());
+
+    const toggleBtn = screen.getByRole('button', { name: /Shared Characters/i });
+    expect(screen.getByText('Aragorn')).toBeInTheDocument();
+
+    await user.click(toggleBtn);
+    expect(screen.queryByText('Aragorn')).not.toBeInTheDocument();
+
+    await user.click(toggleBtn);
+    expect(screen.getByText('Aragorn')).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/SharedCharactersPanel.test.tsx
+++ b/tests/unit/components/SharedCharactersPanel.test.tsx
@@ -185,6 +185,33 @@ describe('SharedCharactersPanel', () => {
     });
   });
 
+  it('reverts optimistic update when POST fails', async () => {
+    const user = userEvent.setup();
+    const mockFetch = jest.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
+      const url = input.toString();
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/members/me`) return jsonResponse(ACTIVE_PLAYER);
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && !options?.method) return jsonResponse([]);
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && options?.method === 'POST') {
+        return jsonResponse({ error: 'Conflict' }, 409);
+      }
+      return jsonResponse({ error: 'Not found' }, 404);
+    });
+    global.fetch = mockFetch;
+
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} characters={[CHAR_Y]} />);
+
+    await waitFor(() => expect(screen.getByText('Legolas')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('checkbox', { name: /Legolas/i });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Legolas/i })).not.toBeChecked();
+    });
+  });
+
   it('panel collapses and expands on button click', async () => {
     const user = userEvent.setup();
     setupFetch(ACTIVE_PLAYER);

--- a/tests/unit/components/SharedCharactersPanel.test.tsx
+++ b/tests/unit/components/SharedCharactersPanel.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Response as FetchResponse } from 'node-fetch';
+import { SharedCharactersPanel } from '@/lib/components/SharedCharactersPanel';
+import { CampaignMember, Character, CampaignCharacterShare } from '@/lib/types';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/',
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as Response;
+}
+
+const CAMPAIGN_ID = 'camp-1';
+
+const ACTIVE_PLAYER: CampaignMember = {
+  id: 'mem-1',
+  campaignId: CAMPAIGN_ID,
+  userId: 'user-1',
+  role: 'player',
+  status: 'active',
+  history: [],
+};
+
+const CHAR_X: Character = {
+  id: 'char-x',
+  userId: 'user-1',
+  name: 'Aragorn',
+  classes: [],
+  abilityScores: {
+    strength: 10, dexterity: 10, constitution: 10,
+    intelligence: 10, wisdom: 10, charisma: 10,
+  },
+} as unknown as Character;
+
+const CHAR_Y: Character = {
+  id: 'char-y',
+  userId: 'user-1',
+  name: 'Legolas',
+  classes: [],
+  abilityScores: {
+    strength: 10, dexterity: 10, constitution: 10,
+    intelligence: 10, wisdom: 10, charisma: 10,
+  },
+} as unknown as Character;
+
+const SHARE_X: CampaignCharacterShare = {
+  id: 'share-x',
+  campaignId: CAMPAIGN_ID,
+  characterId: 'char-x',
+  userId: 'user-1',
+  sharedAt: new Date(),
+};
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.clearAllMocks();
+});
+
+function setupFetch(characters: unknown[] = [], shares: unknown[] = []) {
+  global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url === '/api/characters') return jsonResponse(characters);
+    if (url === `/api/campaigns/${CAMPAIGN_ID}/characters`) return jsonResponse(shares);
+    return jsonResponse({ error: 'Not found' }, 404);
+  });
+}
+
+describe('SharedCharactersPanel', () => {
+  it('T6-1: panel is NOT rendered when currentUserMember is null', () => {
+    setupFetch();
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={null} />);
+    expect(screen.queryByText(/Shared Characters/i)).not.toBeInTheDocument();
+  });
+
+  it('T6-2: panel is NOT rendered when member is active dm', () => {
+    setupFetch();
+    render(
+      <SharedCharactersPanel
+        campaignId={CAMPAIGN_ID}
+        currentUserMember={{ ...ACTIVE_PLAYER, role: 'dm' }}
+      />
+    );
+    expect(screen.queryByText(/Shared Characters/i)).not.toBeInTheDocument();
+  });
+
+  it('T6-3: panel IS rendered when member is active player', async () => {
+    setupFetch([], []);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+    expect(screen.getByText(/Shared Characters/i)).toBeInTheDocument();
+  });
+
+  it('T6-4: panel lists characters with correct toggle states', async () => {
+    setupFetch([CHAR_X, CHAR_Y], [SHARE_X]);
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Aragorn')).toBeInTheDocument();
+      expect(screen.getByText('Legolas')).toBeInTheDocument();
+    });
+
+    const aragornToggle = screen.getByRole('checkbox', { name: /Aragorn/i });
+    const legolasToggle = screen.getByRole('checkbox', { name: /Legolas/i });
+    expect(aragornToggle).toBeChecked();
+    expect(legolasToggle).not.toBeChecked();
+  });
+
+  it('T6-5: clicking unchecked toggle calls POST', async () => {
+    const user = userEvent.setup();
+    const mockFetch = jest.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/characters') return jsonResponse([CHAR_X, CHAR_Y]);
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && (!options || options.method !== 'POST')) {
+        return jsonResponse([SHARE_X]);
+      }
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && options?.method === 'POST') {
+        return jsonResponse({ id: 'share-y', characterId: 'char-y' }, 201);
+      }
+      return jsonResponse({ error: 'Not found' }, 404);
+    });
+    global.fetch = mockFetch;
+
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Legolas')).toBeInTheDocument();
+    });
+
+    const legolasToggle = screen.getByRole('checkbox', { name: /Legolas/i });
+    await user.click(legolasToggle);
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(
+        ([url, opts]) =>
+          url.toString() === `/api/campaigns/${CAMPAIGN_ID}/characters` &&
+          opts?.method === 'POST'
+      );
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1]!.body as string);
+      expect(body.characterId).toBe('char-y');
+    });
+  });
+
+  it('T6-6: clicking checked toggle calls DELETE', async () => {
+    const user = userEvent.setup();
+    const mockFetch = jest.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/characters') return jsonResponse([CHAR_X, CHAR_Y]);
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && !options?.method) {
+        return jsonResponse([SHARE_X]);
+      }
+      if (url === `/api/campaigns/${CAMPAIGN_ID}/characters/char-x` && options?.method === 'DELETE') {
+        return new FetchResponse(null, { status: 204 }) as unknown as Response;
+      }
+      return jsonResponse({ error: 'Not found' }, 404);
+    });
+    global.fetch = mockFetch;
+
+    render(<SharedCharactersPanel campaignId={CAMPAIGN_ID} currentUserMember={ACTIVE_PLAYER} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Aragorn')).toBeInTheDocument();
+    });
+
+    const aragornToggle = screen.getByRole('checkbox', { name: /Aragorn/i });
+    await user.click(aragornToggle);
+
+    await waitFor(() => {
+      const deleteCall = mockFetch.mock.calls.find(
+        ([url, opts]) =>
+          url.toString() === `/api/campaigns/${CAMPAIGN_ID}/characters/char-x` &&
+          opts?.method === 'DELETE'
+      );
+      expect(deleteCall).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/lib/storage-shares.test.ts
+++ b/tests/unit/lib/storage-shares.test.ts
@@ -157,3 +157,43 @@ describe("storage.listSharesForCampaign", () => {
     expect(mockFind).toHaveBeenCalledWith({ campaignId: "camp-1", userId: "user-1" });
   });
 });
+
+describe("storage.loadCharacterById", () => {
+  const CHARACTER_DOC = {
+    id: "char-1",
+    _id: "mongo-1",
+    userId: "user-1",
+    name: "Hero",
+    deletedAt: null,
+  };
+
+  it("returns null when character not found", async () => {
+    const mockFindOne = jest.fn().mockResolvedValue(null);
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+
+    const result = await storage.loadCharacterById("char-1");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns normalized character with id when found", async () => {
+    const mockFindOne = jest.fn().mockResolvedValue(CHARACTER_DOC);
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+
+    const result = await storage.loadCharacterById("char-1");
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("char-1");
+  });
+
+  it("queries by id and deletedAt null to exclude soft-deleted characters", async () => {
+    const mockFindOne = jest.fn().mockResolvedValue(null);
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+
+    await storage.loadCharacterById("char-1");
+
+    expect(mockFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "char-1" })
+    );
+  });
+});

--- a/tests/unit/lib/storage-shares.test.ts
+++ b/tests/unit/lib/storage-shares.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+import { storage } from "@/lib/storage";
+import { DuplicateShareError } from "@/lib/errors";
+import { CampaignCharacterShare } from "@/lib/types";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+import { getDatabase } from "@/lib/db";
+
+const mockedDb = {
+  collection: jest.fn(),
+};
+
+const mockedInsertCollection = {
+  insertOne: jest.fn(),
+};
+
+const mockedDeleteCollection = {
+  deleteOne: jest.fn(),
+};
+
+const mockedFindCollection = {
+  find: jest.fn(),
+};
+
+jest.mocked(getDatabase).mockResolvedValue(mockedDb as any);
+
+const BASE_SHARE: CampaignCharacterShare = {
+  id: "share-1",
+  campaignId: "camp-1",
+  characterId: "char-1",
+  userId: "user-1",
+  sharedAt: new Date("2026-01-01"),
+};
+
+describe("DuplicateShareError", () => {
+  it("has name DuplicateShareError", () => {
+    const err = new DuplicateShareError("c1", "ch1");
+    expect(err.name).toBe("DuplicateShareError");
+  });
+
+  it("message includes campaignId and characterId", () => {
+    const err = new DuplicateShareError("c1", "ch1");
+    expect(err.message).toContain("c1");
+    expect(err.message).toContain("ch1");
+  });
+
+  it("is an instance of Error", () => {
+    const err = new DuplicateShareError("c1", "ch1");
+    expect(err instanceof Error).toBe(true);
+  });
+});
+
+describe("storage.addShare", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedDb.collection.mockReturnValue(mockedInsertCollection);
+  });
+
+  it("T3-1: inserts share without _id field", async () => {
+    mockedInsertCollection.insertOne.mockResolvedValue({ insertedId: "mongo-id" });
+
+    await storage.addShare(BASE_SHARE);
+
+    expect(mockedInsertCollection.insertOne).toHaveBeenCalledTimes(1);
+    const insertArg = mockedInsertCollection.insertOne.mock.calls[0][0];
+    expect(insertArg).not.toHaveProperty("_id");
+    expect(insertArg.campaignId).toBe("camp-1");
+    expect(insertArg.characterId).toBe("char-1");
+    expect(insertArg.userId).toBe("user-1");
+  });
+
+  it("T3-2: throws DuplicateShareError on code 11000", async () => {
+    mockedInsertCollection.insertOne.mockRejectedValue({ code: 11000 });
+
+    await expect(storage.addShare(BASE_SHARE)).rejects.toThrow(DuplicateShareError);
+  });
+
+  it("T3-3: re-throws non-11000 errors", async () => {
+    const generic = new Error("network failure");
+    mockedInsertCollection.insertOne.mockRejectedValue(generic);
+
+    await expect(storage.addShare(BASE_SHARE)).rejects.toThrow("network failure");
+  });
+});
+
+describe("storage.removeShare", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedDb.collection.mockReturnValue(mockedDeleteCollection);
+  });
+
+  it("T3-4: returns true when a record is deleted", async () => {
+    mockedDeleteCollection.deleteOne.mockResolvedValue({ deletedCount: 1 });
+
+    const result = await storage.removeShare("camp-1", "char-1", "user-1");
+
+    expect(result).toBe(true);
+    expect(mockedDeleteCollection.deleteOne).toHaveBeenCalledWith({
+      campaignId: "camp-1",
+      characterId: "char-1",
+      userId: "user-1",
+    });
+  });
+
+  it("T3-5: returns false when no record found", async () => {
+    mockedDeleteCollection.deleteOne.mockResolvedValue({ deletedCount: 0 });
+
+    const result = await storage.removeShare("camp-1", "char-1", "user-1");
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("storage.listSharesForCampaign", () => {
+  const doc1 = { ...BASE_SHARE, _id: "mongo-1" };
+  const doc2 = { ...BASE_SHARE, id: "share-2", characterId: "char-2", _id: "mongo-2" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("T3-6: returns only the caller's shares with _id stripped", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([doc1, doc2]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.listSharesForCampaign("camp-1", "user-1");
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).not.toHaveProperty("_id");
+    expect(result[0].id).toBe("share-1");
+    expect(result[1].id).toBe("share-2");
+  });
+
+  it("T3-7: returns empty array when no shares match", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.listSharesForCampaign("camp-1", "user-1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("T3-8: query includes both campaignId and userId", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    await storage.listSharesForCampaign("camp-1", "user-1");
+
+    expect(mockFind).toHaveBeenCalledWith({ campaignId: "camp-1", userId: "user-1" });
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #309 — campaign character sharing (phase 3a).

### What's new

- ** type** and **** in  / 
- ** MongoDB collection** with unique compound index 
- **Storage methods:** ,  (scoped by userId for defense-in-depth), , 
- **API routes:**
  -  — active players only; verifies character ownership
  -  — returns caller's own shares only
  -  — verifies ownership before unsharing
  -  — returns current user's member record
- ** React component** — player-only, collapsible, share toggles with optimistic UI + rollback on HTTP error
- **Tests:** unit tests for storage, all three routes, and the UI component; 6 integration tests

### Security
- Players can only share their own characters (ownership check in POST and DELETE)
- GET only returns the caller's own shares (storage-level userId filter)
- removeShare scoped by userId in storage for defense-in-depth
- loadCharacterById uses  view (soft-deleted excluded)

Closes #309