### PR TITLE
docs: archive fix-soft-delete-flaky-test

### DIFF
--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/design.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/design.md
@@ -1,0 +1,127 @@
+## Context
+
+- **Relevant architecture:**
+  - `lib/db.ts` — singleton MongoDB connection module. `connectToDatabase()` maintains module-level `cachedClient`/`cachedDb`. `initializeDatabase()` creates the `characters_active` view and indexes on first connection.
+  - `lib/storage.ts` — storage abstraction. `loadCharacters` queries `characters_active` with fallback to direct collection. `deleteCharacter` uses `updateOne` on the raw `characters` collection.
+  - `tests/integration/characters/softDelete.integration.test.ts` — integration tests running against a live Next.js + MongoDB stack started in `globalSetup`.
+- **Dependencies:** MongoDB driver (`mongodb`), Next.js, Jest test runner with `maxWorkers: '50%'` for integration tests.
+- **Interfaces/contracts touched:**
+  - `connectToDatabase()` — internal module function; no external API contract.
+  - `deleteCharacter(id, userId)` — internal storage method; callers are `app/api/characters/[id]/route.ts` DELETE handler only.
+  - `softDelete.integration.test.ts` — test file; no external contract.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Eliminate the concurrent `initializeDatabase` race by serialising `connectToDatabase` callers.
+- Make `deleteCharacter` fail loudly when no document is matched.
+- Make the 404 test self-diagnosing by asserting intermediate HTTP status codes.
+
+### Non-Goals
+
+- Altering the `characters_active` view pipeline or filter semantics.
+- Changing error-path HTTP status codes for the character DELETE endpoint on the happy path.
+- Fixing other storage methods with similar silent-failure patterns (out of scope for this change).
+
+## Decisions
+
+### Decision 1: Promise mutex for `connectToDatabase`
+
+- **Chosen:** Store the in-flight initialisation in a module-level `connectionPromise: Promise<...> | null`. On first call, assign the promise; on subsequent concurrent calls, return the same promise. Clear `connectionPromise` (set to `null`) in the rejection handler so a failed attempt allows retry on the next call.
+- **Alternatives considered:**
+  - _Synchronous lock via boolean flag_: still allows a window where two callers read `false` before either sets `true` (not safe across async boundaries in Node.js event loop).
+  - _Retry loop with backoff_: addresses flakiness at the caller level but doesn't fix the root race.
+- **Rationale:** A shared promise is the idiomatic Node.js pattern for preventing concurrent async initialisation. Because `cachedDb` is only set after the promise resolves, the race is fully closed.
+- **Trade-offs:** If the initial connection fails, the rejection is surfaced to all concurrent waiters (correct). Clearing `connectionPromise` on failure allows the next request to retry (desired for resilience, no downside).
+
+### Decision 2: `matchedCount` guard in `deleteCharacter`
+
+- **Chosen:** After `updateOne`, read `result.matchedCount`. If `=== 0`, throw `new Error(\`Character ${id} not found\`)`. The error propagates through the `try/catch` in `deleteCharacter` and will be caught by the DELETE route's outer handler, returning HTTP 500.
+- **Alternatives considered:**
+  - _Return a boolean_: changes the function signature; callers would need updates. More invasive than needed.
+  - _No change, add logging only_: improves observability but doesn't make tests fail fast.
+- **Rationale:** The DELETE route already performs an ownership check via `loadCharacters` before calling `deleteCharacter`. In the normal flow, `matchedCount === 0` is only reachable via a race or bug, so throwing is the right signal. It converts a silent no-op into a detectable error.
+- **Trade-offs:** Any future callers that rely on the silent no-op behaviour will break. This is desirable — the silent no-op is a defect, not a feature.
+
+### Decision 3: Explicit status assertions in the 404 test
+
+- **Chosen:** Add `expect(createRes.status).toBe(201)` immediately after the create fetch, and `expect(deleteRes.status).toBe(200)` immediately after the delete fetch, in the "should return 404 when accessing deleted character detail" test.
+- **Alternatives considered:**
+  - _Retry loop on the final GET_: masks root cause; wrong approach.
+  - _Add a `waitFor` helper_: unnecessary given the synchronous HTTP request/response model.
+- **Rationale:** The test was silently continuing with bad state. Asserting each step turns an obscure end-of-test failure into an immediate, specific error pointing at the broken step.
+- **Trade-offs:** None. This is a straightforward test quality improvement.
+
+## Proposal to Design Mapping
+
+- **Proposal element:** `connectToDatabase` concurrent-call race
+  - **Design decision:** Decision 1 (promise mutex)
+  - **Validation approach:** Covered by the existing integration test suite; the race is structural and doesn't require a new test.
+
+- **Proposal element:** `deleteCharacter` silent failure on `matchedCount === 0`
+  - **Design decision:** Decision 2 (`matchedCount` guard)
+  - **Validation approach:** New unit test asserting that `deleteCharacter` throws when `updateOne` returns `matchedCount: 0`. See `tests.md`.
+
+- **Proposal element:** 404 test missing intermediate assertions
+  - **Design decision:** Decision 3 (explicit status assertions)
+  - **Validation approach:** The test itself becomes the validation; a failure in create or delete now surfaces at the right line.
+
+## Functional Requirements Mapping
+
+- **Requirement:** `connectToDatabase` must only call `initializeDatabase` once per process lifetime, even under concurrent callers.
+  - **Design element:** Decision 1 — promise mutex.
+  - **Acceptance criteria reference:** `specs/db-init-concurrency/spec.md` — Scenario: concurrent callers share one initialisation.
+  - **Testability notes:** Can be tested by calling `connectToDatabase` twice concurrently and asserting `initializeDatabase` (mocked) is called exactly once.
+
+- **Requirement:** `deleteCharacter` must throw when the target document is not found.
+  - **Design element:** Decision 2 — `matchedCount` guard.
+  - **Acceptance criteria reference:** `specs/delete-character-not-found/spec.md` — Scenario: deleteCharacter throws on no match.
+  - **Testability notes:** Unit test with mocked MongoDB collection returning `{ matchedCount: 0 }`.
+
+- **Requirement:** The 404 integration test must assert each HTTP operation before proceeding.
+  - **Design element:** Decision 3 — inline `expect` assertions.
+  - **Acceptance criteria reference:** `specs/soft-delete-test-assertions/spec.md` — Scenario: intermediate steps asserted.
+  - **Testability notes:** Verified by the test passing in CI without flaking.
+
+## Non-Functional Requirements Mapping
+
+- **Requirement category:** reliability
+  - **Requirement:** CI integration test suite must not produce intermittent failures on the soft-delete path.
+  - **Design element:** All three decisions together eliminate the known flake vectors.
+  - **Acceptance criteria reference:** Green CI runs across multiple consecutive PR triggers.
+  - **Testability notes:** Observe CI over 5+ PR runs after merge; zero recurrences.
+
+- **Requirement category:** operability
+  - **Requirement:** If `connectToDatabase` fails, the next request must be able to retry.
+  - **Design element:** Decision 1 — clear `connectionPromise` on rejection.
+  - **Acceptance criteria reference:** `specs/db-init-concurrency/spec.md` — Scenario: failed connection allows retry.
+  - **Testability notes:** Unit test that simulates a failed first connect and verifies second attempt succeeds.
+
+## Risks / Trade-offs
+
+- **Risk/trade-off:** Throwing in `deleteCharacter` on `matchedCount === 0` turns a silent no-op into an HTTP 500 for an unexpected race.
+  - **Impact:** An unexpected 500 is more visible than a silent 200. This is intentional. No user-visible 500 is expected in normal operation given the prior ownership check.
+  - **Mitigation:** Confirm via code search that the DELETE route's pre-check ensures `matchedCount === 0` is unreachable in normal flow before shipping.
+
+- **Risk/trade-off:** The promise mutex caches a rejected promise briefly until cleared.
+  - **Impact:** All concurrent callers waiting on the same failed promise will receive the rejection. This is correct behaviour — they all get the error, not a stale connection.
+  - **Mitigation:** Clear `connectionPromise` in the catch block; tested by the retry scenario in specs.
+
+## Rollback / Mitigation
+
+- **Rollback trigger:** New CI failures introduced by the `matchedCount` guard (i.e., a caller that legitimately expected the no-op behaviour).
+- **Rollback steps:** Revert `lib/storage.ts` change only; `lib/db.ts` and test changes are safe to keep.
+- **Data migration considerations:** None — no schema changes.
+- **Verification after rollback:** Re-run integration test suite; confirm original flake rate returns to baseline (i.e., no new failures introduced).
+
+## Operational Blocking Policy
+
+- **If CI checks fail:** Investigate the failure before merge. Do not bypass with `--no-verify` or admin merge.
+- **If security checks fail:** Treat as a blocker; escalate to the repo owner.
+- **If required reviews are blocked/stale:** After 48 hours without review, ping the reviewer and/or re-assign.
+- **Escalation path and timeout:** If CI is green but merge is blocked > 72 hours, escalate to the repository owner (dougis).
+
+## Open Questions
+
+No open questions remain.

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/proposal.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/proposal.md
@@ -1,0 +1,73 @@
+## GitHub Issues
+
+- #386
+
+## Why
+
+- **Problem statement:** The `Character Soft Delete API Integration > DELETE /api/characters/{id} > should return 404 when accessing deleted character detail` test intermittently fails in CI with `Expected: 404, Received: 200`. Three distinct defects contribute: a concurrency gap in database initialization, a silent failure in the delete operation, and missing assertions in the test.
+- **Why now:** The failure was first observed in PR #385 (a docs-only branch), meaning it can block unrelated PRs. Leaving it unresolved degrades CI signal and erodes confidence in the integration test suite.
+- **Business/user impact:** Intermittent CI failures force manual re-triggers, slow down delivery, and mask real regressions when they happen to co-occur with the flake.
+
+## Problem Space
+
+- **Current behavior:**
+  1. `connectToDatabase()` in `lib/db.ts` has no concurrency guard. Multiple simultaneous requests (common with parallel test workers at server startup) all pass the `cachedClient && cachedDb` check and each call `initializeDatabase()`. The second call drops and recreates the `characters_active` MongoDB view, creating a window where the view does not exist. During this window `loadCharacters` falls back to a direct collection query.
+  2. `deleteCharacter()` in `lib/storage.ts` calls `updateOne({ id, userId }, { $set: { deletedAt: new Date() } })` but never checks `matchedCount`. If the update matches 0 documents for any reason, the function returns void, the DELETE endpoint returns HTTP 200, and the character is never actually soft-deleted.
+  3. The 404 test does not assert the status of the POST (create) or DELETE responses. If either silently fails, the test continues with incorrect state and produces a confusing assertion failure.
+- **Desired behavior:**
+  1. `connectToDatabase()` serialises concurrent callers so `initializeDatabase()` runs exactly once per process lifetime.
+  2. `deleteCharacter()` throws if no document was matched, causing the DELETE endpoint to return 500 instead of a misleading 200.
+  3. The 404 test asserts POST returns 201 and DELETE returns 200 before checking the final GET.
+- **Constraints:** Changes must not alter the external API contract (HTTP status codes for happy paths) or break existing tests.
+- **Assumptions:**
+  - The `characters_active` view is always correct once created; the only problem is the drop/recreate race.
+  - The MongoDB instance used in integration tests is standalone (no replica set), so read-your-own-writes is guaranteed once a write is acknowledged.
+- **Edge cases considered:**
+  - A character that does not exist (already deleted or wrong ID): `deleteCharacter` will now throw, which is the correct signal to callers.
+  - Concurrent DELETE requests for the same character: the second call will match 0 documents and now throws. The DELETE endpoint should return 404 for that case. This is handled by the existing ownership check in the route before `deleteCharacter` is called, so the behaviour is unchanged for valid concurrency scenarios.
+
+## Scope
+
+### In Scope
+
+- `lib/db.ts`: add a module-level promise mutex to `connectToDatabase`
+- `lib/storage.ts`: add `matchedCount` guard to `deleteCharacter`
+- `tests/integration/characters/softDelete.integration.test.ts`: add status assertions on POST and DELETE in the failing test
+
+### Out of Scope
+
+- Changes to any other storage methods (e.g., `deleteEncounter`, `deleteParty`)
+- Changes to the `characters_active` view definition or filter pipeline
+- Adding retries or polling to integration tests
+- Changing MongoDB write-concern settings
+
+## What Changes
+
+- `lib/db.ts`: `connectToDatabase` stores its work in a module-level `Promise` on first call; subsequent concurrent calls await the same promise instead of starting parallel initialization.
+- `lib/storage.ts`: `deleteCharacter` reads `result.matchedCount` after `updateOne` and throws `Error('Character not found')` when it is 0.
+- `tests/integration/characters/softDelete.integration.test.ts`: the "should return 404 when accessing deleted character detail" test adds `expect(createRes.status).toBe(201)` and `expect(deleteRes.status).toBe(200)` before the final assertion.
+
+## Risks
+
+- **Risk:** The `matchedCount` guard in `deleteCharacter` changes error-path behaviour.
+  - **Impact:** Any caller that previously observed a silent no-op on a missing character will now receive a thrown error. In the current codebase the only direct caller is the DELETE route, which already returns 404 if `loadCharacters` does not find the character (ownership check before `deleteCharacter` is called), so `matchedCount === 0` should never be reached via the normal path.
+  - **Mitigation:** Review all callers of `deleteCharacter` before implementing; confirm the ownership pre-check means `matchedCount === 0` is only reachable via a true bug or race.
+
+- **Risk:** The promise mutex in `connectToDatabase` caches the rejected promise on first failure.
+  - **Impact:** If the initial connection attempt fails (e.g., MongoDB not yet ready), all subsequent callers will receive the same rejection and the server will be unable to recover without a restart.
+  - **Mitigation:** Clear `connectionPromise` on rejection so the next caller retries. This is standard practice for this pattern.
+
+## Open Questions
+
+No unresolved ambiguity exists. All three fixes are self-contained and have been fully scoped from existing code analysis.
+
+## Non-Goals
+
+- Fixing other potentially-flaky integration tests unrelated to soft delete
+- Changing `deleteCharacter` to return the deleted document
+- Adding soft-delete support to encounters, parties, or campaigns
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/proposal.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/proposal.md
@@ -44,7 +44,7 @@
 ## What Changes
 
 - `lib/db.ts`: `connectToDatabase` stores its work in a module-level `Promise` on first call; subsequent concurrent calls await the same promise instead of starting parallel initialization.
