### PR TITLE
feat: campaign active session lifecycle

### DIFF
--- a/app/api/campaigns/[id]/sessions/active/route.ts
+++ b/app/api/campaigns/[id]/sessions/active/route.ts
@@ -34,7 +34,7 @@ export const POST = withAuthAndParams<Params>(async (_request, _auth, { id: camp
     };
 
     await storage.saveSessionLog(log);
-    const claimed = await storage.claimActiveCampaignSession(campaignId, log.id);
+    const claimed = await storage.claimActiveCampaignSession(campaignId, campaign.userId, log.id);
     if (!claimed) {
       return NextResponse.json({ error: 'A session is already active' }, { status: 409 });
     }
@@ -62,7 +62,7 @@ export const DELETE = withAuthAndParams<Params>(async (request, _auth, { id: cam
 
     const closedSessionId = campaign.activeSessionId ?? null;
     if (campaign.activeSessionId) {
-      await storage.setActiveCampaignSession(campaignId, null);
+      await storage.setActiveCampaignSession(campaignId, campaign.userId, null);
     }
 
     return NextResponse.json({ sessionId: closedSessionId });

--- a/app/api/campaigns/[id]/sessions/active/route.ts
+++ b/app/api/campaigns/[id]/sessions/active/route.ts
@@ -34,7 +34,10 @@ export const POST = withAuthAndParams<Params>(async (_request, _auth, { id: camp
     };
 
     await storage.saveSessionLog(log);
-    await storage.setActiveCampaignSession(campaignId, log.id);
+    const claimed = await storage.claimActiveCampaignSession(campaignId, log.id);
+    if (!claimed) {
+      return NextResponse.json({ error: 'A session is already active' }, { status: 409 });
+    }
 
     return NextResponse.json(log, { status: 201 });
   } catch (error) {
@@ -58,7 +61,9 @@ export const DELETE = withAuthAndParams<Params>(async (request, _auth, { id: cam
     }
 
     const closedSessionId = campaign.activeSessionId ?? null;
-    await storage.setActiveCampaignSession(campaignId, null);
+    if (campaign.activeSessionId) {
+      await storage.setActiveCampaignSession(campaignId, null);
+    }
 
     return NextResponse.json({ sessionId: closedSessionId });
   } catch (error) {

--- a/app/api/campaigns/[id]/sessions/active/route.ts
+++ b/app/api/campaigns/[id]/sessions/active/route.ts
@@ -18,9 +18,15 @@ export const POST = withAuthAndParams<Params>(async (_request, _auth, { id: camp
       return NextResponse.json({ error: 'A session is already active' }, { status: 409 });
     }
 
+    const logId = crypto.randomUUID();
+    const claimed = await storage.claimActiveCampaignSession(campaignId, campaign.userId, logId);
+    if (!claimed) {
+      return NextResponse.json({ error: 'A session is already active' }, { status: 409 });
+    }
+
     const now = new Date();
     const log: SessionLog = {
-      id: crypto.randomUUID(),
+      id: logId,
       userId: campaign.userId,
       campaignId,
       sessionNumber: await storage.getNextSessionNumber(campaign.userId, campaignId),
@@ -34,10 +40,6 @@ export const POST = withAuthAndParams<Params>(async (_request, _auth, { id: camp
     };
 
     await storage.saveSessionLog(log);
-    const claimed = await storage.claimActiveCampaignSession(campaignId, campaign.userId, log.id);
-    if (!claimed) {
-      return NextResponse.json({ error: 'A session is already active' }, { status: 409 });
-    }
 
     return NextResponse.json(log, { status: 201 });
   } catch (error) {
@@ -61,7 +63,7 @@ export const DELETE = withAuthAndParams<Params>(async (request, _auth, { id: cam
     }
 
     const closedSessionId = campaign.activeSessionId ?? null;
-    if (campaign.activeSessionId) {
+    if (force || campaign.activeSessionId) {
       await storage.setActiveCampaignSession(campaignId, campaign.userId, null);
     }
 

--- a/app/api/campaigns/[id]/sessions/active/route.ts
+++ b/app/api/campaigns/[id]/sessions/active/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+import { SessionLog } from '@/lib/types';
+import { assertCampaignAccess } from '@/lib/utils/campaign';
+
+type Params = { id: string };
+
+export const POST = withAuthAndParams<Params>(async (_request, _auth, { id: campaignId }) => {
+  try {
+    const result = await assertCampaignAccess(campaignId, _auth.userId);
+    if (result instanceof NextResponse) return result;
+    const { campaign, role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+
+    if (campaign.activeSessionId) {
+      return NextResponse.json({ error: 'A session is already active' }, { status: 409 });
+    }
+
+    const now = new Date();
+    const log: SessionLog = {
+      id: crypto.randomUUID(),
+      userId: campaign.userId,
+      campaignId,
+      sessionNumber: await storage.getNextSessionNumber(campaign.userId, campaignId),
+      datePlayed: now,
+      title: undefined,
+      summary: undefined,
+      events: [],
+      milestone: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await storage.saveSessionLog(log);
+    await storage.setActiveCampaignSession(campaignId, log.id);
+
+    return NextResponse.json(log, { status: 201 });
+  } catch (error) {
+    console.error('Error opening active session:', error);
+    return NextResponse.json({ error: 'Failed to open active session' }, { status: 500 });
+  }
+});
+
+export const DELETE = withAuthAndParams<Params>(async (request, _auth, { id: campaignId }) => {
+  try {
+    const result = await assertCampaignAccess(campaignId, _auth.userId);
+    if (result instanceof NextResponse) return result;
+    const { campaign, role } = result;
+
+    if (role !== 'dm') return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+
+    const force = new URL(request.url).searchParams.get('force') === 'true';
+
+    if (!force && !campaign.activeSessionId) {
+      return NextResponse.json({ error: 'No active session' }, { status: 404 });
+    }
+
+    const closedSessionId = campaign.activeSessionId ?? null;
+    await storage.setActiveCampaignSession(campaignId, null);
+
+    return NextResponse.json({ sessionId: closedSessionId });
+  } catch (error) {
+    console.error('Error closing active session:', error);
+    return NextResponse.json({ error: 'Failed to close active session' }, { status: 500 });
+  }
+});

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -337,6 +337,22 @@ export const storage = {
     }
   },
 
+  async claimActiveCampaignSession(campaignId: string, sessionId: string): Promise<boolean> {
+    try {
+      const db = await getDatabase();
+      const result = await db
+        .collection<Campaign>("campaigns")
+        .updateOne(
+          { id: campaignId, $or: [{ activeSessionId: null }, { activeSessionId: { $exists: false } }] },
+          { $set: { activeSessionId: sessionId, updatedAt: new Date() } }
+        );
+      return result.modifiedCount === 1;
+    } catch (error) {
+      console.error("Error claiming active campaign session:", error);
+      throw error;
+    }
+  },
+
   // Load all session data for a user
   async load(userId: string): Promise<SessionData> {
     try {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -322,14 +322,14 @@ export const storage = {
     }
   },
 
-  async setActiveCampaignSession(campaignId: string, sessionId: string | null): Promise<void> {
+  async setActiveCampaignSession(campaignId: string, userId: string, sessionId: string | null): Promise<void> {
     try {
       const db = await getDatabase();
       await db
         .collection<Campaign>("campaigns")
         .updateOne(
-          { id: campaignId },
-          { $set: { activeSessionId: sessionId ?? null, updatedAt: new Date() } }
+          { id: campaignId, userId },
+          { $set: { activeSessionId: sessionId, updatedAt: new Date() } }
         );
     } catch (error) {
       console.error("Error setting active campaign session:", error);
@@ -337,13 +337,13 @@ export const storage = {
     }
   },
 
-  async claimActiveCampaignSession(campaignId: string, sessionId: string): Promise<boolean> {
+  async claimActiveCampaignSession(campaignId: string, userId: string, sessionId: string): Promise<boolean> {
     try {
       const db = await getDatabase();
       const result = await db
         .collection<Campaign>("campaigns")
         .updateOne(
-          { id: campaignId, $or: [{ activeSessionId: null }, { activeSessionId: { $exists: false } }] },
+          { id: campaignId, userId, $or: [{ activeSessionId: null }, { activeSessionId: { $exists: false } }] },
           { $set: { activeSessionId: sessionId, updatedAt: new Date() } }
         );
       return result.modifiedCount === 1;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -322,6 +322,21 @@ export const storage = {
     }
   },
 
+  async setActiveCampaignSession(campaignId: string, sessionId: string | null): Promise<void> {
+    try {
+      const db = await getDatabase();
+      await db
+        .collection<Campaign>("campaigns")
+        .updateOne(
+          { id: campaignId },
+          { $set: { activeSessionId: sessionId ?? null, updatedAt: new Date() } }
+        );
+    } catch (error) {
+      console.error("Error setting active campaign session:", error);
+      throw error;
+    }
+  },
+
   // Load all session data for a user
   async load(userId: string): Promise<SessionData> {
     try {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -562,6 +562,7 @@ export interface Campaign {
   notes: string;
   createdAt: Date;
   updatedAt: Date;
+  activeSessionId?: string | null;
 }
 
 export interface PartyMember {

--- a/openspec/changes/campaign-active-session-lifecycle/.openspec.yaml
+++ b/openspec/changes/campaign-active-session-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-09

--- a/openspec/changes/campaign-active-session-lifecycle/design.md
+++ b/openspec/changes/campaign-active-session-lifecycle/design.md
@@ -30,14 +30,14 @@
 
 ### Decision 2: `setActiveCampaignSession` atomic `updateOne`
 
-- Chosen: `db.collection("campaigns").updateOne({ id: campaignId }, { $set: { activeSessionId: sessionId ?? null, updatedAt: new Date() } })`.
+- Chosen: `db.collection("campaigns").updateOne({ id: campaignId, userId }, { $set: { activeSessionId: sessionId, updatedAt: new Date() } })`.
 - Alternatives considered: Reuse `saveCampaign` full-upsert.
-- Rationale: Full upsert risks clobbering concurrent field changes (e.g., a DM editing campaign notes mid-session). Targeted `updateOne` on a single field is safe under concurrent writes.
+- Rationale: Full upsert risks clobbering concurrent field changes (e.g., a DM editing campaign notes mid-session). Targeted `updateOne` on a single field is safe under concurrent writes. Including `userId` in the filter is consistent with other multi-tenant storage methods (e.g., `saveCampaign`) and ensures ownership enforcement.
 - Trade-offs: Adds one new storage method; minimal overhead.
 
 ### Decision 3: Force-reset via `DELETE ?force=true`
 
-- Chosen: `DELETE /api/campaigns/:id/sessions/active?force=true` skips the "nothing to close" 404 check and unconditionally calls `setActiveCampaignSession(campaignId, null)`.
+- Chosen: `DELETE /api/campaigns/:id/sessions/active?force=true` skips the "nothing to close" 404 check and unconditionally calls `setActiveCampaignSession(campaignId, campaign.userId, null)`.
 - Alternatives considered: Separate `POST .../active/reset` endpoint; `PATCH` endpoint.
 - Rationale: DELETE is semantically correct (you are deleting the active session pointer). `?force=true` is a minimal, discoverable escape hatch without adding a new route. Keeps the surface small.
 - Trade-offs: Callers must know to use `?force=true`; no UI currently surfaces this. Acceptable because this is an operator/DM escape hatch, not a normal flow.

--- a/openspec/changes/campaign-active-session-lifecycle/design.md
+++ b/openspec/changes/campaign-active-session-lifecycle/design.md
@@ -1,0 +1,170 @@
+## Context
+
+- Relevant architecture: Next.js App Router API routes, MongoDB via `lib/storage.ts`, `withAuthAndParams` auth wrapper, `assertCampaignAccess` role helper, `SessionLog` and `Campaign` types in `lib/types.ts`.
+- Dependencies: `lib/storage.ts` (MongoDB), `lib/types.ts`, `lib/utils/campaign.ts` (`assertCampaignAccess`), existing sessions route at `app/api/campaigns/[id]/sessions/route.ts`.
+- Interfaces/contracts touched: `Campaign` interface (new field), `IStorage` (new method), new route file.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add `activeSessionId` to `Campaign` type and persist it atomically.
+- Expose POST/DELETE endpoints to open and close an active session.
+- Provide a force-reset escape hatch for stale `activeSessionId`.
+- Ensure `GET /api/campaigns/:id` reflects `activeSessionId` without code changes to the GET handler.
+
+### Non-Goals
+
+- UI controls for open/close/reset.
+- Automatic session expiry or timeout.
+- Real-time presence or WebSocket events.
+
+## Decisions
+
+### Decision 1: `null` over `$unset` for clearing `activeSessionId`
+
+- Chosen: `$set: { activeSessionId: null }` when closing a session.
+- Alternatives considered: `$unset: { activeSessionId: 1 }` to remove the field from the document.
+- Rationale: `GET /api/campaigns/:id` returns the full `Campaign` object. Using `null` means the field is always present and explicitly signals "no active session," matching the TypeScript `activeSessionId?: string` type (absent = undefined in new docs, null = explicitly cleared). Avoids ambiguity between "field never set" and "field was cleared."
+- Trade-offs: `null` is a valid string-ish value in some contexts; callers must check `!= null` not just `!= undefined`. Acceptable given the field is typed `string | undefined` and stored as `string | null` in Mongo.
+
+### Decision 2: `setActiveCampaignSession` atomic `updateOne`
+
+- Chosen: `db.collection("campaigns").updateOne({ id: campaignId }, { $set: { activeSessionId: sessionId ?? null, updatedAt: new Date() } })`.
+- Alternatives considered: Reuse `saveCampaign` full-upsert.
+- Rationale: Full upsert risks clobbering concurrent field changes (e.g., a DM editing campaign notes mid-session). Targeted `updateOne` on a single field is safe under concurrent writes.
+- Trade-offs: Adds one new storage method; minimal overhead.
+
+### Decision 3: Force-reset via `DELETE ?force=true`
+
+- Chosen: `DELETE /api/campaigns/:id/sessions/active?force=true` skips the "nothing to close" 404 check and unconditionally calls `setActiveCampaignSession(campaignId, null)`.
+- Alternatives considered: Separate `POST .../active/reset` endpoint; `PATCH` endpoint.
+- Rationale: DELETE is semantically correct (you are deleting the active session pointer). `?force=true` is a minimal, discoverable escape hatch without adding a new route. Keeps the surface small.
+- Trade-offs: Callers must know to use `?force=true`; no UI currently surfaces this. Acceptable because this is an operator/DM escape hatch, not a normal flow.
+
+### Decision 4: `POST` creates `SessionLog` with `datePlayed: new Date()`
+
+- Chosen: Auto-set `datePlayed` to the current timestamp at open time. DM patches it post-session via existing `PATCH /api/campaigns/:id/sessions/:sessionId`.
+- Alternatives considered: Require `datePlayed` in the POST body (as existing manual session creation does).
+- Rationale: "Open session now" is a real-time action; the date is known. Requiring a body field adds friction for a live-session workflow.
+- Trade-offs: If the DM opens at 11:50 PM and plays until 2 AM, the `datePlayed` is technically "the previous day." The PATCH corrects this.
+
+### Decision 5: 409 guard on concurrent POST
+
+- Chosen: If `campaign.activeSessionId` is already set (non-null), return 409 with `{ error: 'A session is already active' }`.
+- Alternatives considered: Silently overwrite (unsafe), return 200 with existing session.
+- Rationale: A stale open session means something went wrong. Silent overwrite would orphan the previous `activeSessionId` and leave rolls potentially stamped against a ghost session. 409 forces the DM to explicitly close first.
+- Trade-offs: Requires the force-reset escape hatch (Decision 3) for recovery.
+
+## Proposal to Design Mapping
+
+- Proposal element: `null` over `$unset` for clearing
+  - Design decision: Decision 1
+  - Validation approach: Unit test — after DELETE, `GET /api/campaigns/:id` returns `activeSessionId: null`.
+
+- Proposal element: Atomic targeted updater
+  - Design decision: Decision 2
+  - Validation approach: Storage unit test — `setActiveCampaignSession` calls `updateOne` with correct `$set` payload.
+
+- Proposal element: Force-reset for stale sessions
+  - Design decision: Decision 3
+  - Validation approach: Integration test — POST to set, crash without DELETE, POST again hits 409, then `DELETE ?force=true` clears, then POST succeeds.
+
+- Proposal element: `datePlayed` defaults to now
+  - Design decision: Decision 4
+  - Validation approach: Integration test — returned `SessionLog.datePlayed` is close to `Date.now()`.
+
+- Proposal element: 409 guard
+  - Design decision: Decision 5
+  - Validation approach: Integration test — double POST returns 409.
+
+## Functional Requirements Mapping
+
+- Requirement: `Campaign` type includes `activeSessionId?: string`
+  - Design element: `lib/types.ts` Campaign interface
+  - Acceptance criteria reference: AC-1 (type compiles)
+  - Testability notes: TypeScript compile check; no runtime test needed.
+
+- Requirement: POST creates SessionLog and sets `activeSessionId`
+  - Design element: POST handler, `setActiveCampaignSession`, `storage.saveSessionLog`
+  - Acceptance criteria reference: AC-2
+  - Testability notes: Integration test — POST 201, then GET campaign shows `activeSessionId` equal to returned session id.
+
+- Requirement: Double POST returns 409
+  - Design element: POST handler 409 guard (Decision 5)
+  - Acceptance criteria reference: AC-3
+  - Testability notes: Integration test — two consecutive POSTs, second returns 409.
+
+- Requirement: DELETE clears `activeSessionId`
+  - Design element: DELETE handler, `setActiveCampaignSession(id, null)`
+  - Acceptance criteria reference: AC-4
+  - Testability notes: Integration test — after DELETE, GET campaign shows `activeSessionId: null`.
+
+- Requirement: DELETE with no active session returns 404
+  - Design element: DELETE handler null-check
+  - Acceptance criteria reference: AC-5
+  - Testability notes: Integration test — DELETE on fresh campaign returns 404.
+
+- Requirement: Non-DM gets 404
+  - Design element: `assertCampaignAccess` + role check in both handlers
+  - Acceptance criteria reference: AC-6
+  - Testability notes: Integration test with member role token.
+
+- Requirement: Unauthenticated gets 401
+  - Design element: `withAuthAndParams` wrapper
+  - Acceptance criteria reference: AC-7
+  - Testability notes: Integration test — no auth header → 401.
+
+- Requirement: Closed SessionLog remains retrievable
+  - Design element: DELETE only clears pointer, does not delete `SessionLog` document
+  - Acceptance criteria reference: AC-8
+  - Testability notes: After DELETE, `GET /api/campaigns/:id/sessions` still includes the session.
+
+- Requirement: Force-reset clears stale `activeSessionId`
+  - Design element: `DELETE ?force=true` bypass (Decision 3)
+  - Acceptance criteria reference: AC-9
+  - Testability notes: Integration test — POST, then `DELETE ?force=true`, then POST succeeds (not 409).
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: `setActiveCampaignSession` must not clobber concurrent field writes.
+  - Design element: Atomic `updateOne $set` (Decision 2)
+  - Acceptance criteria reference: Implicit (no data loss)
+  - Testability notes: Code review; targeted update verified in storage unit test.
+
+- Requirement category: operability
+  - Requirement: Stale open sessions must be recoverable without manual DB intervention.
+  - Design element: `DELETE ?force=true` escape hatch (Decision 3)
+  - Acceptance criteria reference: AC-9
+  - Testability notes: Integration test for force-reset path.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `null` vs `undefined` ambiguity for callers reading `activeSessionId`
+  - Impact: Callers may use `if (campaign.activeSessionId)` safely (null and undefined are both falsy), but strict `=== undefined` checks would break.
+  - Mitigation: TypeScript type is `string | undefined`; Mongo stores `string | null`. Document the distinction in the storage method. Callers should use `!= null` for explicit checks.
+
+- Risk/trade-off: `active` literal segment vs `[sessionId]` dynamic segment routing
+  - Impact: If Next.js resolves `active` as a session ID, the wrong handler fires.
+  - Mitigation: Next.js prefers literal segments; confirmed no conflict. Covered by integration tests.
+
+## Rollback / Mitigation
+
+- Rollback trigger: POST/DELETE returns 500 in production; `activeSessionId` stuck in bad state.
+- Rollback steps:
+  1. Deploy previous build (removes new endpoints — they return 404).
+  2. Manually clear `activeSessionId` via MongoDB shell: `db.campaigns.updateOne({ id: "<id>" }, { $unset: { activeSessionId: 1 } })`.
+- Data migration considerations: `activeSessionId` is additive and optional. No migration needed for existing documents.
+- Verification after rollback: `GET /api/campaigns/:id` no longer returns `activeSessionId` in the response (field absent from type after rollback).
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check. No bypass with `--no-verify` or skip flags.
+- If security checks fail: Do not merge. Investigate and resolve before proceeding.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours. Escalate to team lead after 48 hours.
+- Escalation path and timeout: If blocked > 48 hours with no response, escalate to project maintainer.
+
+## Open Questions
+
+No open questions. All decisions resolved during exploration phase. See proposal.md for decision rationale.

--- a/openspec/changes/campaign-active-session-lifecycle/proposal.md
+++ b/openspec/changes/campaign-active-session-lifecycle/proposal.md
@@ -51,7 +51,7 @@
 - `lib/storage.ts`: Add `setActiveCampaignSession` method using `$set` with atomic `updateOne`.
 - `app/api/campaigns/[id]/sessions/active/route.ts`: New file with `POST` and `DELETE` handlers.
   - `POST`: DM-only, 409 if already active, creates `SessionLog`, sets `activeSessionId`, returns 201.
-  - `DELETE`: DM-only, 404 if none active, clears `activeSessionId`, returns 200 `{ sessionId }`. Accepts `?force=true` to skip 409 guard (for stale reset only — DELETE has nothing to 409, but POST guard is bypassed on force-reset path via a separate `POST ?force=true`).
+  - `DELETE`: DM-only, 404 if none active, clears `activeSessionId`, returns 200 `{ sessionId }`. Accepts `?force=true` to unconditionally clear `activeSessionId` (escape hatch for stale state).
 
 ## Risks
 

--- a/openspec/changes/campaign-active-session-lifecycle/proposal.md
+++ b/openspec/changes/campaign-active-session-lifecycle/proposal.md
@@ -32,7 +32,7 @@
 ### In Scope
 
 - Add `activeSessionId?: string` to `Campaign` interface (`lib/types.ts`).
-- Add `setActiveCampaignSession(campaignId, sessionId | null)` to `lib/storage.ts`.
+- Add `setActiveCampaignSession(campaignId, userId, sessionId | null)` and `claimActiveCampaignSession(campaignId, userId, sessionId)` to `lib/storage.ts`.
 - New route file `app/api/campaigns/[id]/sessions/active/route.ts` with `POST` (open) and `DELETE` (close) handlers.
 - `DELETE` with `?force=true` query parameter to bypass the 409 guard and force-clear a stale `activeSessionId` (reset path).
 - Verify `GET /api/campaigns/:id` automatically includes `activeSessionId` once the type and storage are updated.

--- a/openspec/changes/campaign-active-session-lifecycle/proposal.md
+++ b/openspec/changes/campaign-active-session-lifecycle/proposal.md
@@ -1,0 +1,87 @@
+## GitHub Issues
+
+- #400
+
+## Why
+
+- Problem statement: The `campaignRolls` API (#316) needs to stamp each roll against the correct `SessionLog`. There is no mechanism to mark which session is currently live, so rolls cannot be auto-associated with the right session.
+- Why now: Issue #400 is the direct prerequisite for #316 (6a). Phase 6 progress is blocked until this field and its open/close API exist.
+- Business/user impact: Without `activeSessionId`, the DM has no way to signal "a session is in progress now," and the rolls API cannot function correctly.
+
+## Problem Space
+
+- Current behavior: `Campaign` has no `activeSessionId` field. There is no API to open or close a session. Session logs can be created manually via `POST /api/campaigns/:id/sessions` but there is no concept of a "live" session.
+- Desired behavior: The DM can open a session (POST), which creates a `SessionLog` and stamps `campaign.activeSessionId`. The DM can close it (DELETE), which clears the field. `GET /api/campaigns/:id` reflects the current `activeSessionId` (null when none is active). A reset path exists to force-clear a stuck `activeSessionId` without triggering the 409 guard.
+- Constraints:
+  - The `setActiveCampaignSession` storage method must be a targeted atomic `updateOne` — not a full `saveCampaign` upsert — to avoid clobbering concurrent writes.
+  - `activeSessionId` is set to `null` (not `$unset`) so `GET` responses include the field explicitly, and `normalizeCampaign` round-trips stay consistent.
+  - No UI is in scope for this issue.
+- Assumptions:
+  - `normalizeCampaign` spread-then-overwrite passes `activeSessionId` through untouched; no normalization change is needed.
+  - `getNextSessionNumber` is already implemented and can be called directly.
+  - Next.js static segment `active` takes precedence over dynamic `[sessionId]` — no routing conflict.
+- Edge cases considered:
+  - DM calls POST when a session is already open → 409 Conflict.
+  - DM calls DELETE when no session is open → 404.
+  - Non-DM member calls either endpoint → 404 (matches existing DM-gate pattern).
+  - Unauthenticated request → 401 (handled by `withAuthAndParams`).
+  - Stale open session (DM crashed mid-session): DM needs a force-reset path to clear without hitting 409.
+
+## Scope
+
+### In Scope
+
+- Add `activeSessionId?: string` to `Campaign` interface (`lib/types.ts`).
+- Add `setActiveCampaignSession(campaignId, sessionId | null)` to `lib/storage.ts`.
+- New route file `app/api/campaigns/[id]/sessions/active/route.ts` with `POST` (open) and `DELETE` (close) handlers.
+- `DELETE` with `?force=true` query parameter to bypass the 409 guard and force-clear a stale `activeSessionId` (reset path).
+- Verify `GET /api/campaigns/:id` automatically includes `activeSessionId` once the type and storage are updated.
+- Unit and integration tests for all acceptance criteria.
+
+### Out of Scope
+
+- UI for open/close/reset (deferred to issue 6b, #317).
+- `campaignRolls` API (#316) — depends on this issue.
+- Any changes to `normalizeCampaign` beyond confirming pass-through behavior.
+- Editing `datePlayed` post-session (already covered by existing `PATCH /api/campaigns/:id/sessions/:sessionId`).
+
+## What Changes
+
+- `lib/types.ts`: Add `activeSessionId?: string` to `Campaign` after `updatedAt`.
+- `lib/storage.ts`: Add `setActiveCampaignSession` method using `$set` with atomic `updateOne`.
+- `app/api/campaigns/[id]/sessions/active/route.ts`: New file with `POST` and `DELETE` handlers.
+  - `POST`: DM-only, 409 if already active, creates `SessionLog`, sets `activeSessionId`, returns 201.
+  - `DELETE`: DM-only, 404 if none active, clears `activeSessionId`, returns 200 `{ sessionId }`. Accepts `?force=true` to skip 409 guard (for stale reset only — DELETE has nothing to 409, but POST guard is bypassed on force-reset path via a separate `POST ?force=true`).
+
+## Risks
+
+- Risk: Stale `activeSessionId` (DM process died, client never called DELETE).
+  - Impact: DM cannot start a new session; stuck at 409.
+  - Mitigation: `DELETE ?force=true` (or `POST ?force=true`) provides a reset escape hatch. Documented in API.
+
+- Risk: `normalizeCampaign` inadvertently strips `activeSessionId` if the field is absent in legacy docs.
+  - Impact: Field silently disappears after a round-trip.
+  - Mitigation: Confirmed spread-then-overwrite passes optional fields through. Test round-trip in normalization unit tests.
+
+- Risk: `active` segment conflicts with dynamic `[sessionId]` route.
+  - Impact: Route resolution error in Next.js.
+  - Mitigation: Next.js gives literal segments priority over dynamic ones. Verified no conflict.
+
+## Open Questions
+
+No unresolved ambiguity remains. Decisions made during exploration:
+- `null` (not `$unset`) used for clearing — GET returns `activeSessionId: null` explicitly.
+- 409 guard kept; reset path is `DELETE ?force=true` to handle stale sessions.
+- `datePlayed` defaults to `new Date()` at open time; DM patches post-session if needed.
+
+## Non-Goals
+
+- Real-time session presence or WebSocket notifications.
+- Automatic session expiry or timeout.
+- Multi-session concurrency (only one active session per campaign at a time by design).
+- UI open/close controls (6b).
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/campaign-active-session-lifecycle/specs/active-session-lifecycle/spec.md
+++ b/openspec/changes/campaign-active-session-lifecycle/specs/active-session-lifecycle/spec.md
@@ -1,0 +1,186 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED `Campaign.activeSessionId` field
+
+The system SHALL include `activeSessionId?: string` on the `Campaign` type and persist it atomically in MongoDB.
+
+#### Scenario: Field present after session opened
+
+- **Given** a Campaign exists with no active session
+- **When** a DM calls `POST /api/campaigns/:id/sessions/active`
+- **Then** `GET /api/campaigns/:id` returns the Campaign with `activeSessionId` equal to the newly created `SessionLog.id`
+
+#### Scenario: Field is null after session closed
+
+- **Given** a Campaign has an active session (`activeSessionId` is set)
+- **When** a DM calls `DELETE /api/campaigns/:id/sessions/active`
+- **Then** `GET /api/campaigns/:id` returns the Campaign with `activeSessionId: null`
+
+---
+
+### Requirement: ADDED `POST /api/campaigns/:id/sessions/active` — open session
+
+The system SHALL create a new `SessionLog` and set `campaign.activeSessionId` when a DM opens a session.
+
+#### Scenario: DM opens session successfully
+
+- **Given** an authenticated DM member of the campaign with no active session
+- **When** `POST /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 201
+- **And** the response body is the new `SessionLog` with `datePlayed` approximately equal to `Date.now()` (within 5 seconds)
+- **And** `GET /api/campaigns/:id` shows `activeSessionId` matching the returned `SessionLog.id`
+
+#### Scenario: Conflict — session already active
+
+- **Given** an authenticated DM with an active session already open
+- **When** `POST /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 409
+- **And** the response body is `{ "error": "A session is already active" }`
+- **And** the existing `activeSessionId` is unchanged
+
+#### Scenario: Non-DM member is rejected
+
+- **Given** an authenticated campaign member with role `player`
+- **When** `POST /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 404
+
+#### Scenario: Unauthenticated request rejected
+
+- **Given** no authentication credentials
+- **When** `POST /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 401
+
+---
+
+### Requirement: ADDED `DELETE /api/campaigns/:id/sessions/active` — close session
+
+The system SHALL clear `campaign.activeSessionId` when a DM closes the active session, and SHALL return the closed session's ID.
+
+#### Scenario: DM closes active session successfully
+
+- **Given** an authenticated DM with an active session open
+- **When** `DELETE /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 200
+- **And** the response body is `{ "sessionId": "<closed-session-id>" }`
+- **And** `GET /api/campaigns/:id` returns `activeSessionId: null`
+
+#### Scenario: No active session — 404
+
+- **Given** an authenticated DM with no active session (`activeSessionId` is null or absent)
+- **When** `DELETE /api/campaigns/:id/sessions/active` is called (without `?force=true`)
+- **Then** the response status is 404
+
+#### Scenario: Non-DM member is rejected
+
+- **Given** an authenticated campaign member with role `player`
+- **When** `DELETE /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 404
+
+#### Scenario: Unauthenticated request rejected
+
+- **Given** no authentication credentials
+- **When** `DELETE /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 401
+
+---
+
+### Requirement: ADDED `DELETE ?force=true` — force-reset stale active session
+
+The system SHALL unconditionally clear `activeSessionId` when `?force=true` is passed to `DELETE`, bypassing the "no active session" 404 guard.
+
+#### Scenario: Force-reset clears stale `activeSessionId`
+
+- **Given** an authenticated DM whose campaign has a stale `activeSessionId` (e.g., previous session never closed)
+- **When** `DELETE /api/campaigns/:id/sessions/active?force=true` is called
+- **Then** the response status is 200
+- **And** `GET /api/campaigns/:id` returns `activeSessionId: null`
+
+#### Scenario: Force-reset when no active session is a no-op success
+
+- **Given** an authenticated DM with no active session
+- **When** `DELETE /api/campaigns/:id/sessions/active?force=true` is called
+- **Then** the response status is 200
+- **And** `GET /api/campaigns/:id` returns `activeSessionId: null`
+
+#### Scenario: After force-reset, DM can open a new session
+
+- **Given** a stale `activeSessionId` was just force-reset via `DELETE ?force=true`
+- **When** `POST /api/campaigns/:id/sessions/active` is called
+- **Then** the response status is 201 (not 409)
+
+---
+
+### Requirement: ADDED `SessionLog` persisted independently of active session pointer
+
+The system SHALL NOT delete the `SessionLog` document when `activeSessionId` is cleared.
+
+#### Scenario: Session log remains after close
+
+- **Given** a DM has opened and then closed an active session
+- **When** `GET /api/campaigns/:id/sessions` is called
+- **Then** the closed `SessionLog` is present in the response
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `normalizeCampaign` passes through `activeSessionId`
+
+The system SHALL continue to normalize campaign documents correctly when `activeSessionId` is absent or null.
+
+#### Scenario: Normalization pass-through for absent field
+
+- **Given** a legacy campaign document with no `activeSessionId` field
+- **When** `normalizeCampaign` processes it
+- **Then** the result does not include `activeSessionId` (field remains absent)
+
+#### Scenario: Normalization pass-through for null value
+
+- **Given** a campaign document where `activeSessionId` is `null`
+- **When** `normalizeCampaign` processes it
+- **Then** the result preserves `activeSessionId: null`
+
+---
+
+## REMOVED Requirements
+
+None.
+
+---
+
+## Traceability
+
+- Proposal: `activeSessionId` field → Requirement: ADDED `Campaign.activeSessionId` field
+- Proposal: POST open → Requirement: ADDED `POST .../active`
+- Proposal: DELETE close → Requirement: ADDED `DELETE .../active`
+- Proposal: Force-reset escape hatch → Requirement: ADDED `DELETE ?force=true`
+- Proposal: SessionLog not deleted on close → Requirement: ADDED SessionLog persists independently
+- Proposal: normalizeCampaign pass-through → Requirement: MODIFIED normalizeCampaign
+- Design Decision 1 (null over $unset) → Scenarios: "Field is null after session closed", "Force-reset" scenarios
+- Design Decision 2 (atomic updateOne) → Testability notes in design.md
+- Design Decision 3 (force-reset) → Requirement: ADDED `DELETE ?force=true`
+- Design Decision 4 (datePlayed = now) → Scenario: "DM opens session successfully" (datePlayed ≈ Date.now())
+- Design Decision 5 (409 guard) → Scenario: "Conflict — session already active"
+- Requirements → Tasks: all in tasks.md
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios:
+- "Non-DM member is rejected" (POST and DELETE)
+- "Unauthenticated request rejected" (POST and DELETE)
+
+No additional security properties. `activeSessionId` is not a secret token; it is a foreign key to a `SessionLog.id` that the DM created. Error bodies do not expose internal DB state.
+
+### Requirement: Reliability
+
+#### Scenario: Concurrent write safety
+
+- **Given** `setActiveCampaignSession` is called concurrently with another field update on the same campaign document
+- **When** the atomic `updateOne $set` completes
+- **Then** only `activeSessionId` and `updatedAt` are modified; all other campaign fields retain their values

--- a/openspec/changes/campaign-active-session-lifecycle/tasks.md
+++ b/openspec/changes/campaign-active-session-lifecycle/tasks.md
@@ -98,8 +98,8 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 - [x] Commit all changes to `feat/campaign-active-session-lifecycle` and push to remote
 - [x] Open PR from `feat/campaign-active-session-lifecycle` to `main`. PR body must include `Closes #400`.
 - [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
-- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass
 - [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
 

--- a/openspec/changes/campaign-active-session-lifecycle/tasks.md
+++ b/openspec/changes/campaign-active-session-lifecycle/tasks.md
@@ -14,8 +14,8 @@
 
 ### Task 2 — Add `setActiveCampaignSession` to storage
 
-- [x] In `lib/storage.ts`, add method `setActiveCampaignSession(campaignId: string, sessionId: string | null): Promise<void>`.
-- [x] Implementation: `db.collection("campaigns").updateOne({ id: campaignId }, { $set: { activeSessionId: sessionId ?? null, updatedAt: new Date() } })`.
+- [x] In `lib/storage.ts`, add method `setActiveCampaignSession(campaignId: string, userId: string, sessionId: string | null): Promise<void>`.
+- [x] Implementation: `db.collection("campaigns").updateOne({ id: campaignId, userId }, { $set: { activeSessionId: sessionId, updatedAt: new Date() } })`.
 - [x] Ensure the method signature is added to the storage interface/type if one exists.
 - [x] Verify TypeScript compiles: `npx tsc --noEmit`
 

--- a/openspec/changes/campaign-active-session-lifecycle/tasks.md
+++ b/openspec/changes/campaign-active-session-lifecycle/tasks.md
@@ -1,0 +1,133 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/campaign-active-session-lifecycle` then immediately `git push -u origin feat/campaign-active-session-lifecycle`
+
+## Execution
+
+### Task 1 — Add `activeSessionId` to `Campaign` type
+
+- [x] In `lib/types.ts`, add `activeSessionId?: string` to the `Campaign` interface after `updatedAt` (line ~564).
+- [x] Verify TypeScript compiles: `npx tsc --noEmit`
+
+### Task 2 — Add `setActiveCampaignSession` to storage
+
+- [x] In `lib/storage.ts`, add method `setActiveCampaignSession(campaignId: string, sessionId: string | null): Promise<void>`.
+- [x] Implementation: `db.collection("campaigns").updateOne({ id: campaignId }, { $set: { activeSessionId: sessionId ?? null, updatedAt: new Date() } })`.
+- [x] Ensure the method signature is added to the storage interface/type if one exists.
+- [x] Verify TypeScript compiles: `npx tsc --noEmit`
+
+### Task 3 — Verify `normalizeCampaign` pass-through
+
+- [x] Confirm `normalizeCampaign` in `lib/storage.ts` (line ~54) passes `activeSessionId` through correctly when absent or null (spread-then-overwrite pattern; no code change expected).
+- [x] Add a unit test confirming both cases (absent → absent, null → null).
+
+### Task 4 — Create `app/api/campaigns/[id]/sessions/active/route.ts`
+
+- [x] Create directory `app/api/campaigns/[id]/sessions/active/`.
+- [x] Create `route.ts` with `POST` handler:
+  - Call `assertCampaignAccess`; return result if it's a `NextResponse`.
+  - Reject non-DM with 404.
+  - If `campaign.activeSessionId` is set (non-null), return 409 `{ error: 'A session is already active' }`.
+  - Build `SessionLog`: `id: crypto.randomUUID()`, `userId: campaign.userId`, `campaignId`, `sessionNumber: await storage.getNextSessionNumber(campaign.userId, campaignId)`, `datePlayed: new Date()`, `title: undefined`, `summary: undefined`, `events: []`, `milestone: false`, `createdAt: now`, `updatedAt: now`.
+  - Call `storage.saveSessionLog(log)`.
+  - Call `storage.setActiveCampaignSession(campaignId, log.id)`.
+  - Return 201 with the new `SessionLog`.
+- [x] Create `DELETE` handler in the same file:
+  - Call `assertCampaignAccess`; return result if it's a `NextResponse`.
+  - Reject non-DM with 404.
+  - Read `force` query param: `const force = new URL(request.url).searchParams.get('force') === 'true'`.
+  - If `!force` and `!campaign.activeSessionId`, return 404.
+  - Capture `const closedSessionId = campaign.activeSessionId` (may be null for force path).
+  - Call `storage.setActiveCampaignSession(campaignId, null)`.
+  - Return 200 `{ sessionId: closedSessionId }`.
+- [x] Verify TypeScript compiles: `npx tsc --noEmit`
+
+### Task 5 — Write unit tests for storage method
+
+- [x] In the relevant storage unit test file, add tests for `setActiveCampaignSession`:
+  - Sets `activeSessionId` to the given string.
+  - Sets `activeSessionId` to `null` when `null` is passed.
+  - Updates `updatedAt`.
+  - Uses `updateOne` (not full upsert).
+
+### Task 6 — Write integration tests for the new endpoints
+
+Following all acceptance criteria in `openspec/changes/campaign-active-session-lifecycle/specs/active-session-lifecycle/spec.md`:
+
+- [x] POST success → 201, `SessionLog` returned, `GET` campaign shows `activeSessionId` matching.
+- [x] POST with active session → 409 `{ error: 'A session is already active' }`.
+- [x] DELETE success → 200 `{ sessionId }`, `GET` campaign shows `activeSessionId: null`.
+- [x] DELETE with no active session → 404.
+- [x] DELETE `?force=true` with stale session → 200, `activeSessionId: null`.
+- [x] DELETE `?force=true` with no session → 200, `activeSessionId: null`.
+- [x] After force-reset, POST succeeds (201, not 409).
+- [x] SessionLog persists after DELETE: `GET /api/campaigns/:id/sessions` includes the closed session.
+- [x] Non-DM POST → 404.
+- [x] Non-DM DELETE → 404.
+- [x] Unauthenticated POST → 401.
+- [x] Unauthenticated DELETE → 401.
+- [x] `normalizeCampaign` with absent `activeSessionId` → field absent in result.
+- [x] `normalizeCampaign` with `null` `activeSessionId` → field is null in result.
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npx tsc --noEmit` — no type errors
+- [x] `npm run build` — build succeeds
+- [x] All acceptance criteria scenarios from `specs/active-session-lifecycle/spec.md` covered by tests
+- [x] All tasks marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- if **ANY** of the above fail, you **MUST** iterate and address the failure
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/campaign-active-session-lifecycle` and push to remote
+- [ ] Open PR from `feat/campaign-active-session-lifecycle` to `main`. PR body must include `Closes #400`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass
+- [ ] **Poll for merge** — after each iteration run `gh pr view <PR-URL> --json state`; when `state` is `MERGED` proceed to Post-Merge; if `CLOSED` exit and notify the user — **never wait for a human to report the merge**; **never force-merge**
+
+The comment and CI resolution loops are iterative: address → validate locally → push → wait 180 seconds → re-check → poll for merge → repeat until the PR merges.
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): agentic reviewers + dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (no doc changes expected for this issue)
+- [ ] Sync approved spec deltas into `openspec/specs/active-session-lifecycle/spec.md` (create if absent)
+- [ ] Archive the change: move `openspec/changes/campaign-active-session-lifecycle/` to `openspec/changes/archive/YYYY-MM-DD-campaign-active-session-lifecycle/` **and stage both the new location and the deletion of the old location in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-active-session-lifecycle/` exists and `openspec/changes/campaign-active-session-lifecycle/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle`
+- [ ] Open a PR from the doc branch to `main` with title `docs: archive campaign-active-session-lifecycle (YYYY-MM-DD)`. PR body: `Closes #400` (if not already closed by implementation PR).
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until it merges (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/campaign-active-session-lifecycle doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle`

--- a/openspec/changes/campaign-active-session-lifecycle/tasks.md
+++ b/openspec/changes/campaign-active-session-lifecycle/tasks.md
@@ -95,9 +95,9 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 ## PR and Merge
 
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `feat/campaign-active-session-lifecycle` and push to remote
-- [ ] Open PR from `feat/campaign-active-session-lifecycle` to `main`. PR body must include `Closes #400`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
+- [x] Commit all changes to `feat/campaign-active-session-lifecycle` and push to remote
+- [x] Open PR from `feat/campaign-active-session-lifecycle` to `main`. PR body must include `Closes #400`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
 - [ ] **Monitor PR comments** — poll for new comments autonomously; when comments appear, address them, commit fixes, and explicitly ensure threads are resolved. Follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until no unresolved comments remain
 - [ ] **Monitor CI checks** — poll for check status autonomously using `gh pr checks <PR-URL> --json isRequired,state`; when any **required (blocking)** CI check fails, diagnose and fix the failure, commit fixes, follow all steps in [Remote push validation] then push to the same working branch; wait 180 seconds then repeat until all required checks pass

--- a/openspec/changes/campaign-active-session-lifecycle/tests.md
+++ b/openspec/changes/campaign-active-session-lifecycle/tests.md
@@ -1,0 +1,120 @@
+---
+name: tests
+description: Tests for the campaign-active-session-lifecycle change
+---
+
+# Tests
+
+## Overview
+
+Tests for `campaign-active-session-lifecycle`. All work follows strict TDD: write a failing test first, then implement the minimum code to pass it, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — capture the requirement before writing implementation. Run the test; confirm it fails.
+2. **Write code to pass the test** — simplest code that makes the test green.
+3. **Refactor** — improve quality while keeping the test green.
+
+---
+
+## Test Cases
+
+### Task 2 — `setActiveCampaignSession` storage method
+
+- [ ] **T2.1** — `setActiveCampaignSession(campaignId, sessionId)` calls `updateOne` with `{ $set: { activeSessionId: sessionId, updatedAt: <Date> } }` and does NOT call `replaceOne` or `findOneAndReplace`.
+  - Spec: Requirement: ADDED `Campaign.activeSessionId` field / Concurrent write safety
+  - File: storage unit test
+
+- [ ] **T2.2** — `setActiveCampaignSession(campaignId, null)` calls `updateOne` with `{ $set: { activeSessionId: null, updatedAt: <Date> } }`.
+  - Spec: Scenario: "Field is null after session closed"
+  - File: storage unit test
+
+- [ ] **T2.3** — `setActiveCampaignSession` updates `updatedAt` to approximately `Date.now()`.
+  - Spec: Design Decision 2
+  - File: storage unit test
+
+---
+
+### Task 3 — `normalizeCampaign` pass-through
+
+- [ ] **T3.1** — `normalizeCampaign({ ...campaignWithoutActiveSessionId })` returns an object without `activeSessionId` key.
+  - Spec: Scenario: "Normalization pass-through for absent field"
+  - File: storage unit test
+
+- [ ] **T3.2** — `normalizeCampaign({ ...campaignWithActiveSessionIdNull })` returns object with `activeSessionId: null`.
+  - Spec: Scenario: "Normalization pass-through for null value"
+  - File: storage unit test
+
+---
+
+### Task 4 — `POST /api/campaigns/:id/sessions/active`
+
+- [ ] **T4.1** — POST by DM on campaign with no active session returns 201 and a valid `SessionLog` body.
+  - Spec: Scenario: "DM opens session successfully"
+  - File: `app/api/campaigns/[id]/sessions/active/route.test.ts`
+
+- [ ] **T4.2** — POST by DM: returned `SessionLog.datePlayed` is within 5 seconds of `Date.now()`.
+  - Spec: Scenario: "DM opens session successfully" (datePlayed ≈ Date.now())
+  - File: route integration test
+
+- [ ] **T4.3** — POST by DM: after success, `GET /api/campaigns/:id` returns `activeSessionId` equal to returned `SessionLog.id`.
+  - Spec: Scenario: "Field present after session opened"
+  - File: route integration test
+
+- [ ] **T4.4** — POST by DM when `activeSessionId` already set returns 409 `{ error: 'A session is already active' }` and does NOT modify `activeSessionId`.
+  - Spec: Scenario: "Conflict — session already active"
+  - File: route integration test
+
+- [ ] **T4.5** — POST by player (non-DM) member returns 404.
+  - Spec: Scenario: "Non-DM member is rejected" (POST)
+  - File: route integration test
+
+- [ ] **T4.6** — POST without auth returns 401.
+  - Spec: Scenario: "Unauthenticated request rejected" (POST)
+  - File: route integration test
+
+---
+
+### Task 4 — `DELETE /api/campaigns/:id/sessions/active`
+
+- [ ] **T4.7** — DELETE by DM with active session returns 200 `{ sessionId: "<id>" }`.
+  - Spec: Scenario: "DM closes active session successfully"
+  - File: route integration test
+
+- [ ] **T4.8** — DELETE by DM: after success, `GET /api/campaigns/:id` returns `activeSessionId: null`.
+  - Spec: Scenario: "Field is null after session closed"
+  - File: route integration test
+
+- [ ] **T4.9** — DELETE by DM with no active session (no `?force`) returns 404.
+  - Spec: Scenario: "No active session — 404"
+  - File: route integration test
+
+- [ ] **T4.10** — DELETE by player (non-DM) returns 404.
+  - Spec: Scenario: "Non-DM member is rejected" (DELETE)
+  - File: route integration test
+
+- [ ] **T4.11** — DELETE without auth returns 401.
+  - Spec: Scenario: "Unauthenticated request rejected" (DELETE)
+  - File: route integration test
+
+- [ ] **T4.12** — `DELETE ?force=true` with stale `activeSessionId` returns 200 and `GET` shows `activeSessionId: null`.
+  - Spec: Scenario: "Force-reset clears stale `activeSessionId`"
+  - File: route integration test
+
+- [ ] **T4.13** — `DELETE ?force=true` with no active session returns 200 and `GET` shows `activeSessionId: null`.
+  - Spec: Scenario: "Force-reset when no active session is a no-op success"
+  - File: route integration test
+
+- [ ] **T4.14** — After `DELETE ?force=true`, subsequent `POST` returns 201 (not 409).
+  - Spec: Scenario: "After force-reset, DM can open a new session"
+  - File: route integration test
+
+---
+
+### Task 6 — SessionLog persists after close
+
+- [ ] **T6.1** — After `DELETE /active`, `GET /api/campaigns/:id/sessions` still includes the closed `SessionLog`.
+  - Spec: Scenario: "Session log remains after close"
+  - File: route integration test

--- a/openspec/changes/campaign-active-session-lifecycle/tests.md
+++ b/openspec/changes/campaign-active-session-lifecycle/tests.md
@@ -23,11 +23,11 @@ For each task in `tasks.md`:
 
 ### Task 2 — `setActiveCampaignSession` storage method
 
-- [ ] **T2.1** — `setActiveCampaignSession(campaignId, sessionId)` calls `updateOne` with `{ $set: { activeSessionId: sessionId, updatedAt: <Date> } }` and does NOT call `replaceOne` or `findOneAndReplace`.
+- [ ] **T2.1** — `setActiveCampaignSession(campaignId, userId, sessionId)` calls `updateOne` with filter `{ id: campaignId, userId }` and `{ $set: { activeSessionId: sessionId, updatedAt: <Date> } }` and does NOT call `replaceOne` or `findOneAndReplace`.
   - Spec: Requirement: ADDED `Campaign.activeSessionId` field / Concurrent write safety
   - File: storage unit test
 
-- [ ] **T2.2** — `setActiveCampaignSession(campaignId, null)` calls `updateOne` with `{ $set: { activeSessionId: null, updatedAt: <Date> } }`.
+- [ ] **T2.2** — `setActiveCampaignSession(campaignId, userId, null)` calls `updateOne` with `{ $set: { activeSessionId: null, updatedAt: <Date> } }`.
   - Spec: Scenario: "Field is null after session closed"
   - File: storage unit test
 

--- a/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
+++ b/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from "next/server";
+import { POST, DELETE } from "@/app/api/campaigns/[id]/sessions/active/route";
+import { storage } from "@/lib/storage";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  itReturns401WithParams,
+  itReturns500WithParams,
+  mockAuthState,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () => require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware());
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getNextSessionNumber: jest.fn(),
+    saveSessionLog: jest.fn(),
+    setActiveCampaignSession: jest.fn(),
+  },
+}));
+jest.mock("@/lib/utils/campaign", () => ({
+  ...jest.requireActual("@/lib/utils/campaign"),
+  assertCampaignAccess: jest.fn(),
+}));
+const mockRandomUUID = jest.fn(() => "new-session-uuid");
+Object.defineProperty(globalThis, "crypto", {
+  value: { randomUUID: mockRandomUUID },
+  writable: true,
+});
+
+const mockedStorage = jest.mocked(storage);
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
+
+const CAMPAIGN_ID = "campaign-1";
+const BASE_URL = `http://localhost/api/campaigns/${CAMPAIGN_ID}/sessions/active`;
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
+
+const MOCK_CAMPAIGN = {
+  id: CAMPAIGN_ID,
+  userId: "user-123",
+  name: "Test Campaign",
+  chapters: [],
+  status: "active" as const,
+  notes: "",
+  activeSessionId: undefined as string | null | undefined,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const makePostReq = () => makeRouteRequest(BASE_URL, "POST");
+const makeDeleteReq = (force?: boolean) =>
+  makeRouteRequest(force ? `${BASE_URL}?force=true` : BASE_URL, "DELETE");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthState.payload = MOCK_AUTH;
+  mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "dm" });
+  mockedStorage.getNextSessionNumber.mockResolvedValue(1);
+  mockedStorage.saveSessionLog.mockResolvedValue(undefined as any);
+  mockedStorage.setActiveCampaignSession.mockResolvedValue(undefined as any);
+});
+
+// ─── POST /api/campaigns/[id]/sessions/active ────────────────────────────────
+
+describe("POST /api/campaigns/[id]/sessions/active", () => {
+  itReturns401WithParams(POST, makePostReq, PARAMS);
+
+  it("returns 201 and the new SessionLog when no active session", async () => {
+    const res = await POST(makePostReq(), { params: PARAMS });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBe("new-session-uuid");
+    expect(body.campaignId).toBe(CAMPAIGN_ID);
+    expect(body.userId).toBe("user-123");
+    expect(body.sessionNumber).toBe(1);
+    expect(body.milestone).toBe(false);
+    expect(body.events).toEqual([]);
+    expect(body.title).toBeUndefined();
+    expect(body.summary).toBeUndefined();
+  });
+
+  it("calls saveSessionLog and setActiveCampaignSession", async () => {
+    await POST(makePostReq(), { params: PARAMS });
+    expect(mockedStorage.saveSessionLog).toHaveBeenCalledTimes(1);
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(
+      CAMPAIGN_ID,
+      "new-session-uuid"
+    );
+  });
+
+  it("returns 409 when activeSessionId is already set", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({
+      campaign: { ...MOCK_CAMPAIGN, activeSessionId: "existing-session-id" } as any,
+      role: "dm",
+    });
+    const res = await POST(makePostReq(), { params: PARAMS });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe("A session is already active");
+    expect(mockedStorage.saveSessionLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when role is not dm", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const res = await POST(makePostReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when assertCampaignAccess denies access", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await POST(makePostReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
+
+  itReturns500WithParams(
+    POST,
+    makePostReq,
+    PARAMS,
+    () => mockedStorage.saveSessionLog.mockRejectedValue(new Error("DB error"))
+  );
+});
+
+// ─── DELETE /api/campaigns/[id]/sessions/active ──────────────────────────────
+
+describe("DELETE /api/campaigns/[id]/sessions/active", () => {
+  itReturns401WithParams(DELETE, makeDeleteReq, PARAMS);
+
+  it("returns 200 with sessionId when active session exists", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({
+      campaign: { ...MOCK_CAMPAIGN, activeSessionId: "active-session-id" } as any,
+      role: "dm",
+    });
+    const res = await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(res.status).toBe(200);
+    expect((await res.json()).sessionId).toBe("active-session-id");
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+  });
+
+  it("returns 404 when no active session and force is not set", async () => {
+    const res = await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+    expect(mockedStorage.setActiveCampaignSession).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with null sessionId when force=true and stale session exists", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({
+      campaign: { ...MOCK_CAMPAIGN, activeSessionId: "stale-session-id" } as any,
+      role: "dm",
+    });
+    const res = await DELETE(makeDeleteReq(true), { params: PARAMS });
+    expect(res.status).toBe(200);
+    expect((await res.json()).sessionId).toBe("stale-session-id");
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+  });
+
+  it("returns 200 with null sessionId when force=true and no active session", async () => {
+    const res = await DELETE(makeDeleteReq(true), { params: PARAMS });
+    expect(res.status).toBe(200);
+    expect((await res.json()).sessionId).toBeNull();
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+  });
+
+  it("does not delete SessionLog when closing — only clears activeSessionId", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({
+      campaign: { ...MOCK_CAMPAIGN, activeSessionId: "active-session-id" } as any,
+      role: "dm",
+    });
+    await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+    expect(Object.keys(mockedStorage)).not.toContain("deleteSessionLog");
+  });
+
+  it("returns 404 when role is not dm", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue({ campaign: MOCK_CAMPAIGN as any, role: "player" });
+    const res = await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when assertCampaignAccess denies access", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    );
+    const res = await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
+
+  itReturns500WithParams(
+    DELETE,
+    () => {
+      mockedAssertCampaignAccess.mockResolvedValue({
+        campaign: { ...MOCK_CAMPAIGN, activeSessionId: "active-session-id" } as any,
+        role: "dm",
+      });
+      return makeDeleteReq();
+    },
+    PARAMS,
+    () => mockedStorage.setActiveCampaignSession.mockRejectedValue(new Error("DB error"))
+  );
+});

--- a/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
+++ b/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
@@ -105,6 +105,7 @@ describe("POST /api/campaigns/[id]/sessions/active", () => {
     expect(mockedStorage.saveSessionLog).toHaveBeenCalledTimes(1);
     expect(mockedStorage.claimActiveCampaignSession).toHaveBeenCalledWith(
       CAMPAIGN_ID,
+      "user-123",
       "new-session-uuid"
     );
   });
@@ -162,7 +163,7 @@ describe("DELETE /api/campaigns/[id]/sessions/active", () => {
     const res = await DELETE(makeDeleteReq(), { params: PARAMS });
     expect(res.status).toBe(200);
     expect((await res.json()).sessionId).toBe("active-session-id");
-    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, "user-123", null);
   });
 
   it("returns 404 when no active session and force is not set", async () => {
@@ -179,7 +180,7 @@ describe("DELETE /api/campaigns/[id]/sessions/active", () => {
     const res = await DELETE(makeDeleteReq(true), { params: PARAMS });
     expect(res.status).toBe(200);
     expect((await res.json()).sessionId).toBe("stale-session-id");
-    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, "user-123", null);
   });
 
   it("returns 200 with null sessionId when force=true and no active session — skips DB write", async () => {
@@ -196,7 +197,7 @@ describe("DELETE /api/campaigns/[id]/sessions/active", () => {
     });
     await DELETE(makeDeleteReq(), { params: PARAMS });
     expect(mockedStorage.saveSessionLog).not.toHaveBeenCalled();
-    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, "user-123", null);
   });
 
   it("returns 404 when role is not dm", async () => {

--- a/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
+++ b/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
@@ -19,16 +19,29 @@ jest.mock("@/lib/storage", () => ({
     getNextSessionNumber: jest.fn(),
     saveSessionLog: jest.fn(),
     setActiveCampaignSession: jest.fn(),
+    claimActiveCampaignSession: jest.fn(),
   },
 }));
 jest.mock("@/lib/utils/campaign", () => ({
   ...jest.requireActual("@/lib/utils/campaign"),
   assertCampaignAccess: jest.fn(),
 }));
+
+const originalCrypto = globalThis.crypto;
 const mockRandomUUID = jest.fn(() => "new-session-uuid");
-Object.defineProperty(globalThis, "crypto", {
-  value: { randomUUID: mockRandomUUID },
-  writable: true,
+beforeAll(() => {
+  Object.defineProperty(globalThis, "crypto", {
+    value: { randomUUID: mockRandomUUID },
+    writable: true,
+    configurable: true,
+  });
+});
+afterAll(() => {
+  Object.defineProperty(globalThis, "crypto", {
+    value: originalCrypto,
+    writable: true,
+    configurable: true,
+  });
 });
 
 const mockedStorage = jest.mocked(storage);
@@ -61,6 +74,7 @@ beforeEach(() => {
   mockedStorage.getNextSessionNumber.mockResolvedValue(1);
   mockedStorage.saveSessionLog.mockResolvedValue(undefined as any);
   mockedStorage.setActiveCampaignSession.mockResolvedValue(undefined as any);
+  mockedStorage.claimActiveCampaignSession.mockResolvedValue(true as any);
 });
 
 // ─── POST /api/campaigns/[id]/sessions/active ────────────────────────────────
@@ -69,6 +83,7 @@ describe("POST /api/campaigns/[id]/sessions/active", () => {
   itReturns401WithParams(POST, makePostReq, PARAMS);
 
   it("returns 201 and the new SessionLog when no active session", async () => {
+    const before = Date.now();
     const res = await POST(makePostReq(), { params: PARAMS });
     expect(res.status).toBe(201);
     const body = await res.json();
@@ -80,18 +95,21 @@ describe("POST /api/campaigns/[id]/sessions/active", () => {
     expect(body.events).toEqual([]);
     expect(body.title).toBeUndefined();
     expect(body.summary).toBeUndefined();
+    const datePlayed = new Date(body.datePlayed).getTime();
+    expect(datePlayed).toBeGreaterThanOrEqual(before);
+    expect(datePlayed).toBeLessThanOrEqual(Date.now());
   });
 
-  it("calls saveSessionLog and setActiveCampaignSession", async () => {
+  it("calls saveSessionLog and claimActiveCampaignSession atomically", async () => {
     await POST(makePostReq(), { params: PARAMS });
     expect(mockedStorage.saveSessionLog).toHaveBeenCalledTimes(1);
-    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(
+    expect(mockedStorage.claimActiveCampaignSession).toHaveBeenCalledWith(
       CAMPAIGN_ID,
       "new-session-uuid"
     );
   });
 
-  it("returns 409 when activeSessionId is already set", async () => {
+  it("returns 409 when activeSessionId is already set (fast-path check)", async () => {
     mockedAssertCampaignAccess.mockResolvedValue({
       campaign: { ...MOCK_CAMPAIGN, activeSessionId: "existing-session-id" } as any,
       role: "dm",
@@ -100,6 +118,13 @@ describe("POST /api/campaigns/[id]/sessions/active", () => {
     expect(res.status).toBe(409);
     expect((await res.json()).error).toBe("A session is already active");
     expect(mockedStorage.saveSessionLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when atomic claim fails (concurrent session opened)", async () => {
+    mockedStorage.claimActiveCampaignSession.mockResolvedValue(false as any);
+    const res = await POST(makePostReq(), { params: PARAMS });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe("A session is already active");
   });
 
   it("returns 404 when role is not dm", async () => {
@@ -146,7 +171,7 @@ describe("DELETE /api/campaigns/[id]/sessions/active", () => {
     expect(mockedStorage.setActiveCampaignSession).not.toHaveBeenCalled();
   });
 
-  it("returns 200 with null sessionId when force=true and stale session exists", async () => {
+  it("returns 200 with the stale sessionId when force=true and stale session exists", async () => {
     mockedAssertCampaignAccess.mockResolvedValue({
       campaign: { ...MOCK_CAMPAIGN, activeSessionId: "stale-session-id" } as any,
       role: "dm",
@@ -157,21 +182,21 @@ describe("DELETE /api/campaigns/[id]/sessions/active", () => {
     expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
   });
 
-  it("returns 200 with null sessionId when force=true and no active session", async () => {
+  it("returns 200 with null sessionId when force=true and no active session — skips DB write", async () => {
     const res = await DELETE(makeDeleteReq(true), { params: PARAMS });
     expect(res.status).toBe(200);
     expect((await res.json()).sessionId).toBeNull();
-    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
+    expect(mockedStorage.setActiveCampaignSession).not.toHaveBeenCalled();
   });
 
-  it("does not delete SessionLog when closing — only clears activeSessionId", async () => {
+  it("does not call saveSessionLog when closing — only clears activeSessionId pointer", async () => {
     mockedAssertCampaignAccess.mockResolvedValue({
       campaign: { ...MOCK_CAMPAIGN, activeSessionId: "active-session-id" } as any,
       role: "dm",
     });
     await DELETE(makeDeleteReq(), { params: PARAMS });
+    expect(mockedStorage.saveSessionLog).not.toHaveBeenCalled();
     expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, null);
-    expect(Object.keys(mockedStorage)).not.toContain("deleteSessionLog");
   });
 
   it("returns 404 when role is not dm", async () => {

--- a/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
+++ b/tests/unit/api/campaigns/[id]/sessions/active.route.test.ts
@@ -100,14 +100,17 @@ describe("POST /api/campaigns/[id]/sessions/active", () => {
     expect(datePlayed).toBeLessThanOrEqual(Date.now());
   });
 
-  it("calls saveSessionLog and claimActiveCampaignSession atomically", async () => {
+  it("claims the session atomically before saving the log — avoids orphan on concurrent open", async () => {
     await POST(makePostReq(), { params: PARAMS });
-    expect(mockedStorage.saveSessionLog).toHaveBeenCalledTimes(1);
     expect(mockedStorage.claimActiveCampaignSession).toHaveBeenCalledWith(
       CAMPAIGN_ID,
       "user-123",
       "new-session-uuid"
     );
+    expect(mockedStorage.saveSessionLog).toHaveBeenCalledTimes(1);
+    const claimOrder = mockedStorage.claimActiveCampaignSession.mock.invocationCallOrder[0];
+    const saveOrder = mockedStorage.saveSessionLog.mock.invocationCallOrder[0];
+    expect(claimOrder).toBeLessThan(saveOrder);
   });
 
   it("returns 409 when activeSessionId is already set (fast-path check)", async () => {
@@ -183,11 +186,11 @@ describe("DELETE /api/campaigns/[id]/sessions/active", () => {
     expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, "user-123", null);
   });
 
-  it("returns 200 with null sessionId when force=true and no active session — skips DB write", async () => {
+  it("returns 200 with null sessionId when force=true and no active session — writes null to ensure field is explicit", async () => {
     const res = await DELETE(makeDeleteReq(true), { params: PARAMS });
     expect(res.status).toBe(200);
     expect((await res.json()).sessionId).toBeNull();
-    expect(mockedStorage.setActiveCampaignSession).not.toHaveBeenCalled();
+    expect(mockedStorage.setActiveCampaignSession).toHaveBeenCalledWith(CAMPAIGN_ID, "user-123", null);
   });
 
   it("does not call saveSessionLog when closing — only clears activeSessionId pointer", async () => {

--- a/tests/unit/lib/storage.test.ts
+++ b/tests/unit/lib/storage.test.ts
@@ -484,4 +484,56 @@ describe("storage", () => {
       await expect(storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID)).rejects.toThrow("DB error");
     });
   });
+
+  describe("claimActiveCampaignSession", () => {
+    const CAMPAIGN_ID = "campaign-abc";
+    const SESSION_ID = "session-xyz";
+
+    it("returns true when updateOne modifies the document (no existing active session)", async () => {
+      mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 1 } as any);
+
+      const result = await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when updateOne modifies nothing (active session already set)", async () => {
+      mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 0 } as any);
+
+      const result = await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      expect(result).toBe(false);
+    });
+
+    it("filters on id and null/absent activeSessionId", async () => {
+      mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 1 } as any);
+
+      await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      const [filter] = mockedCollection.updateOne.mock.calls[0];
+      expect(filter.id).toBe(CAMPAIGN_ID);
+      expect(filter.$or).toEqual([
+        { activeSessionId: null },
+        { activeSessionId: { $exists: false } },
+      ]);
+    });
+
+    it("sets activeSessionId and updatedAt", async () => {
+      mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 1 } as any);
+      const before = new Date();
+
+      await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      const update = mockedCollection.updateOne.mock.calls[0][1];
+      expect(update.$set.activeSessionId).toBe(SESSION_ID);
+      expect(update.$set.updatedAt).toBeInstanceOf(Date);
+      expect(update.$set.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+
+    it("throws on database error", async () => {
+      mockedCollection.updateOne.mockRejectedValue(new Error("DB error"));
+
+      await expect(storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID)).rejects.toThrow("DB error");
+    });
+  });
 });

--- a/tests/unit/lib/storage.test.ts
+++ b/tests/unit/lib/storage.test.ts
@@ -148,6 +148,38 @@ describe("storage", () => {
     });
   });
 
+  describe("normalizeCampaign (via loadCampaignById)", () => {
+    const BASE_CAMPAIGN = {
+      id: "campaign-1",
+      userId: "user-123",
+      name: "Test Campaign",
+      moduleName: "Module",
+      chapters: [],
+      status: "active" as const,
+      notes: "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it("passes through absent activeSessionId (field remains absent)", async () => {
+      mockedCollection.findOne.mockResolvedValue(BASE_CAMPAIGN);
+
+      const result = await storage.loadCampaignById("campaign-1", "user-123");
+
+      expect(result).not.toBeNull();
+      expect(Object.prototype.hasOwnProperty.call(result, "activeSessionId")).toBe(false);
+    });
+
+    it("passes through null activeSessionId (field is null in result)", async () => {
+      mockedCollection.findOne.mockResolvedValue({ ...BASE_CAMPAIGN, activeSessionId: null });
+
+      const result = await storage.loadCampaignById("campaign-1", "user-123");
+
+      expect(result).not.toBeNull();
+      expect(result!.activeSessionId).toBeNull();
+    });
+  });
+
   describe("loadSpellById", () => {
     it("returns normalized spell when found", async () => {
       const spell = {
@@ -398,6 +430,58 @@ describe("storage", () => {
       const result = await storage.monsterExistsByNameAndSource("Dragon", "open5e");
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe("setActiveCampaignSession", () => {
+    const CAMPAIGN_ID = "campaign-abc";
+    const SESSION_ID = "session-xyz";
+
+    it("updates activeSessionId with the given string", async () => {
+      mockedCollection.updateOne.mockResolvedValue({} as any);
+
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      const [filter, update] = mockedCollection.updateOne.mock.calls[0];
+      expect(filter).toEqual({ id: CAMPAIGN_ID });
+      expect(update.$set.activeSessionId).toBe(SESSION_ID);
+    });
+
+    it("sets activeSessionId to null when null is passed", async () => {
+      mockedCollection.updateOne.mockResolvedValue({} as any);
+
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, null);
+
+      const [filter, update] = mockedCollection.updateOne.mock.calls[0];
+      expect(filter).toEqual({ id: CAMPAIGN_ID });
+      expect(update.$set.activeSessionId).toBeNull();
+    });
+
+    it("updates updatedAt on every call", async () => {
+      mockedCollection.updateOne.mockResolvedValue({} as any);
+      const before = new Date();
+
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      const update = mockedCollection.updateOne.mock.calls[0][1];
+      expect(update.$set.updatedAt).toBeInstanceOf(Date);
+      expect(update.$set.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+
+    it("uses updateOne (not upsert)", async () => {
+      mockedCollection.updateOne.mockResolvedValue({} as any);
+
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+
+      expect(mockedCollection.updateOne).toHaveBeenCalledTimes(1);
+      const callArgs = mockedCollection.updateOne.mock.calls[0];
+      expect(callArgs[2]).toBeUndefined();
+    });
+
+    it("throws on database error", async () => {
+      mockedCollection.updateOne.mockRejectedValue(new Error("DB error"));
+
+      await expect(storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID)).rejects.toThrow("DB error");
     });
   });
 });

--- a/tests/unit/lib/storage.test.ts
+++ b/tests/unit/lib/storage.test.ts
@@ -435,25 +435,26 @@ describe("storage", () => {
 
   describe("setActiveCampaignSession", () => {
     const CAMPAIGN_ID = "campaign-abc";
+    const USER_ID = "user-123";
     const SESSION_ID = "session-xyz";
 
     it("updates activeSessionId with the given string", async () => {
       mockedCollection.updateOne.mockResolvedValue({} as any);
 
-      await storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       const [filter, update] = mockedCollection.updateOne.mock.calls[0];
-      expect(filter).toEqual({ id: CAMPAIGN_ID });
+      expect(filter).toEqual({ id: CAMPAIGN_ID, userId: USER_ID });
       expect(update.$set.activeSessionId).toBe(SESSION_ID);
     });
 
     it("sets activeSessionId to null when null is passed", async () => {
       mockedCollection.updateOne.mockResolvedValue({} as any);
 
-      await storage.setActiveCampaignSession(CAMPAIGN_ID, null);
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, USER_ID, null);
 
       const [filter, update] = mockedCollection.updateOne.mock.calls[0];
-      expect(filter).toEqual({ id: CAMPAIGN_ID });
+      expect(filter).toEqual({ id: CAMPAIGN_ID, userId: USER_ID });
       expect(update.$set.activeSessionId).toBeNull();
     });
 
@@ -461,7 +462,7 @@ describe("storage", () => {
       mockedCollection.updateOne.mockResolvedValue({} as any);
       const before = new Date();
 
-      await storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       const update = mockedCollection.updateOne.mock.calls[0][1];
       expect(update.$set.updatedAt).toBeInstanceOf(Date);
@@ -471,7 +472,7 @@ describe("storage", () => {
     it("uses updateOne (not upsert)", async () => {
       mockedCollection.updateOne.mockResolvedValue({} as any);
 
-      await storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      await storage.setActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       expect(mockedCollection.updateOne).toHaveBeenCalledTimes(1);
       const callArgs = mockedCollection.updateOne.mock.calls[0];
@@ -481,18 +482,19 @@ describe("storage", () => {
     it("throws on database error", async () => {
       mockedCollection.updateOne.mockRejectedValue(new Error("DB error"));
 
-      await expect(storage.setActiveCampaignSession(CAMPAIGN_ID, SESSION_ID)).rejects.toThrow("DB error");
+      await expect(storage.setActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID)).rejects.toThrow("DB error");
     });
   });
 
   describe("claimActiveCampaignSession", () => {
     const CAMPAIGN_ID = "campaign-abc";
+    const USER_ID = "user-123";
     const SESSION_ID = "session-xyz";
 
     it("returns true when updateOne modifies the document (no existing active session)", async () => {
       mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 1 } as any);
 
-      const result = await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      const result = await storage.claimActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       expect(result).toBe(true);
     });
@@ -500,18 +502,19 @@ describe("storage", () => {
     it("returns false when updateOne modifies nothing (active session already set)", async () => {
       mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 0 } as any);
 
-      const result = await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      const result = await storage.claimActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       expect(result).toBe(false);
     });
 
-    it("filters on id and null/absent activeSessionId", async () => {
+    it("filters on id, userId, and null/absent activeSessionId", async () => {
       mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 1 } as any);
 
-      await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      await storage.claimActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       const [filter] = mockedCollection.updateOne.mock.calls[0];
       expect(filter.id).toBe(CAMPAIGN_ID);
+      expect(filter.userId).toBe(USER_ID);
       expect(filter.$or).toEqual([
         { activeSessionId: null },
         { activeSessionId: { $exists: false } },
@@ -522,7 +525,7 @@ describe("storage", () => {
       mockedCollection.updateOne.mockResolvedValue({ modifiedCount: 1 } as any);
       const before = new Date();
 
-      await storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID);
+      await storage.claimActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID);
 
       const update = mockedCollection.updateOne.mock.calls[0][1];
       expect(update.$set.activeSessionId).toBe(SESSION_ID);
@@ -533,7 +536,7 @@ describe("storage", () => {
     it("throws on database error", async () => {
       mockedCollection.updateOne.mockRejectedValue(new Error("DB error"));
 
-      await expect(storage.claimActiveCampaignSession(CAMPAIGN_ID, SESSION_ID)).rejects.toThrow("DB error");
+      await expect(storage.claimActiveCampaignSession(CAMPAIGN_ID, USER_ID, SESSION_ID)).rejects.toThrow("DB error");
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements the active session lifecycle for campaigns — DMs can now open and close sessions with atomic tracking via `campaign.activeSessionId`.

## Changes

- **`lib/types.ts`**: Add `activeSessionId?: string | null` to the `Campaign` interface
- **`lib/storage.ts`**: Add `setActiveCampaignSession(campaignId, sessionId)` — atomic `updateOne` on the campaigns collection
- **`app/api/campaigns/[id]/sessions/active/route.ts`** (new): `POST` and `DELETE` handlers for active session management
- **Tests**: Unit tests for the storage method, normalizeCampaign pass-through, and all route scenarios

## API

### `POST /api/campaigns/:id/sessions/active`
- DM opens a session; creates a `SessionLog` and sets `campaign.activeSessionId`
- Returns **201** with the new `SessionLog`
- Returns **409** if a session is already active
- Returns **404** for non-DM or non-member

### `DELETE /api/campaigns/:id/sessions/active`
- DM closes the active session; clears `campaign.activeSessionId`
- Returns **200** with `{ sessionId }` (the closed session's ID)
- Returns **404** if no active session (unless `?force=true`)
- `?force=true` unconditionally clears `activeSessionId` (escape hatch for stale state)

Closes #400