### PR TITLE
feat: campaign chat dock shell (phase 4c)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@
 import type { Metadata } from 'next'
 import { IBM_Plex_Sans, IBM_Plex_Mono, IBM_Plex_Serif } from 'next/font/google'
 import { NavBar } from '@/lib/components/NavBar'
+import { CampaignChat } from '@/lib/components/CampaignChat'
 import './globals.css'
 
 const plexSans = IBM_Plex_Sans({
@@ -87,6 +88,7 @@ export default async function RootLayout({
             <span>{formatDate(versionData.buildDate)}</span>
           </div>
         </footer>
+        <CampaignChat />
       </body>
     </html>
   )

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { LocalStore } from '@/lib/offline/LocalStore'
+
+const PIN_KEY = 'campaign-chat-pin'
+
+export function CampaignChat() {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [isPinned, setIsPinned] = useState(false)
+
+  useEffect(() => {
+    const pinned = LocalStore.get<boolean>(PIN_KEY)
+    if (pinned) {
+      setIsExpanded(true)
+      setIsPinned(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isExpanded) return
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsExpanded(false)
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [isExpanded])
+
+  function handlePinToggle() {
+    if (isPinned) {
+      LocalStore.remove(PIN_KEY)
+      setIsPinned(false)
+    } else {
+      try {
+        LocalStore.set(PIN_KEY, true)
+        setIsPinned(true)
+      } catch {
+        // StorageQuotaError: pin preference not persisted; drawer stays open
+      }
+    }
+  }
+
+  if (!isExpanded) {
+    return (
+      <button
+        className="fixed bottom-4 right-4 z-40 bg-gray-800 border border-gray-700 rounded-full px-4 py-2 text-sm text-white hover:bg-gray-700"
+        onClick={() => setIsExpanded(true)}
+      >
+        Chat ›
+      </button>
+    )
+  }
+
+  return (
+    <div
+      role="complementary"
+      aria-label="Campaign Chat"
+      className="fixed bottom-0 right-0 z-40 w-80 flex flex-col bg-gray-800 border-l border-t border-gray-700 rounded-tl-lg"
+      style={{ height: '33vh' }}
+    >
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700 flex-shrink-0">
+        <span className="text-sm font-semibold text-white">Campaign Chat</span>
+        <div className="flex items-center gap-2">
+          <button
+            aria-pressed={isPinned}
+            aria-label={isPinned ? 'Unpin chat' : 'Pin chat open'}
+            onClick={handlePinToggle}
+            className="text-gray-400 hover:text-white"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M10 2a1 1 0 011 1v1.07A6.002 6.002 0 0115.93 9H17a1 1 0 010 2h-1.07A6.002 6.002 0 0111 15.93V17a1 1 0 01-2 0v-1.07A6.002 6.002 0 014.07 11H3a1 1 0 010-2h1.07A6.002 6.002 0 019 4.07V3a1 1 0 011-1z" />
+            </svg>
+          </button>
+          <button
+            aria-label="Collapse chat"
+            onClick={() => setIsExpanded(false)}
+            className="text-gray-400 hover:text-white text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4">
+        <p className="text-gray-500 text-sm">No messages yet.</p>
+      </div>
+    </div>
+  )
+}

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -1,26 +1,67 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useReducer, useEffect, useRef } from 'react'
 import { LocalStore } from '@/lib/offline/LocalStore'
 
 const PIN_KEY = 'campaign-chat-pin'
 
+type DockState = { isExpanded: boolean; isPinned: boolean }
+type DockAction =
+  | { type: 'INIT'; pinned: boolean }
+  | { type: 'EXPAND' }
+  | { type: 'COLLAPSE' }
+  | { type: 'PIN' }
+  | { type: 'UNPIN' }
+
+function dockReducer(state: DockState, action: DockAction): DockState {
+  switch (action.type) {
+    case 'INIT':
+      return { isExpanded: action.pinned, isPinned: action.pinned }
+    case 'EXPAND':
+      return { ...state, isExpanded: true }
+    case 'COLLAPSE':
+      return { ...state, isExpanded: false }
+    case 'PIN':
+      return { ...state, isPinned: true }
+    case 'UNPIN':
+      return { ...state, isPinned: false }
+  }
+}
+
 export function CampaignChat() {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [isPinned, setIsPinned] = useState(false)
+  const [{ isExpanded, isPinned }, dispatch] = useReducer(dockReducer, {
+    isExpanded: false,
+    isPinned: false,
+  })
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const isMounted = useRef(false)
 
   useEffect(() => {
-    const pinned = LocalStore.get<boolean>(PIN_KEY)
-    if (pinned) {
-      setIsExpanded(true)
-      setIsPinned(true)
+    let pinned = false
+    try {
+      pinned = !!LocalStore.get<boolean>(PIN_KEY)
+    } catch {
+      // storage unavailable: start collapsed
     }
+    dispatch({ type: 'INIT', pinned })
   }, [])
+
+  // Restore focus to the pill after the drawer closes. Skip on initial mount
+  // so we don't steal focus when the page first loads or auto-expands from pin.
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true
+      return
+    }
+    if (!isExpanded) {
+      triggerRef.current?.focus()
+    }
+  }, [isExpanded])
 
   useEffect(() => {
     if (!isExpanded) return
     const handler = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsExpanded(false)
+      if (event.key === 'Escape') dispatch({ type: 'COLLAPSE' })
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
@@ -28,12 +69,16 @@ export function CampaignChat() {
 
   function handlePinToggle() {
     if (isPinned) {
-      LocalStore.remove(PIN_KEY)
-      setIsPinned(false)
+      try {
+        LocalStore.remove(PIN_KEY)
+      } catch {
+        // storage unavailable: pin cleared in memory only
+      }
+      dispatch({ type: 'UNPIN' })
     } else {
       try {
         LocalStore.set(PIN_KEY, true)
-        setIsPinned(true)
+        dispatch({ type: 'PIN' })
       } catch {
         // StorageQuotaError: pin preference not persisted; drawer stays open
       }
@@ -43,8 +88,9 @@ export function CampaignChat() {
   if (!isExpanded) {
     return (
       <button
+        ref={triggerRef}
         className="fixed bottom-4 right-4 z-40 bg-gray-800 border border-gray-700 rounded-full px-4 py-2 text-sm text-white hover:bg-gray-700"
-        onClick={() => setIsExpanded(true)}
+        onClick={() => dispatch({ type: 'EXPAND' })}
       >
         Chat ›
       </button>
@@ -74,12 +120,12 @@ export function CampaignChat() {
               fill="currentColor"
               aria-hidden="true"
             >
-              <path d="M10 2a1 1 0 011 1v1.07A6.002 6.002 0 0115.93 9H17a1 1 0 010 2h-1.07A6.002 6.002 0 0111 15.93V17a1 1 0 01-2 0v-1.07A6.002 6.002 0 014.07 11H3a1 1 0 010-2h1.07A6.002 6.002 0 019 4.07V3a1 1 0 011-1z" />
+              <path d="M11.5 3a1.5 1.5 0 00-3 0v3.586L6.293 8.793A1 1 0 006 9.5v1a1 1 0 001 1h2.5v4.5a.5.5 0 001 0v-4.5H13a1 1 0 001-1v-1a1 1 0 00-.293-.707L11.5 6.586V3z" />
             </svg>
           </button>
           <button
             aria-label="Collapse chat"
-            onClick={() => setIsExpanded(false)}
+            onClick={() => dispatch({ type: 'COLLAPSE' })}
             className="text-gray-400 hover:text-white text-lg leading-none"
           >
             ×

--- a/openspec/changes/campaign-chat-dock-shell/tasks.md
+++ b/openspec/changes/campaign-chat-dock-shell/tasks.md
@@ -1,0 +1,115 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/campaign-chat-dock-shell` then immediately `git push -u origin feat/campaign-chat-dock-shell`
+
+## Execution
+
+### Task 1 — Create `lib/components/CampaignChat.tsx`
+
+- [x] Create `lib/components/CampaignChat.tsx` as a `'use client'` component
+- [x] Implement `isExpanded` state (default `false`)
+- [x] On mount (`useEffect`), read `LocalStore.get<boolean>('campaign-chat-pin')` and set `isExpanded` to `true` if result is truthy
+- [x] Implement `isPinned` state (default `false`), seeded from the same mount read
+- [x] **Collapsed state** — render a `<button>` with:
+  - `className="fixed bottom-4 right-4 z-40 bg-gray-800 border border-gray-700 rounded-full px-4 py-2 text-sm text-white hover:bg-gray-700"`
+  - Accessible name containing "Chat" (e.g., `Chat ›`)
+  - `onClick` sets `isExpanded(true)`
+- [x] **Expanded state** — render a `<div>` with:
+  - `role="complementary"` and `aria-label="Campaign Chat"`
+  - `className="fixed bottom-0 right-0 z-40 w-80 flex flex-col bg-gray-800 border-l border-t border-gray-700 rounded-tl-lg"` with inline `style={{ height: '33vh' }}`
+  - **Header row** (`flex items-center justify-between px-4 py-3 border-b border-gray-700 flex-shrink-0`):
+    - Title: `<span className="text-sm font-semibold text-white">Campaign Chat</span>`
+    - Pin button: `<button aria-pressed={isPinned} aria-label={isPinned ? 'Unpin chat' : 'Pin chat open'} onClick={handlePinToggle}>` — renders a pin icon (inline SVG or `📌` text; prefer inline SVG `20×20` matching existing iconography)
+    - Close button: `<button aria-label="Collapse chat" onClick={() => setIsExpanded(false)}>×</button>`
+  - **Body** (`flex-1 overflow-y-auto p-4`): placeholder `<p className="text-gray-500 text-sm">No messages yet.</p>`
+- [x] Implement `handlePinToggle`:
+  - If not pinned: `LocalStore.set('campaign-chat-pin', true)`, `setIsPinned(true)`
+  - If pinned: `LocalStore.remove('campaign-chat-pin')`, `setIsPinned(false)`
+  - Do NOT change `isExpanded`
+- [x] Add Escape key handler: `useEffect` on `isExpanded` — when `true`, attach `keydown` listener on `document`; if `event.key === 'Escape'` call `setIsExpanded(false)`. Clean up on `isExpanded` change or unmount.
+
+### Task 2 — Mount in `app/layout.tsx`
+
+- [x] Import `CampaignChat` in `app/layout.tsx`: `import { CampaignChat } from '@/lib/components/CampaignChat'`
+- [x] Add `<CampaignChat />` as the last child of `<body>`, after `<footer>`:
+  ```tsx
+  <footer .../>
+  <CampaignChat />
+  ```
+
+### Task 3 — Unit tests `tests/unit/components/CampaignChat.test.tsx`
+
+Write tests covering all spec scenarios. Mock `LocalStore` at the module level.
+
+- [x] **Scenario: Pill present on initial render** — render, assert `getByRole('button', { name: /chat/i })` present
+- [x] **Scenario: Drawer absent on initial render** — render with `LocalStore.get` returning `null`, assert `queryByRole('complementary')` is null
+- [x] **Scenario: Expand by clicking pill** — click pill, assert `getByRole('complementary', { name: /campaign chat/i })` present
+- [x] **Scenario: Collapse by clicking close button** — expand, click close, assert `queryByRole('complementary')` is null
+- [x] **Scenario: Collapse via Escape key** — expand, fire `keydown` Escape, assert `queryByRole('complementary')` is null
+- [x] **Scenario: Escape does nothing when collapsed** — fire Escape, assert no error and pill still present
+- [x] **Scenario: Pin button toggles to pinned** — expand, click pin, assert `aria-pressed="true"` and `LocalStore.set` called with `'campaign-chat-pin'` and `true`
+- [x] **Scenario: Pin button toggles to unpinned** — expand, pin, unpin, assert `aria-pressed="false"` and `LocalStore.remove` called with `'campaign-chat-pin'`
+- [x] **Scenario: Dock opens on mount when pinned** — mock `LocalStore.get` returning `true`, render, assert drawer present without any click
+- [x] **Scenario: Unpinning does not collapse** — mount with pin, unpin, assert drawer still present
+- [x] **Scenario: Pin button reports aria-pressed state** — expand, assert pin button has `aria-pressed="false"`; pin it, assert `aria-pressed="true"`
+- [x] **Scenario: Drawer has correct landmark and label** — expand, assert `getByRole('complementary', { name: 'Campaign Chat' })`
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm test -- --testPathPattern=CampaignChat` — all new tests pass
+- [x] `npm test` — full unit suite passes (no regressions)
+- [x] `npx tsc --noEmit` — no type errors in new files
+- [x] `npm run build` — build succeeds
+- [x] All tasks above marked complete
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Unit tests** — `npm test`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- If **ANY** of the above fail, iterate and address the failure before pushing
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/campaign-chat-dock-shell` and push to remote
+- [ ] Open PR from `feat/campaign-chat-dock-shell` to `main`. PR body MUST include: `Closes #313`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, validate locally, push; wait 180 seconds then repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, validate locally, push; wait 180 seconds then repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: agent (`/opsx:apply`)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update `openspec/specs/campaign-chat-dock/spec.md` — sync from `openspec/changes/campaign-chat-dock-shell/specs/campaign-chat-dock/spec.md` (update relative paths to `../../changes/archive/YYYY-MM-DD-campaign-chat-dock-shell/design.md` and `tasks.md`)
+- [ ] Archive the change: move `openspec/changes/campaign-chat-dock-shell/` to `openspec/changes/archive/YYYY-MM-DD-campaign-chat-dock-shell/` — stage both the new location and deletion of the old in a **single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-chat-dock-shell/` exists and `openspec/changes/campaign-chat-dock-shell/` is gone
+- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-chat-dock-shell` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-chat-dock-shell`
+- [ ] Open PR from `doc/archive-YYYY-MM-DD-campaign-chat-dock-shell` to `main` with title `docs: archive campaign-chat-dock-shell (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until it merges (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/campaign-chat-dock-shell doc/archive-YYYY-MM-DD-campaign-chat-dock-shell`

--- a/tests/unit/components/CampaignChat.test.tsx
+++ b/tests/unit/components/CampaignChat.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CampaignChat } from '@/lib/components/CampaignChat'
+import { LocalStore } from '@/lib/offline/LocalStore'
+
+jest.mock('@/lib/offline/LocalStore', () => ({
+  LocalStore: {
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    remove: jest.fn(),
+  },
+}))
+
+const mockedLocalStore = LocalStore as jest.Mocked<typeof LocalStore>
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockedLocalStore.get.mockReturnValue(null)
+})
+
+// TC-01
+it('pill button is present on initial render', () => {
+  render(<CampaignChat />)
+  expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()
+})
+
+// TC-02
+it('drawer is absent on initial render when no pin stored', () => {
+  render(<CampaignChat />)
+  expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+})
+
+// TC-03
+it('drawer is present on mount when pin is stored', async () => {
+  mockedLocalStore.get.mockReturnValue(true)
+  render(<CampaignChat />)
+  expect(screen.getByRole('complementary', { name: /campaign chat/i })).toBeInTheDocument()
+})
+
+// TC-04
+it('clicking pill expands the drawer', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  expect(screen.getByRole('complementary')).toBeInTheDocument()
+})
+
+// TC-05
+it('clicking close button collapses the drawer', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await user.click(screen.getByRole('button', { name: /collapse/i }))
+  expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+})
+
+// TC-06
+it('pressing Escape collapses the drawer', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  fireEvent.keyDown(document, { key: 'Escape' })
+  expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+})
+
+// TC-07
+it('pressing Escape when collapsed has no effect', () => {
+  render(<CampaignChat />)
+  fireEvent.keyDown(document, { key: 'Escape' })
+  expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()
+})
+
+// TC-08
+it('pin button has aria-pressed="false" when not pinned', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute('aria-pressed', 'false')
+})
+
+// TC-09
+it('clicking pin sets aria-pressed="true" and calls LocalStore.set', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const pinButton = screen.getByRole('button', { name: /pin/i })
+  await user.click(pinButton)
+  expect(pinButton).toHaveAttribute('aria-pressed', 'true')
+  expect(mockedLocalStore.set).toHaveBeenCalledWith('campaign-chat-pin', true)
+})
+
+// TC-10
+it('clicking pin again sets aria-pressed="false" and calls LocalStore.remove', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const pinButton = screen.getByRole('button', { name: /pin/i })
+  await user.click(pinButton)
+  await user.click(pinButton)
+  expect(pinButton).toHaveAttribute('aria-pressed', 'false')
+  expect(mockedLocalStore.remove).toHaveBeenCalledWith('campaign-chat-pin')
+})
+
+// TC-11
+it('unpinning while expanded does not collapse the drawer', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const pinButton = screen.getByRole('button', { name: /pin/i })
+  await user.click(pinButton)
+  await user.click(pinButton)
+  expect(screen.getByRole('complementary')).toBeInTheDocument()
+})
+
+// TC-12
+it('drawer has role="complementary" and aria-label="Campaign Chat"', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  expect(screen.getByRole('complementary', { name: 'Campaign Chat' })).toBeInTheDocument()
+})
+
+// TC-13
+it('pill button is keyboard-activatable with Enter', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat />)
+  const pill = screen.getByRole('button', { name: /chat/i })
+  pill.focus()
+  await user.keyboard('{Enter}')
+  expect(screen.getByRole('complementary')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary

Adds the `CampaignChat` dock shell component — the collapsible/pinnable chat container for Phase 4c of multi-user campaign messaging.

## Changes

- **New:** `lib/components/CampaignChat.tsx` — `'use client'` component with collapsed pill and expanded drawer states
- **Modified:** `app/layout.tsx` — mounts `<CampaignChat />` globally after `<footer>`
- **New:** `tests/unit/components/CampaignChat.test.tsx` — 13 unit tests covering all spec scenarios

## Features

- Fixed-position pill (`bottom-4 right-4 z-40`) always present; clicking expands a drawer (`w-80 h-[33vh]`)
- Pin preference persisted via `LocalStore` (key: `campaign-chat-pin`); restored on mount
- Escape key collapses the drawer regardless of pin state
- Full keyboard accessibility: `role="complementary"`, `aria-label`, `aria-pressed` on pin button
- `StorageQuotaError` handled gracefully — drawer stays functional if persistence fails
- No data wiring — layout/interaction states only (Phase 5 handles messaging)

## Test Coverage

All 13 scenarios from the spec pass:
- Pill present on initial render
- Drawer absent when no pin stored
- Drawer auto-opens when pinned
- Expand/collapse via click and Escape
- Pin toggle with `LocalStore.set` / `LocalStore.remove`
- Unpinning does not collapse current session
- Correct `aria-pressed` state on pin button
- Correct landmark (`role="complementary"`, `aria-label="Campaign Chat"`)

Closes #313