-- `lib/storage.ts`: `deleteCharacter` reads `result.matchedCount` after `updateOne` and throws `Error('Character not found')` when it is 0.
+- `lib/storage.ts`: `deleteCharacter` reads `result.matchedCount` after `updateOne` and throws `Error('Character ${id} not found')` when it is 0.
 - `tests/integration/characters/softDelete.integration.test.ts`: the "should return 404 when accessing deleted character detail" test adds `expect(createRes.status).toBe(201)` and `expect(deleteRes.status).toBe(200)` before the final assertion.
 
 ## Risks

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED connectToDatabase initialises the database exactly once per process
+
+The system SHALL ensure that `initializeDatabase` is called at most once per process lifetime, regardless of how many concurrent calls to `connectToDatabase` are made before the first call completes.
+
+#### Scenario: Concurrent callers share one initialisation
+
+- **Given** the module-level `cachedClient` and `cachedDb` are both `null` (server just started)
+- **When** two or more requests call `connectToDatabase` concurrently before any of them has set the cache
+- **Then** `initializeDatabase` is invoked exactly once, and all callers receive the same resolved `{ client, db }` result
+
+#### Scenario: Subsequent callers after initialisation use the cache
+
+- **Given** `cachedClient` and `cachedDb` are already set (initialisation completed)
+- **When** any subsequent call to `connectToDatabase` is made
+- **Then** the cached values are returned immediately without calling `initializeDatabase` again
+
+#### Scenario: Failed connection allows retry
+
+- **Given** the first call to `connectToDatabase` fails (e.g., MongoDB not reachable)
+- **When** a subsequent call to `connectToDatabase` is made after the failure
+- **Then** a new connection attempt is made (the failed promise is not reused), and the caller can successfully connect if MongoDB has become available
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: `connectToDatabase` concurrent-call race -> Requirement: MODIFIED connectToDatabase initialises exactly once
+- Design decision: Decision 1 (promise mutex) -> Requirement: MODIFIED connectToDatabase initialises exactly once
+- Requirement -> Task(s): Task 1 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Recovery behavior
+
+- **Given** MongoDB is temporarily unavailable at server startup
+- **When** the first `connectToDatabase` call rejects and MongoDB becomes available
+- **Then** the next `connectToDatabase` call succeeds and the server resumes normal operation (the stale rejected promise does not permanently block subsequent attempts)

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md
@@ -38,8 +38,4 @@ No requirements removed.
 
 ### Requirement: Reliability
 
