### PR TITLE
feat: player invitations inbox

### DIFF
--- a/app/invitations/page.tsx
+++ b/app/invitations/page.tsx
@@ -10,12 +10,14 @@ interface Invitation {
   campaignId: string;
   campaignName: string;
   invitedBy: string;
-  invitedAt: string;
+  invitedAt: string | null;
 }
 
-function relativeTime(date: string): string {
+function relativeTime(date: string | null): string {
+  if (!date) return 'just now';
   const diff = Date.now() - new Date(date).getTime();
   const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
   if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
@@ -28,6 +30,7 @@ function InvitationsContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [respondingId, setRespondingId] = useState<string | null>(null);
   const { toast, showToast } = useToast();
 
   const fetchInvitations = useCallback(async () => {
@@ -49,6 +52,7 @@ function InvitationsContent() {
 
   async function handleRespond(campaignId: string, campaignName: string, action: 'accept' | 'decline') {
     setActionError(null);
+    setRespondingId(campaignId);
     try {
       const res = await fetch(`/api/campaigns/${campaignId}/members/me`, {
         method: 'PATCH',
@@ -65,6 +69,8 @@ function InvitationsContent() {
       void fetchInvitations();
     } catch {
       setActionError(`Failed to ${action} invitation`);
+    } finally {
+      setRespondingId(null);
     }
   }
 
@@ -79,29 +85,34 @@ function InvitationsContent() {
         <p className="text-center text-gray-400">No pending invitations</p>
       ) : (
         <ul className="space-y-4">
-          {invitations.map((inv) => (
-            <li key={inv.id} className="bg-gray-800 rounded-lg p-4 flex items-center justify-between gap-4">
-              <div>
-                <p className="font-bold text-white">{inv.campaignName}</p>
-                <p className="text-sm text-gray-400">Invited by: {inv.invitedBy}</p>
-                <p className="text-sm text-gray-500">{relativeTime(inv.invitedAt)}</p>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => void handleRespond(inv.campaignId, inv.campaignName, 'accept')}
-                  className="bg-green-600 hover:bg-green-700 text-white text-sm px-3 py-1 rounded"
-                >
-                  Accept
-                </button>
-                <button
-                  onClick={() => void handleRespond(inv.campaignId, inv.campaignName, 'decline')}
-                  className="border border-gray-500 hover:border-red-500 text-gray-300 hover:text-red-400 text-sm px-3 py-1 rounded"
-                >
-                  Decline
-                </button>
-              </div>
-            </li>
-          ))}
+          {invitations.map((inv) => {
+            const isResponding = respondingId !== null;
+            return (
+              <li key={inv.id} className="bg-gray-800 rounded-lg p-4 flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-bold text-white">{inv.campaignName}</p>
+                  <p className="text-sm text-gray-400">Invited by: {inv.invitedBy}</p>
+                  <p className="text-sm text-gray-500">{relativeTime(inv.invitedAt)}</p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    disabled={isResponding}
+                    onClick={() => void handleRespond(inv.campaignId, inv.campaignName, 'accept')}
+                    className="bg-green-600 hover:bg-green-700 disabled:bg-gray-600 text-white text-sm px-3 py-1 rounded"
+                  >
+                    Accept
+                  </button>
+                  <button
+                    disabled={isResponding}
+                    onClick={() => void handleRespond(inv.campaignId, inv.campaignName, 'decline')}
+                    className="border border-gray-500 hover:border-red-500 disabled:border-gray-700 text-gray-300 hover:text-red-400 disabled:text-gray-600 text-sm px-3 py-1 rounded"
+                  >
+                    Decline
+                  </button>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
       <Toast toast={toast} />

--- a/app/invitations/page.tsx
+++ b/app/invitations/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
+import { ErrorBanner, LoadingState } from '@/lib/components/ui';
+import { useToast, Toast } from '@/lib/components/Toast';
+
+interface Invitation {
+  id: string;
+  campaignId: string;
+  campaignName: string;
+  invitedBy: string;
+  invitedAt: string;
+}
+
+function relativeTime(date: string): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+function InvitationsContent() {
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const { toast, showToast } = useToast();
+
+  const fetchInvitations = useCallback(async () => {
+    try {
+      const res = await fetch('/api/me/invitations');
+      if (!res.ok) throw new Error('Failed to load invitations');
+      const data = (await res.json()) as { invitations: Invitation[] };
+      setInvitations(data.invitations);
+    } catch {
+      setError('Failed to load invitations');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchInvitations();
+  }, [fetchInvitations]);
+
+  async function handleRespond(campaignId: string, campaignName: string, action: 'accept' | 'decline') {
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/campaigns/${campaignId}/members/me`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      });
+      if (!res.ok) throw new Error(`Failed to ${action} invitation`);
+      setInvitations((prev) => prev.filter((inv) => inv.campaignId !== campaignId));
+      if (action === 'accept') {
+        showToast(`Joined "${campaignName}"!`, 'success');
+      } else {
+        showToast(`Declined "${campaignName}"`, 'success');
+      }
+      void fetchInvitations();
+    } catch {
+      setActionError(`Failed to ${action} invitation`);
+    }
+  }
+
+  if (loading) return <LoadingState label="Loading invitations..." />;
+  if (error) return <ErrorBanner message={error} />;
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold text-white mb-6">Pending Invitations</h1>
+      <ErrorBanner message={actionError} />
+      {invitations.length === 0 ? (
+        <p className="text-center text-gray-400">No pending invitations</p>
+      ) : (
+        <ul className="space-y-4">
+          {invitations.map((inv) => (
+            <li key={inv.id} className="bg-gray-800 rounded-lg p-4 flex items-center justify-between gap-4">
+              <div>
+                <p className="font-bold text-white">{inv.campaignName}</p>
+                <p className="text-sm text-gray-400">Invited by: {inv.invitedBy}</p>
+                <p className="text-sm text-gray-500">{relativeTime(inv.invitedAt)}</p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => void handleRespond(inv.campaignId, inv.campaignName, 'accept')}
+                  className="bg-green-600 hover:bg-green-700 text-white text-sm px-3 py-1 rounded"
+                >
+                  Accept
+                </button>
+                <button
+                  onClick={() => void handleRespond(inv.campaignId, inv.campaignName, 'decline')}
+                  className="border border-gray-500 hover:border-red-500 text-gray-300 hover:text-red-400 text-sm px-3 py-1 rounded"
+                >
+                  Decline
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Toast toast={toast} />
+    </div>
+  );
+}
+
+export default function InvitationsPage() {
+  return (
+    <ProtectedRoute>
+      <InvitationsContent />
+    </ProtectedRoute>
+  );
+}

--- a/lib/components/NavBar.tsx
+++ b/lib/components/NavBar.tsx
@@ -10,14 +10,16 @@ export function NavBar() {
 
   useEffect(() => {
     if (!isAuthenticated || loading) return;
+    let active = true;
     fetch('/api/me/invitations')
-      .then((res) => res.json())
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data: { invitations?: unknown[] }) => {
-        setInvitationCount(data.invitations?.length ?? 0);
+        if (active) setInvitationCount(data.invitations?.length ?? 0);
       })
       .catch(() => {
-        setInvitationCount(0);
+        if (active) setInvitationCount(0);
       });
+    return () => { active = false; };
   }, [isAuthenticated, loading]);
 
   return (

--- a/lib/components/NavBar.tsx
+++ b/lib/components/NavBar.tsx
@@ -1,10 +1,24 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/lib/hooks/useAuth';
 
 export function NavBar() {
   const { isAuthenticated, loading, logout } = useAuth();
+  const [invitationCount, setInvitationCount] = useState(0);
+
+  useEffect(() => {
+    if (!isAuthenticated || loading) return;
+    fetch('/api/me/invitations')
+      .then((res) => res.json())
+      .then((data: { invitations?: unknown[] }) => {
+        setInvitationCount(data.invitations?.length ?? 0);
+      })
+      .catch(() => {
+        setInvitationCount(0);
+      });
+  }, [isAuthenticated, loading]);
 
   return (
     <nav className="flex-shrink-0 bg-gray-950 border-b border-gray-800 px-4 py-2">
@@ -27,6 +41,11 @@ export function NavBar() {
         <Link href="/combat" className="text-gray-400 hover:text-white transition-colors text-sm">
           Combat
         </Link>
+        {isAuthenticated && !loading && invitationCount > 0 && (
+          <Link href="/invitations" className="text-yellow-400 hover:text-yellow-300 transition-colors text-sm">
+            Invitations ({invitationCount})
+          </Link>
+        )}
         {isAuthenticated && !loading && (
           <button
             data-testid="logout-button"

--- a/lib/components/Toast.tsx
+++ b/lib/components/Toast.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+type ToastType = 'success' | 'error';
+
+interface ToastState {
+  message: string;
+  type: ToastType;
+}
+
+export function useToast() {
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const showToast = useCallback((message: string, type: ToastType) => {
+    setToast({ message, type });
+    const timer = setTimeout(() => setToast(null), 3000);
+    (timer as unknown as { unref?: () => void }).unref?.();
+  }, []);
+
+  return { toast, showToast };
+}
+
+export function Toast({ toast }: { toast: ToastState | null }) {
+  if (!toast) return null;
+
+  const bgClass = toast.type === 'success' ? 'bg-green-700' : 'bg-red-700';
+
+  return (
+    <div
+      role="status"
+      className={`fixed bottom-6 right-6 px-5 py-3 rounded-full text-white text-sm font-medium shadow-lg ${bgClass}`}
+    >
+      {toast.message}
+    </div>
+  );
+}

--- a/lib/components/Toast.tsx
+++ b/lib/components/Toast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 type ToastType = 'success' | 'error';
 
@@ -11,11 +11,20 @@ interface ToastState {
 
 export function useToast() {
   const [toast, setToast] = useState<ToastState | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const showToast = useCallback((message: string, type: ToastType) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
     setToast({ message, type });
     const timer = setTimeout(() => setToast(null), 3000);
+    timerRef.current = timer;
     (timer as unknown as { unref?: () => void }).unref?.();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
   }, []);
 
   return { toast, showToast };

--- a/openspec/changes/player-invitations-inbox/.openspec.yaml
+++ b/openspec/changes/player-invitations-inbox/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-07

--- a/openspec/changes/player-invitations-inbox/design.md
+++ b/openspec/changes/player-invitations-inbox/design.md
@@ -1,0 +1,165 @@
+## Context
+
+- Relevant architecture: Next.js App Router, client components with `useState`/`useEffect`, `ProtectedRoute` wrapper, `useAuth()` for session, Tailwind CSS with semantic token conventions, `lib/components/ui.tsx` for shared primitives.
+- Dependencies: `GET /api/me/invitations` (returns `{ invitations: [{ id, campaignId, campaignName, invitedBy, invitedAt }] }`), `PATCH /api/campaigns/[id]/members/me` with `{ action: "accept" | "decline" }`. Both are stable and tested.
+- Interfaces/contracts touched: `lib/components/NavBar.tsx` (modified), new `lib/components/Toast.tsx`, new `app/invitations/page.tsx`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Player can see pending invitation count in the NavBar at all times when authenticated
+- Player can navigate to `/invitations` and accept or decline each invite
+- Success feedback via toast on respond
+- Campaign appears in `/campaigns` after accepting
+
+### Non-Goals
+
+- Real-time badge updates (polling, websockets)
+- Migrating combat toast to new component (tracked in #389)
+- Pagination
+- Bulk operations
+
+## Decisions
+
+### Decision 1: Standalone `lib/components/Toast.tsx` (not added to `ui.tsx`)
+
+- Chosen: New dedicated file `lib/components/Toast.tsx` exporting `useToast()` hook and `<Toast>` renderer.
+- Alternatives considered: Adding `useToast` + `Toast` inline in `ui.tsx` alongside `ErrorBanner`.
+- Rationale: User preference — toast is clearly its own piece of work, not a generic form primitive. Keeping it separate makes it easy to find, import, and migrate combat view later (#389).
+- Trade-offs: One more file, but cleaner separation.
+
+### Decision 2: NavBar fetches invitations on mount (no shared context)
+
+- Chosen: `NavBar` calls `GET /api/me/invitations` inside a `useEffect` when `isAuthenticated && !loading`. Count is local state.
+- Alternatives considered: Global context/provider shared between NavBar and the invitations page so they stay in sync; polling at an interval.
+- Rationale: The app has no global state manager. A shared context would be new infrastructure for a single badge count. Since NavBar re-mounts on every page navigation in Next.js App Router (it's in the root layout), the count refreshes naturally on navigation — including after accept/decline on the invitations page.
+- Trade-offs: Badge count is slightly stale within a single page visit (e.g., if an invite arrives while the user is on another page). Acceptable for this use case.
+
+### Decision 3: Optimistic removal on respond, re-fetch count
+
+- Chosen: On successful accept/decline, immediately remove the invite from the local list (optimistic). After each respond, the invitations page re-fetches `GET /api/me/invitations` to reconcile. NavBar updates on next navigation.
+- Alternatives considered: Full page reload after respond; no optimistic update (wait for re-fetch).
+- Rationale: Optimistic removal feels snappy. Re-fetch after respond ensures count accuracy if multiple tabs are open or if the server returns unexpected state.
+- Trade-offs: Brief moment where the badge in the NavBar shows a stale count (higher than actual) until the user navigates. Acceptable.
+
+### Decision 4: `invitedAt` displayed as relative time
+
+- Chosen: Display `invitedAt` as a human-readable relative string (e.g., "2 days ago") using `Date` arithmetic, no external library.
+- Alternatives considered: Absolute date string; using `date-fns`.
+- Rationale: Relative time is more meaningful in an inbox. The project has no `date-fns` dependency; a small inline helper keeps it self-contained.
+- Trade-offs: Relative formatting will be simple (days/hours/minutes), not as nuanced as a full library.
+
+### Decision 5: Empty state and badge visibility
+
+- Chosen: Badge link is hidden entirely when count is 0 (not rendered, not zero-count visible). Invitations page shows a centred "No pending invitations" message.
+- Alternatives considered: Always show "Invitations" link, show "(0)" badge.
+- Rationale: A zero badge is noise. NavBar is already link-dense; only show the link when it matters.
+- Trade-offs: Users won't discover `/invitations` by browsing the nav unless they have pending invites. Acceptable — the page is only useful when there are invitations.
+
+## Proposal to Design Mapping
+
+- Proposal element: Standalone `Toast` component
+  - Design decision: Decision 1
+  - Validation approach: Unit test that `showToast` renders the toast and it disappears after timeout
+
+- Proposal element: NavBar count pill
+  - Design decision: Decision 2
+  - Validation approach: Unit test NavBar with mocked fetch returning invitations; assert link + count rendered
+
+- Proposal element: Accept/decline with optimistic removal
+  - Design decision: Decision 3
+  - Validation approach: Unit test that list item disappears after responding; mock API returns success
+
+- Proposal element: `invitedAt` display
+  - Design decision: Decision 4
+  - Validation approach: Unit test relative time helper with fixed dates
+
+- Proposal element: Hidden badge when 0 invitations
+  - Design decision: Decision 5
+  - Validation approach: Unit test NavBar with empty invitations response; assert link not rendered
+
+## Functional Requirements Mapping
+
+- Requirement: Player sees pending invite count in NavBar
+  - Design element: NavBar `useEffect` + count state (Decision 2)
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — NavBar badge
+  - Testability notes: Mock `fetch` in NavBar test; assert count pill text and href
+
+- Requirement: Player navigates to `/invitations` from badge
+  - Design element: `<Link href="/invitations">` in NavBar (Decision 5)
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — NavBar badge
+  - Testability notes: Assert `href="/invitations"` on the rendered link
+
+- Requirement: Player sees invite list with campaign name, inviter, date
+  - Design element: `app/invitations/page.tsx` renders `invitations` array
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — Inbox page
+  - Testability notes: Mock `GET /api/me/invitations`; assert campaign name, invitedBy, relative date rendered
+
+- Requirement: Player can accept an invite
+  - Design element: Accept button → `PATCH /api/campaigns/[id]/members/me` `{ action: "accept" }`
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — Accept flow
+  - Testability notes: Mock PATCH success; assert invite removed from list, success toast shown
+
+- Requirement: Player can decline an invite
+  - Design element: Decline button → `PATCH /api/campaigns/[id]/members/me` `{ action: "decline" }`
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — Decline flow
+  - Testability notes: Mock PATCH success; assert invite removed from list, success toast shown
+
+- Requirement: Success toast shown after respond
+  - Design element: `useToast()` in `app/invitations/page.tsx` (Decision 1)
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — Toast feedback
+  - Testability notes: Assert toast text rendered after mock PATCH success
+
+- Requirement: Error shown if respond fails
+  - Design element: `ErrorBanner` on PATCH failure
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — Error handling
+  - Testability notes: Mock PATCH failure; assert `ErrorBanner` renders error text
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: performance
+  - Requirement: NavBar invitation fetch must not block rendering
+  - Design element: `useEffect` runs after mount (Decision 2); badge renders after async resolves
+  - Acceptance criteria reference: N/A (structural)
+  - Testability notes: Verify component renders without badge during loading, badge appears after fetch
+
+- Requirement category: reliability
+  - Requirement: NavBar invitation fetch failure must not break the nav
+  - Design element: Fetch error is caught and silently swallowed; badge simply doesn't render
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — NavBar error resilience
+  - Testability notes: Mock fetch to throw; assert NavBar renders without badge and without crashing
+
+- Requirement category: security
+  - Requirement: `/invitations` page and badge only accessible when authenticated
+  - Design element: `ProtectedRoute` on page; NavBar guard on `isAuthenticated && !loading`
+  - Acceptance criteria reference: specs/invitations-inbox/spec.md — Auth guard
+  - Testability notes: NavBar test with `isAuthenticated = false`; assert badge not rendered
+
+## Risks / Trade-offs
+
+- Risk/trade-off: NavBar badge stale after accepting on invitations page
+  - Impact: User sees stale count in badge until they navigate away and back
+  - Mitigation: Acceptable UX given App Router's per-navigation NavBar remount. Can add shared context in future if needed.
+
+- Risk/trade-off: Extra network request on every page load from NavBar
+  - Impact: Minor; `GET /api/me/invitations` is a lightweight indexed query
+  - Mitigation: Request only fires when `isAuthenticated && !loading`; unauthenticated users incur no cost
+
+## Rollback / Mitigation
+
+- Rollback trigger: Toast component causes regressions in existing pages; NavBar fetch breaks navigation.
+- Rollback steps: Revert `lib/components/NavBar.tsx` to pre-change version; delete `app/invitations/page.tsx` and `lib/components/Toast.tsx`. No database schema changes; no migration needed.
+- Data migration considerations: None — this is purely UI over existing APIs.
+- Verification after rollback: Run `npm test`; manually verify NavBar and campaigns page render correctly.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix failing tests or type errors before proceeding.
+- If security checks fail: Do not merge. Investigate and resolve before proceeding.
+- If required reviews are blocked/stale: Re-request review after 24 hours; escalate to maintainer after 48 hours.
+- Escalation path and timeout: Tag `@dougis` on the PR if blocked for more than 48 hours.
+
+## Open Questions
+
+No open questions. All design decisions resolved during exploration session.

--- a/openspec/changes/player-invitations-inbox/proposal.md
+++ b/openspec/changes/player-invitations-inbox/proposal.md
@@ -1,0 +1,76 @@
+## GitHub Issues
+
+- #308
+
+## Why
+
+- Problem statement: Players who are invited to join a campaign have no UI surface to see or respond to those invitations. The invite/respond APIs (2b) are complete but unreachable from the browser.
+- Why now: Phase 2 (invite & accept flow) is otherwise complete (2a, 2b, 2c closed). This is the last sub-issue before the epic is done.
+- Business/user impact: Without this, the multi-user campaign feature is unusable for players — a DM can invite but the invited player has no way to accept.
+
+## Problem Space
+
+- Current behavior: `GET /api/me/invitations` and `PATCH /api/campaigns/[id]/members/me` exist and are tested, but there is no UI that calls them. The NavBar has no indication of pending invites.
+- Desired behavior: A player sees a count pill in the NavBar when they have pending invitations. Clicking it takes them to `/invitations`, where they see each invite with campaign name, inviter, and date. They can accept or decline. Accepting causes the campaign to appear in their campaigns list.
+- Constraints: Must follow existing UI patterns — `ProtectedRoute`, `ErrorBanner`, `LoadingState`, Tailwind semantic tokens, no external toast library.
+- Assumptions: The `GET /api/me/invitations` response shape `{ invitations: [{ id, campaignId, campaignName, invitedBy, invitedAt }] }` is stable.
+- Edge cases considered:
+  - No pending invitations (empty state, badge hidden)
+  - Accept/decline API errors (shown via `ErrorBanner`)
+  - User accepts then navigates to `/campaigns` (campaign appears because `/campaigns` re-fetches)
+  - User declines (invite removed from list immediately)
+  - Nav badge count drift after responding (badge re-fetches after respond action)
+
+## Scope
+
+### In Scope
+
+- `lib/components/Toast.tsx` — standalone reusable toast component (hook + renderer)
+- `lib/components/NavBar.tsx` — invitation count pill linking to `/invitations`
+- `app/invitations/page.tsx` — new ProtectedRoute inbox page
+- Unit tests for the inbox page and NavBar badge
+- Toast shows success message on accept and decline
+
+### Out of Scope
+
+- Migrating `ActiveCombatView` / `useCombat` to use the new Toast component (tracked in #389)
+- Real-time / polling for new invitations (badge refreshes on page load only)
+- Email or push notifications
+- Pagination of the invitations list
+
+## What Changes
+
+- New file `lib/components/Toast.tsx`: `useToast()` hook returning `{ showToast, Toast }`. Toast auto-dismisses after 3 seconds, renders fixed bottom-right, supports `success` and `error` types.
+- Modified `lib/components/NavBar.tsx`: fetches `/api/me/invitations` on mount (when authenticated), renders `Invitations (N)` link with yellow pill when N > 0, hidden when 0.
+- New file `app/invitations/page.tsx`: lists pending invitations, accept/decline per invite, success toast on respond, optimistic removal from list, empty state.
+- New test file `tests/unit/components/InvitationsPage.test.tsx`
+- Updated `tests/unit/components/NavBar.test.tsx` (or new test file if none exists)
+
+## Risks
+
+- Risk: NavBar fetches `/api/me/invitations` on every page load, adding a network request to the critical render path.
+  - Impact: Minor latency; badge appears slightly after nav renders.
+  - Mitigation: Request is lightweight (indexed query). Badge renders after auth check already completes, so no perceptible delay.
+- Risk: Badge count goes stale after the user responds on the invitations page.
+  - Impact: Badge still shows old count until next navigation.
+  - Mitigation: After any respond action succeeds, re-fetch invitations to update the local list; NavBar will update on next navigation naturally. If needed, a simple callback or context can be added later.
+
+## Open Questions
+
+No unresolved ambiguity. All decisions were made during exploration:
+- Inbox location: `/invitations` (dedicated page, consistent with app pattern)
+- Nav badge: link with count pill, hidden when 0
+- Toast: standalone `lib/components/Toast.tsx`, not added to `ui.tsx`
+- Combat view migration: deferred to #389
+
+## Non-Goals
+
+- Persisting toast state across navigation
+- Bulk accept/decline
+- Filtering or sorting invitations
+- Wiring Toast into any page other than `/invitations` (that's per-page follow-up work)
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/player-invitations-inbox/specs/invitations-inbox/spec.md
+++ b/openspec/changes/player-invitations-inbox/specs/invitations-inbox/spec.md
@@ -1,0 +1,186 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `Toast` component — success/error feedback
+
+The system SHALL provide a reusable `useToast()` hook and `<Toast>` renderer in `lib/components/Toast.tsx` that displays a temporary message at a fixed bottom-right position and auto-dismisses after 3 seconds.
+
+#### Scenario: Toast renders on showToast call
+
+- **Given** a component has called `useToast()` and mounted `<Toast />`
+- **When** `showToast("Joined campaign!", "success")` is called
+- **Then** a visible element containing "Joined campaign!" is rendered with success styling (green)
+
+#### Scenario: Toast auto-dismisses after 3 seconds
+
+- **Given** a toast is visible
+- **When** 3000ms elapses
+- **Then** the toast element is no longer rendered
+
+#### Scenario: Toast renders error variant
+
+- **Given** a component has called `useToast()` and mounted `<Toast />`
+- **When** `showToast("Something went wrong", "error")` is called
+- **Then** a visible element containing "Something went wrong" is rendered with error styling (red)
+
+---
+
+### Requirement: ADDED NavBar invitation count badge
+
+The system SHALL display a count pill link to `/invitations` in the NavBar when the authenticated user has one or more pending invitations.
+
+#### Scenario: Badge shows count when invitations exist
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` returns 2 pending invitations
+- **When** the NavBar mounts
+- **Then** a link labelled "Invitations (2)" with `href="/invitations"` is rendered
+
+#### Scenario: Badge is hidden when no invitations
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` returns an empty list
+- **When** the NavBar mounts
+- **Then** no "Invitations" link is rendered
+
+#### Scenario: Badge is hidden when unauthenticated
+
+- **Given** the user is not authenticated
+- **When** the NavBar renders
+- **Then** no "Invitations" link is rendered and no fetch to `/api/me/invitations` is made
+
+#### Scenario: NavBar fetch failure does not break navigation
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` throws a network error
+- **When** the NavBar mounts
+- **Then** the NavBar renders without crashing and no "Invitations" link is shown
+
+---
+
+### Requirement: ADDED `/invitations` inbox page
+
+The system SHALL provide a `ProtectedRoute` page at `/invitations` that lists the authenticated user's pending campaign invitations.
+
+#### Scenario: Inbox lists pending invitations
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` returns `[{ id, campaignId, campaignName: "Lost Mine", invitedBy: "dm_alice", invitedAt: <timestamp> }]`
+- **When** the user navigates to `/invitations`
+- **Then** the page renders a row showing "Lost Mine", "dm_alice", and a relative time string (e.g., "2 days ago")
+
+#### Scenario: Inbox shows empty state
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` returns an empty list
+- **When** the user navigates to `/invitations`
+- **Then** the page renders a "No pending invitations" message and no invite rows
+
+#### Scenario: Inbox shows loading state
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` has not yet resolved
+- **When** the page renders
+- **Then** a loading indicator is shown
+
+---
+
+### Requirement: ADDED Accept invitation flow
+
+The system SHALL allow an invited player to accept a campaign invitation from the inbox.
+
+#### Scenario: Accept removes invite from list and shows toast
+
+- **Given** the inbox displays a pending invitation for "Lost Mine of Phandelver"
+- **When** the user clicks "Accept"
+- **And** `PATCH /api/campaigns/[id]/members/me` with `{ action: "accept" }` succeeds
+- **Then** the invite row is removed from the list immediately
+- **And** a success toast containing "Joined" and "Lost Mine of Phandelver" is shown
+
+#### Scenario: Accept failure shows error banner
+
+- **Given** the inbox displays a pending invitation
+- **When** the user clicks "Accept"
+- **And** `PATCH /api/campaigns/[id]/members/me` returns a non-OK response
+- **Then** an `ErrorBanner` is rendered with a relevant error message
+- **And** the invite row remains in the list
+
+---
+
+### Requirement: ADDED Decline invitation flow
+
+The system SHALL allow an invited player to decline a campaign invitation from the inbox.
+
+#### Scenario: Decline removes invite from list and shows toast
+
+- **Given** the inbox displays a pending invitation for "Curse of Strahd"
+- **When** the user clicks "Decline"
+- **And** `PATCH /api/campaigns/[id]/members/me` with `{ action: "decline" }` succeeds
+- **Then** the invite row is removed from the list immediately
+- **And** a success toast containing "Declined" and "Curse of Strahd" is shown
+
+#### Scenario: Decline failure shows error banner
+
+- **Given** the inbox displays a pending invitation
+- **When** the user clicks "Decline"
+- **And** `PATCH /api/campaigns/[id]/members/me` returns a non-OK response
+- **Then** an `ErrorBanner` is rendered with a relevant error message
+- **And** the invite row remains in the list
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED NavBar — authenticated nav link set
+
+The NavBar SHALL conditionally render an "Invitations (N)" link when the authenticated user has pending invitations (N > 0).
+
+#### Scenario: Invitations link appears alongside existing nav links
+
+- **Given** the user is authenticated with 1 pending invitation
+- **When** the NavBar mounts
+- **Then** "Invitations (1)" is rendered as a link in the same nav row as Campaigns, Encounters, etc.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal: Standalone `Toast` component → Requirement: ADDED `Toast` component
+- Proposal: NavBar count pill → Requirement: ADDED NavBar invitation count badge
+- Proposal: `/invitations` inbox page → Requirement: ADDED `/invitations` inbox page
+- Proposal: Accept flow → Requirement: ADDED Accept invitation flow
+- Proposal: Decline flow → Requirement: ADDED Decline invitation flow
+- Design Decision 1 (Toast.tsx) → Requirement: ADDED `Toast` component
+- Design Decision 2 (NavBar fetch on mount) → Requirement: ADDED NavBar invitation count badge
+- Design Decision 3 (optimistic removal) → Requirements: Accept flow, Decline flow
+- Design Decision 4 (relative time) → Requirement: ADDED `/invitations` inbox page (invite row display)
+- Design Decision 5 (hidden when 0) → Requirement: ADDED NavBar invitation count badge (hidden scenarios)
+- All requirements → tasks.md (implementation tasks)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: NavBar invitation fetch does not delay initial render
+
+- **Given** the user navigates to any page
+- **When** the NavBar mounts
+- **Then** all existing nav links (Campaigns, Encounters, etc.) are rendered immediately without waiting for the invitations fetch to resolve
+- **And** the badge appears asynchronously once the fetch completes
+
+### Requirement: Security
+
+See functional scenarios: "Badge is hidden when unauthenticated", "NavBar fetch failure does not break navigation".
+
+The invitations API itself is protected by `withAuth` middleware (existing, tested separately). No new access-control surface is introduced by the UI.
+
+### Requirement: Reliability
+
+#### Scenario: Inbox fetch failure shows error state
+
+- **Given** the user is authenticated
+- **And** `GET /api/me/invitations` returns a non-OK response
+- **When** the user navigates to `/invitations`
+- **Then** an `ErrorBanner` is rendered with an error message
+- **And** no invite rows are shown

--- a/openspec/changes/player-invitations-inbox/tasks.md
+++ b/openspec/changes/player-invitations-inbox/tasks.md
@@ -75,8 +75,8 @@ File: `tests/unit/components/NavBar.test.tsx` (create if not exists)
 
 ## Validation
 
-- [x] `npm test -- --testPathPattern="Toast|InvitationsPage|NavBar"` — all new and updated tests pass
-- [x] `npm test` — full test suite passes with no regressions
+- [x] `npm run test:unit -- --testPathPattern="Toast|InvitationsPage|NavBar"` — all new and updated tests pass
+- [x] `npm run test:unit` — full test suite passes with no regressions
 - [x] `npm run build` — build succeeds with no type errors
 - [x] `npm run lint` — no lint errors
 - [x] All tasks above marked complete
@@ -85,7 +85,7 @@ File: `tests/unit/components/NavBar.test.tsx` (create if not exists)
 
 Verification requirements (all must pass before PR or pushing updates to a PR):
 
-- **Unit tests** — `npm test` — all tests must pass
+- **Unit tests** — `npm run test:unit` — all tests must pass
 - **Build** — `npm run build` — must succeed with no errors
 - **Lint** — `npm run lint` — must pass
 

--- a/openspec/changes/player-invitations-inbox/tasks.md
+++ b/openspec/changes/player-invitations-inbox/tasks.md
@@ -1,0 +1,129 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/308-player-invitations-inbox` then immediately `git push -u origin feat/308-player-invitations-inbox`
+
+## Execution
+
+### Task 1 — Create `lib/components/Toast.tsx`
+
+- [x] Create `lib/components/Toast.tsx` exporting:
+  - `useToast()` hook returning `{ toast, showToast }` where `toast` is `{ message: string; type: 'success' | 'error' } | null`
+  - `showToast(message: string, type: 'success' | 'error')` sets toast state and schedules auto-clear after 3000ms
+  - `<Toast toast={toast} />` component renders `null` when `toast` is null; otherwise renders a `fixed bottom-6 right-6` pill with green (success) or red (error) background
+- [x] Verify: component renders and auto-dismisses in isolation (covered by unit tests in Task 4)
+
+### Task 2 — Update `lib/components/NavBar.tsx`
+
+- [x] Add `useEffect` that fetches `GET /api/me/invitations` when `isAuthenticated && !loading`; store count in local state (default 0)
+- [x] Wrap fetch in try/catch — failure silently leaves count at 0 (no badge)
+- [x] When count > 0, render `<Link href="/invitations" className="...">Invitations ({count})</Link>` with a yellow count pill
+- [x] When count === 0 or unauthenticated, render nothing for the invitations link
+- [x] Style: use `text-yellow-400` for the badge to distinguish from standard nav links
+
+### Task 3 — Create `app/invitations/page.tsx`
+
+- [x] Create `app/invitations/page.tsx` with default export wrapping `InvitationsContent` in `<ProtectedRoute>`
+- [x] `InvitationsContent` fetches `GET /api/me/invitations` on mount; shows `<LoadingState>` while loading, `<ErrorBanner>` on error
+- [x] On success, render a list of invite rows. Each row shows:
+  - Campaign name (bold)
+  - "Invited by: {invitedBy}"
+  - Relative time string from `invitedAt` (e.g., "2 days ago") — use a small inline `relativeTime(date: string): string` helper
+  - "Accept" button (green) and "Decline" button (gray/red outline)
+- [x] Empty state: centred "No pending invitations" message (styled as `text-gray-400`)
+- [x] Accept handler: calls `PATCH /api/campaigns/{campaignId}/members/me` with `{ action: "accept" }`, removes invite from list on success, calls `showToast(\`Joined "\${campaignName}"!\`, 'success')`, sets `ErrorBanner` on failure
+- [x] Decline handler: calls `PATCH /api/campaigns/{campaignId}/members/me` with `{ action: "decline" }`, removes invite from list on success, calls `showToast(\`Declined "\${campaignName}"\`, 'success')`, sets `ErrorBanner` on failure
+- [x] Mount `<Toast toast={toast} />` at bottom of component
+- [x] After any respond action succeeds, re-fetch `GET /api/me/invitations` to reconcile list
+
+### Task 4 — Write unit tests for `Toast` component
+
+File: `tests/unit/components/Toast.test.tsx`
+
+- [x] Test: `showToast` renders the toast with correct message and success styling
+- [x] Test: `showToast` renders error variant with error styling
+- [x] Test: toast auto-dismisses after 3000ms (use `jest.useFakeTimers()`)
+- [x] Test: no toast rendered initially
+
+### Task 5 — Write unit tests for `InvitationsPage`
+
+File: `tests/unit/components/InvitationsPage.test.tsx`
+
+- [x] Test: renders invite rows with campaign name, invitedBy, relative time
+- [x] Test: renders empty state when invitations list is empty
+- [x] Test: renders loading state while fetch is pending
+- [x] Test: renders error banner when fetch fails
+- [x] Test: Accept click calls PATCH with `{ action: "accept" }`, removes invite from list, shows success toast
+- [x] Test: Decline click calls PATCH with `{ action: "decline" }`, removes invite from list, shows success toast
+- [x] Test: Accept failure renders error banner and keeps invite in list
+- [x] Test: Decline failure renders error banner and keeps invite in list
+
+### Task 6 — Write / update unit tests for `NavBar`
+
+File: `tests/unit/components/NavBar.test.tsx` (create if not exists)
+
+- [x] Test: renders "Invitations (2)" link when fetch returns 2 invitations
+- [x] Test: does not render invitations link when fetch returns empty list
+- [x] Test: does not render invitations link when unauthenticated
+- [x] Test: does not render invitations link when fetch throws error
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm test -- --testPathPattern="Toast|InvitationsPage|NavBar"` — all new and updated tests pass
+- [x] `npm test` — full test suite passes with no regressions
+- [x] `npm run build` — build succeeds with no type errors
+- [x] `npm run lint` — no lint errors
+- [x] All tasks above marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test` — all tests must pass
+- **Build** — `npm run build` — must succeed with no errors
+- **Lint** — `npm run lint` — must pass
+
+If **ANY** of the above fail, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/308-player-invitations-inbox` and push to remote
+- [ ] Open PR from `feat/308-player-invitations-inbox` to `main`. PR body must include `Closes #308`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, validate locally, push; wait 180 seconds; repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any required failures, validate locally, push; wait 180 seconds; repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify user
+
+Ownership metadata:
+
+- Implementer: @dougis
+- Reviewer(s): automated (CI + agentic review)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec delta to `openspec/specs/invitations-inbox/spec.md` (create directory if needed; update relative references in spec to point to `../../changes/archive/YYYY-MM-DD-player-invitations-inbox/design.md` and `../../changes/archive/YYYY-MM-DD-player-invitations-inbox/tasks.md`)
+- [ ] Archive the change: move `openspec/changes/player-invitations-inbox/` to `openspec/changes/archive/YYYY-MM-DD-player-invitations-inbox/` — stage both the new location and the deletion of the old in **a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-player-invitations-inbox/` exists and `openspec/changes/player-invitations-inbox/` is gone
+- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-player-invitations-inbox` then `git push -u origin doc/archive-YYYY-MM-DD-player-invitations-inbox`
+- [ ] Open PR from doc branch to `main` with title `docs: archive player-invitations-inbox (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor doc PR until merged (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -d feat/308-player-invitations-inbox doc/archive-YYYY-MM-DD-player-invitations-inbox`

--- a/openspec/changes/player-invitations-inbox/tests.md
+++ b/openspec/changes/player-invitations-inbox/tests.md
@@ -1,0 +1,145 @@
+---
+name: tests
+description: Tests for the player-invitations-inbox change
+---
+
+# Tests
+
+## Overview
+
+Tests for the `player-invitations-inbox` change. All work follows strict TDD: write failing test → write implementation → refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Write the test before any implementation. Run it and confirm it fails.
+2. **Write code to pass the test:** Write the minimum code to make it green.
+3. **Refactor:** Improve structure while keeping tests green.
+
+## Test Cases
+
+### Task 1 — `lib/components/Toast.tsx`
+
+File: `tests/unit/components/Toast.test.tsx`
+Spec scenarios: "Toast renders on showToast call", "Toast auto-dismisses after 3 seconds", "Toast renders error variant"
+
+- [ ] **TC-T1-1:** `useToast()` — initial state renders no toast element
+  - Given: component mounts with `<Toast toast={null} />`
+  - When: rendered
+  - Then: no toast element in DOM
+
+- [ ] **TC-T1-2:** `showToast("Joined!", "success")` — renders success toast
+  - Given: component mounts with `useToast()` and `<Toast>`
+  - When: `showToast("Joined!", "success")` is called
+  - Then: element with text "Joined!" is in DOM; element has green background class
+
+- [ ] **TC-T1-3:** `showToast("Oops", "error")` — renders error toast
+  - Given: component mounts with `useToast()` and `<Toast>`
+  - When: `showToast("Oops", "error")` is called
+  - Then: element with text "Oops" is in DOM; element has red background class
+
+- [ ] **TC-T1-4:** Toast auto-dismisses after 3000ms
+  - Given: a success toast is visible
+  - When: `jest.advanceTimersByTime(3000)` is called
+  - Then: toast element is no longer in DOM
+
+### Task 2 — `lib/components/NavBar.tsx`
+
+File: `tests/unit/components/NavBar.test.tsx`
+Spec scenarios: "Badge shows count when invitations exist", "Badge is hidden when no invitations", "Badge is hidden when unauthenticated", "NavBar fetch failure does not break navigation"
+
+- [ ] **TC-T2-1:** Renders "Invitations (2)" link when fetch returns 2 invitations
+  - Given: `useAuth` returns `{ isAuthenticated: true, loading: false }`
+  - And: `fetch('/api/me/invitations')` resolves to `{ invitations: [{...}, {...}] }`
+  - When: NavBar renders and fetch resolves
+  - Then: link with text "Invitations (2)" and `href="/invitations"` is in DOM
+
+- [ ] **TC-T2-2:** No invitations link when fetch returns empty list
+  - Given: `useAuth` returns `{ isAuthenticated: true, loading: false }`
+  - And: `fetch('/api/me/invitations')` resolves to `{ invitations: [] }`
+  - When: NavBar renders and fetch resolves
+  - Then: no element with text matching /Invitations/ is in DOM
+
+- [ ] **TC-T2-3:** No invitations link when unauthenticated
+  - Given: `useAuth` returns `{ isAuthenticated: false, loading: false }`
+  - When: NavBar renders
+  - Then: no element with text matching /Invitations/ is in DOM; fetch not called
+
+- [ ] **TC-T2-4:** No invitations link when fetch throws
+  - Given: `useAuth` returns `{ isAuthenticated: true, loading: false }`
+  - And: `fetch('/api/me/invitations')` throws a network error
+  - When: NavBar renders and fetch rejects
+  - Then: NavBar renders without crashing; no invitations link shown
+
+### Task 3 — `app/invitations/page.tsx`
+
+File: `tests/unit/components/InvitationsPage.test.tsx`
+Spec scenarios: all inbox page scenarios from `specs/invitations-inbox/spec.md`
+
+- [ ] **TC-T3-1:** Renders invite rows with campaign name, invitedBy, relative time
+  - Given: `GET /api/me/invitations` returns one invite: `{ campaignName: "Lost Mine", invitedBy: "dm_alice", invitedAt: <ISO date 2 days ago> }`
+  - When: page renders and fetch resolves
+  - Then: "Lost Mine" text in DOM; "dm_alice" text in DOM; "days ago" text in DOM
+
+- [ ] **TC-T3-2:** Renders empty state when no invitations
+  - Given: `GET /api/me/invitations` returns `{ invitations: [] }`
+  - When: page renders and fetch resolves
+  - Then: "No pending invitations" text in DOM; no Accept/Decline buttons
+
+- [ ] **TC-T3-3:** Shows loading state while fetch is pending
+  - Given: `GET /api/me/invitations` has not resolved
+  - When: page renders
+  - Then: loading indicator is in DOM
+
+- [ ] **TC-T3-4:** Shows error banner when fetch fails
+  - Given: `GET /api/me/invitations` returns a non-OK response
+  - When: page renders and fetch resolves
+  - Then: error banner with error text is in DOM; no invite rows
+
+- [ ] **TC-T3-5:** Accept — removes invite from list and shows success toast
+  - Given: inbox shows one invite for "Lost Mine of Phandelver"
+  - And: `PATCH /api/campaigns/{id}/members/me` resolves OK
+  - When: user clicks "Accept"
+  - Then: invite row is removed from DOM
+  - And: toast with text containing "Joined" and "Lost Mine of Phandelver" is in DOM
+
+- [ ] **TC-T3-6:** Decline — removes invite from list and shows success toast
+  - Given: inbox shows one invite for "Curse of Strahd"
+  - And: `PATCH /api/campaigns/{id}/members/me` resolves OK with `action: "decline"`
+  - When: user clicks "Decline"
+  - Then: invite row is removed from DOM
+  - And: toast with text containing "Declined" and "Curse of Strahd" is in DOM
+
+- [ ] **TC-T3-7:** Accept failure — shows error banner, invite remains in list
+  - Given: inbox shows one invite
+  - And: `PATCH /api/campaigns/{id}/members/me` returns a non-OK response
+  - When: user clicks "Accept"
+  - Then: error banner is in DOM; invite row is still in DOM
+
+- [ ] **TC-T3-8:** Decline failure — shows error banner, invite remains in list
+  - Given: inbox shows one invite
+  - And: `PATCH /api/campaigns/{id}/members/me` returns a non-OK response
+  - When: user clicks "Decline"
+  - Then: error banner is in DOM; invite row is still in DOM
+
+## Traceability
+
+| Test ID   | Task (tasks.md)     | Spec scenario                                         |
+|-----------|---------------------|-------------------------------------------------------|
+| TC-T1-1   | Task 1              | Toast: initial state                                  |
+| TC-T1-2   | Task 1 / Task 4     | Toast renders on showToast call                       |
+| TC-T1-3   | Task 1 / Task 4     | Toast renders error variant                           |
+| TC-T1-4   | Task 1 / Task 4     | Toast auto-dismisses after 3 seconds                  |
+| TC-T2-1   | Task 2 / Task 6     | Badge shows count when invitations exist              |
+| TC-T2-2   | Task 2 / Task 6     | Badge is hidden when no invitations                   |
+| TC-T2-3   | Task 2 / Task 6     | Badge is hidden when unauthenticated                  |
+| TC-T2-4   | Task 2 / Task 6     | NavBar fetch failure does not break navigation        |
+| TC-T3-1   | Task 3 / Task 5     | Inbox lists pending invitations                       |
+| TC-T3-2   | Task 3 / Task 5     | Inbox shows empty state                               |
+| TC-T3-3   | Task 3 / Task 5     | Inbox shows loading state                             |
+| TC-T3-4   | Task 3 / Task 5     | Inbox fetch failure shows error state (NFAC)          |
+| TC-T3-5   | Task 3 / Task 5     | Accept removes invite and shows toast                 |
+| TC-T3-6   | Task 3 / Task 5     | Decline removes invite and shows toast                |
+| TC-T3-7   | Task 3 / Task 5     | Accept failure shows error banner                     |
+| TC-T3-8   | Task 3 / Task 5     | Decline failure shows error banner                    |

--- a/tests/unit/components/InvitationsPage.test.tsx
+++ b/tests/unit/components/InvitationsPage.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Response as FetchResponse } from 'node-fetch';
+
+jest.mock('@/lib/components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+jest.mock('@/lib/components/ui', () => ({
+  ErrorBanner: ({ message }: { message: string | null }) =>
+    message ? React.createElement('div', { role: 'alert' }, message) : null,
+  LoadingState: ({ label }: { label: string }) =>
+    React.createElement('div', { 'data-testid': 'loading' }, label),
+}));
+
+import InvitationsPage from '@/app/invitations/page';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as Response;
+}
+
+const MOCK_INVITATIONS = [
+  {
+    id: 'inv-1',
+    campaignId: 'camp-1',
+    campaignName: 'Dragon Heist',
+    invitedBy: 'dungeonmaster',
+    invitedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 'inv-2',
+    campaignId: 'camp-2',
+    campaignName: 'Curse of Strahd',
+    invitedBy: 'otherDM',
+    invitedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  },
+];
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+  jest.useFakeTimers({ advanceTimers: true });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('InvitationsPage', () => {
+  it('renders loading state while fetch is pending', () => {
+    global.fetch = jest.fn(() => new Promise(() => {})) as jest.MockedFunction<typeof fetch>;
+    render(<InvitationsPage />);
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+  });
+
+  it('renders error banner when fetch fails', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error'))) as jest.MockedFunction<typeof fetch>;
+    render(<InvitationsPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty state when invitations list is empty', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ invitations: [] }))
+    ) as jest.MockedFunction<typeof fetch>;
+    render(<InvitationsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('No pending invitations')).toBeInTheDocument();
+    });
+  });
+
+  it('renders invite rows with campaign name, invitedBy, relative time', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ invitations: MOCK_INVITATIONS }))
+    ) as jest.MockedFunction<typeof fetch>;
+    render(<InvitationsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Dragon Heist')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Invited by: dungeonmaster')).toBeInTheDocument();
+    expect(screen.getByText(/2 days ago/)).toBeInTheDocument();
+    expect(screen.getByText('Curse of Strahd')).toBeInTheDocument();
+  });
+
+  it('Accept click calls PATCH with { action: "accept" }, removes invite from list, shows success toast', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
+    let fetchCalls = 0;
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (init?.method === 'PATCH') return jsonResponse({ status: 'accepted' });
+      fetchCalls++;
+      return jsonResponse({ invitations: fetchCalls === 1 ? MOCK_INVITATIONS : [] });
+    }) as jest.MockedFunction<typeof fetch>;
+
+    render(<InvitationsPage />);
+    await waitFor(() => expect(screen.getByText('Dragon Heist')).toBeInTheDocument());
+
+    const acceptButtons = screen.getAllByRole('button', { name: /accept/i });
+    await user.click(acceptButtons[0]);
+
+    await waitFor(() => {
+      const patchCall = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls.find(
+        ([, init]) => (init as RequestInit)?.method === 'PATCH'
+      );
+      expect(patchCall).toBeDefined();
+      expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({ action: 'accept' });
+    });
+
+    await waitFor(() => expect(screen.queryByText('Dragon Heist')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Joined "Dragon Heist"!'));
+  });
+
+  it('Decline click calls PATCH with { action: "decline" }, removes invite from list, shows success toast', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
+    let fetchCalls = 0;
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (init?.method === 'PATCH') return jsonResponse({ status: 'declined' });
+      fetchCalls++;
+      return jsonResponse({ invitations: fetchCalls === 1 ? MOCK_INVITATIONS : [] });
+    }) as jest.MockedFunction<typeof fetch>;
+
+    render(<InvitationsPage />);
+    await waitFor(() => expect(screen.getByText('Dragon Heist')).toBeInTheDocument());
+
+    const declineButtons = screen.getAllByRole('button', { name: /decline/i });
+    await user.click(declineButtons[0]);
+
+    await waitFor(() => {
+      const patchCall = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls.find(
+        ([, init]) => (init as RequestInit)?.method === 'PATCH'
+      );
+      expect(patchCall).toBeDefined();
+      expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({ action: 'decline' });
+    });
+
+    await waitFor(() => expect(screen.queryByText('Dragon Heist')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Declined "Dragon Heist"'));
+  });
+
+  it('Accept failure renders error banner and keeps invite in list', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
+    global.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'PATCH') return jsonResponse({ error: 'Failed' }, 500);
+      return jsonResponse({ invitations: MOCK_INVITATIONS });
+    }) as jest.MockedFunction<typeof fetch>;
+
+    render(<InvitationsPage />);
+    await waitFor(() => expect(screen.getByText('Dragon Heist')).toBeInTheDocument());
+
+    const acceptButtons = screen.getAllByRole('button', { name: /accept/i });
+    await user.click(acceptButtons[0]);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText('Dragon Heist')).toBeInTheDocument();
+  });
+
+  it('Decline failure renders error banner and keeps invite in list', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
+    global.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'PATCH') return jsonResponse({ error: 'Failed' }, 500);
+      return jsonResponse({ invitations: MOCK_INVITATIONS });
+    }) as jest.MockedFunction<typeof fetch>;
+
+    render(<InvitationsPage />);
+    await waitFor(() => expect(screen.getByText('Dragon Heist')).toBeInTheDocument());
+
+    const declineButtons = screen.getAllByRole('button', { name: /decline/i });
+    await user.click(declineButtons[0]);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText('Dragon Heist')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/InvitationsPage.test.tsx
+++ b/tests/unit/components/InvitationsPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Response as FetchResponse } from 'node-fetch';
 
