### PR TITLE
docs(multi-user-campaigns): sync status with GitHub issue states (2026-06-08)

### DIFF
--- a/docs/multi-user-campaigns/02-invite-and-accept.md
+++ b/docs/multi-user-campaigns/02-invite-and-accept.md
@@ -1,4 +1,4 @@
-# Phase 2 — Invite & accept flow (partially complete)
+# Phase 2 — Invite & accept flow ✅ COMPLETE
 
 **Goal:** Let a DM find users by username and invite them; let invited users accept
 or decline. Membership only becomes `active` on acceptance.
@@ -6,7 +6,7 @@ or decline. Membership only becomes `active` on acceptance.
 **Depends on:** Phase 1 (1c search, 1d members, 1e access). ✅ Phase 1 complete.
 
 > **Tracking:** epic [#294](https://github.com/dougis-org/session-combat/issues/294) — OPEN
-> **Status:** 3 of 4 sub-issues closed (2a, 2b, 2c delivered). **2d (#308) open — next to work on.**
+> **Status:** All 4 sub-issues CLOSED ✅ — Phase 2 complete. Epic #294 pending close.
 
 ## Membership lifecycle
 
@@ -89,7 +89,7 @@ sequenceDiagram
 - **Acceptance:** DM can search, invite, see pending/active members, and remove a
   member; follows existing `lib/components` + Tailwind semantic-token conventions.
 
-### 🟡 2d. Player invitations inbox UI · [#308](https://github.com/dougis-org/session-combat/issues/308) — OPEN (next up)
+### ✅ 2d. Player invitations inbox UI · [#308](https://github.com/dougis-org/session-combat/issues/308) — CLOSED
 - A surface (nav badge + page/panel) where a player sees pending campaign invites
   and accepts/declines.
 - **Depends on:** 2b.

--- a/docs/multi-user-campaigns/03-cross-user-characters.md
+++ b/docs/multi-user-campaigns/03-cross-user-characters.md
@@ -1,4 +1,4 @@
-# Phase 3 — Cross-user characters into parties
+# Phase 3 — Cross-user characters into parties ✅ COMPLETE
 
 **Goal:** Let players opt their own characters into a campaign, and let the DM pull
 those shared characters into the parties they build — even though the DM doesn't

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -176,13 +176,8 @@ on its own. `→` marks hard dependencies; everything else can run in parallel.
 | Phase | Theme | Epic | Sub-issues | Depends on | Status |
 |-------|-------|------|------------|------------|--------|
 | 1 | Identity & membership foundations | [#293](https://github.com/dougis-org/session-combat/issues/293) CLOSED | ✅ [1a #300](https://github.com/dougis-org/session-combat/issues/300) · ✅ [1b #301](https://github.com/dougis-org/session-combat/issues/301) · ✅ [1c #302](https://github.com/dougis-org/session-combat/issues/302) · ✅ [1d #303](https://github.com/dougis-org/session-combat/issues/303) · ✅ [1e #304](https://github.com/dougis-org/session-combat/issues/304) | — | ✅ **Complete** |
-<<<<<<< HEAD
 | 2 | Invite & accept flow | [#294](https://github.com/dougis-org/session-combat/issues/294) CLOSED | ✅ [2a #305](https://github.com/dougis-org/session-combat/issues/305) · ✅ [2b #306](https://github.com/dougis-org/session-combat/issues/306) · ✅ [2c #307](https://github.com/dougis-org/session-combat/issues/307) · ✅ [2d #308](https://github.com/dougis-org/session-combat/issues/308) | Phase 1 | ✅ **Complete** |
 | 3 | Cross-user characters into parties | [#295](https://github.com/dougis-org/session-combat/issues/295) CLOSED | ✅ [3a #309](https://github.com/dougis-org/session-combat/issues/309) · ✅ [3b #310](https://github.com/dougis-org/session-combat/issues/310) | Phase 1 | ✅ **Complete** |
-=======
-| 2 | Invite & accept flow | [#294](https://github.com/dougis-org/session-combat/issues/294) OPEN | ✅ [2a #305](https://github.com/dougis-org/session-combat/issues/305) · ✅ [2b #306](https://github.com/dougis-org/session-combat/issues/306) · ✅ [2c #307](https://github.com/dougis-org/session-combat/issues/307) · ✅ [2d #308](https://github.com/dougis-org/session-combat/issues/308) | Phase 1 | ✅ **Complete** |
-| 3 | Cross-user characters into parties | [#295](https://github.com/dougis-org/session-combat/issues/295) OPEN | ✅ [3a #309](https://github.com/dougis-org/session-combat/issues/309) · ✅ [3b #310](https://github.com/dougis-org/session-combat/issues/310) | Phase 1 | ✅ **Complete** |
->>>>>>> 4393fb9 (docs(multi-user-campaigns): update status to reflect closed issues)
 | 4 | Real-time transport | [#296](https://github.com/dougis-org/session-combat/issues/296) OPEN | 🟡 [4a #311](https://github.com/dougis-org/session-combat/issues/311) · 🟡 [4b #312](https://github.com/dougis-org/session-combat/issues/312) · 🟡 [4c #313](https://github.com/dougis-org/session-combat/issues/313) | Phase 1 | 🟡 Not started |
 | 5 | Messaging | [#297](https://github.com/dougis-org/session-combat/issues/297) OPEN | 🟡 [5a #314](https://github.com/dougis-org/session-combat/issues/314) · 🟡 [5b #315](https://github.com/dougis-org/session-combat/issues/315) | Phase 4 | 🟡 Not started |
 | 6 | Shared dice rolls (session-scoped) | [#298](https://github.com/dougis-org/session-combat/issues/298) OPEN | 🟡 [6a #316](https://github.com/dougis-org/session-combat/issues/316) · 🟡 [6b #317](https://github.com/dougis-org/session-combat/issues/317) | Phase 5 | 🟡 Not started |
@@ -310,13 +305,8 @@ gantt
 |------|-----------|-------|
 | 1 | ~~**1a, 1d, 4b, 4c, 7a**~~ | ✅ Phase 1 fully delivered. 4b, 4c, 7a remain ready to start. |
 | 2 | ~~**1b, 1c, 1e, 2b**~~ | ✅ All delivered. |
-<<<<<<< HEAD
-| 3 | ~~**2d, 3a, 4a–4c, 5a, 6a**~~ | ✅ All delivered. 4a/4b/4c, 5a, 6a remain ready to start. |
-| 4 | **3b → done, 5b** | `5b` is the integration point (needs `4b` + `4c` + `5a`). **Phase 4 is the natural next target.** |
-=======
-| 3 | ~~**2d, 3a, 4a–4c, 5a, 6a**~~ | ✅ 2d (#308) and 3a (#309) delivered. **4a, 4b, 4c, 5a, 6a are now the active wave — all unblocked.** |
+| 3 | ~~**2d, 3a**~~, **4a–4c, 5a, 6a** | ✅ 2d (#308) and 3a (#309) delivered. **4a, 4b, 4c, 5a, 6a are now the active wave — all unblocked.** |
 | 4 | ~~**2c → done, 3b**~~ · **5b** | 2c and 3b delivered. `5b` is the integration point (needs `4b` + `4c` + `5a`). |
->>>>>>> 4393fb9 (docs(multi-user-campaigns): update status to reflect closed issues)
 | 5 | **6b, 7b** | Feature UIs that sit on top of messaging (`5b`). |
 
 See the per-phase docs for deliverables, acceptance criteria, and affected files:

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -176,8 +176,13 @@ on its own. `→` marks hard dependencies; everything else can run in parallel.
 | Phase | Theme | Epic | Sub-issues | Depends on | Status |
 |-------|-------|------|------------|------------|--------|
 | 1 | Identity & membership foundations | [#293](https://github.com/dougis-org/session-combat/issues/293) CLOSED | ✅ [1a #300](https://github.com/dougis-org/session-combat/issues/300) · ✅ [1b #301](https://github.com/dougis-org/session-combat/issues/301) · ✅ [1c #302](https://github.com/dougis-org/session-combat/issues/302) · ✅ [1d #303](https://github.com/dougis-org/session-combat/issues/303) · ✅ [1e #304](https://github.com/dougis-org/session-combat/issues/304) | — | ✅ **Complete** |
+<<<<<<< HEAD
 | 2 | Invite & accept flow | [#294](https://github.com/dougis-org/session-combat/issues/294) CLOSED | ✅ [2a #305](https://github.com/dougis-org/session-combat/issues/305) · ✅ [2b #306](https://github.com/dougis-org/session-combat/issues/306) · ✅ [2c #307](https://github.com/dougis-org/session-combat/issues/307) · ✅ [2d #308](https://github.com/dougis-org/session-combat/issues/308) | Phase 1 | ✅ **Complete** |
 | 3 | Cross-user characters into parties | [#295](https://github.com/dougis-org/session-combat/issues/295) CLOSED | ✅ [3a #309](https://github.com/dougis-org/session-combat/issues/309) · ✅ [3b #310](https://github.com/dougis-org/session-combat/issues/310) | Phase 1 | ✅ **Complete** |
+=======
+| 2 | Invite & accept flow | [#294](https://github.com/dougis-org/session-combat/issues/294) OPEN | ✅ [2a #305](https://github.com/dougis-org/session-combat/issues/305) · ✅ [2b #306](https://github.com/dougis-org/session-combat/issues/306) · ✅ [2c #307](https://github.com/dougis-org/session-combat/issues/307) · ✅ [2d #308](https://github.com/dougis-org/session-combat/issues/308) | Phase 1 | ✅ **Complete** |
+| 3 | Cross-user characters into parties | [#295](https://github.com/dougis-org/session-combat/issues/295) OPEN | ✅ [3a #309](https://github.com/dougis-org/session-combat/issues/309) · ✅ [3b #310](https://github.com/dougis-org/session-combat/issues/310) | Phase 1 | ✅ **Complete** |
+>>>>>>> 4393fb9 (docs(multi-user-campaigns): update status to reflect closed issues)
 | 4 | Real-time transport | [#296](https://github.com/dougis-org/session-combat/issues/296) OPEN | 🟡 [4a #311](https://github.com/dougis-org/session-combat/issues/311) · 🟡 [4b #312](https://github.com/dougis-org/session-combat/issues/312) · 🟡 [4c #313](https://github.com/dougis-org/session-combat/issues/313) | Phase 1 | 🟡 Not started |
 | 5 | Messaging | [#297](https://github.com/dougis-org/session-combat/issues/297) OPEN | 🟡 [5a #314](https://github.com/dougis-org/session-combat/issues/314) · 🟡 [5b #315](https://github.com/dougis-org/session-combat/issues/315) | Phase 4 | 🟡 Not started |
 | 6 | Shared dice rolls (session-scoped) | [#298](https://github.com/dougis-org/session-combat/issues/298) OPEN | 🟡 [6a #316](https://github.com/dougis-org/session-combat/issues/316) · 🟡 [6b #317](https://github.com/dougis-org/session-combat/issues/317) | Phase 5 | 🟡 Not started |
@@ -305,8 +310,13 @@ gantt
 |------|-----------|-------|
 | 1 | ~~**1a, 1d, 4b, 4c, 7a**~~ | ✅ Phase 1 fully delivered. 4b, 4c, 7a remain ready to start. |
 | 2 | ~~**1b, 1c, 1e, 2b**~~ | ✅ All delivered. |
+<<<<<<< HEAD
 | 3 | ~~**2d, 3a, 4a–4c, 5a, 6a**~~ | ✅ All delivered. 4a/4b/4c, 5a, 6a remain ready to start. |
 | 4 | **3b → done, 5b** | `5b` is the integration point (needs `4b` + `4c` + `5a`). **Phase 4 is the natural next target.** |
+=======
+| 3 | ~~**2d, 3a, 4a–4c, 5a, 6a**~~ | ✅ 2d (#308) and 3a (#309) delivered. **4a, 4b, 4c, 5a, 6a are now the active wave — all unblocked.** |
+| 4 | ~~**2c → done, 3b**~~ · **5b** | 2c and 3b delivered. `5b` is the integration point (needs `4b` + `4c` + `5a`). |
+>>>>>>> 4393fb9 (docs(multi-user-campaigns): update status to reflect closed issues)
 | 5 | **6b, 7b** | Feature UIs that sit on top of messaging (`5b`). |
 
 See the per-phase docs for deliverables, acceptance criteria, and affected files:

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -303,9 +303,9 @@ gantt
 
 | Wave | Can start | Notes |
 |------|-----------|-------|
-| 1 | ~~**1a, 1d, 4b, 4c, 7a**~~ | ✅ Phase 1 fully delivered. 4b, 4c, 7a remain ready to start. |
+| 1 | ~~**1a, 1d**~~, **4b, 4c, 7a** | ✅ 1a, 1d delivered. **4b, 4c, 7a** have no upstream deps and remain available to start at any time. |
 | 2 | ~~**1b, 1c, 1e, 2b**~~ | ✅ All delivered. |
-| 3 | ~~**2d, 3a**~~, **4a–4c, 5a, 6a** | ✅ 2d (#308) and 3a (#309) delivered. **4a, 4b, 4c, 5a, 6a are now the active wave — all unblocked.** |
+| 3 | ~~**2d, 3a**~~, **4a, 5a, 6a** | ✅ 2d (#308) and 3a (#309) delivered. **4a, 5a, 6a are now unblocked** (1e complete). 4b, 4c, 7a also remain available (see Wave 1). |
 | 4 | ~~**2c → done, 3b**~~ · **5b** | 2c and 3b delivered. `5b` is the integration point (needs `4b` + `4c` + `5a`). |
 | 5 | **6b, 7b** | Feature UIs that sit on top of messaging (`5b`). |
 


### PR DESCRIPTION
Automated documentation status sync.

Updates issue status markers (✅/🔄/🟡), refreshes the Status column in the phase roadmap table, and updates per-phase doc headings to reflect current GitHub issue states.

- Phase 2 fully complete: all sub-issues (#305, #306, #307, #308) closed
- Phase 3 fully complete: all sub-issues (#309, #310) closed
- Wave 3 notes updated: 4a, 4b, 4c, 5a, 6a are now the active unblocked wave

All changes are doc-only (no code).