-#### Scenario: Recovery behavior
-
-- **Given** MongoDB is temporarily unavailable at server startup
-- **When** the first `connectToDatabase` call rejects and MongoDB becomes available
-- **Then** the next `connectToDatabase` call succeeds and the server resumes normal operation (the stale rejected promise does not permanently block subsequent attempts)
+See functional scenario: [Failed connection allows retry]

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md
@@ -16,7 +16,7 @@ The system SHALL throw an `Error` when `deleteCharacter` is called with an `id`/
 
 - **Given** no document in the `characters` collection matches the given `id` and `userId`
 - **When** `deleteCharacter(id, userId)` is called
-- **Then** the function throws `` Error(`Character ${id} not found`) `` and the DELETE endpoint returns HTTP 500
+- **Then** the function throws an `Error` with message `Character <id> not found` and the DELETE endpoint returns HTTP 500
 
 #### Scenario: Delete is not re-entrant for an already-deleted character
 

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md
@@ -16,7 +16,7 @@ The system SHALL throw an `Error` when `deleteCharacter` is called with an `id`/
 
 - **Given** no document in the `characters` collection matches the given `id` and `userId`
 - **When** `deleteCharacter(id, userId)` is called
-- **Then** the function throws `Error('Character not found')` and the DELETE endpoint returns HTTP 500
+- **Then** the function throws `` Error(`Character ${id} not found`) `` and the DELETE endpoint returns HTTP 500
 
 #### Scenario: Delete is not re-entrant for an already-deleted character
 
@@ -38,8 +38,4 @@ No requirements removed.
 
 ### Requirement: Reliability
 
