### PR TITLE
feat: party builder shared characters

### DIFF
--- a/app/api/campaigns/[id]/characters/[cid]/route.ts
+++ b/app/api/campaigns/[id]/characters/[cid]/route.ts
@@ -25,6 +25,12 @@ export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: cam
       return NextResponse.json({ error: 'Share not found' }, { status: 404 });
     }
 
+    try {
+      await storage.setPartyMemberLeftAt(campaignId, characterId, new Date());
+    } catch (cleanupError) {
+      console.error('Error during party cleanup after unshare:', cleanupError);
+    }
+
     return new NextResponse(null, { status: 204 });
   } catch (error) {
     console.error('Error unsharing character:', error);

--- a/app/api/campaigns/[id]/characters/[cid]/route.ts
+++ b/app/api/campaigns/[id]/characters/[cid]/route.ts
@@ -25,11 +25,9 @@ export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: cam
       return NextResponse.json({ error: 'Share not found' }, { status: 404 });
     }
 
-    try {
-      await storage.setPartyMemberLeftAt(campaignId, characterId, new Date());
-    } catch (cleanupError) {
-      console.error('Error during party cleanup after unshare:', cleanupError);
-    }
+    void storage.setPartyMemberLeftAt(campaignId, characterId, new Date()).catch(
+      (e: unknown) => console.error('Error during party cleanup after unshare:', e)
+    );
 
     return new NextResponse(null, { status: 204 });
   } catch (error) {

--- a/app/api/campaigns/[id]/characters/route.ts
+++ b/app/api/campaigns/[id]/characters/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
 import { DuplicateShareError } from '@/lib/errors';
+import type { SharedCharacterEntry } from '@/lib/types';
 
 type Params = { id: string };
 
@@ -59,6 +60,11 @@ export const GET = withAuthAndParams<Params>(async (_request, auth, { id: campai
     const member = await storage.getMember(campaignId, auth.userId);
     if (!member || member.status !== 'active') {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    if (member.role === 'dm') {
+      const entries: SharedCharacterEntry[] = await storage.buildSharedCharacterEntries(campaignId);
+      return NextResponse.json(entries);
     }
 
     const shares = await storage.listSharesForCampaign(campaignId, auth.userId);

--- a/app/api/campaigns/[id]/members/[userId]/route.ts
+++ b/app/api/campaigns/[id]/members/[userId]/route.ts
@@ -22,16 +22,18 @@ export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: cam
 
     await storage.updateMemberStatus(campaignId, targetUserId, 'removed', auth.userId);
 
-    try {
-      const shares = await storage.listAllSharesForCampaign(campaignId);
-      const targetShares = shares.filter(s => s.userId === targetUserId);
-      const now = new Date();
-      for (const share of targetShares) {
-        await storage.setPartyMemberLeftAt(campaignId, share.characterId, now);
+    void (async () => {
+      try {
+        const shares = await storage.listAllSharesForCampaign(campaignId);
+        const targetShares = shares.filter(s => s.userId === targetUserId);
+        const now = new Date();
+        await Promise.all(
+          targetShares.map(share => storage.setPartyMemberLeftAt(campaignId, share.characterId, now))
+        );
+      } catch (cleanupError) {
+        console.error('Error during party cleanup after member removal:', cleanupError);
       }
-    } catch (cleanupError) {
-      console.error('Error during party cleanup after member removal:', cleanupError);
-    }
+    })();
 
     return NextResponse.json({ status: 'removed' });
   } catch (error) {

--- a/app/api/campaigns/[id]/members/[userId]/route.ts
+++ b/app/api/campaigns/[id]/members/[userId]/route.ts
@@ -21,6 +21,18 @@ export const DELETE = withAuthAndParams<Params>(async (_request, auth, { id: cam
     }
 
     await storage.updateMemberStatus(campaignId, targetUserId, 'removed', auth.userId);
+
+    try {
+      const shares = await storage.listAllSharesForCampaign(campaignId);
+      const targetShares = shares.filter(s => s.userId === targetUserId);
+      const now = new Date();
+      for (const share of targetShares) {
+        await storage.setPartyMemberLeftAt(campaignId, share.characterId, now);
+      }
+    } catch (cleanupError) {
+      console.error('Error during party cleanup after member removal:', cleanupError);
+    }
+
     return NextResponse.json({ status: 'removed' });
   } catch (error) {
     console.error('Error removing member:', error);

--- a/app/api/parties/[id]/route.ts
+++ b/app/api/parties/[id]/route.ts
@@ -49,13 +49,12 @@ export const PUT = withAuthAndParams<Params>(async (request, auth, { id }) => {
       const campaignChanged = effectiveCampaignId !== existingParty.campaignId;
 
       if (effectiveCampaignId) {
-        for (const charId of newIdSet) {
-          if (campaignChanged || !existingActiveIds.has(charId)) {
-            const allowed = await storage.canAddToCampaignParty(effectiveCampaignId, charId, auth.userId);
-            if (!allowed) {
-              return NextResponse.json({ error: 'Character not shared into campaign' }, { status: 403 });
-            }
-          }
+        const charsToCheck = Array.from(newIdSet).filter(charId => campaignChanged || !existingActiveIds.has(charId));
+        const checks = await Promise.all(
+          charsToCheck.map(charId => storage.canAddToCampaignParty(effectiveCampaignId, charId, auth.userId))
+        );
+        if (checks.some(allowed => !allowed)) {
+          return NextResponse.json({ error: 'Character not shared into campaign' }, { status: 403 });
         }
       }
 

--- a/app/api/parties/[id]/route.ts
+++ b/app/api/parties/[id]/route.ts
@@ -42,6 +42,23 @@ export const PUT = withAuthAndParams<Params>(async (request, auth, { id }) => {
       const existingActiveIds = new Set<string>(
         existingParty.members.filter(m => !m.leftAt).map(m => m.characterId)
       );
+
+      const effectiveCampaignId = campaignId !== undefined
+        ? (typeof campaignId === 'string' ? campaignId.trim() : '')
+        : existingParty.campaignId;
+      const campaignChanged = effectiveCampaignId !== existingParty.campaignId;
+
+      if (effectiveCampaignId) {
+        for (const charId of newIdSet) {
+          if (campaignChanged || !existingActiveIds.has(charId)) {
+            const allowed = await storage.canAddToCampaignParty(effectiveCampaignId, charId, auth.userId);
+            if (!allowed) {
+              return NextResponse.json({ error: 'Character not shared into campaign' }, { status: 403 });
+            }
+          }
+        }
+      }
+
       updatedMembers = existingParty.members.map(m => {
         if (!m.leftAt && !newIdSet.has(m.characterId)) {
           return { ...m, leftAt: now };

--- a/app/api/parties/route.ts
+++ b/app/api/parties/route.ts
@@ -24,6 +24,17 @@ export const POST = withAuth(async (request, auth) => {
 
     const now = new Date();
     const ids: string[] = Array.isArray(characterIds) ? characterIds : [];
+
+    if (typeof campaignId === 'string' && campaignId.trim()) {
+      const cid = campaignId.trim();
+      for (const charId of ids) {
+        const allowed = await storage.canAddToCampaignParty(cid, charId, auth.userId);
+        if (!allowed) {
+          return NextResponse.json({ error: 'Character not shared into campaign' }, { status: 403 });
+        }
+      }
+    }
+
     const members: PartyMember[] = ids.map(characterId => ({ characterId, addedAt: now }));
 
     const party: Party = {

--- a/app/api/parties/route.ts
+++ b/app/api/parties/route.ts
@@ -27,11 +27,9 @@ export const POST = withAuth(async (request, auth) => {
 
     if (typeof campaignId === 'string' && campaignId.trim()) {
       const cid = campaignId.trim();
-      for (const charId of ids) {
-        const allowed = await storage.canAddToCampaignParty(cid, charId, auth.userId);
-        if (!allowed) {
-          return NextResponse.json({ error: 'Character not shared into campaign' }, { status: 403 });
-        }
+      const checks = await Promise.all(ids.map(charId => storage.canAddToCampaignParty(cid, charId, auth.userId)));
+      if (checks.some(allowed => !allowed)) {
+        return NextResponse.json({ error: 'Character not shared into campaign' }, { status: 403 });
       }
     }
 

--- a/app/parties/page.tsx
+++ b/app/parties/page.tsx
@@ -270,7 +270,7 @@ function PartiesContent() {
   );
 }
 
-function PartyEditor({
+export function PartyEditor({
   party,
   characters,
   campaigns,

--- a/app/parties/page.tsx
+++ b/app/parties/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
 import { ErrorBanner, LoadingState, FormField, EditorShell, textInputClass } from '@/lib/components/ui';
-import { Party, Character, Campaign, CHARACTER_TYPE_ORDER, CHARACTER_TYPE_LABELS, getCharacterType } from '@/lib/types';
+import { Party, Character, Campaign, CHARACTER_TYPE_ORDER, CHARACTER_TYPE_LABELS, getCharacterType, SharedCharacterEntry } from '@/lib/types';
 import { CharacterMiniSummary } from '@/lib/components/CharacterMiniSummary';
 
 function PartiesContent() {
@@ -15,6 +15,7 @@ function PartiesContent() {
   const [error, setError] = useState<string | null>(null);
   const [editingParty, setEditingParty] = useState<Party | null>(null);
   const [isAdding, setIsAdding] = useState(false);
+  const [sharedCharacters, setSharedCharacters] = useState<SharedCharacterEntry[]>([]);
 
   useEffect(() => {
     fetchData();
@@ -43,6 +44,24 @@ function PartiesContent() {
     }
   };
 
+  const fetchSharedCharacters = async (campaignId: string) => {
+    if (!campaignId) {
+      setSharedCharacters([]);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/campaigns/${campaignId}/characters`);
+      if (res.ok) {
+        const data = await res.json();
+        setSharedCharacters(Array.isArray(data) ? data : []);
+      } else {
+        setSharedCharacters([]);
+      }
+    } catch {
+      setSharedCharacters([]);
+    }
+  };
+
   const addParty = () => {
     const newParty: Party = {
       id: '',
@@ -53,6 +72,7 @@ function PartiesContent() {
       createdAt: new Date(),
       updatedAt: new Date(),
     };
+    setSharedCharacters([]);
     setEditingParty(newParty);
     setIsAdding(true);
   };
@@ -134,8 +154,10 @@ function PartiesContent() {
             party={editingParty}
             characters={characters}
             campaigns={campaigns}
+            sharedCharacters={sharedCharacters}
             onSave={saveParty}
             onCancel={cancelEdit}
+            onCampaignChange={fetchSharedCharacters}
             isNew={isAdding}
           />
         )}
@@ -223,6 +245,7 @@ function PartiesContent() {
                           onClick={() => {
                             setEditingParty(party);
                             setIsAdding(false);
+                            fetchSharedCharacters(party.campaignId ?? '');
                           }}
                           className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
                         >
@@ -251,15 +274,19 @@ function PartyEditor({
   party,
   characters,
   campaigns,
+  sharedCharacters,
   onSave,
   onCancel,
+  onCampaignChange,
   isNew,
 }: {
   party: Party;
   characters: Character[];
   campaigns: Campaign[];
+  sharedCharacters: SharedCharacterEntry[];
   onSave: (party: Party, characterIds: string[]) => Promise<void>;
   onCancel: () => void;
+  onCampaignChange: (campaignId: string) => void;
   isNew: boolean;
 }) {
   const [name, setName] = useState(party.name);
@@ -322,7 +349,10 @@ function PartyEditor({
         </FormField>
 
         <FormField label="Campaign">
-          <select value={campaignId} onChange={(e) => setCampaignId(e.target.value)}
+          <select value={campaignId} onChange={(e) => {
+            setCampaignId(e.target.value);
+            onCampaignChange(e.target.value);
+          }}
             className={textInputClass()} disabled={saving}>
             <option value="">None</option>
             {campaigns.map(campaign => (
@@ -334,7 +364,7 @@ function PartyEditor({
 
       <div className="mb-4">
         <label className="block mb-2 text-sm font-semibold">Party Members</label>
-        {characters.length === 0 ? (
+        {characters.length === 0 && sharedCharacters.length === 0 ? (
           <p className="text-gray-400 text-sm">No characters available. Create characters first.</p>
         ) : (
           <div className="space-y-4">
@@ -357,6 +387,35 @@ function PartyEditor({
                 </div>
               );
             })}
+            {campaignId && sharedCharacters.length > 0 && (() => {
+              const activeShared = sharedCharacters.filter(e => !e.character.deletedAt);
+              if (activeShared.length === 0) return null;
+              const byOwner = new Map<string, SharedCharacterEntry[]>();
+              for (const entry of activeShared) {
+                const key = entry.share.userId;
+                if (!byOwner.has(key)) byOwner.set(key, []);
+                byOwner.get(key)!.push(entry);
+              }
+              return (
+                <div>
+                  <p className="text-xs text-gray-400 uppercase tracking-wide mb-1">Shared by Campaign Members</p>
+                  {Array.from(byOwner.entries()).map(([ownerId, entries]) => (
+                    <div key={ownerId} className="mb-2">
+                      <p className="text-xs text-gray-500 mb-1" aria-label={`Shared by: ${ownerId}`}>{ownerId}</p>
+                      <div className="grid md:grid-cols-2 gap-2">
+                        {entries.map(entry => (
+                          <label key={entry.character.id} className="flex items-center gap-2 cursor-pointer">
+                            <input type="checkbox" checked={characterIds.has(entry.character.id)}
+                              onChange={() => toggleCharacter(entry.character.id)} disabled={saving} className="cursor-pointer" />
+                            <span className="text-sm">{entry.character.name}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              );
+            })()}
           </div>
         )}
       </div>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -21,6 +21,7 @@ import {
   MemberStatus,
   MemberHistoryEntry,
   PublicUser,
+  SharedCharacterEntry,
 } from "./types";
 import { DuplicateMemberError, DuplicateShareError } from "./errors";
 import { GLOBAL_USER_ID } from "./constants";
@@ -1048,6 +1049,111 @@ export const storage = {
       console.error("Error listing campaign character shares:", error);
       return [];
     }
+  },
+
+  async listAllSharesForCampaign(campaignId: string): Promise<CampaignCharacterShare[]> {
+    try {
+      const db = await getDatabase();
+      const shares = await db
+        .collection<CampaignCharacterShare>("campaignCharacterShares")
+        .find({ campaignId })
+        .toArray();
+      return shares.map((s) => {
+        const normalized = normalizeStoredEntityId(s);
+        const { _id, ...rest } = normalized;
+        return rest as CampaignCharacterShare;
+      });
+    } catch (error) {
+      console.error("Error listing all campaign character shares:", error);
+      return [];
+    }
+  },
+
+  async loadPartiesByCampaign(campaignId: string): Promise<Party[]> {
+    // TODO: add campaignId index on parties if >50ms becomes common
+    const start = Date.now();
+    try {
+      const db = await getDatabase();
+      const parties = await db
+        .collection<LegacyPartyDoc>("parties")
+        .find({ campaignId } as unknown as Filter<LegacyPartyDoc>)
+        .toArray();
+      const duration = Date.now() - start;
+      if (duration > 10) {
+        console.log(`[perf] loadPartiesByCampaign ${campaignId}: ${duration}ms`);
+      }
+      return parties.map(normalizeStoredEntityId).map(migrateParty);
+    } catch (error) {
+      console.error("Error loading parties by campaign:", error);
+      return [];
+    }
+  },
+
+  async setPartyMemberLeftAt(campaignId: string, characterId: string, timestamp: Date): Promise<void> {
+    try {
+      const parties = await this.loadPartiesByCampaign(campaignId);
+      for (const party of parties) {
+        let modified = false;
+        const updatedMembers = party.members.map((m) => {
+          if (m.characterId === characterId && !m.leftAt) {
+            modified = true;
+            return { ...m, leftAt: timestamp };
+          }
+          return m;
+        });
+        if (modified) {
+          try {
+            await this.saveParty({ ...party, members: updatedMembers });
+          } catch (saveError) {
+            console.error(`Error saving party ${party.id} during setPartyMemberLeftAt:`, saveError);
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error in setPartyMemberLeftAt:", error);
+    }
+  },
+
+  async canAddToCampaignParty(campaignId: string, characterId: string, dmUserId: string): Promise<boolean> {
+    try {
+      const character = await this.loadCharacterById(characterId);
+      if (!character) return false;
+      if (character.userId === dmUserId) return true;
+
+      const db = await getDatabase();
+      const share = await db
+        .collection<CampaignCharacterShare>("campaignCharacterShares")
+        .findOne({ campaignId, characterId });
+      if (!share) return false;
+
+      const member = await this.getMember(campaignId, share.userId);
+      return member?.status === 'active';
+    } catch (error) {
+      console.error("Error in canAddToCampaignParty:", error);
+      return false;
+    }
+  },
+
+  async buildSharedCharacterEntries(campaignId: string): Promise<SharedCharacterEntry[]> {
+    const shares = await this.listAllSharesForCampaign(campaignId);
+    const entries: SharedCharacterEntry[] = [];
+    for (const share of shares) {
+      const member = await this.getMember(campaignId, share.userId);
+      if (!member || member.status !== 'active') continue;
+      const character = await this.loadCharacterById(share.characterId);
+      if (!character || character.deletedAt) continue;
+      entries.push({
+        share,
+        character: {
+          id: character.id,
+          name: character.name,
+          characterType: character.characterType,
+          userId: character.userId,
+          deletedAt: character.deletedAt,
+        },
+      });
+    }
+    return entries;
   },
 
   async loadCharacterById(id: string): Promise<Character | null> {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1136,24 +1136,18 @@ export const storage = {
 
   async buildSharedCharacterEntries(campaignId: string): Promise<SharedCharacterEntry[]> {
     const shares = await this.listAllSharesForCampaign(campaignId);
-    const entries: SharedCharacterEntry[] = [];
-    for (const share of shares) {
-      const member = await this.getMember(campaignId, share.userId);
-      if (!member || member.status !== 'active') continue;
-      const character = await this.loadCharacterById(share.characterId);
-      if (!character || character.deletedAt) continue;
-      entries.push({
-        share,
-        character: {
-          id: character.id,
-          name: character.name,
-          characterType: character.characterType,
-          userId: character.userId,
-          deletedAt: character.deletedAt,
-        },
-      });
-    }
-    return entries;
+    const results = await Promise.all(
+      shares.map(async (share) => {
+        const [member, character] = await Promise.all([
+          this.getMember(campaignId, share.userId),
+          this.loadCharacterById(share.characterId),
+        ]);
+        if (!member || member.status !== 'active') return null;
+        if (!character || character.deletedAt) return null;
+        return { share, character };
+      })
+    );
+    return results.filter((e): e is SharedCharacterEntry => e !== null);
   },
 
   async loadCharacterById(id: string): Promise<Character | null> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -755,6 +755,6 @@ export interface CampaignCharacterShare {
 
 export interface SharedCharacterEntry {
   share: CampaignCharacterShare;
-  character: Pick<Character, 'id' | 'name' | 'characterType' | 'userId' | 'deletedAt'>;
+  character: Character;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -753,3 +753,8 @@ export interface CampaignCharacterShare {
   sharedAt: Date;
 }
 
+export interface SharedCharacterEntry {
+  share: CampaignCharacterShare;
+  character: Pick<Character, 'id' | 'name' | 'characterType' | 'userId' | 'deletedAt'>;
+}
+

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -1,15 +1,19 @@
-import { Campaign, Character, CampaignContext, Party, PartyMember, SessionLog } from '@/lib/types';
+import { Campaign, Character, CampaignContext, Party, PartyMember, SessionLog, SharedCharacterEntry } from '@/lib/types';
 
 export async function fetchCampaignContext(
   campaignId: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<CampaignContext> {
-  const [campaignRes, partiesRes, charactersRes, sessionsRes] = await Promise.all([
+  const [campaignRes, partiesRes, charactersRes, sessionsRes, sharedCharsRes] = await Promise.all([
     fetchImpl(`/api/campaigns/${campaignId}`),
     fetchImpl('/api/parties'),
     fetchImpl('/api/characters'),
     fetchImpl(`/api/campaigns/${campaignId}/sessions?limit=3`).catch((e: unknown) => {
       console.error('Sessions fetch error:', e);
+      return null;
+    }),
+    fetchImpl(`/api/campaigns/${campaignId}/characters`).catch((e: unknown) => {
+      console.error('Shared characters fetch error:', e);
       return null;
     }),
   ]);
@@ -18,11 +22,41 @@ export async function fetchCampaignContext(
   if (!partiesRes.ok) throw new Error('Failed to fetch parties');
   if (!charactersRes.ok) throw new Error('Failed to fetch characters');
 
-  const [campaign, allParties, allCharacters]: [Campaign, Party[], Character[]] = await Promise.all([
+  const [campaign, allParties, dmCharacters]: [Campaign, Party[], Character[]] = await Promise.all([
     campaignRes.json(),
     partiesRes.json(),
     charactersRes.json(),
   ]);
+
+  let sharedEntries: SharedCharacterEntry[] = [];
+  try {
+    if (sharedCharsRes?.ok) {
+      const data = await sharedCharsRes.json();
+      sharedEntries = Array.isArray(data) ? data as SharedCharacterEntry[] : [];
+    } else if (sharedCharsRes) {
+      console.error('Shared characters fetch failed with status:', sharedCharsRes.status);
+    }
+  } catch (e) {
+    console.error('Shared characters response parse error:', e);
+  }
+
+  const activeShareIds = new Set(
+    sharedEntries.filter(e => !e.character.deletedAt).map(e => e.share.characterId)
+  );
+
+  const sharedCharacters: Character[] = sharedEntries
+    .filter(e => !e.character.deletedAt)
+    .map(e => e.character as unknown as Character);
+
+  const allCharactersById = new Map<string, Character>();
+  for (const c of dmCharacters) {
+    allCharactersById.set(c.id, c);
+  }
+  for (const c of sharedCharacters) {
+    if (!allCharactersById.has(c.id)) {
+      allCharactersById.set(c.id, c);
+    }
+  }
 
   const parties = allParties.filter(p => p.campaignId === campaignId);
   const allMembersRaw = parties.flatMap(p => p.members);
@@ -43,9 +77,14 @@ export async function fetchCampaignContext(
     ? (campaign.chapters.find(c => c.id === campaign.currentChapterId) ?? null)
     : null;
 
-  const characters = allCharacters.filter(
-    c => memberIds.has(c.id) && !c.deletedAt,
-  );
+  const dmUserIds = new Set(dmCharacters.map(c => c.userId));
+
+  const characters = Array.from(allCharactersById.values()).filter(c => {
+    if (!memberIds.has(c.id)) return false;
+    if (c.deletedAt) return false;
+    if (!dmUserIds.has(c.userId) && !activeShareIds.has(c.id)) return false;
+    return true;
+  });
 
   let recentSessions: SessionLog[] = [];
   try {

--- a/lib/utils/campaignContext.ts
+++ b/lib/utils/campaignContext.ts
@@ -46,7 +46,7 @@ export async function fetchCampaignContext(
 
   const sharedCharacters: Character[] = sharedEntries
     .filter(e => !e.character.deletedAt)
-    .map(e => e.character as unknown as Character);
+    .map(e => e.character);
 
   const allCharactersById = new Map<string, Character>();
   for (const c of dmCharacters) {

--- a/openspec/changes/party-builder-shared-characters/.openspec.yaml
+++ b/openspec/changes/party-builder-shared-characters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-07

--- a/openspec/changes/party-builder-shared-characters/design.md
+++ b/openspec/changes/party-builder-shared-characters/design.md
@@ -1,0 +1,204 @@
+## Context
+
+- **Relevant architecture:**
+  - `lib/storage.ts` — all MongoDB access; existing methods `addShare`, `removeShare`, `listSharesForCampaign`, `loadParties`, `saveParty`
+  - `lib/types.ts` — `Party`, `PartyMember`, `CampaignCharacterShare`, `Character`, `CampaignMember`
+  - `app/api/parties/` — POST (create) and PUT (update) routes; currently accept any `characterId` with no ownership check
+  - `app/api/campaigns/[id]/characters/` — POST (share), GET (list caller's shares), DELETE (unshare)
+  - `app/api/campaigns/[id]/members/[userId]/` — DELETE (remove member from campaign)
+  - `app/parties/page.tsx` — `PartyEditor` component; currently fetches `GET /api/characters` only
+  - `lib/utils/campaignContext.ts` — `fetchCampaignContext`; fetches DM-owned characters only
+
+- **Dependencies:**
+  - 3a (issue #309) is complete: `campaignCharacterShares` collection exists with unique `{campaignId, characterId}` index; `addShare`, `removeShare`, `listSharesForCampaign` storage methods exist; `CampaignCharacterShare` type exists
+  - `storage.getMember(campaignId, userId)` exists — used to check member role/status
+  - `storage.loadCharacterById(id)` exists
+
+- **Interfaces/contracts touched:**
+  - `GET /api/campaigns/[id]/characters` — response shape extended for DM callers
+  - `POST /api/parties`, `PUT /api/parties/[id]` — new 403 response path when access rule fails
+  - `DELETE /api/campaigns/[id]/characters/[cid]` — side-effect: party cleanup
+  - `DELETE /api/campaigns/[id]/members/[userId]` — side-effect: cascaded party cleanup
+  - `fetchCampaignContext` — now fetches shared characters and applies reactive filter
+
+## Goals / Non-Goals
+
+### Goals
+
+- DM can select shared player characters in the party builder when a campaign is selected
+- Party access rule enforced at POST and PUT: shared-or-owned per campaign context
+- Proactive cleanup: unshare and member-removal set `leftAt` on affected party entries
+- Reactive guard in `fetchCampaignContext` filters stale shared characters as defense-in-depth
+- Observability: timing logged for full-scan storage queries
+
+### Non-Goals
+
+- `campaignId` index on `parties` collection
+- Player-facing UI changes
+- Real-time revocation notifications
+
+## Decisions
+
+### Decision 1: Enriched DM GET response for shared characters
+
+- **Chosen:** `GET /api/campaigns/[id]/characters` returns `SharedCharacterEntry[]` when caller is DM: `{ share: CampaignCharacterShare, character: Pick<Character, 'id'|'name'|'characterType'|'userId'|'deletedAt'> }`. When caller is a player, existing behavior (bare shares for the caller) is preserved.
+- **Alternatives considered:** Separate endpoint `GET /api/campaigns/[id]/shared-characters`; client-side second round-trip to resolve character metadata.
+- **Rationale:** Role-aware response on the existing route avoids adding a new route; the character metadata required by the UI (name, type, owner, soft-delete flag) is compact and safe to include given DM ownership of the campaign.
+- **Trade-offs:** Response shape is polymorphic based on caller role. Documented in spec. The caller must know to check their role or parse the response shape.
+
+### Decision 2: Access rule in `canAddToCampaignParty` storage helper
+
+- **Chosen:** A new `storage.canAddToCampaignParty(campaignId, characterId, dmUserId): Promise<boolean>` helper checks: (1) character is owned by `dmUserId`, OR (2) an active share exists in `campaignCharacterShares` where `characterId` matches AND `userId` resolves to a campaign member with `status === 'active'`. This requires a two-collection join: `campaignCharacterShares` → `campaignMembers`.
+- **Alternatives considered:** Inline the check in each route; a separate service layer.
+- **Rationale:** Storage helper is the established pattern in this codebase for cross-collection reads. Testable in isolation. Reused by both POST and PUT party routes.
+- **Trade-offs:** Two DB reads per validated character (share lookup + member status check). Acceptable given party sizes are small.
+
+### Decision 3: `listAllSharesForCampaign` — no userId filter
+
+- **Chosen:** New `storage.listAllSharesForCampaign(campaignId): Promise<CampaignCharacterShare[]>` queries `campaignCharacterShares` with `{ campaignId }` only, returning all shares regardless of which player created them.
+- **Alternatives considered:** Extend `listSharesForCampaign` with an optional `userId` parameter.
+- **Rationale:** Separate method name is explicit about intent and avoids a conditional signature on the existing method.
+- **Trade-offs:** Small duplication of query logic. Acceptable.
+
+### Decision 4: `loadPartiesByCampaign` with timing observability
+
+- **Chosen:** New `storage.loadPartiesByCampaign(campaignId: string): Promise<Party[]>` queries all parties documents with `{ campaignId }` (full collection scan, no index). Wraps the query in `Date.now()` timing and logs `[perf] loadPartiesByCampaign <campaignId>: <ms>ms` when duration exceeds 10ms. Includes a `// TODO: add campaignId index if >50ms becomes common` comment.
+- **Alternatives considered:** Extend `loadParties(userId)` with an optional `campaignId` filter.
+- **Rationale:** Separate method avoids coupling the DM's party-list query with the campaign-scoped cleanup query. Timing log establishes a baseline.
+- **Trade-offs:** Full scan acceptable at current scale; log provides data to justify an index later.
+
+### Decision 5: `setPartyMemberLeftAt` as a fire-and-forget cleanup path
+
+- **Chosen:** `storage.setPartyMemberLeftAt(campaignId, characterId, timestamp)` calls `loadPartiesByCampaign`, iterates parties, sets `leftAt` on matching active members, and calls `saveParty` for each modified party. Errors are caught and logged, not re-thrown. Callers (unshare route, member-removal route) do not fail if cleanup errors.
+- **Alternatives considered:** Fail the primary operation if cleanup fails; a MongoDB aggregation pipeline update.
+- **Rationale:** Cleanup is secondary to the primary operation (unshare / remove member). The reactive guard in `fetchCampaignContext` is the safety net. A simple iterative approach is easy to test and understand.
+- **Trade-offs:** Non-atomic; a crash mid-cleanup leaves partial state. The reactive guard handles this.
+
+### Decision 6: Reactive guard in `fetchCampaignContext`
+
+- **Chosen:** After merging DM-owned and shared characters, filter out shared characters (those with `userId !== dmUserId`) whose `characterId` is not in the current `campaignCharacterShares` set for the campaign. The shares are fetched as part of the same `Promise.all` that already fetches parties and characters.
+- **Alternatives considered:** Trust `leftAt` exclusively; no reactive guard.
+- **Rationale:** Defense-in-depth; the proactive `leftAt` path is best-effort (fire-and-forget). The reactive filter is cheap — it's a set membership check on data already fetched.
+- **Trade-offs:** One additional fetch (`GET /api/campaigns/[id]/characters` with DM role) on every context load. Acceptable given it returns a compact JSON list.
+
+### Decision 7: `SharedCharacterEntry` type in `lib/types.ts`
+
+- **Chosen:** Export `interface SharedCharacterEntry { share: CampaignCharacterShare; character: Pick<Character, 'id' | 'name' | 'characterType' | 'userId' | 'deletedAt'> }` from `lib/types.ts`. Used as the response type for the DM-facing GET.
+- **Alternatives considered:** Inline type in the route; extend `CampaignCharacterShare` with character fields.
+- **Rationale:** Exported type is usable in both the API route and the `PartyEditor` client component without duplication.
+- **Trade-offs:** Adds a type to `lib/types.ts`; acceptable given the file already owns all domain types.
+
+## Proposal to Design Mapping
+
+- Proposal element: Enriched DM GET for shared characters
+  - Design decision: Decision 1
+  - Validation approach: Route test — DM caller receives `SharedCharacterEntry[]`; player caller receives bare shares
+
+- Proposal element: `canAddToCampaignParty` access rule helper
+  - Design decision: Decision 2
+  - Validation approach: Unit test — owns char → true; active share → true; inactive member → false; no share → false; no campaignId → true (DM-owned pass)
+
+- Proposal element: `listAllSharesForCampaign` (no userId filter)
+  - Design decision: Decision 3
+  - Validation approach: Unit test — returns shares from multiple players in campaign
+
+- Proposal element: `loadPartiesByCampaign` with timing log
+  - Design decision: Decision 4
+  - Validation approach: Unit test confirms filtering; integration/log test confirms timing line emitted
+
+- Proposal element: `setPartyMemberLeftAt` proactive cleanup
+  - Design decision: Decision 5
+  - Validation approach: Unit test — active member gets `leftAt`; already-left member unchanged; errors don't throw
+
+- Proposal element: Reactive guard in `fetchCampaignContext`
+  - Design decision: Decision 6
+  - Validation approach: Unit test — character with revoked share excluded from context characters list
+
+- Proposal element: `SharedCharacterEntry` type
+  - Design decision: Decision 7
+  - Validation approach: TypeScript compilation
+
+## Functional Requirements Mapping
+
+- Requirement: DM can add a shared character to a campaign party
+  - Design element: Decision 2 (`canAddToCampaignParty`), Decision 1 (UI fetch)
+  - Acceptance criteria reference: specs/party-access-rule
+  - Testability notes: Route test POST/PUT with shared char → 201/200; unshared char → 403
+
+- Requirement: DM cannot add an unshared character (not owned and not shared)
+  - Design element: Decision 2
+  - Acceptance criteria reference: specs/party-access-rule
+  - Testability notes: Route test with foreign characterId not in shares → 403
+
+- Requirement: Party builder surfaces shared characters grouped by owner
+  - Design element: Decision 1, Decision 7
+  - Acceptance criteria reference: specs/party-builder-ui
+  - Testability notes: Component test — renders shared character section when campaignId set; absent when no campaignId
+
+- Requirement: Unshare triggers proactive `leftAt` on party entries
+  - Design element: Decision 5
+  - Acceptance criteria reference: specs/party-cleanup
+  - Testability notes: Route test DELETE `/campaigns/[id]/characters/[cid]` → party member has `leftAt`
+
+- Requirement: Member removal cascades `leftAt` across all their shared characters
+  - Design element: Decision 5
+  - Acceptance criteria reference: specs/party-cleanup
+  - Testability notes: Route test DELETE `/campaigns/[id]/members/[userId]` → all party members for that user's shares have `leftAt`
+
+- Requirement: Shared characters appear in campaign context (prompts)
+  - Design element: Decision 6
+  - Acceptance criteria reference: specs/campaign-context-shared-chars
+  - Testability notes: Unit test `fetchCampaignContext` — shared character in party appears in `context.characters`
+
+- Requirement: Revoked-share characters excluded from campaign context
+  - Design element: Decision 6
+  - Acceptance criteria reference: specs/campaign-context-shared-chars
+  - Testability notes: Unit test — character with no active share not in `context.characters` even if in `party.members`
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: performance
+  - Requirement: Full-scan `loadPartiesByCampaign` query must be observable
+  - Design element: Decision 4 — timing log at >10ms
+  - Acceptance criteria reference: Log line present in cleanup paths
+  - Testability notes: Manual verification; or spy on `console.log` in storage test
+
+- Requirement category: reliability
+  - Requirement: Party cleanup failure must not fail primary operations (unshare / remove member)
+  - Design element: Decision 5 — errors caught and logged, not re-thrown
+  - Acceptance criteria reference: specs/party-cleanup error scenario
+  - Testability notes: Unit test — mock `saveParty` to throw; cleanup function does not throw; primary route returns success
+
+- Requirement category: security
+  - Requirement: DM-enriched GET must not be accessible by non-members
+  - Design element: Decision 1 — existing `getMember` check gates the route; DM role check for enriched path
+  - Acceptance criteria reference: specs/campaign-character-shares DM GET scenarios
+  - Testability notes: Route test — non-member gets 403; player gets bare shares; DM gets enriched list
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Polymorphic GET response shape (role-dependent)
+  - Impact: Client code must handle two shapes; easy to accidentally use player-shape in DM context
+  - Mitigation: `SharedCharacterEntry` export makes the DM shape explicit; party builder imports it
+
+- Risk/trade-off: Fire-and-forget cleanup leaves window for stale party data
+  - Impact: A party could briefly show a revoked character as active between unshare and next context load
+  - Mitigation: Reactive guard in `fetchCampaignContext` closes the gap; `leftAt` is set before response returns in the happy path
+
+## Rollback / Mitigation
+
+- Rollback trigger: POST/PUT party returns unexpected 403 for DM-owned characters; or cascade cleanup breaks unshare/remove-member response
+- Rollback steps: Revert the 5 modified route files and `lib/storage.ts` additions. New `SharedCharacterEntry` type and `lib/utils/campaignContext.ts` changes can be reverted independently. No schema migrations — no new collections or indexes.
+- Data migration considerations: None. `leftAt` on existing party members was already a valid state before this change.
+- Verification after rollback: Existing party CRUD tests pass; party builder shows DM-owned characters only (prior behavior).
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check or open a tracked issue before proceeding.
+- If security checks fail: Do not merge. Escalate to repo owner.
+- If required reviews are blocked/stale: Wait 48 hours, then re-request review. After 72 hours, escalate to repo owner.
+- Escalation path and timeout: Tag `@dougis` in the PR after 72-hour stale review timeout.
+
+## Open Questions
+
+No open questions. All design decisions resolved during exploration and proposal phases.

--- a/openspec/changes/party-builder-shared-characters/proposal.md
+++ b/openspec/changes/party-builder-shared-characters/proposal.md
@@ -1,0 +1,112 @@
+## GitHub Issues
+
+- #310 (sub-issue of #295)
+
+## Why
+
+- **Problem statement:** Phase 3a delivered the ability for players to share their characters into a campaign. Phase 3b closes the loop: the DM can't yet see or add those shared characters when building a party. The party builder only surfaces DM-owned characters, and no access rule guards against adding unowned, unshared characters.
+- **Why now:** 3a is merged and closed. 3b is the unblocked next issue in the Phase 3 epic.
+- **Business/user impact:** Without 3b, campaign-level party management is incomplete — the DM can't use player characters in parties, which is the core value proposition of the sharing feature. The campaign context (prompts, session journal) also silently drops player characters from context, making it appear the feature doesn't work.
+
+## Problem Space
+
+- **Current behavior:**
+  - `GET /api/parties` and `PUT /api/parties/[id]` only handle DM-owned characters; no validation that a `characterId` is owned by the DM.
+  - `GET /api/campaigns/[id]/characters` returns only the *caller's own* shares (filtered by `userId`); a DM calling it gets an empty list.
+  - `PartyEditor` fetches `GET /api/characters` (DM-owned only) and shows a flat checkbox list; no awareness of shared characters or campaign context.
+  - `fetchCampaignContext` assembles characters from `GET /api/characters` (DM-owned only) and filters by party membership. Shared characters owned by players never appear in the list — they are silently absent from prompt context even if added to a party.
+  - When a player unshares a character or is removed from a campaign, active `Party.members[]` entries for that character are not cleaned up.
+
+- **Desired behavior:**
+  - DM can add a shared character to a campaign party; attempt to add an unshared character is rejected (403).
+  - Party builder shows both DM-owned characters and shared player characters (grouped by owner) when a `campaignId` is set.
+  - Unshare and member-removal proactively set `leftAt` on affected party member entries.
+  - Shared player characters appear in campaign prompt context when they are active party members.
+  - A reactive guard in `fetchCampaignContext` filters out any character whose share is no longer active (defense-in-depth).
+
+- **Constraints:**
+  - A full-scan of `parties` by `campaignId` is acceptable for now, but the query must be logged with timing to establish an observability baseline.
+  - The enriched DM GET endpoint must include character metadata (name, type, owner userId) to avoid a second round-trip in the party builder UI.
+  - Access rule logic must live in a testable helper (`canAddToCampaignParty`), not inline in the route.
+
+- **Assumptions:**
+  - "Active member" means `CampaignMember.status === 'active'`. An `invited` member's shared characters are not usable in parties until they accept.
+  - `characters_active` semantics are enforced via `Character.deletedAt` check — soft-deleted characters are excluded from the enriched share list.
+  - The `campaignCharacterShares` collection already has a unique `{campaignId, characterId}` index (delivered by 3a).
+
+- **Edge cases considered:**
+  - Character shared by a player who later leaves or is removed → proactive `leftAt` on party entry; reactive guard in context loader.
+  - Character soft-deleted by its owner after being shared → excluded by `deletedAt` check in enriched GET and context loader.
+  - DM tries to add a character they own to a campaign party (already valid path) → no regression; the access rule allows DM-owned characters unconditionally.
+  - Party has no `campaignId` → access rule skips the share check; DM-owned characters only (existing behavior preserved).
+  - Member removal cascades to multiple shared characters → all are cleaned up in a single pass.
+
+## Scope
+
+### In Scope
+
+- New `storage.listAllSharesForCampaign(campaignId)` — all shares, no userId filter
+- New `storage.loadPartiesByCampaign(campaignId)` — parties filtered by `campaignId`, with timing log
+- New `storage.setPartyMemberLeftAt(campaignId, characterId, timestamp)` — proactive cleanup helper
+- New `storage.canAddToCampaignParty(campaignId, characterId, dmUserId)` — access rule helper
+- Extend `GET /api/campaigns/[id]/characters` — when caller is DM, return enriched `{ share, character }[]` for all active shares
+- Extend `PUT /api/parties/[id]` — call `canAddToCampaignParty` for each new character when party has a `campaignId`
+- Extend `POST /api/parties` — same access rule on creation
+- Extend `DELETE /api/campaigns/[id]/characters/[cid]` — after unshare, call `setPartyMemberLeftAt`
+- Extend `DELETE /api/campaigns/[id]/members/[userId]` — after member removal, cascade `setPartyMemberLeftAt` for all their shares
+- Update `PartyEditor` — when `campaignId` selected, fetch shared characters and render grouped by owner; respect soft-delete
+- Update `fetchCampaignContext` — merge shared characters; reactive guard filters unshared characters
+- Unit tests for all new storage helpers and access rule
+- Route-level tests for the modified endpoints
+
+### Out of Scope
+
+- Adding a `campaignId` index to `parties` collection (acceptable tech debt, noted for future)
+- Player-facing UI changes (already delivered in 3a)
+- Transfer of character ownership
+- Party management within the campaign page itself (separate feature)
+
+## What Changes
+
+- `lib/storage.ts` — 4 new storage methods
+- `app/api/campaigns/[id]/characters/route.ts` — GET extended with DM enriched view
+- `app/api/parties/route.ts` — POST access rule added
+- `app/api/parties/[id]/route.ts` — PUT access rule added
+- `app/api/campaigns/[id]/characters/[cid]/route.ts` — DELETE triggers party cleanup
+- `app/api/campaigns/[id]/members/[userId]/route.ts` — DELETE cascades party cleanup
+- `app/parties/page.tsx` — PartyEditor fetches and renders shared characters
+- `lib/utils/campaignContext.ts` — merges shared characters; reactive filter
+- `lib/types.ts` — new `SharedCharacterEntry` type for enriched GET response
+- New test files for storage helpers and updated route tests
+
+## Risks
+
+- Risk: Full-scan of `parties` by `campaignId` is O(n) over all parties in the system.
+  - Impact: Slow cleanup on large datasets; not a concern for current scale.
+  - Mitigation: Log query timing in `loadPartiesByCampaign` and `setPartyMemberLeftAt`. Add a note in code to revisit with an index if timing exceeds 50ms.
+
+- Risk: Cascade cleanup in member-removal route makes an HTTP response depend on a secondary write that could fail.
+  - Impact: Member removed but party entries not cleaned up.
+  - Mitigation: Log and swallow cleanup errors — don't fail the removal response. The reactive guard in `fetchCampaignContext` is the safety net.
+
+- Risk: DM-enriched GET exposes player character metadata (name, type) to the DM.
+  - Impact: Minimal — DM is the campaign owner; this is intentional and consistent with existing DM access to campaign members.
+  - Mitigation: None needed.
+
+## Open Questions
+
+No unresolved ambiguity. All design decisions were made during exploration:
+- Enriched list (not bare share IDs) for DM GET: confirmed.
+- Access rule in a `canAddToCampaignParty` helper: confirmed.
+- Full-scan with timing observability (no index for now): confirmed.
+
+## Non-Goals
+
+- Real-time push notification when a share is revoked
+- Bulk party management across multiple campaigns
+- Exposing `setPartyMemberLeftAt` as a standalone API endpoint
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/party-builder-shared-characters/specs/campaign-character-shares-dm-get/spec.md
+++ b/openspec/changes/party-builder-shared-characters/specs/campaign-character-shares-dm-get/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED `GET /api/campaigns/[id]/characters` — role-aware response
+
+The system SHALL return an enriched `SharedCharacterEntry[]` response (including character metadata) when the authenticated caller is a DM of the campaign, and SHALL return the existing bare-share list for player callers.
+
+`SharedCharacterEntry`:
+```ts
+interface SharedCharacterEntry {
+  share: CampaignCharacterShare;
+  character: Pick<Character, 'id' | 'name' | 'characterType' | 'userId' | 'deletedAt'>;
+}
+```
+
+#### Scenario: DM receives enriched share list
+
+- **Given** campaign `C` has two active player members P1 and P2, each having shared one character
+- **When** the DM calls `GET /api/campaigns/C/characters`
+- **Then** the response is HTTP 200 with a JSON array of two `SharedCharacterEntry` objects, each containing both the share record and the character's `id`, `name`, `characterType`, `userId`, and `deletedAt` fields
+
+#### Scenario: DM receives only active-member shares
+
+- **Given** campaign `C` has player P1 (active, shared character X) and player P2 (status `removed`, shared character Y)
+- **When** the DM calls `GET /api/campaigns/C/characters`
+- **Then** the response contains only the entry for character X; character Y is excluded because P2 is not an active member
+
+#### Scenario: Soft-deleted character excluded from DM list
+
+- **Given** player P1 has shared character X into campaign `C`, and character X has `deletedAt` set
+- **When** the DM calls `GET /api/campaigns/C/characters`
+- **Then** the response does not include character X
+
+#### Scenario: Player receives own shares only (unchanged)
+
+- **Given** player P1 has shared characters A and B into campaign `C`; player P2 has shared character C
+- **When** P1 calls `GET /api/campaigns/C/characters`
+- **Then** the response contains only P1's shares (characters A and B), in the existing bare-share format (not `SharedCharacterEntry`)
+
+#### Scenario: Non-member receives 403
+
+- **Given** user U is not a member of campaign `C`
+- **When** U calls `GET /api/campaigns/C/characters`
+- **Then** the response is HTTP 403
+
+#### Scenario: Invited (non-active) member receives 403
+
+- **Given** user U has `status: 'invited'` in campaign `C`
+- **When** U calls `GET /api/campaigns/C/characters`
+- **Then** the response is HTTP 403
+
+## Traceability
+
+- Proposal element "Extend GET /api/campaigns/[id]/characters — DM gets enriched view" → Requirement: MODIFIED GET route
+- Design decision 1 (enriched DM GET) → Requirement: MODIFIED GET route
+- Design decision 3 (`listAllSharesForCampaign`) → used by the DM GET path
+- Design decision 7 (`SharedCharacterEntry` type) → shapes the DM response
+- Requirement → Task: "Extend GET /api/campaigns/[id]/characters for DM role"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios: "Non-member receives 403", "Invited member receives 403", "Player receives own shares only".
+
+No distinct NFAC security scenarios — all access-control cases are fully covered by the functional scenarios above.

--- a/openspec/changes/party-builder-shared-characters/specs/campaign-context-shared-chars/spec.md
+++ b/openspec/changes/party-builder-shared-characters/specs/campaign-context-shared-chars/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED `fetchCampaignContext` — includes shared player characters
+
+The system SHALL include shared player characters in `CampaignContext.characters` when those characters are active party members in the campaign. Shared characters SHALL be fetched from `GET /api/campaigns/[id]/characters` (DM-enriched response) and merged with DM-owned characters. The function SHALL also apply a reactive guard: any non-DM-owned character whose `characterId` is not present in the current active shares list is excluded from `characters`, regardless of party membership.
+
+#### Scenario: Shared character in active party appears in context
+
+- **Given** player P1 has shared character X into campaign `C`; party P in `C` has X as an active member (no `leftAt`)
+- **When** `fetchCampaignContext('C')` is called by the DM
+- **Then** `context.characters` includes character X
+
+#### Scenario: DM-owned character in party still appears (no regression)
+
+- **Given** party P in campaign `C` has DM-owned character Y as an active member
+- **When** `fetchCampaignContext('C')` is called
+- **Then** `context.characters` includes character Y
+
+#### Scenario: Reactive guard excludes character with revoked share
+
+- **Given** character X was added to party P in campaign `C`; the share for X has since been deleted (X is not in the active shares list), but `leftAt` was not set (proactive cleanup failed)
+- **When** `fetchCampaignContext('C')` is called
+- **Then** `context.characters` does NOT include character X
+
+#### Scenario: Soft-deleted shared character excluded
+
+- **Given** character X is shared into campaign `C` and is an active party member, but has `deletedAt` set
+- **When** `fetchCampaignContext('C')` is called
+- **Then** `context.characters` does NOT include character X
+
+#### Scenario: Shared character with leftAt is excluded
+
+- **Given** character X was a shared party member but now has `leftAt` set on the party member entry
+- **When** `fetchCampaignContext('C')` is called
+- **Then** `context.characters` does NOT include character X (filtered out by existing `leftAt` logic)
+
+#### Scenario: Context fetch is parallel (no sequential dependency)
+
+- **Given** `fetchCampaignContext` is called
+- **When** the function executes
+- **Then** `GET /api/campaigns/[id]/characters` is fetched in the same `Promise.all` as `GET /api/parties` and `GET /api/characters`; no sequential blocking between the three fetches
+
+## Traceability
+
+- Proposal element "fetchCampaignContext merges shared characters + reactive guard" → Requirement: MODIFIED fetchCampaignContext
+- Design decision 6 (reactive guard) → Requirement: reactive guard excludes revoked-share characters
+- Requirement → Task: "Update fetchCampaignContext to include shared characters and apply reactive guard"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: No additional sequential round-trips added
+
+- **Given** `fetchCampaignContext` is called
+- **When** network requests are observed
+- **Then** the shared-character fetch (`GET /api/campaigns/[id]/characters`) executes in parallel with the existing fetches; total context load time increases only by the max of (shared-char fetch latency vs. existing parallel fetches), not by an additive sequential latency
+
+### Requirement: Reliability
+
+#### Scenario: Shared-character fetch failure degrades gracefully
+
+- **Given** `GET /api/campaigns/[id]/characters` returns a non-OK response
+- **When** `fetchCampaignContext` processes the result
+- **Then** `context.characters` contains only DM-owned characters (degraded mode); the function does not throw; an error is logged

--- a/openspec/changes/party-builder-shared-characters/specs/party-access-rule/spec.md
+++ b/openspec/changes/party-builder-shared-characters/specs/party-access-rule/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `canAddToCampaignParty` access rule
+
+The system SHALL expose a `storage.canAddToCampaignParty(campaignId, characterId, dmUserId): Promise<boolean>` helper that returns `true` if and only if the character is owned by `dmUserId` OR an active share exists in `campaignCharacterShares` where `characterId` matches and the share's `userId` belongs to a campaign member with `status === 'active'`.
+
+#### Scenario: DM-owned character is always allowed
+
+- **Given** character X is owned by the DM (character.userId === dmUserId)
+- **When** `canAddToCampaignParty(campaignId, X.id, dmUserId)` is called
+- **Then** returns `true`
+
+#### Scenario: Shared character from active member is allowed
+
+- **Given** character X is owned by player P1 who is an active member of campaign `C` and has shared X into `C`
+- **When** `canAddToCampaignParty('C', X.id, dmUserId)` is called
+- **Then** returns `true`
+
+#### Scenario: Shared character from invited (non-active) member is rejected
+
+- **Given** character X is owned by player P1 who has `status: 'invited'` in campaign `C` and has a share record for X in `C`
+- **When** `canAddToCampaignParty('C', X.id, dmUserId)` is called
+- **Then** returns `false`
+
+#### Scenario: Character not shared into campaign is rejected
+
+- **Given** character X is owned by player P1 who is an active member of campaign `C` but has NOT shared X
+- **When** `canAddToCampaignParty('C', X.id, dmUserId)` is called
+- **Then** returns `false`
+
+#### Scenario: Character from removed member is rejected
+
+- **Given** character X was shared into campaign `C` by player P1 whose status is now `removed`
+- **When** `canAddToCampaignParty('C', X.id, dmUserId)` is called
+- **Then** returns `false`
+
+### Requirement: ADDED party POST access rule enforcement
+
+The system SHALL reject `POST /api/parties` with HTTP 403 if any `characterId` in the request fails `canAddToCampaignParty` when the request body includes a `campaignId`.
+
+#### Scenario: POST with DM-owned characters succeeds
+
+- **Given** all `characterIds` in the request are owned by the DM
+- **When** DM calls `POST /api/parties` with or without `campaignId`
+- **Then** response is HTTP 201
+
+#### Scenario: POST with shared character in campaign party succeeds
+
+- **Given** character X is shared into campaign `C` by an active member
+- **When** DM calls `POST /api/parties` with `campaignId: 'C'` and `characterIds: [X.id]`
+- **Then** response is HTTP 201
+
+#### Scenario: POST with unshared character in campaign party is rejected
+
+- **Given** character X is not shared into campaign `C`
+- **When** DM calls `POST /api/parties` with `campaignId: 'C'` and `characterIds: [X.id]`
+- **Then** response is HTTP 403
+
+#### Scenario: POST without campaignId skips share check
+
+- **Given** character X is owned by a player and not shared
+- **When** DM calls `POST /api/parties` without `campaignId` and `characterIds: [X.id]`
+- **Then** response is HTTP 403 only if X is not DM-owned; no share lookup occurs
+
+### Requirement: ADDED party PUT access rule enforcement
+
+The system SHALL reject `PUT /api/parties/[id]` with HTTP 403 if any newly added `characterId` fails `canAddToCampaignParty` when the party has a `campaignId`.
+
+#### Scenario: PUT adding shared character succeeds
+
+- **Given** party P is in campaign `C`; character X is shared into `C` by an active member
+- **When** DM calls `PUT /api/parties/P` adding X to `characterIds`
+- **Then** response is HTTP 200
+
+#### Scenario: PUT adding unshared character is rejected
+
+- **Given** party P is in campaign `C`; character X is not shared into `C`
+- **When** DM calls `PUT /api/parties/P` adding X to `characterIds`
+- **Then** response is HTTP 403
+
+#### Scenario: PUT re-adding an existing active member is idempotent (no re-check)
+
+- **Given** party P already has character X as an active member
+- **When** DM calls `PUT /api/parties/P` with characterIds including X
+- **Then** no new access check is performed for X; response is HTTP 200
+
+#### Scenario: PUT on party without campaignId skips share check
+
+- **Given** party P has no `campaignId`; character X is DM-owned
+- **When** DM calls `PUT /api/parties/P` adding X
+- **Then** response is HTTP 200 without share lookup
+
+## Traceability
+
+- Proposal element "access rule helper `canAddToCampaignParty`" → Requirement: ADDED `canAddToCampaignParty`
+- Design decision 2 (access rule helper) → Requirement: ADDED `canAddToCampaignParty`, ADDED POST rule, ADDED PUT rule
+- Requirement → Tasks: "Add `canAddToCampaignParty` storage helper", "Enforce access rule in POST /api/parties", "Enforce access rule in PUT /api/parties/[id]"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios: "POST with unshared character is rejected", "PUT adding unshared character is rejected", "Character from removed member is rejected".
+
+No distinct NFAC security scenarios — all access-control cases are fully covered by the functional scenarios above.
+
+### Requirement: Performance
+
+#### Scenario: Access rule check latency
+
+- **Given** `canAddToCampaignParty` is called for a party with up to 10 character additions
+- **When** each character requires a share lookup and member status check
+- **Then** total additional latency per party save is under 200ms (two indexed MongoDB reads per character, small party sizes)

--- a/openspec/changes/party-builder-shared-characters/specs/party-builder-ui/spec.md
+++ b/openspec/changes/party-builder-shared-characters/specs/party-builder-ui/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: MODIFIED `PartyEditor` — surfaces shared characters when campaign is selected
+
+The system SHALL show a second character group ("Shared by Campaign Members") in the `PartyEditor` when a `campaignId` is selected. Shared characters SHALL be grouped by owner, exclude soft-deleted characters, and be selectable alongside DM-owned characters. When no `campaignId` is selected, only DM-owned characters SHALL be shown (existing behavior).
+
+#### Scenario: Shared characters shown when campaignId selected
+
+- **Given** the DM opens `PartyEditor` for a party in campaign `C`; player P1 has shared characters A and B into `C`
+- **When** the editor renders
+- **Then** a "Shared by Campaign Members" section is visible; characters A and B appear grouped under P1's identifier; each has a checkbox
+
+#### Scenario: Shared characters grouped by owner
+
+- **Given** campaign `C` has two players P1 (shared X) and P2 (shared Y and Z)
+- **When** the DM opens `PartyEditor` for a party in `C`
+- **Then** X is listed under P1's group; Y and Z are listed under P2's group
+
+#### Scenario: Soft-deleted shared character not shown
+
+- **Given** player P1 has shared character X into campaign `C`; X has `deletedAt` set
+- **When** the DM opens `PartyEditor` for a party in `C`
+- **Then** character X does not appear in the shared character section
+
+#### Scenario: No shared characters section when no campaignId
+
+- **Given** the party has no `campaignId` (or `campaignId` is empty)
+- **When** the DM opens `PartyEditor`
+- **Then** only DM-owned characters are shown; no "Shared by Campaign Members" section is rendered
+
+#### Scenario: Shared character selected and saved
+
+- **Given** character X is shared into campaign `C` and the DM checks X in `PartyEditor`
+- **When** the DM saves the party
+- **Then** the `PUT /api/parties/[id]` request includes X in `characterIds`; the party is saved successfully
+
+#### Scenario: Previously selected shared character deselected
+
+- **Given** party P has active member X (a shared character)
+- **When** the DM unchecks X and saves
+- **Then** the PUT request does not include X; `leftAt` is set on X's party member entry
+
+#### Scenario: Loading state while shared characters fetch
+
+- **Given** the DM opens `PartyEditor` for a campaign party
+- **When** the `GET /api/campaigns/[id]/characters` fetch is in progress
+- **Then** the shared characters section shows a loading indicator (or is absent until resolved)
+
+## Traceability
+
+- Proposal element "PartyEditor surfaces shared characters grouped by owner" → Requirement: MODIFIED PartyEditor
+- Design decision 1 (enriched DM GET) → used by PartyEditor to populate shared character list
+- Design decision 7 (`SharedCharacterEntry` type) → PartyEditor imports and uses this type
+- Requirement → Task: "Update PartyEditor to fetch and render shared characters"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenario: "No shared characters section when no campaignId". The UI only fetches and renders shared characters when a campaign is explicitly associated — no shared character data is surfaced in non-campaign contexts.

--- a/openspec/changes/party-builder-shared-characters/specs/party-cleanup/spec.md
+++ b/openspec/changes/party-builder-shared-characters/specs/party-cleanup/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `setPartyMemberLeftAt` storage helper
+
+The system SHALL expose `storage.setPartyMemberLeftAt(campaignId: string, characterId: string, timestamp: Date): Promise<void>` that finds all parties in the campaign, locates active members matching `characterId` (no `leftAt`), sets `leftAt` to `timestamp`, and saves each modified party. Errors SHALL be caught and logged without re-throwing.
+
+#### Scenario: Active party member gets leftAt set
+
+- **Given** party P is in campaign `C` and has an active member with `characterId: X`
+- **When** `setPartyMemberLeftAt('C', 'X', now)` is called
+- **Then** the party member entry for X has `leftAt` set to `now`; the party is persisted
+
+#### Scenario: Already-left member is not modified
+
+- **Given** party P is in campaign `C` and has a member with `characterId: X` where `leftAt` is already set
+- **When** `setPartyMemberLeftAt('C', 'X', now)` is called
+- **Then** that member's `leftAt` is unchanged
+
+#### Scenario: Multiple parties in campaign are all cleaned up
+
+- **Given** campaign `C` has parties P1 and P2, both with active members for `characterId: X`
+- **When** `setPartyMemberLeftAt('C', 'X', now)` is called
+- **Then** the member entry for X in both P1 and P2 has `leftAt` set
+
+#### Scenario: Storage error does not propagate
+
+- **Given** `storage.saveParty` throws an error during cleanup
+- **When** `setPartyMemberLeftAt` is called
+- **Then** the error is logged and the function returns without throwing
+
+### Requirement: ADDED proactive cleanup on character unshare
+
+The system SHALL call `setPartyMemberLeftAt(campaignId, characterId, now)` after a successful `DELETE /api/campaigns/[id]/characters/[cid]` response. Cleanup errors SHALL NOT affect the HTTP response.
+
+#### Scenario: Unshare triggers leftAt on party member
+
+- **Given** player P1 has shared character X into campaign `C`; party P in `C` has X as an active member
+- **When** P1 calls `DELETE /api/campaigns/C/characters/X`
+- **Then** the response is HTTP 204; the party member entry for X has `leftAt` set
+
+#### Scenario: Unshare cleanup failure does not fail the response
+
+- **Given** `setPartyMemberLeftAt` encounters a storage error
+- **When** P1 calls `DELETE /api/campaigns/C/characters/X` (share exists and is deleted successfully)
+- **Then** the response is still HTTP 204
+
+### Requirement: ADDED proactive cleanup on member removal
+
+The system SHALL enumerate all shares in the campaign belonging to the removed member and call `setPartyMemberLeftAt` for each after a successful `DELETE /api/campaigns/[id]/members/[userId]`. Cleanup errors SHALL NOT affect the HTTP response.
+
+#### Scenario: Member removal cascades leftAt to all their shared characters
+
+- **Given** player P1 (active member) has shared characters X and Y into campaign `C`; both are active members of party P
+- **When** the DM calls `DELETE /api/campaigns/C/members/P1`
+- **Then** the response is HTTP 200 with `{ status: 'removed' }`; party member entries for both X and Y have `leftAt` set
+
+#### Scenario: Member with no shares — removal still succeeds
+
+- **Given** player P1 is an active member of campaign `C` with no shared characters
+- **When** the DM calls `DELETE /api/campaigns/C/members/P1`
+- **Then** the response is HTTP 200; no party entries are modified
+
+#### Scenario: Member removal cleanup failure does not fail the response
+
+- **Given** `setPartyMemberLeftAt` throws during the cascade
+- **When** the DM calls `DELETE /api/campaigns/C/members/P1` (member status update succeeds)
+- **Then** the response is still HTTP 200 with `{ status: 'removed' }`
+
+## ADDED Requirements — Storage Helpers
+
+### Requirement: ADDED `listAllSharesForCampaign` storage method
+
+The system SHALL expose `storage.listAllSharesForCampaign(campaignId: string): Promise<CampaignCharacterShare[]>` that returns all shares in the campaign regardless of which user created them.
+
+#### Scenario: Returns shares from multiple players
+
+- **Given** campaign `C` has shares from players P1 and P2 (two records total)
+- **When** `listAllSharesForCampaign('C')` is called
+- **Then** both share records are returned
+
+#### Scenario: Returns empty array for campaign with no shares
+
+- **Given** campaign `C` has no shares
+- **When** `listAllSharesForCampaign('C')` is called
+- **Then** returns `[]`
+
+### Requirement: ADDED `loadPartiesByCampaign` storage method with timing observability
+
+The system SHALL expose `storage.loadPartiesByCampaign(campaignId: string): Promise<Party[]>` that returns all parties with `campaignId` matching, logging `[perf] loadPartiesByCampaign <campaignId>: <ms>ms` to `console.log` when query duration exceeds 10ms.
+
+#### Scenario: Returns only parties in the specified campaign
+
+- **Given** parties P1 (campaignId: C) and P2 (campaignId: D) exist
+- **When** `loadPartiesByCampaign('C')` is called
+- **Then** only P1 is returned
+
+#### Scenario: Timing log emitted for slow queries
+
+- **Given** the MongoDB query takes longer than 10ms
+- **When** `loadPartiesByCampaign` is called
+- **Then** a `[perf]` line is written to `console.log` containing the campaignId and duration in ms
+
+## Traceability
+
+- Proposal element "setPartyMemberLeftAt proactive cleanup" → Requirement: ADDED `setPartyMemberLeftAt`, proactive cleanup on unshare, proactive cleanup on member removal
+- Proposal element "listAllSharesForCampaign" → Requirement: ADDED `listAllSharesForCampaign`
+- Proposal element "loadPartiesByCampaign with timing" → Requirement: ADDED `loadPartiesByCampaign`
+- Design decision 5 (fire-and-forget cleanup) → Requirement: cleanup errors do not propagate
+- Design decision 4 (timing log) → Requirement: timing log emitted
+- Requirements → Tasks: "Add storage helpers", "Extend unshare route with cleanup", "Extend member-removal route with cleanup"
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Cleanup errors do not degrade primary operations
+
+See functional scenarios: "Unshare cleanup failure does not fail the response", "Member removal cleanup failure does not fail the response", "Storage error does not propagate". No distinct NFAC reliability scenario needed.
+
+### Requirement: Performance (observability)
+
+#### Scenario: Perf log baseline established
+
+- **Given** `loadPartiesByCampaign` is called during a cleanup operation
+- **When** the query completes in any duration
+- **Then** if duration > 10ms, a `[perf] loadPartiesByCampaign` log line is emitted; this provides data to justify a future `campaignId` index on the `parties` collection

--- a/openspec/changes/party-builder-shared-characters/tasks.md
+++ b/openspec/changes/party-builder-shared-characters/tasks.md
@@ -1,0 +1,150 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/party-builder-shared-characters` then immediately `git push -u origin feat/party-builder-shared-characters`
+
+## Execution
+
+### Group A — Storage layer
+
+- [x] **A1 — Add `SharedCharacterEntry` type to `lib/types.ts`**
+  - Export `interface SharedCharacterEntry { share: CampaignCharacterShare; character: Pick<Character, 'id' | 'name' | 'characterType' | 'userId' | 'deletedAt'> }`
+  - Verify: `npm run build` passes
+
+- [x] **A2 — Add `listAllSharesForCampaign(campaignId)` to `lib/storage.ts`**
+  - Query `campaignCharacterShares` with `{ campaignId }` only (no userId filter)
+  - Normalize and return `CampaignCharacterShare[]`
+  - Unit test: multiple players' shares returned; empty campaign returns `[]`
+
+- [x] **A3 — Add `loadPartiesByCampaign(campaignId)` to `lib/storage.ts`**
+  - Query `parties` collection with `{ campaignId }`
+  - Wrap query in `Date.now()` timing; log `[perf] loadPartiesByCampaign <campaignId>: <ms>ms` when > 10ms
+  - Include `// TODO: add campaignId index on parties if >50ms becomes common` comment
+  - Unit test: returns only parties in specified campaign; other campaign's parties excluded
+
+- [x] **A4 — Add `setPartyMemberLeftAt(campaignId, characterId, timestamp)` to `lib/storage.ts`**
+  - Call `loadPartiesByCampaign(campaignId)`; for each party, find active members (`!leftAt`) with matching `characterId`, set `leftAt = timestamp`, call `saveParty`
+  - Catch and log errors from `saveParty`; do not re-throw
+  - Unit test: active member gets `leftAt`; already-left member unchanged; multiple parties both updated; `saveParty` throw does not propagate
+
+- [x] **A5 — Add `canAddToCampaignParty(campaignId, characterId, dmUserId)` to `lib/storage.ts`**
+  - Return `true` if character is DM-owned (load character by id, check `userId === dmUserId`)
+  - Else: find share in `campaignCharacterShares` where `{ campaignId, characterId }`; if found, check `getMember(campaignId, share.userId)` returns `status === 'active'`; return `true` only if both conditions pass
+  - Unit test: owns char → `true`; active share → `true`; invited-member share → `false`; removed-member share → `false`; no share → `false`
+
+### Group B — API routes
+
+- [x] **B1 — Extend `GET /api/campaigns/[id]/characters` for DM role**
+  - File: `app/api/campaigns/[id]/characters/route.ts`
+  - After existing member check: if `member.role === 'dm'`, call `storage.listAllSharesForCampaign(campaignId)`, load each share's character via `storage.loadCharacterById`, filter out `deletedAt` characters and those whose share's `userId` member is not `active`, return `SharedCharacterEntry[]`
+  - If `member.role === 'player'`, existing behavior unchanged (caller's own shares only)
+  - Route test: DM gets enriched list; DM list excludes soft-deleted chars; DM list excludes inactive-member chars; player gets own shares in bare format; non-member gets 403
+
+- [x] **B2 — Enforce access rule in `POST /api/parties`**
+  - File: `app/api/parties/route.ts`
+  - After building `ids` list: if `campaignId` is provided, call `canAddToCampaignParty(campaignId, charId, auth.userId)` for each new characterId; if any returns `false`, return HTTP 403 `{ error: 'Character not shared into campaign' }`
+  - Route test: DM-owned char → 201; shared char → 201; unshared char → 403; no campaignId → no share check (existing behavior)
+
+- [x] **B3 — Enforce access rule in `PUT /api/parties/[id]`**
+  - File: `app/api/parties/[id]/route.ts`
+  - After computing `newIdSet`: identify *newly added* characterIds (in `newIdSet` but not in `existingActiveIds`); if party has `campaignId`, call `canAddToCampaignParty` for each new id; return 403 if any fails
+  - Route test: DM-owned → 200; shared → 200; unshared → 403; no campaignId → no share check; re-adding existing active member → no re-check, 200
+
+- [x] **B4 — Extend `DELETE /api/campaigns/[id]/characters/[cid]` with cleanup**
+  - File: `app/api/campaigns/[id]/characters/[cid]/route.ts`
+  - After `storage.removeShare(...)` succeeds: call `storage.setPartyMemberLeftAt(campaignId, characterId, new Date())` in a try/catch; log errors but do not affect the 204 response
+  - Route test: unshare returns 204; party member has `leftAt` after unshare; cleanup error does not change response
+
+- [x] **B5 — Extend `DELETE /api/campaigns/[id]/members/[userId]` with cleanup**
+  - File: `app/api/campaigns/[id]/members/[userId]/route.ts`
+  - After `storage.updateMemberStatus(..., 'removed', ...)` succeeds: call `storage.listAllSharesForCampaign(campaignId)`, filter to `share.userId === targetUserId`, call `storage.setPartyMemberLeftAt` for each share's `characterId` in a try/catch; log errors but do not affect the 200 response
+  - Route test: removal returns `{ status: 'removed' }`; all target's shared chars get `leftAt`; member with no shares — no error; cleanup error does not change response
+
+### Group C — Campaign context
+
+- [x] **C1 — Update `lib/utils/campaignContext.ts`**
+  - Add `GET /api/campaigns/${campaignId}/characters` to the `Promise.all` fetch list
+  - On non-OK response: log error, treat as empty array (degraded gracefully)
+  - Merge `SharedCharacterEntry[]` characters with `allCharacters` (deduplicate by id)
+  - Reactive guard: for each non-DM-owned character in the merged list, verify its `characterId` appears in the fetched shares list; exclude if not found or if `deletedAt` set
+  - Existing `leftAt` filter on `memberIds` already handles the `leftAt` case — no change needed there
+  - Unit test: shared char in party appears in `context.characters`; revoked-share char excluded; soft-deleted shared char excluded; DM-owned chars unaffected; failed shares fetch degrades to DM-only chars
+
+### Group D — Party builder UI
+
+- [x] **D1 — Update `PartyEditor` in `app/parties/page.tsx`**
+  - Add `sharedCharacters: SharedCharacterEntry[]` prop (passed from `PartiesContent`)
+  - When `campaignId` is selected, fetch `GET /api/campaigns/${campaignId}/characters` and pass result as `sharedCharacters`; re-fetch when `campaignId` changes
+  - In `PartyEditor`: below the DM-owned character groups, render a "Shared by Campaign Members" section; group entries by `share.userId`; display owner userId or name label; render a checkbox per character; exclude entries where `character.deletedAt` is set
+  - Checkboxes work identically to DM-owned character checkboxes (`toggleCharacter`)
+  - When `campaignId` is empty/unset, `sharedCharacters` is `[]` and the section is not rendered
+  - Component test: section rendered with campaignId; section absent without campaignId; soft-deleted char not shown; toggle and save works
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test` — all unit tests pass
+- [x] `npm run test:integration` — all integration tests pass
+- [x] `npm run build` — TypeScript build succeeds
+- [x] `npm run lint` — no lint errors
+- [x] All spec scenarios from `specs/campaign-character-shares-dm-get/spec.md`, `specs/party-access-rule/spec.md`, `specs/party-cleanup/spec.md`, `specs/party-builder-ui/spec.md`, `specs/campaign-context-shared-chars/spec.md` are covered by passing tests
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test` — all tests must pass
+- **Integration tests** — `npm run test:integration` — all tests must pass
+- **Build** — `npm run build` — must succeed with no errors
+- **Lint** — `npm run lint` — must succeed with no errors
+
+If **ANY** of the above fail, iterate and fix before pushing.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/party-builder-shared-characters` and push to remote
+- [ ] Open PR from `feat/party-builder-shared-characters` to `main`. PR body must include `Closes #310`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address, commit fixes, validate locally, push, wait 180 seconds, repeat until no unresolved comments
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, validate locally, push, wait 180 seconds, repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: agentic (Claude Code)
+- Reviewer(s): @dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → diagnose → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks complete
+- [ ] Sync approved spec deltas to `openspec/specs/`:
+  - Copy `openspec/changes/party-builder-shared-characters/specs/campaign-character-shares-dm-get/spec.md` → `openspec/specs/campaign-character-shares/spec.md` (update existing)
+  - Copy `openspec/changes/party-builder-shared-characters/specs/party-access-rule/spec.md` → `openspec/specs/party-access-rule/spec.md` (new)
+  - Copy `openspec/changes/party-builder-shared-characters/specs/party-cleanup/spec.md` → `openspec/specs/party-cleanup/spec.md` (new)
+  - Copy `openspec/changes/party-builder-shared-characters/specs/party-builder-ui/spec.md` → `openspec/specs/party-builder-ui/spec.md` (update existing)
+  - Copy `openspec/changes/party-builder-shared-characters/specs/campaign-context-shared-chars/spec.md` → `openspec/specs/campaign-context-shared-chars/spec.md` (new)
+  - Update relative references in each copied spec: `design.md` → `../../changes/archive/YYYY-MM-DD-party-builder-shared-characters/design.md`; `tasks.md` → `../../changes/archive/YYYY-MM-DD-party-builder-shared-characters/tasks.md`
+- [ ] Archive: move `openspec/changes/party-builder-shared-characters/` to `openspec/changes/archive/YYYY-MM-DD-party-builder-shared-characters/` — stage both copy and deletion in a **single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-party-builder-shared-characters/` exists and `openspec/changes/party-builder-shared-characters/` is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-party-builder-shared-characters` → `git push -u origin doc/archive-YYYY-MM-DD-party-builder-shared-characters`
+- [ ] Open PR: `docs: archive party-builder-shared-characters (YYYY-MM-DD)` from doc branch to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on doc PR
+- [ ] Monitor doc PR until merged (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/party-builder-shared-characters doc/archive-YYYY-MM-DD-party-builder-shared-characters`
+- [ ] Update `docs/multi-user-campaigns/03-cross-user-characters.md`: mark issue #310 as CLOSED, set Phase 3 status to complete

--- a/openspec/changes/party-builder-shared-characters/tasks.md
+++ b/openspec/changes/party-builder-shared-characters/tasks.md
@@ -88,7 +88,7 @@
 
 ## Validation
 
-- [x] `npm run test` — all unit tests pass
+- [x] `npm run test:unit` — all unit tests pass
 - [x] `npm run test:integration` — all integration tests pass
 - [x] `npm run build` — TypeScript build succeeds
 - [x] `npm run lint` — no lint errors
@@ -108,9 +108,9 @@ If **ANY** of the above fail, iterate and fix before pushing.
 ## PR and Merge
 
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `feat/party-builder-shared-characters` and push to remote
-- [ ] Open PR from `feat/party-builder-shared-characters` to `main`. PR body must include `Closes #310`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
+- [x] Commit all changes to `feat/party-builder-shared-characters` and push to remote
+- [x] Open PR from `feat/party-builder-shared-characters` to `main`. PR body must include `Closes #310`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge`
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
 - [ ] **Monitor PR comments** — poll autonomously; address, commit fixes, validate locally, push, wait 180 seconds, repeat until no unresolved comments
 - [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, validate locally, push, wait 180 seconds, repeat

--- a/openspec/changes/party-builder-shared-characters/tests.md
+++ b/openspec/changes/party-builder-shared-characters/tests.md
@@ -1,0 +1,301 @@
+---
+name: tests
+description: TDD test plan for party-builder-shared-characters change
+---
+
+# Tests
+
+## Overview
+
+Test plan for the `party-builder-shared-characters` change. All work follows strict TDD: write a failing test first, implement the minimum code to pass, then refactor.
+
+Test files map to existing conventions:
+- Storage unit tests → `tests/unit/lib/storage-shares.test.ts` (extend) or `tests/unit/lib/storage.test.ts`
+- New storage helpers → new `describe` blocks in `tests/unit/lib/storage-shares.test.ts`
+- Route integration tests → `tests/integration/campaigns.character-sharing.integration.test.ts` (extend) and `tests/integration/api.integration.test.ts` (party routes)
+- `fetchCampaignContext` unit tests → `tests/unit/lib/campaignContext.test.ts` (new file)
+- `PartyEditor` component tests → `tests/unit/components/PartyEditor.test.tsx` (new file)
+
+## Testing Steps
+
+For each task group:
+1. **Write failing test** before any implementation
+2. **Implement** minimum code to pass
+3. **Refactor** while keeping tests green
+
+---
+
+## Task A1 — `SharedCharacterEntry` type
+
+- [ ] TypeScript compilation test: import `SharedCharacterEntry` from `lib/types`; construct a valid object; assert shape matches expectation
+  - Spec: `design.md` Decision 7
+  - File: `tests/unit/lib/types.test.ts` (or build check)
+
+---
+
+## Task A2 — `listAllSharesForCampaign`
+
+- [ ] Returns all shares for campaign regardless of userId
+  - Setup: insert shares from two different userIds for the same campaignId
+  - Call: `storage.listAllSharesForCampaign(campaignId)`
+  - Assert: both shares returned
+  - Spec: `specs/party-cleanup/spec.md` — "Returns shares from multiple players"
+
+- [ ] Returns empty array when no shares exist
+  - Setup: empty `campaignCharacterShares` collection for campaignId
+  - Assert: `[]`
+  - Spec: `specs/party-cleanup/spec.md` — "Returns empty array for campaign with no shares"
+
+- [ ] Does not return shares from other campaigns
+  - Setup: share in campaignA and share in campaignB
+  - Call: `listAllSharesForCampaign(campaignA)`
+  - Assert: only campaignA share returned
+
+---
+
+## Task A3 — `loadPartiesByCampaign`
+
+- [ ] Returns only parties matching the campaignId
+  - Setup: party P1 with campaignId: C, party P2 with campaignId: D
+  - Call: `loadPartiesByCampaign('C')`
+  - Assert: only P1 returned
+  - Spec: `specs/party-cleanup/spec.md` — "Returns only parties in the specified campaign"
+
+- [ ] Returns empty array for campaign with no parties
+  - Assert: `[]`
+
+- [ ] Timing log emitted when query exceeds 10ms (spy on `console.log`)
+  - Setup: mock `Date.now` to return values 15ms apart
+  - Assert: `console.log` called with string matching `/\[perf\] loadPartiesByCampaign/`
+  - Spec: `specs/party-cleanup/spec.md` — "Timing log emitted for slow queries"
+
+---
+
+## Task A4 — `setPartyMemberLeftAt`
+
+- [ ] Sets leftAt on active member matching characterId
+  - Setup: party in campaign C with active member `characterId: X`
+  - Call: `setPartyMemberLeftAt('C', 'X', now)`
+  - Assert: member.leftAt === now; `saveParty` called with updated party
+  - Spec: `specs/party-cleanup/spec.md` — "Active party member gets leftAt set"
+
+- [ ] Does not modify already-left member
+  - Setup: member with existing `leftAt`
+  - Assert: `leftAt` value unchanged after call
+  - Spec: `specs/party-cleanup/spec.md` — "Already-left member is not modified"
+
+- [ ] Updates multiple parties in same campaign
+  - Setup: P1 and P2 both in campaign C, both with active member X
+  - Assert: both parties saved with X having `leftAt`
+  - Spec: `specs/party-cleanup/spec.md` — "Multiple parties in campaign are all cleaned up"
+
+- [ ] Does not throw when `saveParty` throws
+  - Setup: mock `saveParty` to throw
+  - Assert: `setPartyMemberLeftAt` resolves without error
+  - Spec: `specs/party-cleanup/spec.md` — "Storage error does not propagate"
+
+---
+
+## Task A5 — `canAddToCampaignParty`
+
+- [ ] Returns true for DM-owned character
+  - Setup: character.userId === dmUserId
+  - Assert: `true`
+  - Spec: `specs/party-access-rule/spec.md` — "DM-owned character is always allowed"
+
+- [ ] Returns true for shared character from active member
+  - Setup: share exists; `getMember` returns `{ status: 'active' }`
+  - Assert: `true`
+  - Spec: `specs/party-access-rule/spec.md` — "Shared character from active member is allowed"
+
+- [ ] Returns false for share from invited member
+  - Setup: share exists; `getMember` returns `{ status: 'invited' }`
+  - Assert: `false`
+  - Spec: `specs/party-access-rule/spec.md` — "Shared character from invited member is rejected"
+
+- [ ] Returns false when no share exists
+  - Setup: no share in `campaignCharacterShares` for this characterId/campaignId
+  - Assert: `false`
+  - Spec: `specs/party-access-rule/spec.md` — "Character not shared into campaign is rejected"
+
+- [ ] Returns false for share from removed member
+  - Setup: share exists; `getMember` returns `{ status: 'removed' }`
+  - Assert: `false`
+  - Spec: `specs/party-access-rule/spec.md` — "Character from removed member is rejected"
+
+---
+
+## Task B1 — `GET /api/campaigns/[id]/characters` DM enriched response
+
+Integration tests in `tests/integration/campaigns.character-sharing.integration.test.ts`:
+
+- [ ] DM receives `SharedCharacterEntry[]` with character metadata
+  - Setup: two players share characters; DM is campaign member with role `dm`
+  - Call: `GET /api/campaigns/:id/characters` as DM
+  - Assert: 200; each item has `{ share: {...}, character: { id, name, characterType, userId } }`
+  - Spec: `specs/campaign-character-shares-dm-get/spec.md` — "DM receives enriched share list"
+
+- [ ] DM list excludes shares from inactive members
+  - Setup: P1 (active, shared X); P2 (removed, shared Y)
+  - Assert: only X's entry returned
+  - Spec: "DM receives only active-member shares"
+
+- [ ] DM list excludes soft-deleted characters
+  - Setup: P1 shared X; X has `deletedAt` set
+  - Assert: X not in response
+  - Spec: "Soft-deleted character excluded from DM list"
+
+- [ ] Player still receives own shares in bare format
+  - Setup: P1 and P2 each shared a character
+  - Call: `GET` as P1
+  - Assert: 200; response is array of `CampaignCharacterShare` objects (no `character` field); only P1's shares
+  - Spec: "Player receives own shares only"
+
+- [ ] Non-member gets 403 (see existing test coverage; verify still passes)
+
+---
+
+## Task B2 — `POST /api/parties` access rule
+
+Integration tests in `tests/integration/api.integration.test.ts` (party section):
+
+- [ ] DM-owned characters accepted without campaignId
+  - Call: `POST /api/parties` with DM-owned characterIds, no campaignId
+  - Assert: 201
+  - Spec: `specs/party-access-rule/spec.md` — "POST with DM-owned characters succeeds"
+
+- [ ] Shared character accepted with campaignId
+  - Setup: character X shared into campaign C by active member
+  - Call: `POST /api/parties` with `campaignId: C`, `characterIds: [X.id]`
+  - Assert: 201
+  - Spec: "POST with shared character in campaign party succeeds"
+
+- [ ] Unshared foreign character rejected with campaignId
+  - Call: `POST /api/parties` with `campaignId: C`, characterId not shared
+  - Assert: 403
+  - Spec: "POST with unshared character in campaign party is rejected"
+
+---
+
+## Task B3 — `PUT /api/parties/[id]` access rule
+
+- [ ] Adding shared character to campaign party accepted
+  - Assert: 200
+  - Spec: "PUT adding shared character succeeds"
+
+- [ ] Adding unshared character to campaign party rejected
+  - Assert: 403
+  - Spec: "PUT adding unshared character is rejected"
+
+- [ ] Re-adding existing active member is idempotent (no check, 200)
+  - Setup: character already in party members with no `leftAt`
+  - Assert: 200; no `canAddToCampaignParty` call for that characterId
+  - Spec: "PUT re-adding existing active member is idempotent"
+
+- [ ] Party without campaignId — no share check, DM-owned accepted
+  - Assert: 200
+
+---
+
+## Task B4 — `DELETE /api/campaigns/[id]/characters/[cid]` cleanup
+
+- [ ] Unshare returns 204 and triggers leftAt on party member
+  - Setup: share exists; party has active member for that characterId
+  - Call: `DELETE /api/campaigns/:id/characters/:cid`
+  - Assert: 204; party member has `leftAt` set
+  - Spec: `specs/party-cleanup/spec.md` — "Unshare triggers leftAt on party member"
+
+- [ ] Cleanup error does not change 204 response
+  - Setup: mock `setPartyMemberLeftAt` to throw
+  - Assert: 204 returned regardless
+  - Spec: "Unshare cleanup failure does not fail the response"
+
+---
+
+## Task B5 — `DELETE /api/campaigns/[id]/members/[userId]` cleanup
+
+- [ ] Member removal returns `{ status: 'removed' }` and cascades leftAt for all their shares
+  - Setup: target user has 2 shared characters; both in party as active members
+  - Call: `DELETE /api/campaigns/:id/members/:userId`
+  - Assert: 200 `{ status: 'removed' }`; both party members have `leftAt` set
+  - Spec: `specs/party-cleanup/spec.md` — "Member removal cascades leftAt to all their shared characters"
+
+- [ ] Member with no shares — removal still returns 200
+  - Assert: 200; no party entries modified
+  - Spec: "Member with no shares — removal still succeeds"
+
+- [ ] Cleanup error does not fail removal response
+  - Setup: mock cascade to throw
+  - Assert: 200 `{ status: 'removed' }`
+  - Spec: "Member removal cleanup failure does not fail the response"
+
+---
+
+## Task C1 — `fetchCampaignContext` shared characters
+
+Unit tests in `tests/unit/lib/campaignContext.test.ts` (new file), mocking `fetch`:
+
+- [ ] Shared character active in party appears in `context.characters`
+  - Setup: mock GET `/api/characters` → DM chars; mock GET `/api/campaigns/:id/characters` → SharedCharacterEntry with char X; mock GET `/api/parties` → party with X as active member
+  - Assert: `context.characters` includes X
+  - Spec: `specs/campaign-context-shared-chars/spec.md` — "Shared character in active party appears in context"
+
+- [ ] DM-owned character in party still appears (no regression)
+  - Assert: DM chars still in `context.characters`
+  - Spec: "DM-owned character in party still appears"
+
+- [ ] Reactive guard excludes character with revoked share
+  - Setup: X is active party member; shared-chars fetch does NOT include X (share deleted)
+  - Assert: X not in `context.characters`
+  - Spec: "Reactive guard excludes character with revoked share"
+
+- [ ] Soft-deleted shared character excluded
+  - Setup: SharedCharacterEntry for X has `character.deletedAt` set
+  - Assert: X not in `context.characters`
+  - Spec: "Soft-deleted shared character excluded"
+
+- [ ] Shared char with leftAt excluded (existing leftAt logic)
+  - Setup: X in SharedCharacterEntry; party member for X has `leftAt` set
+  - Assert: X not in `context.characters`
+  - Spec: "Shared character with leftAt is excluded"
+
+- [ ] Failed shares fetch degrades to DM-only characters (no throw)
+  - Setup: mock GET `/api/campaigns/:id/characters` → non-OK response
+  - Assert: `context.characters` contains only DM-owned chars; function resolves without error
+  - Spec: `specs/campaign-context-shared-chars/spec.md` — "Shared-character fetch failure degrades gracefully"
+
+- [ ] Shared-chars fetch runs in parallel (no sequential blocking)
+  - Setup: spy on `fetch`; record call order
+  - Assert: `/api/campaigns/:id/characters`, `/api/parties`, `/api/characters` are all called in the same `Promise.all` tick (fetch calls initiated before any await resolves)
+
+---
+
+## Task D1 — `PartyEditor` UI
+
+Component tests in `tests/unit/components/PartyEditor.test.tsx` (new file), using React Testing Library:
+
+- [ ] Shared character section rendered when campaignId set
+  - Setup: render PartyEditor with `sharedCharacters` containing one entry
+  - Assert: "Shared by Campaign Members" heading visible; character name visible with checkbox
+  - Spec: `specs/party-builder-ui/spec.md` — "Shared characters shown when campaignId selected"
+
+- [ ] Shared characters grouped by owner
+  - Setup: two entries with different `share.userId`
+  - Assert: two distinct owner group labels rendered
+  - Spec: "Shared characters grouped by owner"
+
+- [ ] Soft-deleted shared character not shown
+  - Setup: entry with `character.deletedAt` set
+  - Assert: character name not present in the shared section
+  - Spec: "Soft-deleted shared character not shown"
+
+- [ ] Shared character section absent when no campaignId
+  - Setup: render with `sharedCharacters: []`
+  - Assert: no "Shared by Campaign Members" heading
+  - Spec: "No shared characters section when no campaignId"
+
+- [ ] Shared character checkbox toggles and is included in save
+  - Setup: render; check a shared character
+  - Simulate save
+  - Assert: `onSave` called with characterId included in the `characterIds` array
+  - Spec: "Shared character selected and saved"

--- a/openspec/changes/party-builder-shared-characters/tests.md
+++ b/openspec/changes/party-builder-shared-characters/tests.md
@@ -13,7 +13,7 @@ Test files map to existing conventions:
 - Storage unit tests → `tests/unit/lib/storage-shares.test.ts` (extend) or `tests/unit/lib/storage.test.ts`
 - New storage helpers → new `describe` blocks in `tests/unit/lib/storage-shares.test.ts`
 - Route integration tests → `tests/integration/campaigns.character-sharing.integration.test.ts` (extend) and `tests/integration/api.integration.test.ts` (party routes)
-- `fetchCampaignContext` unit tests → `tests/unit/lib/campaignContext.test.ts` (new file)
+- `fetchCampaignContext` unit tests → `tests/unit/utils/campaignContext.test.ts` (existing file, extended)
 - `PartyEditor` component tests → `tests/unit/components/PartyEditor.test.tsx` (new file)
 
 ## Testing Steps

--- a/tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts
@@ -20,6 +20,7 @@ jest.mock("@/lib/storage", () => ({
     getMember: jest.fn(),
     removeShare: jest.fn(),
     loadCharacterById: jest.fn(),
+    setPartyMemberLeftAt: jest.fn(),
   },
 }));
 
@@ -27,6 +28,7 @@ const mockedStorage = jest.mocked(storage) as {
   getMember: jest.MockedFunction<typeof storage.getMember>;
   removeShare: jest.MockedFunction<typeof storage.removeShare>;
   loadCharacterById: jest.MockedFunction<typeof storage.loadCharacterById>;
+  setPartyMemberLeftAt: jest.MockedFunction<typeof storage.setPartyMemberLeftAt>;
 };
 
 const CAMPAIGN_ID = "camp-1";
@@ -105,6 +107,29 @@ describe("DELETE /api/campaigns/[id]/characters/[cid]", () => {
     mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
     mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
     mockedStorage.removeShare.mockResolvedValue(true);
+    mockedStorage.setPartyMemberLeftAt.mockResolvedValue();
+    const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(response.status).toBe(204);
+  });
+
+  it("B4-1: calls setPartyMemberLeftAt after successful unshare", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
+    mockedStorage.removeShare.mockResolvedValue(true);
+    mockedStorage.setPartyMemberLeftAt.mockResolvedValue();
+    await DELETE(makeDeleteRequest(), { params: PARAMS });
+    expect(mockedStorage.setPartyMemberLeftAt).toHaveBeenCalledWith(
+      CAMPAIGN_ID,
+      CHARACTER_ID,
+      expect.any(Date)
+    );
+  });
+
+  it("B4-2: cleanup error does not change 204 response", async () => {
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.loadCharacterById.mockResolvedValue(OWN_CHARACTER);
+    mockedStorage.removeShare.mockResolvedValue(true);
+    mockedStorage.setPartyMemberLeftAt.mockRejectedValue(new Error("cleanup failed"));
     const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
     expect(response.status).toBe(204);
   });

--- a/tests/unit/api/campaigns/[id]/characters/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/characters/route.test.ts
@@ -22,6 +22,7 @@ jest.mock("@/lib/storage", () => ({
     addShare: jest.fn(),
     listSharesForCampaign: jest.fn(),
     loadCharacterById: jest.fn(),
+    buildSharedCharacterEntries: jest.fn(),
   },
 }));
 
@@ -30,6 +31,7 @@ const mockedStorage = jest.mocked(storage) as {
   addShare: jest.MockedFunction<typeof storage.addShare>;
   listSharesForCampaign: jest.MockedFunction<typeof storage.listSharesForCampaign>;
   loadCharacterById: jest.MockedFunction<typeof storage.loadCharacterById>;
+  buildSharedCharacterEntries: jest.MockedFunction<typeof storage.buildSharedCharacterEntries>;
 };
 
 const CAMPAIGN_ID = "camp-1";
@@ -189,5 +191,45 @@ describe("GET /api/campaigns/[id]/characters", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toEqual([]);
+  });
+
+  it("B1-1: DM gets enriched SharedCharacterEntry[] response", async () => {
+    const dmMember = { ...ACTIVE_PLAYER, role: "dm" as const };
+    const entry = {
+      share: { id: "s1", campaignId: CAMPAIGN_ID, characterId: "char-2", userId: "player-1", sharedAt: new Date() },
+      character: { id: "char-2", name: "Arya", characterType: "character", userId: "player-1", deletedAt: undefined },
+    };
+    mockedStorage.getMember.mockResolvedValue(dmMember);
+    mockedStorage.buildSharedCharacterEntries.mockResolvedValue([entry] as any);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toHaveProperty("share");
+    expect(body[0]).toHaveProperty("character");
+    expect(body[0].character.name).toBe("Arya");
+  });
+
+  it("B1-2: DM gets empty array when no shares exist", async () => {
+    const dmMember = { ...ACTIVE_PLAYER, role: "dm" as const };
+    mockedStorage.getMember.mockResolvedValue(dmMember);
+    mockedStorage.buildSharedCharacterEntries.mockResolvedValue([]);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual([]);
+  });
+
+  it("B1-3: player still gets own shares in bare format", async () => {
+    const shares = [
+      { id: "s1", campaignId: CAMPAIGN_ID, characterId: "ch1", userId: MOCK_AUTH.userId, sharedAt: new Date() },
+    ];
+    mockedStorage.getMember.mockResolvedValue(ACTIVE_PLAYER);
+    mockedStorage.listSharesForCampaign.mockResolvedValue(shares);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).not.toHaveProperty("character");
   });
 });

--- a/tests/unit/api/campaigns/[id]/members/[userId]/route.unit.test.ts
+++ b/tests/unit/api/campaigns/[id]/members/[userId]/route.unit.test.ts
@@ -19,12 +19,16 @@ jest.mock("@/lib/storage", () => ({
   storage: {
     getMember: jest.fn(),
     updateMemberStatus: jest.fn(),
+    listAllSharesForCampaign: jest.fn(),
+    setPartyMemberLeftAt: jest.fn(),
   },
 }));
 
 const mockedStorage = jest.mocked(storage) as {
   getMember: jest.MockedFunction<typeof storage.getMember>;
   updateMemberStatus: jest.MockedFunction<typeof storage.updateMemberStatus>;
+  listAllSharesForCampaign: jest.MockedFunction<typeof storage.listAllSharesForCampaign>;
+  setPartyMemberLeftAt: jest.MockedFunction<typeof storage.setPartyMemberLeftAt>;
 };
 
 const CAMPAIGN_ID = "camp-1";
@@ -50,6 +54,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockAuthState.payload = MOCK_AUTH;
   mockedStorage.updateMemberStatus.mockResolvedValue(undefined);
+  mockedStorage.listAllSharesForCampaign.mockResolvedValue([]);
+  mockedStorage.setPartyMemberLeftAt.mockResolvedValue();
 });
 
 describe("DELETE /api/campaigns/[id]/members/[userId]", () => {
@@ -207,6 +213,56 @@ describe("DELETE /api/campaigns/[id]/members/[userId]", () => {
       const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
       expect(response.status).toBe(404);
       expect(mockedStorage.updateMemberStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("B5: party cleanup on member removal", () => {
+    const ACTIVE_TARGET: CampaignMember = {
+      id: "mem-target",
+      campaignId: CAMPAIGN_ID,
+      userId: TARGET_USER_ID,
+      role: "player",
+      status: "active",
+      history: [],
+    };
+
+    beforeEach(() => {
+      mockedStorage.getMember
+        .mockResolvedValueOnce(ACTIVE_DM)
+        .mockResolvedValueOnce(ACTIVE_TARGET);
+    });
+
+    it("B5-1: cascades leftAt to all shares owned by removed member", async () => {
+      const shares = [
+        { id: "s1", campaignId: CAMPAIGN_ID, characterId: "char-X", userId: TARGET_USER_ID, sharedAt: new Date() },
+        { id: "s2", campaignId: CAMPAIGN_ID, characterId: "char-Y", userId: TARGET_USER_ID, sharedAt: new Date() },
+      ];
+      mockedStorage.listAllSharesForCampaign.mockResolvedValue(shares as any);
+
+      await DELETE(makeDeleteRequest(), { params: PARAMS });
+
+      expect(mockedStorage.setPartyMemberLeftAt).toHaveBeenCalledTimes(2);
+      expect(mockedStorage.setPartyMemberLeftAt).toHaveBeenCalledWith(CAMPAIGN_ID, "char-X", expect.any(Date));
+      expect(mockedStorage.setPartyMemberLeftAt).toHaveBeenCalledWith(CAMPAIGN_ID, "char-Y", expect.any(Date));
+    });
+
+    it("B5-2: member with no shares — removal still returns 200", async () => {
+      mockedStorage.listAllSharesForCampaign.mockResolvedValue([]);
+
+      const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+
+      expect(response.status).toBe(200);
+      expect(mockedStorage.setPartyMemberLeftAt).not.toHaveBeenCalled();
+    });
+
+    it("B5-3: cleanup error does not fail removal response", async () => {
+      mockedStorage.listAllSharesForCampaign.mockRejectedValue(new Error("cleanup failed"));
+
+      const response = await DELETE(makeDeleteRequest(), { params: PARAMS });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({ status: "removed" });
     });
   });
 });

--- a/tests/unit/api/parties/route.test.ts
+++ b/tests/unit/api/parties/route.test.ts
@@ -21,6 +21,7 @@ jest.mock("@/lib/storage", () => ({
     loadParties: jest.fn(),
     saveParty: jest.fn(),
     deleteParty: jest.fn(),
+    canAddToCampaignParty: jest.fn(),
   },
 }));
 
@@ -109,6 +110,42 @@ describe("POST /api/parties", () => {
     () => makeRequest({ name: "Doomed Party" }),
     () => mockedStorage.saveParty.mockRejectedValue(new Error("Storage error"))
   );
+
+  it("B2-1: returns 403 when campaignId set and character not shared", async () => {
+    mockAuthState.payload = MOCK_AUTH;
+    (mockedStorage as any).canAddToCampaignParty.mockResolvedValue(false);
+    mockedStorage.saveParty.mockResolvedValue(undefined as any);
+
+    const response = await POST(
+      makeRequest({ name: "Campaign Party", campaignId: "camp-1", characterIds: ["char-foreign"] })
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("not shared");
+  });
+
+  it("B2-2: returns 201 when campaignId set and shared character allowed", async () => {
+    mockAuthState.payload = MOCK_AUTH;
+    (mockedStorage as any).canAddToCampaignParty.mockResolvedValue(true);
+    mockedStorage.saveParty.mockResolvedValue(undefined as any);
+
+    const response = await POST(
+      makeRequest({ name: "Campaign Party", campaignId: "camp-1", characterIds: ["char-shared"] })
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  it("B2-3: no share check when campaignId absent", async () => {
+    mockAuthState.payload = MOCK_AUTH;
+    mockedStorage.saveParty.mockResolvedValue(undefined as any);
+
+    const response = await POST(makeRequest({ name: "No Campaign", characterIds: ["char-1"] }));
+
+    expect(response.status).toBe(201);
+    expect((mockedStorage as any).canAddToCampaignParty).not.toHaveBeenCalled();
+  });
 });
 
 describe("PUT /api/parties/[id]", () => {
@@ -209,6 +246,69 @@ describe("PUT /api/parties/[id]", () => {
       { params: Promise.resolve({ id: "missing" }) }
     );
     expect(response.status).toBe(404);
+  });
+
+  it("B3-1: returns 403 when adding unshared character to campaign party", async () => {
+    const partyWithCampaign = { ...EXISTING_PARTY, campaignId: "camp-1" };
+    mockedStorage.loadParties.mockResolvedValue([partyWithCampaign] as any);
+    (mockedStorage as any).canAddToCampaignParty.mockResolvedValue(false);
+
+    const response = await PUT(
+      makeRouteRequest("http://localhost/api/parties/party-123", "PUT", {
+        name: "Name",
+        characterIds: ["char-new-unshared"],
+      }),
+      { params: Promise.resolve({ id: "party-123" }) }
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("B3-2: returns 200 when adding shared character to campaign party", async () => {
+    const partyWithCampaign = { ...EXISTING_PARTY, campaignId: "camp-1" };
+    mockedStorage.loadParties.mockResolvedValue([partyWithCampaign] as any);
+    (mockedStorage as any).canAddToCampaignParty.mockResolvedValue(true);
+
+    const response = await PUT(
+      makeRouteRequest("http://localhost/api/parties/party-123", "PUT", {
+        name: "Name",
+        characterIds: ["char-new-shared"],
+      }),
+      { params: Promise.resolve({ id: "party-123" }) }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("B3-3: re-adding existing active member does not trigger share check", async () => {
+    const partyWithCampaign = { ...EXISTING_PARTY, campaignId: "camp-1" };
+    mockedStorage.loadParties.mockResolvedValue([partyWithCampaign] as any);
+
+    const response = await PUT(
+      makeRouteRequest("http://localhost/api/parties/party-123", "PUT", {
+        name: "Name",
+        characterIds: ["char-1"],
+      }),
+      { params: Promise.resolve({ id: "party-123" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect((mockedStorage as any).canAddToCampaignParty).not.toHaveBeenCalled();
+  });
+
+  it("B3-4: no share check when party has no campaignId", async () => {
+    mockedStorage.loadParties.mockResolvedValue([EXISTING_PARTY] as any);
+
+    const response = await PUT(
+      makeRouteRequest("http://localhost/api/parties/party-123", "PUT", {
+        name: "Name",
+        characterIds: ["char-new"],
+      }),
+      { params: Promise.resolve({ id: "party-123" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect((mockedStorage as any).canAddToCampaignParty).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/components/PartyEditor.test.tsx
+++ b/tests/unit/components/PartyEditor.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { SharedCharacterEntry, Party } from '@/lib/types';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PartyEditor } from '@/app/parties/page';
+import { SharedCharacterEntry, Party, Character, Campaign } from '@/lib/types';
 
 jest.mock('@/lib/components/ui', () => ({
   ErrorBanner: () => null,
@@ -25,17 +26,6 @@ jest.mock('@/lib/components/ui', () => ({
   textInputClass: () => '',
 }));
 
-jest.mock('next/link', () => ({
-  __esModule: true,
-  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
-    React.createElement('a', { href }, children),
-}));
-
-jest.mock('@/lib/components/ProtectedRoute', () => ({
-  ProtectedRoute: ({ children }: { children: React.ReactNode }) =>
-    React.createElement(React.Fragment, null, children),
-}));
-
 jest.mock('@/lib/components/CharacterMiniSummary', () => ({
   CharacterMiniSummary: () => null,
 }));
@@ -51,109 +41,112 @@ const makeParty = (overrides: Partial<Party> = {}): Party => ({
   ...overrides,
 });
 
-const makeSharedEntry = (characterId: string, userId: string, name: string, deletedAt?: Date): SharedCharacterEntry => ({
-  share: { id: `share-${characterId}`, campaignId: 'camp-1', characterId, userId, sharedAt: new Date() },
-  character: { id: characterId, name, characterType: 'character', userId, deletedAt },
+const makeCharacter = (id: string, name: string): Character => ({
+  id,
+  userId: 'dm-1',
+  name,
+  classes: [{ class: 'Fighter', level: 1 }],
+  abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+  ac: 10,
+  hp: 10,
+  maxHp: 10,
 });
 
-describe('PartyEditor shared characters UI', () => {
+const makeSharedEntry = (characterId: string, userId: string, name: string, deletedAt?: Date): SharedCharacterEntry => ({
+  share: { id: `share-${characterId}`, campaignId: 'camp-1', characterId, userId, sharedAt: new Date() },
+  character: makeCharacter(characterId, name),
+});
+
+const makeCampaign = (id: string, name: string): Campaign => ({
+  id,
+  userId: 'dm-1',
+  name,
+  moduleName: 'Test',
+  chapters: [],
+  status: 'active',
+  notes: '',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const defaultProps = {
+  party: makeParty({ campaignId: 'camp-1' }),
+  characters: [] as Character[],
+  campaigns: [makeCampaign('camp-1', 'Campaign Alpha')],
+  sharedCharacters: [] as SharedCharacterEntry[],
+  onSave: jest.fn().mockResolvedValue(undefined),
+  onCancel: jest.fn(),
+  onCampaignChange: jest.fn(),
+  isNew: false,
+};
+
+describe('PartyEditor — shared characters', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test('D1-1: shared character section rendered when campaignId set', () => {
-    const sharedEntry = makeSharedEntry('sc-1', 'player-1', 'Arya Stark');
-    // Simulate the section rendering by checking what PartyEditor renders
-    // We use a minimal render of just the section logic inline
-    const Wrapper = () => {
-      const entries = [sharedEntry];
-      const campaignId = 'camp-1';
-      const byOwner = new Map<string, typeof entries>();
-      for (const e of entries) {
-        const k = e.share.userId;
-        if (!byOwner.has(k)) byOwner.set(k, []);
-        byOwner.get(k)!.push(e);
-      }
-      if (!campaignId || entries.length === 0) return null;
-      return React.createElement('div', null,
-        React.createElement('p', null, 'Shared by Campaign Members'),
-        ...Array.from(byOwner.entries()).map(([ownerId, es]) =>
-          React.createElement('div', { key: ownerId },
-            React.createElement('p', { 'aria-label': `Shared by: ${ownerId}` }, ownerId),
-            ...es.map(e =>
-              React.createElement('label', { key: e.character.id },
-                React.createElement('input', { type: 'checkbox', readOnly: true, checked: false }),
-                React.createElement('span', null, e.character.name)
-              )
-            )
-          )
-        )
-      );
-    };
-
-    render(React.createElement(Wrapper));
+  test('D1-1: shows "Shared by Campaign Members" section when campaignId set and sharedCharacters present', () => {
+    const shared = [makeSharedEntry('sc-1', 'player-1', 'Arya Stark')];
+    render(React.createElement(PartyEditor, { ...defaultProps, sharedCharacters: shared }));
     expect(screen.getByText('Shared by Campaign Members')).toBeTruthy();
     expect(screen.getByText('Arya Stark')).toBeTruthy();
   });
 
   test('D1-2: shared characters grouped by owner', () => {
-    const e1 = makeSharedEntry('sc-1', 'player-1', 'Arya');
-    const e2 = makeSharedEntry('sc-2', 'player-2', 'Sansa');
-    const e3 = makeSharedEntry('sc-3', 'player-2', 'Bran');
-    const entries = [e1, e2, e3];
-    const byOwner = new Map<string, typeof entries>();
-    for (const e of entries) {
-      const k = e.share.userId;
-      if (!byOwner.has(k)) byOwner.set(k, []);
-      byOwner.get(k)!.push(e);
-    }
-    const Wrapper = () => React.createElement('div', null,
-      ...Array.from(byOwner.entries()).map(([ownerId, es]) =>
-        React.createElement('div', { key: ownerId },
-          React.createElement('p', { 'aria-label': `Shared by: ${ownerId}` }, ownerId),
-          ...es.map(e =>
-            React.createElement('span', { key: e.character.id }, e.character.name)
-          )
-        )
-      )
-    );
-    render(React.createElement(Wrapper));
-    expect(screen.getByText('player-1')).toBeTruthy();
-    expect(screen.getByText('player-2')).toBeTruthy();
+    const shared = [
+      makeSharedEntry('sc-1', 'player-1', 'Arya'),
+      makeSharedEntry('sc-2', 'player-2', 'Sansa'),
+      makeSharedEntry('sc-3', 'player-2', 'Bran'),
+    ];
+    render(React.createElement(PartyEditor, { ...defaultProps, sharedCharacters: shared }));
+    const p1Label = screen.getByLabelText('Shared by: player-1');
+    const p2Label = screen.getByLabelText('Shared by: player-2');
+    expect(p1Label).toBeTruthy();
+    expect(p2Label).toBeTruthy();
     expect(screen.getByText('Arya')).toBeTruthy();
     expect(screen.getByText('Sansa')).toBeTruthy();
     expect(screen.getByText('Bran')).toBeTruthy();
   });
 
-  test('D1-3: soft-deleted shared character not shown', () => {
-    const deleted = makeSharedEntry('sc-del', 'player-1', 'Deleted Char', new Date());
-    const active = makeSharedEntry('sc-act', 'player-1', 'Active Char');
-    const entries = [deleted, active].filter(e => !e.character.deletedAt);
-    expect(entries).toHaveLength(1);
-    expect(entries[0].character.name).toBe('Active Char');
+  test('D1-3: soft-deleted shared character is not shown', () => {
+    const deletedEntry = makeSharedEntry('sc-del', 'player-1', 'Deleted Char');
+    deletedEntry.character.deletedAt = new Date();
+    const shared = [deletedEntry, makeSharedEntry('sc-act', 'player-1', 'Active Char')];
+    render(React.createElement(PartyEditor, { ...defaultProps, sharedCharacters: shared }));
+    expect(screen.queryByText('Deleted Char')).toBeNull();
+    expect(screen.getByText('Active Char')).toBeTruthy();
   });
 
   test('D1-4: no shared section when sharedCharacters is empty', () => {
-    const Wrapper = () => {
-      const entries: SharedCharacterEntry[] = [];
-      const campaignId = 'camp-1';
-      if (!campaignId || entries.length === 0) return React.createElement('div', null, 'No shared');
-      return React.createElement('p', null, 'Shared by Campaign Members');
-    };
-    render(React.createElement(Wrapper));
-    expect(screen.queryByText('Shared by Campaign Members')).toBeNull();
+    render(React.createElement(PartyEditor, { ...defaultProps, sharedCharacters: [] }));
+    expect(screen.queryByText('Shared by Campaign Members')).not.toBeInTheDocument();
   });
 
-  test('D1-5: shared character checkbox toggles and id is included in state', () => {
-    const sharedEntry = makeSharedEntry('sc-1', 'player-1', 'Arya');
-    const selected = new Set<string>();
-    const toggle = (id: string) => {
-      if (selected.has(id)) selected.delete(id);
-      else selected.add(id);
-    };
-    toggle(sharedEntry.character.id);
-    expect(selected.has('sc-1')).toBe(true);
-    toggle(sharedEntry.character.id);
-    expect(selected.has('sc-1')).toBe(false);
+  test('D1-5: no shared section when party has no campaignId', () => {
+    render(React.createElement(PartyEditor, {
+      ...defaultProps,
+      party: makeParty({ campaignId: undefined }),
+      sharedCharacters: [makeSharedEntry('sc-1', 'player-1', 'Arya')],
+    }));
+    expect(screen.queryByText('Shared by Campaign Members')).not.toBeInTheDocument();
+  });
+
+  test('D1-6: shared character checkbox toggles and is included in save payload', async () => {
+    const shared = [makeSharedEntry('sc-1', 'player-1', 'Arya Stark')];
+    render(React.createElement(PartyEditor, { ...defaultProps, sharedCharacters: shared }));
+    const checkbox = screen.getByRole('checkbox', { name: /Arya Stark/i });
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByTestId('save-btn'));
+    await Promise.resolve();
+    expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+    const [, characterIds] = defaultProps.onSave.mock.calls[0];
+    expect(characterIds).toContain('sc-1');
+  });
+
+  test('D1-7: onCampaignChange is called when campaign select changes', () => {
+    render(React.createElement(PartyEditor, { ...defaultProps }));
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'camp-1' } });
+    expect(defaultProps.onCampaignChange).toHaveBeenCalledWith('camp-1');
   });
 });

--- a/tests/unit/components/PartyEditor.test.tsx
+++ b/tests/unit/components/PartyEditor.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SharedCharacterEntry, Party } from '@/lib/types';
+
+jest.mock('@/lib/components/ui', () => ({
+  ErrorBanner: () => null,
+  LoadingState: () => React.createElement('div', null, 'Loading...'),
+  FormField: ({ label, children }: { label: string; children: React.ReactNode }) =>
+    React.createElement('div', null, React.createElement('label', null, label), children),
+  EditorShell: ({ children, onSave, onCancel }: {
+    children: React.ReactNode;
+    onSave: () => void;
+    onCancel: () => void;
+    title?: string;
+    validationError?: string | null;
+    saving?: boolean;
+    canSave?: boolean;
+    saveLabel?: string;
+  }) =>
+    React.createElement('div', null,
+      children,
+      React.createElement('button', { onClick: onSave, 'data-testid': 'save-btn' }, 'Save'),
+      React.createElement('button', { onClick: onCancel }, 'Cancel'),
+    ),
+  textInputClass: () => '',
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement('a', { href }, children),
+}));
+
+jest.mock('@/lib/components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+jest.mock('@/lib/components/CharacterMiniSummary', () => ({
+  CharacterMiniSummary: () => null,
+}));
+
+const makeParty = (overrides: Partial<Party> = {}): Party => ({
+  id: 'p-1',
+  userId: 'dm-1',
+  name: 'Test Party',
+  description: '',
+  members: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeSharedEntry = (characterId: string, userId: string, name: string, deletedAt?: Date): SharedCharacterEntry => ({
+  share: { id: `share-${characterId}`, campaignId: 'camp-1', characterId, userId, sharedAt: new Date() },
+  character: { id: characterId, name, characterType: 'character', userId, deletedAt },
+});
+
+describe('PartyEditor shared characters UI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('D1-1: shared character section rendered when campaignId set', () => {
+    const sharedEntry = makeSharedEntry('sc-1', 'player-1', 'Arya Stark');
+    // Simulate the section rendering by checking what PartyEditor renders
+    // We use a minimal render of just the section logic inline
+    const Wrapper = () => {
+      const entries = [sharedEntry];
+      const campaignId = 'camp-1';
+      const byOwner = new Map<string, typeof entries>();
+      for (const e of entries) {
+        const k = e.share.userId;
+        if (!byOwner.has(k)) byOwner.set(k, []);
+        byOwner.get(k)!.push(e);
+      }
+      if (!campaignId || entries.length === 0) return null;
+      return React.createElement('div', null,
+        React.createElement('p', null, 'Shared by Campaign Members'),
+        ...Array.from(byOwner.entries()).map(([ownerId, es]) =>
+          React.createElement('div', { key: ownerId },
+            React.createElement('p', { 'aria-label': `Shared by: ${ownerId}` }, ownerId),
+            ...es.map(e =>
+              React.createElement('label', { key: e.character.id },
+                React.createElement('input', { type: 'checkbox', readOnly: true, checked: false }),
+                React.createElement('span', null, e.character.name)
+              )
+            )
+          )
+        )
+      );
+    };
+
+    render(React.createElement(Wrapper));
+    expect(screen.getByText('Shared by Campaign Members')).toBeTruthy();
+    expect(screen.getByText('Arya Stark')).toBeTruthy();
+  });
+
+  test('D1-2: shared characters grouped by owner', () => {
+    const e1 = makeSharedEntry('sc-1', 'player-1', 'Arya');
+    const e2 = makeSharedEntry('sc-2', 'player-2', 'Sansa');
+    const e3 = makeSharedEntry('sc-3', 'player-2', 'Bran');
+    const entries = [e1, e2, e3];
+    const byOwner = new Map<string, typeof entries>();
+    for (const e of entries) {
+      const k = e.share.userId;
+      if (!byOwner.has(k)) byOwner.set(k, []);
+      byOwner.get(k)!.push(e);
+    }
+    const Wrapper = () => React.createElement('div', null,
+      ...Array.from(byOwner.entries()).map(([ownerId, es]) =>
+        React.createElement('div', { key: ownerId },
+          React.createElement('p', { 'aria-label': `Shared by: ${ownerId}` }, ownerId),
+          ...es.map(e =>
+            React.createElement('span', { key: e.character.id }, e.character.name)
+          )
+        )
+      )
+    );
+    render(React.createElement(Wrapper));
+    expect(screen.getByText('player-1')).toBeTruthy();
+    expect(screen.getByText('player-2')).toBeTruthy();
+    expect(screen.getByText('Arya')).toBeTruthy();
+    expect(screen.getByText('Sansa')).toBeTruthy();
+    expect(screen.getByText('Bran')).toBeTruthy();
+  });
+
+  test('D1-3: soft-deleted shared character not shown', () => {
+    const deleted = makeSharedEntry('sc-del', 'player-1', 'Deleted Char', new Date());
+    const active = makeSharedEntry('sc-act', 'player-1', 'Active Char');
+    const entries = [deleted, active].filter(e => !e.character.deletedAt);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].character.name).toBe('Active Char');
+  });
+
+  test('D1-4: no shared section when sharedCharacters is empty', () => {
+    const Wrapper = () => {
+      const entries: SharedCharacterEntry[] = [];
+      const campaignId = 'camp-1';
+      if (!campaignId || entries.length === 0) return React.createElement('div', null, 'No shared');
+      return React.createElement('p', null, 'Shared by Campaign Members');
+    };
+    render(React.createElement(Wrapper));
+    expect(screen.queryByText('Shared by Campaign Members')).toBeNull();
+  });
+
+  test('D1-5: shared character checkbox toggles and id is included in state', () => {
+    const sharedEntry = makeSharedEntry('sc-1', 'player-1', 'Arya');
+    const selected = new Set<string>();
+    const toggle = (id: string) => {
+      if (selected.has(id)) selected.delete(id);
+      else selected.add(id);
+    };
+    toggle(sharedEntry.character.id);
+    expect(selected.has('sc-1')).toBe(true);
+    toggle(sharedEntry.character.id);
+    expect(selected.has('sc-1')).toBe(false);
+  });
+});

--- a/tests/unit/lib/storage-shares.test.ts
+++ b/tests/unit/lib/storage-shares.test.ts
@@ -158,6 +158,267 @@ describe("storage.listSharesForCampaign", () => {
   });
 });
 
+describe("storage.listAllSharesForCampaign", () => {
+  const share1 = { ...BASE_SHARE, _id: "mongo-1", userId: "user-1" };
+  const share2 = { ...BASE_SHARE, id: "share-2", characterId: "char-2", _id: "mongo-2", userId: "user-2" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("A2-1: returns shares from multiple different users", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([share1, share2]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.listAllSharesForCampaign("camp-1");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].userId).toBe("user-1");
+    expect(result[1].userId).toBe("user-2");
+  });
+
+  it("A2-2: returns empty array when no shares exist", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.listAllSharesForCampaign("camp-1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("A2-3: query uses only campaignId (no userId filter)", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    await storage.listAllSharesForCampaign("camp-1");
+
+    expect(mockFind).toHaveBeenCalledWith({ campaignId: "camp-1" });
+  });
+
+  it("A2-4: strips _id from returned shares", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([share1]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.listAllSharesForCampaign("camp-1");
+
+    expect(result[0]).not.toHaveProperty("_id");
+  });
+});
+
+describe("storage.loadPartiesByCampaign", () => {
+  const makeParty = (id: string, campaignId: string) => ({
+    id,
+    userId: "dm-1",
+    name: `Party ${id}`,
+    members: [],
+    campaignId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("A3-1: returns only parties matching the campaignId", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([makeParty("p-1", "camp-A")]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.loadPartiesByCampaign("camp-A");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("p-1");
+  });
+
+  it("A3-2: returns empty array when no parties in campaign", async () => {
+    const mockToArray = jest.fn().mockResolvedValue([]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const result = await storage.loadPartiesByCampaign("camp-X");
+
+    expect(result).toEqual([]);
+  });
+
+  it("A3-3: emits perf log when query exceeds 10ms", async () => {
+    let nowCallCount = 0;
+    const nowSpy = jest.spyOn(Date, "now").mockImplementation(() => {
+      nowCallCount++;
+      return nowCallCount === 1 ? 1000 : 1020; // 20ms elapsed
+    });
+
+    const mockToArray = jest.fn().mockResolvedValue([]);
+    const mockFind = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockedDb.collection.mockReturnValue({ find: mockFind });
+
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    await storage.loadPartiesByCampaign("camp-slow");
+
+    const perfCalls = consoleSpy.mock.calls.filter(
+      args => typeof args[0] === "string" && args[0].includes("[perf] loadPartiesByCampaign")
+    );
+    expect(perfCalls.length).toBeGreaterThan(0);
+
+    nowSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("storage.setPartyMemberLeftAt", () => {
+  const makeParty = (id: string, members: object[]) => ({
+    id,
+    userId: "dm-1",
+    name: `Party ${id}`,
+    campaignId: "camp-1",
+    members,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("A4-1: sets leftAt on active member with matching characterId", async () => {
+    const party = makeParty("p-1", [{ characterId: "char-X", addedAt: new Date() }]);
+    jest.spyOn(storage, "loadPartiesByCampaign").mockResolvedValue([party] as any);
+    const saveSpy = jest.spyOn(storage, "saveParty").mockResolvedValue();
+
+    const now = new Date();
+    await storage.setPartyMemberLeftAt("camp-1", "char-X", now);
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const savedParty = saveSpy.mock.calls[0][0];
+    const member = savedParty.members.find((m: any) => m.characterId === "char-X");
+    expect(member?.leftAt).toBe(now);
+  });
+
+  it("A4-2: does not modify already-left members", async () => {
+    const existingLeftAt = new Date("2026-01-01");
+    const party = makeParty("p-1", [{ characterId: "char-X", addedAt: new Date(), leftAt: existingLeftAt }]);
+    jest.spyOn(storage, "loadPartiesByCampaign").mockResolvedValue([party] as any);
+    const saveSpy = jest.spyOn(storage, "saveParty").mockResolvedValue();
+
+    await storage.setPartyMemberLeftAt("camp-1", "char-X", new Date());
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("A4-3: updates multiple parties in the same campaign", async () => {
+    const p1 = makeParty("p-1", [{ characterId: "char-X", addedAt: new Date() }]);
+    const p2 = makeParty("p-2", [{ characterId: "char-X", addedAt: new Date() }]);
+    jest.spyOn(storage, "loadPartiesByCampaign").mockResolvedValue([p1, p2] as any);
+    const saveSpy = jest.spyOn(storage, "saveParty").mockResolvedValue();
+
+    await storage.setPartyMemberLeftAt("camp-1", "char-X", new Date());
+
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("A4-4: does not throw when saveParty throws", async () => {
+    const party = makeParty("p-1", [{ characterId: "char-X", addedAt: new Date() }]);
+    jest.spyOn(storage, "loadPartiesByCampaign").mockResolvedValue([party] as any);
+    jest.spyOn(storage, "saveParty").mockRejectedValue(new Error("DB error"));
+
+    await expect(storage.setPartyMemberLeftAt("camp-1", "char-X", new Date())).resolves.not.toThrow();
+  });
+});
+
+describe("storage.canAddToCampaignParty", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("A5-1: returns true when character is owned by the DM", async () => {
+    jest.spyOn(storage, "loadCharacterById").mockResolvedValue({
+      id: "char-1", userId: "dm-user"
+    } as any);
+
+    const result = await storage.canAddToCampaignParty("camp-1", "char-1", "dm-user");
+
+    expect(result).toBe(true);
+  });
+
+  it("A5-2: returns true when share exists and member is active", async () => {
+    jest.spyOn(storage, "loadCharacterById").mockResolvedValue({
+      id: "char-1", userId: "player-1"
+    } as any);
+    const mockFindOne = jest.fn().mockResolvedValue({
+      campaignId: "camp-1", characterId: "char-1", userId: "player-1"
+    });
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+    jest.spyOn(storage, "getMember").mockResolvedValue({ status: "active" } as any);
+
+    const result = await storage.canAddToCampaignParty("camp-1", "char-1", "dm-user");
+
+    expect(result).toBe(true);
+  });
+
+  it("A5-3: returns false when share exists but member is invited", async () => {
+    jest.spyOn(storage, "loadCharacterById").mockResolvedValue({
+      id: "char-1", userId: "player-1"
+    } as any);
+    const mockFindOne = jest.fn().mockResolvedValue({
+      campaignId: "camp-1", characterId: "char-1", userId: "player-1"
+    });
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+    jest.spyOn(storage, "getMember").mockResolvedValue({ status: "invited" } as any);
+
+    const result = await storage.canAddToCampaignParty("camp-1", "char-1", "dm-user");
+
+    expect(result).toBe(false);
+  });
+
+  it("A5-4: returns false when no share exists", async () => {
+    jest.spyOn(storage, "loadCharacterById").mockResolvedValue({
+      id: "char-1", userId: "player-1"
+    } as any);
+    const mockFindOne = jest.fn().mockResolvedValue(null);
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+
+    const result = await storage.canAddToCampaignParty("camp-1", "char-1", "dm-user");
+
+    expect(result).toBe(false);
+  });
+
+  it("A5-5: returns false when share exists but member is removed", async () => {
+    jest.spyOn(storage, "loadCharacterById").mockResolvedValue({
+      id: "char-1", userId: "player-1"
+    } as any);
+    const mockFindOne = jest.fn().mockResolvedValue({
+      campaignId: "camp-1", characterId: "char-1", userId: "player-1"
+    });
+    mockedDb.collection.mockReturnValue({ findOne: mockFindOne });
+    jest.spyOn(storage, "getMember").mockResolvedValue({ status: "removed" } as any);
+
+    const result = await storage.canAddToCampaignParty("camp-1", "char-1", "dm-user");
+
+    expect(result).toBe(false);
+  });
+
+  it("A5-6: returns false when character not found", async () => {
+    jest.spyOn(storage, "loadCharacterById").mockResolvedValue(null);
+
+    const result = await storage.canAddToCampaignParty("camp-1", "char-1", "dm-user");
+
+    expect(result).toBe(false);
+  });
+});
+
 describe("storage.loadCharacterById", () => {
   const CHARACTER_DOC = {
     id: "char-1",

--- a/tests/unit/utils/campaignContext.test.ts
+++ b/tests/unit/utils/campaignContext.test.ts
@@ -1,4 +1,4 @@
-import { CampaignContext } from '@/lib/types';
+import { CampaignContext, SharedCharacterEntry } from '@/lib/types';
 import { makeSession } from '../fixtures/sessions';
 
 const makeCampaign = (overrides = {}) => ({
@@ -46,24 +46,25 @@ const makeCharacter = (id: string, name: string, overrides = {}) => ({
 
 const makeMember = (characterId: string) => ({ characterId, addedAt: new Date() });
 
-function routeFetch(url: RequestInfo | URL, campaign: object, parties: object[], characters: object[], sessions: object[]): Response {
+function routeFetch(url: RequestInfo | URL, campaign: object, parties: object[], characters: object[], sessions: object[], sharedChars: object[] = []): Response {
   const s = String(url);
   if (s.includes('/sessions')) return { ok: true, json: async () => sessions } as unknown as Response;
+  if (s.match(/\/api\/campaigns\/[^/]+\/characters/)) return { ok: true, json: async () => sharedChars } as unknown as Response;
   if (s.includes('/api/campaigns/') && !s.includes('parties')) return { ok: true, json: async () => campaign } as unknown as Response;
   if (s.includes('/api/parties')) return { ok: true, json: async () => parties } as unknown as Response;
   if (s.includes('/api/characters')) return { ok: true, json: async () => characters } as unknown as Response;
   return { ok: false, json: async () => ({}) } as unknown as Response;
 }
 
-function makeFetch(campaign: object, parties: object[], characters: object[], sessions: object[] = []) {
-  return jest.fn(async (url: RequestInfo | URL) => routeFetch(url, campaign, parties, characters, sessions));
+function makeFetch(campaign: object, parties: object[], characters: object[], sessions: object[] = [], sharedChars: object[] = []) {
+  return jest.fn(async (url: RequestInfo | URL) => routeFetch(url, campaign, parties, characters, sessions, sharedChars));
 }
 
 function makeFetchWithSessionOverride(campaign: object, sessionHandler: (url: string) => Promise<Response>) {
   return jest.fn(async (url: RequestInfo | URL) => {
     const s = String(url);
     if (s.includes('/sessions')) return sessionHandler(s);
-    return routeFetch(url, campaign, [], [], []);
+    return routeFetch(url, campaign, [], [], [], []);
   }) as typeof fetch;
 }
 
@@ -169,7 +170,7 @@ describe('fetchCampaignContext', () => {
     expect(ctx.characters[0].id).toBe('c-1');
   });
 
-  test('A2-8: all four fetches initiated in parallel via Promise.all', async () => {
+  test('A2-8: all five fetches initiated in parallel via Promise.all', async () => {
     const campaign = makeCampaign();
     const started: string[] = [];
     const resolvers: Record<string, (r: Response) => void> = {};
@@ -180,6 +181,9 @@ describe('fetchCampaignContext', () => {
         if (s.includes('/sessions')) {
           started.push('sessions');
           resolvers.sessions = resolve;
+        } else if (s.match(/\/api\/campaigns\/[^/]+\/characters/)) {
+          started.push('sharedChars');
+          resolvers.sharedChars = resolve;
         } else if (s.includes('/api/campaigns/')) {
           started.push('campaign');
           resolvers.campaign = resolve;
@@ -195,25 +199,27 @@ describe('fetchCampaignContext', () => {
 
     const fetchPromise = fetchCampaignContext('camp-1', parallelFetch);
 
-    // Yield to the microtask queue so Promise.all registers all four fetches
+    // Yield to the microtask queue so Promise.all registers all five fetches
     await Promise.resolve();
     await Promise.resolve();
 
-    // All four must have been started before any resolved
+    // All five must have been started before any resolved
     expect(started).toContain('campaign');
     expect(started).toContain('parties');
     expect(started).toContain('characters');
     expect(started).toContain('sessions');
+    expect(started).toContain('sharedChars');
 
-    // Now resolve all four
+    // Now resolve all five
     const ok = (data: unknown) => ({ ok: true, json: async () => data } as unknown as Response);
     resolvers.campaign(ok(campaign));
     resolvers.parties(ok([]));
     resolvers.characters(ok([]));
     resolvers.sessions(ok([]));
+    resolvers.sharedChars(ok([]));
 
     await fetchPromise;
-    expect(parallelFetch).toHaveBeenCalledTimes(4);
+    expect(parallelFetch).toHaveBeenCalledTimes(5);
   });
 
   test('TC-3-1: sessions URL includes ?limit=3', async () => {
@@ -270,9 +276,69 @@ describe('fetchCampaignContext', () => {
       const s = String(url);
       if (s.includes('/api/parties')) return { ok: false, status: 500 } as unknown as Response;
       const campaign = makeCampaign();
+      if (s.match(/\/api\/campaigns\/[^/]+\/characters/)) return { ok: true, json: async () => [] } as unknown as Response;
       return { ok: true, json: async () => s.includes('/api/campaigns') ? campaign : [] } as unknown as Response;
     }) as typeof fetch;
 
     await expect(fetchCampaignContext('camp-1', errorFetch)).rejects.toThrow();
+  });
+
+  const makeSharedEntry = (characterId: string, userId: string, deletedAt?: Date): SharedCharacterEntry => ({
+    share: { id: `share-${characterId}`, campaignId: 'camp-1', characterId, userId, sharedAt: new Date() },
+    character: { id: characterId, name: `Char ${characterId}`, characterType: 'character', userId, deletedAt },
+  });
+
+  test('C1-1: shared character in active party appears in context.characters', async () => {
+    const campaign = makeCampaign();
+    const sharedEntry = makeSharedEntry('shared-char', 'player-1');
+    const party = makeParty('p-1', 'camp-1', [makeMember('shared-char')]);
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], [], [], [sharedEntry]));
+    expect(ctx.characters.map(c => c.id)).toContain('shared-char');
+  });
+
+  test('C1-2: DM-owned character in party still appears (no regression)', async () => {
+    const campaign = makeCampaign();
+    const dmChar = makeCharacter('dm-char', 'DM Hero');
+    const party = makeParty('p-1', 'camp-1', [makeMember('dm-char')]);
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], [dmChar], [], []));
+    expect(ctx.characters.map(c => c.id)).toContain('dm-char');
+  });
+
+  test('C1-3: reactive guard excludes character with revoked share', async () => {
+    const campaign = makeCampaign();
+    const party = makeParty('p-1', 'camp-1', [makeMember('shared-char')]);
+    // shared chars fetch returns empty (share revoked)
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], [], [], []));
+    expect(ctx.characters.map(c => c.id)).not.toContain('shared-char');
+  });
+
+  test('C1-4: soft-deleted shared character excluded', async () => {
+    const campaign = makeCampaign();
+    const deletedEntry = makeSharedEntry('shared-deleted', 'player-1', new Date());
+    const party = makeParty('p-1', 'camp-1', [makeMember('shared-deleted')]);
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], [], [], [deletedEntry]));
+    expect(ctx.characters.map(c => c.id)).not.toContain('shared-deleted');
+  });
+
+  test('C1-5: shared char with leftAt excluded by existing leftAt logic', async () => {
+    const campaign = makeCampaign();
+    const sharedEntry = makeSharedEntry('shared-char', 'player-1');
+    const party = makeParty('p-1', 'camp-1', [{ characterId: 'shared-char', addedAt: new Date(), leftAt: new Date() }]);
+    const ctx = await fetchCampaignContext('camp-1', makeFetch(campaign, [party], [], [], [sharedEntry]));
+    expect(ctx.characters.map(c => c.id)).not.toContain('shared-char');
+  });
+
+  test('C1-6: failed shared-char fetch degrades to DM-only chars without throwing', async () => {
+    const campaign = makeCampaign();
+    const dmChar = makeCharacter('dm-char', 'DM Hero');
+    const party = makeParty('p-1', 'camp-1', [makeMember('dm-char')]);
+    const errorFetch = jest.fn(async (url: RequestInfo | URL) => {
+      const s = String(url);
+      if (s.match(/\/api\/campaigns\/[^/]+\/characters/)) return { ok: false, status: 500 } as unknown as Response;
+      return routeFetch(url, campaign, [party], [dmChar], []);
+    }) as typeof fetch;
+    const ctx = await fetchCampaignContext('camp-1', errorFetch);
+    expect(ctx.characters.map(c => c.id)).toContain('dm-char');
+    expect(ctx.characters.map(c => c.id)).not.toContain('shared-char');
   });
 });


### PR DESCRIPTION
## Summary

Phase 3b: Closes #310 (sub-issue of #295)

Closes the campaign party-builder loop: the DM can now see and add player-shared characters when building a party, an access rule prevents adding unshared characters, and party cleanup runs automatically on unshare and member removal.

## Changes

### Storage layer (`lib/storage.ts`)
- `listAllSharesForCampaign(campaignId)` — all shares for a campaign, no userId filter
- `loadPartiesByCampaign(campaignId)` — parties by campaignId with timing observability
- `setPartyMemberLeftAt(campaignId, characterId, timestamp)` — proactive party cleanup helper (fire-and-forget)
- `canAddToCampaignParty(campaignId, characterId, dmUserId)` — access rule helper
- `buildSharedCharacterEntries(campaignId)` — enriched share list for DM GET

### Types (`lib/types.ts`)
- `SharedCharacterEntry` — enriched response type for DM-facing GET

### API routes
- `GET /api/campaigns/[id]/characters` — DM callers now receive `SharedCharacterEntry[]`; players still get bare shares
- `POST /api/parties` — enforces `canAddToCampaignParty` when `campaignId` present
- `PUT /api/parties/[id]` — enforces access rule for newly-added characters; re-validates all when `campaignId` changes
- `DELETE /api/campaigns/[id]/characters/[cid]` — triggers `setPartyMemberLeftAt` after unshare
- `DELETE /api/campaigns/[id]/members/[userId]` — cascades `setPartyMemberLeftAt` for all target's shared characters

### Campaign context (`lib/utils/campaignContext.ts`)
- Fetches shared characters in parallel with existing fetches
- Merges shared characters into `context.characters`
- Reactive guard: non-DM-owned characters must appear in active shares list

### Party builder UI (`app/parties/page.tsx`)
- `PartyEditor` shows "Shared by Campaign Members" section when `campaignId` set
- Characters grouped by owner userId; soft-deleted chars excluded
- Re-fetches shared characters when campaign selection changes

## Test coverage
- All new storage methods: `listAllSharesForCampaign`, `loadPartiesByCampaign`, `setPartyMemberLeftAt`, `canAddToCampaignParty`
- DM enriched GET, player bare GET
- POST/PUT access rule enforcement (shared allowed, unshared rejected, no campaignId skips check)
- Unshare and member-removal cleanup (success + error-does-not-fail-response)
- `fetchCampaignContext` shared chars, reactive guard, graceful degradation
- `PartyEditor` shared section rendering, grouping, soft-delete exclusion