@@ -95,8 +95,7 @@ describe('InvitationsPage', () => {
   it('Accept click calls PATCH with { action: "accept" }, removes invite from list, shows success toast', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
     let fetchCalls = 0;
-    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = input.toString();
+    global.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'PATCH') return jsonResponse({ status: 'accepted' });
       fetchCalls++;
       return jsonResponse({ invitations: fetchCalls === 1 ? MOCK_INVITATIONS : [] });
@@ -123,8 +122,7 @@ describe('InvitationsPage', () => {
   it('Decline click calls PATCH with { action: "decline" }, removes invite from list, shows success toast', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
     let fetchCalls = 0;
-    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = input.toString();
+    global.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'PATCH') return jsonResponse({ status: 'declined' });
       fetchCalls++;
       return jsonResponse({ invitations: fetchCalls === 1 ? MOCK_INVITATIONS : [] });

--- a/tests/unit/components/NavBar.test.tsx
+++ b/tests/unit/components/NavBar.test.tsx
@@ -1,3 +1,5 @@
+import { Response as FetchResponse } from 'node-fetch';
+
 jest.mock('next/link', () => ({
   __esModule: true,
   default: ({ children, href, ...rest }: { children: React.ReactNode; href: string; [k: string]: unknown }) =>
@@ -9,7 +11,7 @@ jest.mock('@/lib/hooks/useAuth', () => ({
 }));
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NavBar } from '@/lib/components/NavBar';
 import { useAuth } from '@/lib/hooks/useAuth';
@@ -25,6 +27,22 @@ function mockAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
 }
 
 describe('NavBar', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve(new FetchResponse(JSON.stringify({ invitations: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Response)
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
   it('renders all navigation links with correct hrefs', () => {
     mockAuth({});
     render(<NavBar />);
@@ -61,5 +79,61 @@ describe('NavBar', () => {
     render(<NavBar />);
     await user.click(screen.getByTestId('logout-button'));
     expect(logout).toHaveBeenCalledTimes(1);
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as Response;
+}
+
+describe('NavBar — invitations badge', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders "Invitations (2)" link when fetch returns 2 invitations', async () => {
+    mockAuth({ isAuthenticated: true, loading: false, user: { userId: 'u1', email: 'u@test.com' } });
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ invitations: [{ id: '1' }, { id: '2' }] }))
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+    render(<NavBar />);
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Invitations (2)' })).toHaveAttribute('href', '/invitations');
+    });
+  });
+
+  it('does not render invitations link when fetch returns empty list', async () => {
+    mockAuth({ isAuthenticated: true, loading: false, user: { userId: 'u1', email: 'u@test.com' } });
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ invitations: [] }))
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+    render(<NavBar />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByRole('link', { name: /invitations/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render invitations link when unauthenticated', () => {
+    mockAuth({ isAuthenticated: false, loading: false });
+    global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+    render(<NavBar />);
+    expect(screen.queryByRole('link', { name: /invitations/i })).not.toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not render invitations link when fetch throws error', async () => {
+    mockAuth({ isAuthenticated: true, loading: false, user: { userId: 'u1', email: 'u@test.com' } });
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error'))) as unknown as jest.MockedFunction<typeof fetch>;
+    render(<NavBar />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByRole('link', { name: /invitations/i })).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/components/Toast.test.tsx
+++ b/tests/unit/components/Toast.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { useToast, Toast } from '@/lib/components/Toast';
+
+function ToastHarness() {
+  const { toast, showToast } = useToast();
+  return (
+    <>
+      <button onClick={() => showToast('Joined "Campaign"!', 'success')}>show-success</button>
+      <button onClick={() => showToast('Something went wrong', 'error')}>show-error</button>
+      <Toast toast={toast} />
+    </>
+  );
+}
+
+describe('Toast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders no toast initially', () => {
+    render(<ToastHarness />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('renders success toast with correct message and styling', () => {
+    render(<ToastHarness />);
+    act(() => {
+      screen.getByText('show-success').click();
+    });
+    const toast = screen.getByRole('status');
+    expect(toast).toHaveTextContent('Joined "Campaign"!');
+    expect(toast.className).toContain('bg-green-700');
+  });
+
+  it('renders error toast with error styling', () => {
+    render(<ToastHarness />);
+    act(() => {
+      screen.getByText('show-error').click();
+    });
+    const toast = screen.getByRole('status');
+    expect(toast).toHaveTextContent('Something went wrong');
+    expect(toast.className).toContain('bg-red-700');
+  });
+
+  it('auto-dismisses after 3000ms', () => {
+    render(<ToastHarness />);
+    act(() => {
+      screen.getByText('show-success').click();
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a player-facing invitations inbox so users can see, accept, and decline campaign invitations.

### Changes

- **lib/components/Toast.tsx** (new) — useToast() hook + Toast renderer; auto-dismisses after 3s
- **lib/components/NavBar.tsx** — fetches GET /api/me/invitations on mount; shows yellow count badge when pending invites exist
- **app/invitations/page.tsx** (new) — protected page listing pending invitations with Accept/Decline buttons, optimistic removal, toast feedback, and error handling

### Tests

- 4 Toast unit tests
- 8 InvitationsPage unit tests
- 4 NavBar invitation badge unit tests

All 2122 unit tests pass. Build and lint clean.

Closes #308