-#### Scenario: Silent failures are surfaced as errors
-
-- **Given** a storage operation fails to modify any document (e.g., stale ID, concurrent deletion)
-- **When** `deleteCharacter` is called and `updateOne` reports `matchedCount === 0`
-- **Then** an error is thrown (not swallowed), ensuring callers and monitoring systems are aware of the unexpected condition
+See functional scenario: [Delete throws when character is not found]

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED deleteCharacter throws when no document is matched
+
+The system SHALL throw an `Error` when `deleteCharacter` is called with an `id`/`userId` pair that does not match any document in the `characters` collection, converting what was previously a silent no-op into a detectable failure.
+
+#### Scenario: Delete succeeds for an existing character
+
+- **Given** a character exists in the `characters` collection with the given `id` and `userId`
+- **When** `deleteCharacter(id, userId)` is called
+- **Then** the character's `deletedAt` field is set to a current `Date`, the function resolves without error, and the DELETE endpoint returns HTTP 200
+
+#### Scenario: Delete throws when character is not found
+
+- **Given** no document in the `characters` collection matches the given `id` and `userId`
+- **When** `deleteCharacter(id, userId)` is called
+- **Then** the function throws `Error('Character not found')` and the DELETE endpoint returns HTTP 500
+
+#### Scenario: Delete is not re-entrant for an already-deleted character
+
+- **Given** a character has already been soft-deleted (`deletedAt` is set)
+- **When** the DELETE route handler is called again for the same character
+- **Then** the route's `loadCharacters` pre-check returns nothing (character not in `characters_active` view), the handler returns HTTP 404 **before** calling `deleteCharacter`, and `deleteCharacter` is never invoked
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: `deleteCharacter` silent failure on `matchedCount === 0` -> Requirement: MODIFIED deleteCharacter throws when no document is matched
+- Design decision: Decision 2 (`matchedCount` guard) -> Requirement: MODIFIED deleteCharacter throws when no document is matched
+- Requirement -> Task(s): Task 2 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Silent failures are surfaced as errors
+
+- **Given** a storage operation fails to modify any document (e.g., stale ID, concurrent deletion)
+- **When** `deleteCharacter` is called and `updateOne` reports `matchedCount === 0`
+- **Then** an error is thrown (not swallowed), ensuring callers and monitoring systems are aware of the unexpected condition

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED soft-delete 404 test asserts all intermediate HTTP responses
+
+The test "should return 404 when accessing deleted character detail" SHALL assert the HTTP status of the character creation (POST) and the soft-delete (DELETE) requests before asserting the final GET returns 404, ensuring that a failure in any step produces an immediate, targeted assertion error rather than a confusing end-of-test failure.
+
+#### Scenario: All steps pass — test verifies 404 on deleted character
+
+- **Given** the integration test server is running and the test user is authenticated
+- **When** the test POSTs a new character, DELETEs it, and then GETs it
+- **Then** the POST assertion `expect(createRes.status).toBe(201)` passes, the DELETE assertion `expect(deleteRes.status).toBe(200)` passes, and the GET assertion `expect(detailRes.status).toBe(404)` passes
+
+#### Scenario: Character creation fails — test fails at the correct assertion
+
+- **Given** the POST to create a character returns a non-201 status (server error, conflict, etc.)
+- **When** the test executes
+- **Then** `expect(createRes.status).toBe(201)` fails immediately, clearly identifying the create step as the source of the problem
+
+#### Scenario: Delete operation fails — test fails at the correct assertion
+
+- **Given** the character is created successfully (POST returns 201) but the DELETE returns a non-200 status
+- **When** the test executes
+- **Then** `expect(deleteRes.status).toBe(200)` fails immediately, clearly identifying the delete step as the source of the problem rather than producing a confusing 200 on the final GET
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: 404 test missing intermediate assertions -> Requirement: MODIFIED soft-delete 404 test asserts all intermediate HTTP responses
+- Design decision: Decision 3 (explicit status assertions) -> Requirement: MODIFIED soft-delete 404 test asserts all intermediate HTTP responses
+- Requirement -> Task(s): Task 3 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Recovery behavior
+
+- **Given** CI re-triggers the integration test suite after a transient failure
+- **When** all three HTTP operations (POST, DELETE, GET) complete successfully
+- **Then** the test passes without flaking, and no assertion failure is produced by a silent intermediate step

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md
@@ -38,8 +38,4 @@ No requirements removed.
 
 ### Requirement: Reliability
 
-#### Scenario: Recovery behavior
-
-- **Given** CI re-triggers the integration test suite after a transient failure
-- **When** all three HTTP operations (POST, DELETE, GET) complete successfully
-- **Then** the test passes without flaking, and no assertion failure is produced by a silent intermediate step
+See functional scenario: [All steps pass — test verifies 404 on deleted character]

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tasks.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tasks.md
@@ -107,7 +107,7 @@ Blocking resolution flow:
 - [x] Archive the change: move `openspec/changes/fix-soft-delete-flaky-test/` → `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` in a **single atomic commit** (stage both copy and deletion together)
 - [x] Confirm `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` exists and `openspec/changes/fix-soft-delete-flaky-test/` is gone
 - [x] **Create a doc branch:** `git checkout -b doc/archive-fix-soft-delete-flaky-test` then `git push -u origin doc/archive-fix-soft-delete-flaky-test`
-- [ ] Open a PR from `doc/archive-fix-soft-delete-flaky-test` to `main` with title `docs: archive fix-soft-delete-flaky-test`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [x] Open a PR from `doc/archive-fix-soft-delete-flaky-test` to `main` with title `docs: archive fix-soft-delete-flaky-test`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
 - [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)
 - [ ] Prune merged local branches: `git fetch --prune` && `git branch -d fix/soft-delete-flaky-test doc/archive-fix-soft-delete-flaky-test`

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tasks.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tasks.md
@@ -74,13 +74,13 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 ## PR and Merge
 
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `fix/soft-delete-flaky-test` and push to remote
-- [ ] Open PR from `fix/soft-delete-flaky-test` to `main`. PR body must include `Closes #386`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
-- [ ] **Monitor PR comments** — poll for new comments autonomously; address them, commit fixes, resolve threads, follow Remote push validation steps, push to `fix/soft-delete-flaky-test`; wait 180 seconds then repeat
-- [ ] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, follow Remote push validation steps, push, wait 180 seconds, repeat
-- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
+- [x] Commit all changes to `fix/soft-delete-flaky-test` and push to remote
+- [x] Open PR from `fix/soft-delete-flaky-test` to `main`. PR body must include `Closes #386`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll for new comments autonomously; address them, commit fixes, resolve threads, follow Remote push validation steps, push to `fix/soft-delete-flaky-test`; wait 180 seconds then repeat
+- [x] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, follow Remote push validation steps, push, wait 180 seconds, repeat
+- [x] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user
 
 Ownership metadata:
 
@@ -96,17 +96,17 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on `main`
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync approved spec deltas into `openspec/specs/`:
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on `main`
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Sync approved spec deltas into `openspec/specs/`:
   - Copy `openspec/changes/fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md` → `openspec/specs/db-init-concurrency/spec.md`
   - Copy `openspec/changes/fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md` → `openspec/specs/delete-character-not-found/spec.md`
   - Copy `openspec/changes/fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md` → `openspec/specs/soft-delete-test-assertions/spec.md`
   - Update relative links in each promoted spec to point to archived locations (`../../changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/design.md`, etc.)
