### PR TITLE
fix: eliminate soft-delete flaky test (#386)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,6 +5,7 @@ const DB_NAME = process.env.MONGODB_DB || "session-combat";
 
 let cachedClient: MongoClient | null = null;
 let cachedDb: Db | null = null;
+let connectionPromise: Promise<{ client: MongoClient; db: Db }> | null = null;
 
 /**
  * Initialize MongoDB views and indexes after database connection.
@@ -149,31 +150,40 @@ export async function connectToDatabase(): Promise<{
     return { client: cachedClient, db: cachedDb };
   }
 
-  try {
-    const options: MongoClientOptions = {
-      maxPoolSize: 10,
-    };
-
-    const client = new MongoClient(MONGODB_URI, options);
-    await client.connect();
-
-    const db = client.db(DB_NAME);
-
-    // Verify connection
-    await db.admin().ping();
-
-    // Initialize views and indexes
-    await initializeDatabase(db);
-
-    cachedClient = client;
-    cachedDb = db;
-
-    console.log("Connected to MongoDB");
-    return { client, db };
-  } catch (error) {
-    console.error("Error connecting to MongoDB:", error);
-    throw error;
+  if (connectionPromise) {
+    return connectionPromise;
   }
+
+  connectionPromise = (async () => {
+    try {
+      const options: MongoClientOptions = {
+        maxPoolSize: 10,
+      };
+
+      const client = new MongoClient(MONGODB_URI, options);
+      await client.connect();
+
+      const db = client.db(DB_NAME);
+
+      // Verify connection
+      await db.admin().ping();
+
+      // Initialize views and indexes
+      await initializeDatabase(db);
+
+      cachedClient = client;
+      cachedDb = db;
+
+      console.log("Connected to MongoDB");
+      return { client, db };
+    } catch (error) {
+      connectionPromise = null;
+      console.error("Error connecting to MongoDB:", error);
+      throw error;
+    }
+  })();
+
+  return connectionPromise;
 }
 
 export async function getDatabase(): Promise<Db> {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -165,11 +165,16 @@ export async function connectToDatabase(): Promise<{
 
       const db = client.db(DB_NAME);
 
-      // Verify connection
-      await db.admin().ping();
+      try {
+        // Verify connection
+        await db.admin().ping();
 
-      // Initialize views and indexes
-      await initializeDatabase(db);
+        // Initialize views and indexes
+        await initializeDatabase(db);
+      } catch (initError) {
+        await client.close().catch(() => {});
+        throw initError;
+      }
 
       cachedClient = client;
       cachedDb = db;
@@ -192,6 +197,7 @@ export async function getDatabase(): Promise<Db> {
 }
 
 export async function closeDatabase(): Promise<void> {
+  connectionPromise = null;
   if (cachedClient) {
     await cachedClient.close();
     cachedClient = null;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -475,9 +475,12 @@ export const storage = {
     try {
       const db = await getDatabase();
       // Soft delete: mark with deletedAt timestamp
-      await db
+      const result = await db
         .collection<Character>("characters")
         .updateOne({ id, userId }, { $set: { deletedAt: new Date() } });
+      if (result.matchedCount === 0) {
+        throw new Error(`Character ${id} not found`);
+      }
       // Set leftAt on all active party memberships for the deleted character
       await db
         .collection<Party>("parties")

--- a/openspec/changes/fix-soft-delete-flaky-test/tasks.md
+++ b/openspec/changes/fix-soft-delete-flaky-test/tasks.md
@@ -1,0 +1,113 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b fix/soft-delete-flaky-test` then immediately `git push -u origin fix/soft-delete-flaky-test`
+
+## Execution
+
+### Task 1 — Add promise mutex to `connectToDatabase` (`lib/db.ts`)
+
+**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md`
+
+- [x] Add a module-level variable: `let connectionPromise: Promise<{ client: MongoClient; db: Db }> | null = null;`
+- [x] Modify `connectToDatabase` to check `connectionPromise` after the cache check: if `connectionPromise` is non-null, return it directly
+- [x] On first call (cache miss, no in-flight promise), assign `connectionPromise` to the full initialisation work
+- [x] In the `catch` block of the initialisation, set `connectionPromise = null` before re-throwing, so the next call can retry
+- [x] Verify: the existing integration test suite still passes; no new failures introduced
+
+**Verification:**
+```bash
+npm run test:integration -- --testPathPattern="softDelete"
+```
+
+### Task 2 — Add `matchedCount` guard to `deleteCharacter` (`lib/storage.ts`)
+
+**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md`
+
+- [x] Capture the result of `updateOne`: `const result = await db.collection<Character>("characters").updateOne(...)`
+- [x] After the `updateOne`, add: `if (result.matchedCount === 0) { throw new Error(\`Character ${id} not found\`); }`
+- [x] Confirm the existing `try/catch` in `deleteCharacter` re-throws: error propagates to the DELETE route handler → HTTP 500
+- [x] Verify: no existing tests break (the ownership pre-check in the route ensures `matchedCount === 0` is unreachable in normal flow)
+
+**Verification:**
+```bash
+npm run test:unit
+npm run test:integration -- --testPathPattern="softDelete"
+```
+
+### Task 3 — Add intermediate status assertions to the 404 test (`tests/integration/characters/softDelete.integration.test.ts`)
+
+**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md`
+
+- [x] In the "should return 404 when accessing deleted character detail" test, add `expect(createRes.status).toBe(201);` immediately after the POST fetch
+- [x] Capture the DELETE response: `const deleteRes = await fetch(...)` (it was previously fire-and-forget)
+- [x] Add `expect(deleteRes.status).toBe(200);` after the DELETE fetch
+- [x] Run the full soft-delete test file to confirm all tests pass
+
+**Verification:**
+```bash
+npm run test:integration -- --testPathPattern="softDelete"
+```
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test:unit` — all unit tests pass
+- [x] `npm run test:integration` — all integration tests pass (run at least twice to verify no flakiness)
+- [x] `npm run build` — build succeeds with no type errors
+- [x] All tasks 1–3 marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `fix/soft-delete-flaky-test` and push to remote
+- [ ] Open PR from `fix/soft-delete-flaky-test` to `main`. PR body must include `Closes #386`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll for new comments autonomously; address them, commit fixes, resolve threads, follow Remote push validation steps, push to `fix/soft-delete-flaky-test`; wait 180 seconds then repeat
+- [ ] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, follow Remote push validation steps, push, wait 180 seconds, repeat
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+
+Ownership metadata:
+
+- Implementer: assigned agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/`:
+  - Copy `openspec/changes/fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md` → `openspec/specs/db-init-concurrency/spec.md`
+  - Copy `openspec/changes/fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md` → `openspec/specs/delete-character-not-found/spec.md`
+  - Copy `openspec/changes/fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md` → `openspec/specs/soft-delete-test-assertions/spec.md`
+  - Update relative links in each promoted spec to point to archived locations (`../../changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/design.md`, etc.)
+- [ ] Archive the change: move `openspec/changes/fix-soft-delete-flaky-test/` → `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` in a **single atomic commit** (stage both copy and deletion together)
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` exists and `openspec/changes/fix-soft-delete-flaky-test/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-fix-soft-delete-flaky-test` then `git push -u origin doc/archive-fix-soft-delete-flaky-test`
+- [ ] Open a PR from `doc/archive-fix-soft-delete-flaky-test` to `main` with title `docs: archive fix-soft-delete-flaky-test`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -d fix/soft-delete-flaky-test doc/archive-fix-soft-delete-flaky-test`

--- a/tests/integration/characters/softDelete.integration.test.ts
+++ b/tests/integration/characters/softDelete.integration.test.ts
@@ -89,14 +89,16 @@ describe("Character Soft Delete API Integration", () => {
         }),
       });
 
+      expect(createRes.status).toBe(201);
       const character = await createRes.json();
       const characterId = character.id;
 
       // Delete the character
-      await fetch(`${baseUrl}/api/characters/${characterId}`, {
+      const deleteRes = await fetch(`${baseUrl}/api/characters/${characterId}`, {
         method: "DELETE",
         headers: { Cookie: authCookie },
       });
+      expect(deleteRes.status).toBe(200);
 
       // Try to get deleted character detail
       const detailRes = await fetch(

--- a/tests/unit/lib/db.test.ts
+++ b/tests/unit/lib/db.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+
+let mockConnect: jest.Mock;
+let mockCreateCollection: jest.Mock;
+
+beforeEach(() => {
+  mockConnect = jest.fn().mockResolvedValue(undefined);
+  mockCreateCollection = jest.fn().mockResolvedValue({});
+
+  jest.resetModules();
+
+  const mockCreateIndex = jest.fn().mockResolvedValue({});
+  const mockDb = {
+    admin: jest.fn().mockReturnValue({ ping: jest.fn().mockResolvedValue({}) }),
+    collection: jest.fn().mockReturnValue({ createIndex: mockCreateIndex }),
+    createCollection: mockCreateCollection,
+    listCollections: jest
+      .fn()
+      .mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+  };
+
+  jest.doMock("mongodb", () => ({
+    MongoClient: jest.fn().mockImplementation(() => ({
+      connect: mockConnect,
+      db: jest.fn().mockReturnValue(mockDb),
+      close: jest.fn().mockResolvedValue(undefined),
+    })),
+  }));
+});
+
+describe("connectToDatabase", () => {
+  test("T1-A: concurrent callers share one initialisation", async () => {
+    const { connectToDatabase } = require("@/lib/db");
+
+    const [r1, r2] = await Promise.all([
+      connectToDatabase(),
+      connectToDatabase(),
+    ]);
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+    expect(r1.db).toBe(r2.db);
+  });
+
+  test("T1-B: subsequent callers use the cache", async () => {
+    const { connectToDatabase } = require("@/lib/db");
+
+    const r1 = await connectToDatabase();
+    const r2 = await connectToDatabase();
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+    expect(r1.db).toBe(r2.db);
+  });
+
+  test("T1-C: failed connection allows retry", async () => {
+    mockConnect
+      .mockRejectedValueOnce(new Error("connection refused"))
+      .mockResolvedValue(undefined);
+
+    const { connectToDatabase } = require("@/lib/db");
+
+    await expect(connectToDatabase()).rejects.toThrow("connection refused");
+    const result = await connectToDatabase();
+    expect(result).toBeDefined();
+    expect(mockConnect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/lib/storage.characters.test.ts
+++ b/tests/unit/lib/storage.characters.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { storage } from "@/lib/storage";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+import { getDatabase } from "@/lib/db";
+
+const mockedUpdateMany = jest.fn().mockResolvedValue({});
+const mockedUpdateOne = jest.fn();
+
+const mockedCollection = jest.fn().mockReturnValue({
+  updateOne: mockedUpdateOne,
+  updateMany: mockedUpdateMany,
+});
+
+jest.mocked(getDatabase).mockResolvedValue({ collection: mockedCollection } as any);
+
+describe("storage.deleteCharacter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCollection.mockReturnValue({
+      updateOne: mockedUpdateOne,
+      updateMany: mockedUpdateMany,
+    });
+  });
+
+  test("T2-A: resolves without error when character is found (matchedCount === 1)", async () => {
+    mockedUpdateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+
+    await expect(storage.deleteCharacter("char-123", "user-456")).resolves.toBeUndefined();
+    expect(mockedUpdateOne).toHaveBeenCalledTimes(1);
+  });
+
+  test("T2-B: throws when character is not found (matchedCount === 0)", async () => {
+    mockedUpdateOne.mockResolvedValue({ matchedCount: 0, modifiedCount: 0 });
+
+    await expect(storage.deleteCharacter("char-123", "user-456")).rejects.toThrow(
+      "Character char-123 not found"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three distinct defects that caused `Character Soft Delete API Integration > DELETE /api/characters/{id} > should return 404 when accessing deleted character detail` to intermittently fail with `Expected: 404, Received: 200`.

### Changes

**`lib/db.ts`** — Promise mutex in `connectToDatabase`

Added a module-level `connectionPromise` so concurrent callers at server startup share a single initialisation instead of each calling `initializeDatabase()`. The race caused the `characters_active` view to be dropped and recreated mid-query. The promise is cleared on failure so the next caller can retry.

**`lib/storage.ts`** — `matchedCount` guard in `deleteCharacter`

After `updateOne`, check `result.matchedCount === 0` and throw `Error(`Character ${id} not found`)`. Converts a silent no-op into a detectable error (HTTP 500 on an unexpected race, unreachable in normal flow due to the route's ownership pre-check).

**`tests/integration/characters/softDelete.integration.test.ts`** — Intermediate status assertions

Added `expect(createRes.status).toBe(201)` and captured `deleteRes` with `expect(deleteRes.status).toBe(200)` in the previously fire-and-forget 404 test. Failures now surface at the correct line.

**New unit tests**

- `tests/unit/lib/db.test.ts` — T1-A (concurrent callers share one init), T1-B (cache hit), T1-C (retry after failure)
- `tests/unit/lib/storage.characters.test.ts` — T2-A (happy path), T2-B (throws on matchedCount === 0)

Closes #386