-- [ ] Archive the change: move `openspec/changes/fix-soft-delete-flaky-test/` → `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` in a **single atomic commit** (stage both copy and deletion together)
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` exists and `openspec/changes/fix-soft-delete-flaky-test/` is gone
-- [ ] **Create a doc branch:** `git checkout -b doc/archive-fix-soft-delete-flaky-test` then `git push -u origin doc/archive-fix-soft-delete-flaky-test`
+- [x] Archive the change: move `openspec/changes/fix-soft-delete-flaky-test/` → `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` in a **single atomic commit** (stage both copy and deletion together)
+- [x] Confirm `openspec/changes/archive/YYYY-MM-DD-fix-soft-delete-flaky-test/` exists and `openspec/changes/fix-soft-delete-flaky-test/` is gone
+- [x] **Create a doc branch:** `git checkout -b doc/archive-fix-soft-delete-flaky-test` then `git push -u origin doc/archive-fix-soft-delete-flaky-test`
 - [ ] Open a PR from `doc/archive-fix-soft-delete-flaky-test` to `main` with title `docs: archive fix-soft-delete-flaky-test`
 - [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
 - [ ] Monitor the doc PR until it merges (same loop — address comments and CI failures, push to doc branch, repeat)

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tests.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tests.md
@@ -21,90 +21,90 @@ For each task in `tasks.md`:
 
 ## Task 1 — `connectToDatabase` promise mutex (`lib/db.ts`)
 
-**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md`
+**Spec:** `openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md`
 **Test file:** `tests/unit/lib/db.test.ts` (create if it doesn't exist)
 
 ### T1-A — Concurrent callers share one initialisation
 
-- [ ] **Given** `cachedClient`/`cachedDb` are null (module just loaded)
-- [ ] **When** `connectToDatabase()` is called twice concurrently (both calls start before either resolves)
-- [ ] **Then** the mocked `initializeDatabase` is invoked exactly once
-- [ ] **TDD step:** Mock `MongoClient`, `db.admin().ping`, and `initializeDatabase`. Call `connectToDatabase()` twice without `await`, then `await Promise.all([call1, call2])`. Assert mock call count is 1.
+- [x] **Given** `cachedClient`/`cachedDb` are null (module just loaded)
+- [x] **When** `connectToDatabase()` is called twice concurrently (both calls start before either resolves)
+- [x] **Then** the mocked `initializeDatabase` is invoked exactly once
+- [x] **TDD step:** Mock `MongoClient`, `db.admin().ping`, and `initializeDatabase`. Call `connectToDatabase()` twice without `await`, then `await Promise.all([call1, call2])`. Assert mock call count is 1.
 
 ### T1-B — Subsequent callers use the cache
 
-- [ ] **Given** `connectToDatabase()` has been called and the cache is populated
-- [ ] **When** `connectToDatabase()` is called again
-- [ ] **Then** the result is returned immediately and `initializeDatabase` is not called again
-- [ ] **TDD step:** Assert mock call count remains 1 after a second `await connectToDatabase()`.
+- [x] **Given** `connectToDatabase()` has been called and the cache is populated
+- [x] **When** `connectToDatabase()` is called again
+- [x] **Then** the result is returned immediately and `initializeDatabase` is not called again
+- [x] **TDD step:** Assert mock call count remains 1 after a second `await connectToDatabase()`.
 
 ### T1-C — Failed connection allows retry
 
-- [ ] **Given** the first `connectToDatabase()` call rejects (MongoDB unavailable)
-- [ ] **When** a second `connectToDatabase()` call is made after the rejection
-- [ ] **Then** a new connection attempt is made (not the same rejected promise)
-- [ ] **TDD step:** Mock `client.connect` to reject on first call, resolve on second. Assert that the second `connectToDatabase()` call succeeds and `initializeDatabase` was called once (on the successful attempt).
+- [x] **Given** the first `connectToDatabase()` call rejects (MongoDB unavailable)
+- [x] **When** a second `connectToDatabase()` call is made after the rejection
+- [x] **Then** a new connection attempt is made (not the same rejected promise)
+- [x] **TDD step:** Mock `client.connect` to reject on first call, resolve on second. Assert that the second `connectToDatabase()` call succeeds and `initializeDatabase` was called once (on the successful attempt).
 
 ---
 
 ## Task 2 — `deleteCharacter` `matchedCount` guard (`lib/storage.ts`)
 
-**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md`
+**Spec:** `openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md`
 **Test file:** `tests/unit/lib/storage.characters.test.ts` (create or extend)
 
 ### T2-A — Delete succeeds when character exists
 
-- [ ] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 1, modifiedCount: 1 }`
-- [ ] **When** `deleteCharacter(id, userId)` is called
-- [ ] **Then** the function resolves without error
-- [ ] **TDD step:** Confirm existing happy-path test (or write one) still passes after adding the guard.
+- [x] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 1, modifiedCount: 1 }`
+- [x] **When** `deleteCharacter(id, userId)` is called
+- [x] **Then** the function resolves without error
+- [x] **TDD step:** Confirm existing happy-path test (or write one) still passes after adding the guard.
 
 ### T2-B — Delete throws when character is not found
 
-- [ ] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 0, modifiedCount: 0 }`
-- [ ] **When** `deleteCharacter(id, userId)` is called
-- [ ] **Then** the function throws `Error('Character not found')`
-- [ ] **TDD step:** Write the test first; it fails because current code has no guard. Add guard; test passes.
+- [x] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 0, modifiedCount: 0 }`
+- [x] **When** `deleteCharacter(id, userId)` is called
+- [x] **Then** the function throws `Error(`Character ${id} not found`)`
+- [x] **TDD step:** Write the test first; it fails because current code has no guard. Add guard; test passes.
 
 ### T2-C — Integration: DELETE endpoint returns 500 when character not found mid-flight
 
-- [ ] **Given** the integration test server is running and a character exists
-- [ ] **When** the character is deleted from the DB directly (bypassing the API) and then the DELETE endpoint is called via HTTP
-- [ ] **Then** the DELETE endpoint returns HTTP 500 (because the ownership pre-check in `loadCharacters` still finds the character in the raw collection—it's not in the view—OR this is only exercised by a unit test; document which approach is used)
-- [ ] **Note:** This scenario is more naturally covered by unit tests (T2-B). Integration coverage is provided by the overall soft-delete integration suite which still passes.
+- [x] **Given** the integration test server is running and a character exists
+- [x] **When** the character is deleted from the DB directly (bypassing the API) and then the DELETE endpoint is called via HTTP
+- [x] **Then** the DELETE endpoint returns HTTP 500 (because the ownership pre-check in `loadCharacters` still finds the character in the raw collection—it's not in the view—OR this is only exercised by a unit test; document which approach is used)
+- [x] **Note:** This scenario is more naturally covered by unit tests (T2-B). Integration coverage is provided by the overall soft-delete integration suite which still passes.
 
 ---
 
 ## Task 3 — Intermediate status assertions in 404 test (`tests/integration/characters/softDelete.integration.test.ts`)
 
-**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md`
+**Spec:** `openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md`
 **Test file:** `tests/integration/characters/softDelete.integration.test.ts` (modify existing)
 
 ### T3-A — POST assertion surfaces create failures immediately
 
-- [ ] **Given** the "should return 404 when accessing deleted character detail" test
-- [ ] **When** the POST to create the character returns a non-201 status (simulate by temporarily breaking the route or asserting against a known-good server)
-- [ ] **Then** `expect(createRes.status).toBe(201)` fails at line N (not at the end of the test)
-- [ ] **TDD step:** Add the assertion; confirm the test still passes end-to-end on a green server. Confirm that removing the server and re-running fails at the `201` assertion (manual verification acceptable).
+- [x] **Given** the "should return 404 when accessing deleted character detail" test
+- [x] **When** the POST to create the character returns a non-201 status (simulate by temporarily breaking the route or asserting against a known-good server)
+- [x] **Then** `expect(createRes.status).toBe(201)` fails at line N (not at the end of the test)
+- [x] **TDD step:** Add the assertion; confirm the test still passes end-to-end on a green server. Confirm that removing the server and re-running fails at the `201` assertion (manual verification acceptable).
 
 ### T3-B — DELETE assertion surfaces delete failures immediately
 
-- [ ] **Given** the same test, after the character is created
-- [ ] **When** the DELETE returns a non-200 status
-- [ ] **Then** `expect(deleteRes.status).toBe(200)` fails at the correct line before the GET is attempted
-- [ ] **TDD step:** Add the assertion; confirm full test suite still passes.
+- [x] **Given** the same test, after the character is created
+- [x] **When** the DELETE returns a non-200 status
+- [x] **Then** `expect(deleteRes.status).toBe(200)` fails at the correct line before the GET is attempted
+- [x] **TDD step:** Add the assertion; confirm full test suite still passes.
 
 ### T3-C — Full end-to-end: 404 test passes deterministically
 
-- [ ] **Given** the integration test server is running with all three fixes applied
-- [ ] **When** `npm run test:integration -- --testPathPattern="softDelete"` is run **three times** consecutively
-- [ ] **Then** all runs produce green output with no intermittent 404→200 failure
-- [ ] **TDD step:** This is the acceptance gate for the full change.
+- [x] **Given** the integration test server is running with all three fixes applied
+- [x] **When** `npm run test:integration -- --testPathPattern="softDelete"` is run **three times** consecutively
+- [x] **Then** all runs produce green output with no intermittent 404→200 failure
+- [x] **TDD step:** This is the acceptance gate for the full change.
 
 ---
 
 ## Regression
 
-- [ ] Run `npm run test:unit` — no existing unit tests broken
-- [ ] Run `npm run test:integration` — no existing integration tests broken
-- [ ] Run `npm run build` — TypeScript compiles cleanly
+- [x] Run `npm run test:unit` — no existing unit tests broken
+- [x] Run `npm run test:integration` — no existing integration tests broken
+- [x] Run `npm run build` — TypeScript compiles cleanly

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tests.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tests.md
@@ -63,7 +63,7 @@ For each task in `tasks.md`:
 
 - [x] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 0, modifiedCount: 0 }`
 - [x] **When** `deleteCharacter(id, userId)` is called
-- [x] **Then** the function throws `Error(`Character ${id} not found`)`
+- [x] **Then** the function throws an `Error` with message `Character <id> not found`
 - [x] **TDD step:** Write the test first; it fails because current code has no guard. Add guard; test passes.
 
 ### T2-C — Integration: DELETE endpoint returns 500 when character not found mid-flight

--- a/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tests.md
+++ b/openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/tests.md
@@ -1,0 +1,110 @@
+---
+name: tests
+description: Tests for the fix-soft-delete-flaky-test change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `fix-soft-delete-flaky-test` change. All work follows strict TDD: write a failing test first, then write the implementation to make it pass, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — before touching implementation code, write a test that captures the requirement. Run it and confirm it fails.
+2. **Write code to pass the test** — write the simplest implementation that makes the test pass.
+3. **Refactor** — clean up without breaking the test.
+
+---
+
+## Task 1 — `connectToDatabase` promise mutex (`lib/db.ts`)
+
+**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/db-init-concurrency/spec.md`
+**Test file:** `tests/unit/lib/db.test.ts` (create if it doesn't exist)
+
+### T1-A — Concurrent callers share one initialisation
+
+- [ ] **Given** `cachedClient`/`cachedDb` are null (module just loaded)
+- [ ] **When** `connectToDatabase()` is called twice concurrently (both calls start before either resolves)
+- [ ] **Then** the mocked `initializeDatabase` is invoked exactly once
+- [ ] **TDD step:** Mock `MongoClient`, `db.admin().ping`, and `initializeDatabase`. Call `connectToDatabase()` twice without `await`, then `await Promise.all([call1, call2])`. Assert mock call count is 1.
+
+### T1-B — Subsequent callers use the cache
+
+- [ ] **Given** `connectToDatabase()` has been called and the cache is populated
+- [ ] **When** `connectToDatabase()` is called again
+- [ ] **Then** the result is returned immediately and `initializeDatabase` is not called again
+- [ ] **TDD step:** Assert mock call count remains 1 after a second `await connectToDatabase()`.
+
+### T1-C — Failed connection allows retry
+
+- [ ] **Given** the first `connectToDatabase()` call rejects (MongoDB unavailable)
+- [ ] **When** a second `connectToDatabase()` call is made after the rejection
+- [ ] **Then** a new connection attempt is made (not the same rejected promise)
+- [ ] **TDD step:** Mock `client.connect` to reject on first call, resolve on second. Assert that the second `connectToDatabase()` call succeeds and `initializeDatabase` was called once (on the successful attempt).
+
+---
+
+## Task 2 — `deleteCharacter` `matchedCount` guard (`lib/storage.ts`)
+
+**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/delete-character-not-found/spec.md`
+**Test file:** `tests/unit/lib/storage.characters.test.ts` (create or extend)
+
+### T2-A — Delete succeeds when character exists
+
+- [ ] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 1, modifiedCount: 1 }`
+- [ ] **When** `deleteCharacter(id, userId)` is called
+- [ ] **Then** the function resolves without error
+- [ ] **TDD step:** Confirm existing happy-path test (or write one) still passes after adding the guard.
+
+### T2-B — Delete throws when character is not found
+
+- [ ] **Given** a mock MongoDB collection where `updateOne` returns `{ matchedCount: 0, modifiedCount: 0 }`
+- [ ] **When** `deleteCharacter(id, userId)` is called
+- [ ] **Then** the function throws `Error('Character not found')`
+- [ ] **TDD step:** Write the test first; it fails because current code has no guard. Add guard; test passes.
+
+### T2-C — Integration: DELETE endpoint returns 500 when character not found mid-flight
+
+- [ ] **Given** the integration test server is running and a character exists
+- [ ] **When** the character is deleted from the DB directly (bypassing the API) and then the DELETE endpoint is called via HTTP
+- [ ] **Then** the DELETE endpoint returns HTTP 500 (because the ownership pre-check in `loadCharacters` still finds the character in the raw collection—it's not in the view—OR this is only exercised by a unit test; document which approach is used)
+- [ ] **Note:** This scenario is more naturally covered by unit tests (T2-B). Integration coverage is provided by the overall soft-delete integration suite which still passes.
+
+---
+
+## Task 3 — Intermediate status assertions in 404 test (`tests/integration/characters/softDelete.integration.test.ts`)
+
+**Spec:** `openspec/changes/fix-soft-delete-flaky-test/specs/soft-delete-test-assertions/spec.md`
+**Test file:** `tests/integration/characters/softDelete.integration.test.ts` (modify existing)
+
+### T3-A — POST assertion surfaces create failures immediately
+
+- [ ] **Given** the "should return 404 when accessing deleted character detail" test
+- [ ] **When** the POST to create the character returns a non-201 status (simulate by temporarily breaking the route or asserting against a known-good server)
+- [ ] **Then** `expect(createRes.status).toBe(201)` fails at line N (not at the end of the test)
+- [ ] **TDD step:** Add the assertion; confirm the test still passes end-to-end on a green server. Confirm that removing the server and re-running fails at the `201` assertion (manual verification acceptable).
+
+### T3-B — DELETE assertion surfaces delete failures immediately
+
+- [ ] **Given** the same test, after the character is created
+- [ ] **When** the DELETE returns a non-200 status
+- [ ] **Then** `expect(deleteRes.status).toBe(200)` fails at the correct line before the GET is attempted
+- [ ] **TDD step:** Add the assertion; confirm full test suite still passes.
+
+### T3-C — Full end-to-end: 404 test passes deterministically
+
+- [ ] **Given** the integration test server is running with all three fixes applied
+- [ ] **When** `npm run test:integration -- --testPathPattern="softDelete"` is run **three times** consecutively
+- [ ] **Then** all runs produce green output with no intermittent 404→200 failure
+- [ ] **TDD step:** This is the acceptance gate for the full change.
+
+---
+
+## Regression
+
+- [ ] Run `npm run test:unit` — no existing unit tests broken
+- [ ] Run `npm run test:integration` — no existing integration tests broken
+- [ ] Run `npm run build` — TypeScript compiles cleanly

--- a/openspec/specs/db-init-concurrency/spec.md
+++ b/openspec/specs/db-init-concurrency/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED connectToDatabase initialises the database exactly once per process
+
+The system SHALL ensure that `initializeDatabase` is called at most once per process lifetime, regardless of how many concurrent calls to `connectToDatabase` are made before the first call completes.
+
+#### Scenario: Concurrent callers share one initialisation
+
+- **Given** the module-level `cachedClient` and `cachedDb` are both `null` (server just started)
+- **When** two or more requests call `connectToDatabase` concurrently before any of them has set the cache
+- **Then** `initializeDatabase` is invoked exactly once, and all callers receive the same resolved `{ client, db }` result
+
+#### Scenario: Subsequent callers after initialisation use the cache
+
+- **Given** `cachedClient` and `cachedDb` are already set (initialisation completed)
+- **When** any subsequent call to `connectToDatabase` is made
+- **Then** the cached values are returned immediately without calling `initializeDatabase` again
+
+#### Scenario: Failed connection allows retry
+
+- **Given** the first call to `connectToDatabase` fails (e.g., MongoDB not reachable)
+- **When** a subsequent call to `connectToDatabase` is made after the failure
+- **Then** a new connection attempt is made (the failed promise is not reused), and the caller can successfully connect if MongoDB has become available
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: `connectToDatabase` concurrent-call race -> Requirement: MODIFIED connectToDatabase initialises exactly once
+- Design decision: Decision 1 (promise mutex) -> Requirement: MODIFIED connectToDatabase initialises exactly once
+- Requirement -> Task(s): Task 1 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Recovery behavior
+
+- **Given** MongoDB is temporarily unavailable at server startup
+- **When** the first `connectToDatabase` call rejects and MongoDB becomes available
+- **Then** the next `connectToDatabase` call succeeds and the server resumes normal operation (the stale rejected promise does not permanently block subsequent attempts)

--- a/openspec/specs/db-init-concurrency/spec.md
+++ b/openspec/specs/db-init-concurrency/spec.md
@@ -38,8 +38,4 @@ No requirements removed.
 
 ### Requirement: Reliability
 
-#### Scenario: Recovery behavior
-
-- **Given** MongoDB is temporarily unavailable at server startup
-- **When** the first `connectToDatabase` call rejects and MongoDB becomes available
-- **Then** the next `connectToDatabase` call succeeds and the server resumes normal operation (the stale rejected promise does not permanently block subsequent attempts)
+See functional scenario: [Failed connection allows retry]

--- a/openspec/specs/delete-character-not-found/spec.md
+++ b/openspec/specs/delete-character-not-found/spec.md
@@ -16,7 +16,7 @@ The system SHALL throw an `Error` when `deleteCharacter` is called with an `id`/
 
 - **Given** no document in the `characters` collection matches the given `id` and `userId`
 - **When** `deleteCharacter(id, userId)` is called
-- **Then** the function throws `` Error(`Character ${id} not found`) `` and the DELETE endpoint returns HTTP 500
+- **Then** the function throws an `Error` with message `Character <id> not found` and the DELETE endpoint returns HTTP 500
 
 #### Scenario: Delete is not re-entrant for an already-deleted character
 

--- a/openspec/specs/delete-character-not-found/spec.md
+++ b/openspec/specs/delete-character-not-found/spec.md
@@ -16,7 +16,7 @@ The system SHALL throw an `Error` when `deleteCharacter` is called with an `id`/
 
 - **Given** no document in the `characters` collection matches the given `id` and `userId`
 - **When** `deleteCharacter(id, userId)` is called
-- **Then** the function throws `Error('Character not found')` and the DELETE endpoint returns HTTP 500
+- **Then** the function throws `` Error(`Character ${id} not found`) `` and the DELETE endpoint returns HTTP 500
 
 #### Scenario: Delete is not re-entrant for an already-deleted character
 
@@ -38,8 +38,4 @@ No requirements removed.
 
 ### Requirement: Reliability
 
-#### Scenario: Silent failures are surfaced as errors
-
-- **Given** a storage operation fails to modify any document (e.g., stale ID, concurrent deletion)
-- **When** `deleteCharacter` is called and `updateOne` reports `matchedCount === 0`
-- **Then** an error is thrown (not swallowed), ensuring callers and monitoring systems are aware of the unexpected condition
+See functional scenario: [Delete throws when character is not found]

--- a/openspec/specs/delete-character-not-found/spec.md
+++ b/openspec/specs/delete-character-not-found/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED deleteCharacter throws when no document is matched
+
+The system SHALL throw an `Error` when `deleteCharacter` is called with an `id`/`userId` pair that does not match any document in the `characters` collection, converting what was previously a silent no-op into a detectable failure.
+
+#### Scenario: Delete succeeds for an existing character
+
+- **Given** a character exists in the `characters` collection with the given `id` and `userId`
+- **When** `deleteCharacter(id, userId)` is called
+- **Then** the character's `deletedAt` field is set to a current `Date`, the function resolves without error, and the DELETE endpoint returns HTTP 200
+
+#### Scenario: Delete throws when character is not found
+
+- **Given** no document in the `characters` collection matches the given `id` and `userId`
+- **When** `deleteCharacter(id, userId)` is called
+- **Then** the function throws `Error('Character not found')` and the DELETE endpoint returns HTTP 500
+
+#### Scenario: Delete is not re-entrant for an already-deleted character
+
+- **Given** a character has already been soft-deleted (`deletedAt` is set)
+- **When** the DELETE route handler is called again for the same character
+- **Then** the route's `loadCharacters` pre-check returns nothing (character not in `characters_active` view), the handler returns HTTP 404 **before** calling `deleteCharacter`, and `deleteCharacter` is never invoked
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: `deleteCharacter` silent failure on `matchedCount === 0` -> Requirement: MODIFIED deleteCharacter throws when no document is matched
+- Design decision: Decision 2 (`matchedCount` guard) -> Requirement: MODIFIED deleteCharacter throws when no document is matched
+- Requirement -> Task(s): Task 2 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Silent failures are surfaced as errors
+
+- **Given** a storage operation fails to modify any document (e.g., stale ID, concurrent deletion)
+- **When** `deleteCharacter` is called and `updateOne` reports `matchedCount === 0`
+- **Then** an error is thrown (not swallowed), ensuring callers and monitoring systems are aware of the unexpected condition

--- a/openspec/specs/soft-delete-test-assertions/spec.md
+++ b/openspec/specs/soft-delete-test-assertions/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED soft-delete 404 test asserts all intermediate HTTP responses
+
+The test "should return 404 when accessing deleted character detail" SHALL assert the HTTP status of the character creation (POST) and the soft-delete (DELETE) requests before asserting the final GET returns 404, ensuring that a failure in any step produces an immediate, targeted assertion error rather than a confusing end-of-test failure.
+
+#### Scenario: All steps pass — test verifies 404 on deleted character
+
+- **Given** the integration test server is running and the test user is authenticated
+- **When** the test POSTs a new character, DELETEs it, and then GETs it
+- **Then** the POST assertion `expect(createRes.status).toBe(201)` passes, the DELETE assertion `expect(deleteRes.status).toBe(200)` passes, and the GET assertion `expect(detailRes.status).toBe(404)` passes
+
+#### Scenario: Character creation fails — test fails at the correct assertion
+
+- **Given** the POST to create a character returns a non-201 status (server error, conflict, etc.)
+- **When** the test executes
+- **Then** `expect(createRes.status).toBe(201)` fails immediately, clearly identifying the create step as the source of the problem
+
+#### Scenario: Delete operation fails — test fails at the correct assertion
+
+- **Given** the character is created successfully (POST returns 201) but the DELETE returns a non-200 status
+- **When** the test executes
+- **Then** `expect(deleteRes.status).toBe(200)` fails immediately, clearly identifying the delete step as the source of the problem rather than producing a confusing 200 on the final GET
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element: 404 test missing intermediate assertions -> Requirement: MODIFIED soft-delete 404 test asserts all intermediate HTTP responses
+- Design decision: Decision 3 (explicit status assertions) -> Requirement: MODIFIED soft-delete 404 test asserts all intermediate HTTP responses
+- Requirement -> Task(s): Task 3 in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Recovery behavior
+
+- **Given** CI re-triggers the integration test suite after a transient failure
+- **When** all three HTTP operations (POST, DELETE, GET) complete successfully
+- **Then** the test passes without flaking, and no assertion failure is produced by a silent intermediate step

--- a/openspec/specs/soft-delete-test-assertions/spec.md
+++ b/openspec/specs/soft-delete-test-assertions/spec.md
@@ -38,8 +38,4 @@ No requirements removed.
 
 ### Requirement: Reliability
 
-#### Scenario: Recovery behavior
-
-- **Given** CI re-triggers the integration test suite after a transient failure
-- **When** all three HTTP operations (POST, DELETE, GET) complete successfully
-- **Then** the test passes without flaking, and no assertion failure is produced by a silent intermediate step
+See functional scenario: [All steps pass — test verifies 404 on deleted character]


### PR DESCRIPTION
Post-merge cleanup for PR #390 (issue #386).

- Promotes three specs to `openspec/specs/`: db-init-concurrency, delete-character-not-found, soft-delete-test-assertions
- Archives `openspec/changes/fix-soft-delete-flaky-test/` → `openspec/changes/archive/2026-06-07-fix-soft-delete-flaky-test/`