### PR TITLE
docs: archive campaign-chat-dock-shell (2026-06-09)

### DIFF
--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md
@@ -1,0 +1,154 @@
+## Context
+
+- **Relevant architecture:** Next.js App Router, `app/layout.tsx` is an async server component wrapping `<NavBar />`, a scrollable content area, and a footer. Client components are imported directly into server components in App Router — `CampaignChat` will be one such import.
+- **Dependencies:** `lib/offline/LocalStore.ts` (versioned localStorage abstraction), `lib/components/` (existing component patterns), Tailwind v4 (stock tokens only — no custom palette).
+- **Interfaces/contracts touched:**
+  - `app/layout.tsx` — adds `<CampaignChat />` before `</body>`
+  - `lib/offline/LocalStore.ts` — `LocalStore.get` / `LocalStore.set` / `LocalStore.remove` for pin state
+  - No API routes, no data fetching, no shared context providers touched.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Deliver a fixed-position dock shell with two visual states (collapsed pill, expanded drawer)
+- Persist pin preference across page loads via `LocalStore`
+- Mount globally in `app/layout.tsx` so it appears on every route
+- Meet keyboard accessibility requirements: focusable controls, Escape to collapse, `aria-pressed` on pin, `role="complementary"`
+
+### Non-Goals
+
+- Data wiring (stream, messages, campaign ID) — Phase 5
+- Session-gating logic — Phase 5
+- Animations/transitions — not in acceptance criteria
+- Mobile layout optimisation
+
+## Decisions
+
+### Decision 1: Component placement — `lib/components/` not `app/`
+
+- **Chosen:** `lib/components/CampaignChat.tsx`
+- **Alternatives considered:** `app/_components/CampaignChat.tsx` (co-located with layout)
+- **Rationale:** All reusable UI components live in `lib/components/`. Future phases wire the dock to data hooks from `lib/hooks/` — keeping it in `lib/` maintains that locality. The issue spec also explicitly names `lib/components/` as the target.
+- **Trade-offs:** None meaningful at this scale.
+
+### Decision 2: Always render (no session-gating prop for now)
+
+- **Chosen:** `CampaignChat` renders unconditionally — no `campaignId` prop, no visibility gate.
+- **Alternatives considered:** Accept an optional `campaignId?: string` and render nothing when absent.
+- **Rationale:** Session-gating is Phase 5 work. Adding a prop slot now without wiring it risks dead code and test surface that's never exercised. The issue explicitly scopes this to "layout/states/a11y only."
+- **Trade-offs:** The pill is visible to all users on all pages until Phase 5 gates it. Acceptable as a dev/testing convenience — confirmed by user.
+
+### Decision 3: `LocalStore` for pin persistence (key `campaign-chat-pin`)
+
+- **Chosen:** `LocalStore.get<boolean>('campaign-chat-pin')` / `LocalStore.set('campaign-chat-pin', true)`
+- **Alternatives considered:** Raw `localStorage`, a React context with a reducer.
+- **Rationale:** `LocalStore` provides SSR safety (`isBrowser()` guard) and versioned envelopes. Raw `localStorage` is not used anywhere else in components — consistency matters.
+- **Trade-offs:** `LocalStore` wraps the value in a version envelope. A storage-version bump drops the pin preference silently (user gets collapsed dock). Acceptable — this is a UI preference, not data.
+
+### Decision 4: `z-40` for dock, `z-50` for Modals
+
+- **Chosen:** `z-40` on all dock elements.
+- **Alternatives considered:** `z-50` (same as Modal).
+- **Rationale:** Modals must always render above the dock. `z-50` stacking by DOM order is fragile. Explicit separation is safer.
+- **Trade-offs:** If the expanded drawer is open when a modal fires, the modal cleanly overlays the dock — no functional issue, minor visual layering that's expected.
+
+### Decision 5: Unpin = "don't reopen next time" not "collapse immediately"
+
+- **Chosen:** Toggling pin off only clears the `LocalStore` entry; current `isExpanded` state is untouched.
+- **Alternatives considered:** Collapse immediately on unpin.
+- **Rationale:** User opened the drawer intentionally this session. Closing it as a side effect of toggling a persistence preference is surprising. Confirmed by user.
+- **Trade-offs:** Slight mental model complexity ("pin is about reload, not current state") — addressed by `aria-pressed` labeling.
+
+### Decision 6: Escape key collapses regardless of pin state
+
+- **Chosen:** Escape always collapses; pin state is not consulted.
+- **Alternatives considered:** Escape does nothing while pinned.
+- **Rationale:** Keyboard users expect Escape to dismiss overlays. Pin is a persistence preference, not a lock.
+- **Trade-offs:** Pin-then-Escape leaves the dock collapsed until next reload (when it reopens). This is the correct mental model: Escape = "I want this gone right now."
+
+## Proposal to Design Mapping
+
+- Proposal element: Corner pill, `fixed bottom-4 right-4 z-40`
+  - Design decision: D4 (z-40), D1 (component location)
+  - Validation approach: RTL — assert pill button is in the document; CSS class snapshot or computed style check
+
+- Proposal element: Expanded drawer `w-80 h-[33vh]`, anchored `bottom-0 right-0`
+  - Design decision: D1, D4
+  - Validation approach: RTL — after clicking pill, assert drawer is present with correct role/aria-label
+
+- Proposal element: Pin persisted via `LocalStore`
+  - Design decision: D3, D5
+  - Validation approach: Unit test mocking `LocalStore` — assert `set` called on pin toggle, `get` read on mount, `isExpanded` defaults to pin value
+
+- Proposal element: Always renders
+  - Design decision: D2
+  - Validation approach: Render with no props, assert pill present
+
+- Proposal element: Escape collapses
+  - Design decision: D6
+  - Validation approach: RTL — expand drawer, fire `keydown` Escape, assert drawer gone
+
+## Functional Requirements Mapping
+
+- Requirement: Dock collapses/expands on button click
+  - Design element: `isExpanded` state toggled by pill button and close button
+  - Acceptance criteria reference: "dock collapses/expands"
+  - Testability notes: RTL `userEvent.click` on pill → assert drawer present; click close → assert drawer absent
+
+- Requirement: Pin state survives reload
+  - Design element: `LocalStore.get` on mount sets initial `isExpanded`; `LocalStore.set/remove` on pin toggle
+  - Acceptance criteria reference: "pin survives reload"
+  - Testability notes: Mock `LocalStore.get` returning `true` → assert `isExpanded` defaults to `true`
+
+- Requirement: Doesn't obstruct page when collapsed
+  - Design element: Collapsed pill is `rounded-full` small button at corner; no full-width bar
+  - Acceptance criteria reference: "doesn't obstruct the page when collapsed"
+  - Testability notes: Visual / snapshot; confirm drawer element absent when collapsed
+
+- Requirement: Keyboard accessible
+  - Design element: All interactive elements are `<button>`; Escape handler on drawer; `aria-pressed` on pin; `role="complementary"` on drawer; `aria-label="Campaign Chat"` on drawer
+  - Acceptance criteria reference: "keyboard-accessible"
+  - Testability notes: RTL — assert `getByRole('button', { name: /chat/i })`, `getByRole('complementary')`, `getByRole('button', { name: /pin/i, pressed: false })`
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: SSR-safe — no `localStorage` access during server render
+  - Design element: `LocalStore` has `isBrowser()` guard; `useEffect` for mount-time pin read
+  - Acceptance criteria reference: No hydration errors
+  - Testability notes: Jest runs in jsdom; confirm no `localStorage` calls at module import time
+
+- Requirement category: operability
+  - Requirement: No regressions to existing pages — dock is additive, `fixed` positioned
+  - Design element: `fixed` positioning takes the dock out of document flow; no layout shifts
+  - Acceptance criteria reference: Existing test suite passes
+  - Testability notes: Run full unit test suite; no existing test should fail
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `LocalStore` version bump silently drops pin state
+  - Impact: Low — user gets collapsed dock on next load; no data loss
+  - Mitigation: Isolated key (`campaign-chat-pin`) limits blast radius to this preference only
+
+- Risk/trade-off: Dock visible on all pages including `/login` and 404
+  - Impact: Low — shows placeholder pill with no data, harmless
+  - Mitigation: Phase 5 introduces session-gating; acceptable for shell phase
+
+## Rollback / Mitigation
+
+- **Rollback trigger:** Hydration errors in production, or visual regression reports from the dock obstructing critical UI
+- **Rollback steps:** Revert `app/layout.tsx` to remove `<CampaignChat />` import and usage; delete `lib/components/CampaignChat.tsx` and its test file
+- **Data migration considerations:** `LocalStore` key `campaign-chat-pin` remains in users' browsers but is harmless — no reader after rollback
+- **Verification after rollback:** Deploy, confirm no pill visible, run smoke tests on `/combat` and `/encounters`
+
+## Operational Blocking Policy
+
+- **If CI checks fail:** Do not merge. Fix failing tests or type errors before requesting review.
+- **If security checks fail:** Do not merge. This change introduces no auth, no API surface, no user input beyond button clicks — a security failure would indicate a dependency issue requiring investigation.
+- **If required reviews are blocked/stale:** Ping reviewer after 24 hours; escalate to repo owner after 48 hours.
+- **Escalation path and timeout:** After 48 hours unreviewed, repo owner (`dougis`) decides whether to merge or defer.
+
+## Open Questions
+
+No open questions remain. All design decisions confirmed during exploration session.

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md
@@ -73,7 +73,7 @@
   - Design decision: D4 (z-40), D1 (component location)
   - Validation approach: RTL — assert pill button is in the document; CSS class snapshot or computed style check
 
-- Proposal element: Expanded drawer `w-80 h-[33vh]`, anchored `bottom-0 right-0`
+- Proposal element: Expanded drawer `w-80`, height `33vh` via inline style, anchored `bottom-0 right-0`
   - Design decision: D1, D4
   - Validation approach: RTL — after clicking pill, assert drawer is present with correct role/aria-label
 

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/proposal.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/proposal.md
@@ -12,7 +12,7 @@
 ## Problem Space
 
 - **Current behavior:** No chat surface exists anywhere in the app.
-- **Desired behavior:** A fixed corner pill (bottom-right) is always present in the browser. Clicking it expands a drawer (`w-80`, `h-[33vh]`). A pin button persists the expanded state across page loads via `LocalStore`. Dismissing collapses it back to the pill. No data or messages — layout and interaction states only.
+- **Desired behavior:** A fixed corner pill (bottom-right) is always present in the browser. Clicking it expands a drawer (`w-80`, `height 33vh (inline style)`). A pin button persists the expanded state across page loads via `LocalStore`. Dismissing collapses it back to the pill. No data or messages — layout and interaction states only.
 - **Constraints:**
   - Must sit at `z-40` so `Modal` components (`z-50`) always render above it.
   - `LocalStore` (versioned localStorage abstraction) must be used for pin persistence — no raw `localStorage` calls.
@@ -34,7 +34,7 @@
 - `lib/components/CampaignChat.tsx` — new `'use client'` component
 - Mount point in `app/layout.tsx` (add `<CampaignChat />` before `</body>`)
 - Collapsed pill state: `fixed bottom-4 right-4 z-40`, rounded-full button
-- Expanded drawer state: `fixed bottom-0 right-0 w-80 h-[33vh] z-40`, flex-col layout
+- Expanded drawer state: `fixed bottom-0 right-0 w-80 height 33vh (inline style) z-40`, flex-col layout
 - Pin toggle with `LocalStore` persistence (key: `campaign-chat-pin`)
 - Keyboard accessibility: focusable buttons, Escape to collapse, `role="complementary"`, `aria-label`, `aria-pressed` on pin
 - Unit tests for collapse/expand, pin persistence, Escape key, and aria attributes
@@ -70,7 +70,7 @@ No unresolved ambiguity remains. All design decisions were confirmed during expl
 - Always renders (no session gating for now) ✓
 - `z-40` for dock ✓
 - Unpin = don't reopen next time (not collapse immediately) ✓
-- Expanded height: `h-[33vh]`, width: `w-80` ✓
+- Expanded height: `height 33vh (inline style)`, width: `w-80` ✓
 
 ## Non-Goals
 

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/proposal.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/proposal.md
@@ -1,0 +1,85 @@
+## GitHub Issues
+
+- dougis-org/session-combat#313
+- dougis-org/session-combat#296 (parent epic)
+
+## Why
+
+- **Problem statement:** Multi-user campaign sessions need a persistent chat surface accessible from anywhere in the app. Phase 4 (4c) establishes the dock shell — the collapsible/pinnable container — so Phases 5 and 6 can wire in real-time messaging and roll-sharing without rethinking the chrome.
+- **Why now:** 4a (SSE endpoint) and 4b (`useCampaignStream` hook) have no upstream blockers. 4c also has none — it is pure layout. Doing it now unblocks the visual integration work.
+- **Business/user impact:** DMs running live sessions need chat that stays out of the way when not needed but is instantly reachable. The collapsed pill satisfies "doesn't obstruct"; the pin-open control satisfies "stays open when I'm actively using it."
+
+## Problem Space
+
+- **Current behavior:** No chat surface exists anywhere in the app.
+- **Desired behavior:** A fixed corner pill (bottom-right) is always present in the browser. Clicking it expands a drawer (`w-80`, `h-[33vh]`). A pin button persists the expanded state across page loads via `LocalStore`. Dismissing collapses it back to the pill. No data or messages — layout and interaction states only.
+- **Constraints:**
+  - Must sit at `z-40` so `Modal` components (`z-50`) always render above it.
+  - `LocalStore` (versioned localStorage abstraction) must be used for pin persistence — no raw `localStorage` calls.
+  - No data wiring: no props for campaign ID, no event stream, no message list.
+  - Must be keyboard-accessible (focusable buttons, Escape to collapse, `aria-pressed` on pin).
+- **Assumptions:**
+  - Session-gating ("only show when user has an active campaign session") is deferred to Phase 5.
+  - The dock always renders for now, showing placeholder body content.
+  - Unpinning while expanded leaves the drawer open for the current session; pin only controls initial state on next load.
+- **Edge cases considered:**
+  - SSR: `LocalStore` has an `isBrowser()` guard — safe on server render, pin state hydrates client-side.
+  - Modal open + dock expanded simultaneously: `z-40` vs `z-50` ensures no conflict.
+  - Escape key while pinned: still collapses (pin is about reload, not locking the UI).
+
+## Scope
+
+### In Scope
+
+- `lib/components/CampaignChat.tsx` — new `'use client'` component
+- Mount point in `app/layout.tsx` (add `<CampaignChat />` before `</body>`)
+- Collapsed pill state: `fixed bottom-4 right-4 z-40`, rounded-full button
+- Expanded drawer state: `fixed bottom-0 right-0 w-80 h-[33vh] z-40`, flex-col layout
+- Pin toggle with `LocalStore` persistence (key: `campaign-chat-pin`)
+- Keyboard accessibility: focusable buttons, Escape to collapse, `role="complementary"`, `aria-label`, `aria-pressed` on pin
+- Unit tests for collapse/expand, pin persistence, Escape key, and aria attributes
+
+### Out of Scope
+
+- Real-time data wiring (Phase 5, issue #315)
+- Roll-share UI (Phase 6, issue #317)
+- Session-gating / active-campaign detection
+- Animations or CSS transitions (not required by acceptance criteria)
+- Mobile / responsive breakpoints beyond fixed positioning
+
+## What Changes
+
+- **New file:** `lib/components/CampaignChat.tsx` — the dock shell component
+- **Modified file:** `app/layout.tsx` — import and render `<CampaignChat />` inside `<body>`
+- **New file:** `tests/unit/components/CampaignChat.test.tsx` — unit tests
+
+## Risks
+
+- Risk: `LocalStore` versioning causes pin state to be silently dropped on version bump.
+  - Impact: Low — users lose their pin preference, not data. Dock defaults to collapsed.
+  - Mitigation: Use a dedicated key (`campaign-chat-pin`) so a version bump only resets this preference, not other stored state.
+
+- Risk: `z-40` dock visible beneath open modals looks odd if the drawer is expanded when a modal opens.
+  - Impact: Low — visual layering is correct (`z-50` modal wins); no functional issue.
+  - Mitigation: Acceptable for this phase. Future phase may add "collapse on modal open" logic.
+
+## Open Questions
+
+No unresolved ambiguity remains. All design decisions were confirmed during exploration:
+- Dock position: bottom-right corner pill (Option A) ✓
+- Always renders (no session gating for now) ✓
+- `z-40` for dock ✓
+- Unpin = don't reopen next time (not collapse immediately) ✓
+- Expanded height: `h-[33vh]`, width: `w-80` ✓
+
+## Non-Goals
+
+- This is not a full chat feature — no messages, no users, no real-time data.
+- This is not a responsive/mobile layout — the dock is desktop-first.
+- This does not implement session presence or "who's online" indicators.
+- This does not introduce any new design tokens beyond what Tailwind v4 stock provides.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/specs/campaign-chat-dock/spec.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/specs/campaign-chat-dock/spec.md
@@ -1,0 +1,160 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED CampaignChat dock shell renders globally
+
+The system SHALL render a `CampaignChat` component on every page of the application via `app/layout.tsx`.
+
+#### Scenario: Pill present on initial render
+
+- **Given** the application is loaded on any route
+- **When** the page renders
+- **Then** a button with accessible name matching `/chat/i` is present in the document
+
+#### Scenario: Drawer absent on initial render (default collapsed)
+
+- **Given** `LocalStore` has no stored pin preference
+- **When** the component mounts
+- **Then** the element with `role="complementary"` and `aria-label="Campaign Chat"` is not present in the document
+
+---
+
+### Requirement: ADDED Collapse/expand toggle
+
+The system SHALL toggle between collapsed (pill) and expanded (drawer) states on user interaction.
+
+#### Scenario: Expand dock by clicking the pill
+
+- **Given** the dock is in collapsed state
+- **When** the user clicks the pill button
+- **Then** the element with `role="complementary"` and `aria-label="Campaign Chat"` is present in the document
+
+#### Scenario: Collapse dock by clicking the close button
+
+- **Given** the dock is in expanded state
+- **When** the user clicks the close button (accessible name `/close/i` or `/collapse/i`)
+- **Then** the element with `role="complementary"` is removed from the document
+
+#### Scenario: Collapse dock via Escape key
+
+- **Given** the dock is in expanded state
+- **When** the user presses the Escape key
+- **Then** the element with `role="complementary"` is removed from the document
+
+#### Scenario: Escape key does nothing when dock is already collapsed
+
+- **Given** the dock is in collapsed state
+- **When** the user presses the Escape key
+- **Then** no error occurs and the dock remains collapsed
+
+---
+
+### Requirement: ADDED Pin-open control persisted to LocalStore
+
+The system SHALL persist the pin preference using `LocalStore` under the key `campaign-chat-pin`, and restore it on mount.
+
+#### Scenario: Pin button toggles to pinned state
+
+- **Given** the dock is expanded and not pinned
+- **When** the user clicks the pin button
+- **Then** the pin button has `aria-pressed="true"` and `LocalStore.set` is called with key `campaign-chat-pin` and value `true`
+
+#### Scenario: Pin button toggles to unpinned state
+
+- **Given** the dock is expanded and pinned (`aria-pressed="true"`)
+- **When** the user clicks the pin button
+- **Then** the pin button has `aria-pressed="false"` and `LocalStore.remove` is called with key `campaign-chat-pin`
+
+#### Scenario: Dock opens on mount when pin is stored
+
+- **Given** `LocalStore.get('campaign-chat-pin')` returns `true`
+- **When** the component mounts
+- **Then** the element with `role="complementary"` is present in the document (drawer expanded)
+
+#### Scenario: Dock starts collapsed when pin is not stored
+
+- **Given** `LocalStore.get('campaign-chat-pin')` returns `null`
+- **When** the component mounts
+- **Then** the element with `role="complementary"` is not present in the document
+
+#### Scenario: Unpinning while expanded does not collapse the drawer
+
+- **Given** the dock is expanded and pinned
+- **When** the user clicks the pin button to unpin
+- **Then** the element with `role="complementary"` is still present in the document (drawer remains expanded)
+
+---
+
+### Requirement: ADDED Keyboard accessibility
+
+The system SHALL be fully operable via keyboard with appropriate ARIA attributes.
+
+#### Scenario: Pill button is focusable and activatable
+
+- **Given** the dock is collapsed
+- **When** the user focuses the pill button and presses Enter or Space
+- **Then** the drawer expands (same result as click)
+
+#### Scenario: Drawer has complementary landmark and label
+
+- **Given** the dock is expanded
+- **When** the DOM is queried
+- **Then** an element with `role="complementary"` and `aria-label="Campaign Chat"` is present
+
+#### Scenario: Pin button reports pressed state
+
+- **Given** the dock is expanded
+- **When** the DOM is queried
+- **Then** the pin button has `aria-pressed` attribute reflecting current pin state (`"true"` when pinned, `"false"` when not pinned)
+
+---
+
+## MODIFIED Requirements
+
+No existing requirements are modified by this change.
+
+---
+
+## REMOVED Requirements
+
+No existing requirements are removed by this change.
+
+---
+
+## Traceability
+
+- Proposal element "Corner pill, `fixed bottom-4 right-4 z-40`" → Requirement: ADDED CampaignChat dock shell renders globally
+- Proposal element "Expanded drawer `w-80 h-[33vh]`" → Requirement: ADDED Collapse/expand toggle
+- Proposal element "Pin persisted via LocalStore" → Requirement: ADDED Pin-open control persisted to LocalStore
+- Proposal element "Keyboard accessible" → Requirement: ADDED Keyboard accessibility
+- Design decision D2 (always render) → Requirement: ADDED CampaignChat dock shell renders globally → Task: mount in `app/layout.tsx`
+- Design decision D3 (LocalStore) → Requirement: ADDED Pin-open control persisted to LocalStore → Task: implement pin toggle in `CampaignChat`
+- Design decision D5 (unpin = don't collapse) → Scenario: Unpinning while expanded does not collapse the drawer
+- Design decision D6 (Escape always collapses) → Scenario: Collapse dock via Escape key
+- Requirement: ADDED CampaignChat dock shell renders globally → Task: create `lib/components/CampaignChat.tsx`, modify `app/layout.tsx`
+- Requirement: ADDED Keyboard accessibility → Task: add ARIA attributes and Escape handler to `CampaignChat`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability — SSR safety
+
+#### Scenario: No localStorage access during server render
+
+- **Given** the component is rendered in a Node.js (non-browser) environment
+- **When** the module is imported and the component tree is server-rendered
+- **Then** no `localStorage` access is attempted (verified by `LocalStore`'s `isBrowser()` guard and `useEffect`-gated mount logic)
+
+### Requirement: Reliability — no layout regression
+
+#### Scenario: Existing tests pass after layout change
+
+- **Given** `<CampaignChat />` is added to `app/layout.tsx`
+- **When** the full unit and integration test suite is run
+- **Then** no previously passing test fails (the dock is `fixed`-positioned and out of document flow)
+
+### Requirement: Security
+
+See functional scenarios above — no authentication, authorization, or sensitive data is involved in this component. The dock renders static UI with no user-supplied input beyond button clicks.

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/specs/campaign-chat-dock/spec.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/specs/campaign-chat-dock/spec.md
@@ -125,7 +125,7 @@ No existing requirements are removed by this change.
 ## Traceability
 
 - Proposal element "Corner pill, `fixed bottom-4 right-4 z-40`" → Requirement: ADDED CampaignChat dock shell renders globally
-- Proposal element "Expanded drawer `w-80 h-[33vh]`" → Requirement: ADDED Collapse/expand toggle
+- Proposal element "Expanded drawer `w-80`, height `33vh` via inline style" → Requirement: ADDED Collapse/expand toggle
 - Proposal element "Pin persisted via LocalStore" → Requirement: ADDED Pin-open control persisted to LocalStore
 - Proposal element "Keyboard accessible" → Requirement: ADDED Keyboard accessibility
 - Design decision D2 (always render) → Requirement: ADDED CampaignChat dock shell renders globally → Task: mount in `app/layout.tsx`

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/tasks.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/tasks.md
@@ -59,7 +59,7 @@ Write tests covering all spec scenarios. Mock `LocalStore` at the module level.
 
 ## Pre-Commit Code Review
 
-- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
 
 ## Validation
 
@@ -79,14 +79,14 @@ Verification requirements (all must pass before PR or pushing updates to a PR):
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `feat/campaign-chat-dock-shell` and push to remote
-- [ ] Open PR from `feat/campaign-chat-dock-shell` to `main`. PR body MUST include: `Closes #313`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
-- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, validate locally, push; wait 180 seconds then repeat until no unresolved comments remain
-- [ ] **Monitor CI checks** — `gh pr checks <PR-URL> --json isRequired,state`; fix any required failing checks, validate locally, push; wait 180 seconds then repeat
-- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/campaign-chat-dock-shell` and push to remote
+- [x] Open PR from `feat/campaign-chat-dock-shell` to `main`. PR body MUST include: `Closes #313`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [x] **Monitor PR comments** — addressed Gemini (useRef, focus restore, pin SVG) and Copilot (LocalStore try/catch ×2) feedback; refactored to useReducer to fix lint; resolved all 9 threads
+- [x] **Monitor CI checks** — all checks passed (lint, unit-tests, integration-tests, regression-tests, Codacy)
+- [x] **Poll for merge** — PR #403 merged via auto-merge (squash)
 
 Ownership metadata:
 
@@ -102,14 +102,14 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on `main`
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Update `openspec/specs/campaign-chat-dock/spec.md` — sync from `openspec/changes/campaign-chat-dock-shell/specs/campaign-chat-dock/spec.md` (update relative paths to `../../changes/archive/YYYY-MM-DD-campaign-chat-dock-shell/design.md` and `tasks.md`)
-- [ ] Archive the change: move `openspec/changes/campaign-chat-dock-shell/` to `openspec/changes/archive/YYYY-MM-DD-campaign-chat-dock-shell/` — stage both the new location and deletion of the old in a **single commit**
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-chat-dock-shell/` exists and `openspec/changes/campaign-chat-dock-shell/` is gone
-- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-chat-dock-shell` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-chat-dock-shell`
-- [ ] Open PR from `doc/archive-YYYY-MM-DD-campaign-chat-dock-shell` to `main` with title `docs: archive campaign-chat-dock-shell (YYYY-MM-DD)`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
-- [ ] Monitor the doc PR until it merges (same loop as implementation PR)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/campaign-chat-dock-shell doc/archive-YYYY-MM-DD-campaign-chat-dock-shell`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on `main`
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Update `openspec/specs/campaign-chat-dock/spec.md` — created canonical spec (no relative paths to update)
+- [x] Archive the change: move `openspec/changes/campaign-chat-dock-shell/` to `openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/`
+- [x] Confirm archive exists and original is gone
+- [x] **Create doc branch:** `doc/archive-2026-06-09-campaign-chat-dock-shell`
+- [x] Open PR for doc branch
+- [x] Enable auto-merge on doc PR
+- [x] Monitor doc PR until merged
+- [x] Prune merged local branches

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/tests.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/tests.md
@@ -25,7 +25,7 @@ jest.mock('@/lib/offline/LocalStore', () => ({
 ## Testing Steps
 
 For each task, follow the TDD cycle:
-1. **Write a failing test** — run `npm test -- --testPathPattern=CampaignChat`, confirm it fails
+1. **Write a failing test** — run `npx jest --testPathPattern=CampaignChat`, confirm it fails
 2. **Write minimum implementation** — make the test pass
 3. **Refactor** — clean up while keeping tests green
 
@@ -37,75 +37,75 @@ For each task, follow the TDD cycle:
 
 #### Render and initial state
 
-- [ ] **TC-01** — Pill button present on render
+- [x] **TC-01** — Pill button present on render
   - Spec: "Pill present on initial render"
   - `render(<CampaignChat />)` → `expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()`
 
-- [ ] **TC-02** — Drawer absent on initial render (no pin stored)
+- [x] **TC-02** — Drawer absent on initial render (no pin stored)
   - Spec: "Drawer absent on initial render (default collapsed)"
   - Mock `LocalStore.get` returning `null` → `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`
 
-- [ ] **TC-03** — Drawer present on mount when pin is stored
+- [x] **TC-03** — Drawer present on mount when pin is stored
   - Spec: "Dock opens on mount when pin is stored"
   - Mock `LocalStore.get` returning `true` → `expect(screen.getByRole('complementary', { name: /campaign chat/i })).toBeInTheDocument()`
 
 #### Expand / collapse
 
-- [ ] **TC-04** — Clicking pill expands the drawer
+- [x] **TC-04** — Clicking pill expands the drawer
   - Spec: "Expand dock by clicking the pill"
   - `userEvent.click(pill)` → `expect(screen.getByRole('complementary')).toBeInTheDocument()`
 
-- [ ] **TC-05** — Clicking close button collapses the drawer
+- [x] **TC-05** — Clicking close button collapses the drawer
   - Spec: "Collapse dock by clicking the close button"
   - Expand, then `userEvent.click(getByRole('button', { name: /collapse/i }))` → `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`
 
-- [ ] **TC-06** — Pressing Escape collapses the drawer
+- [x] **TC-06** — Pressing Escape collapses the drawer
   - Spec: "Collapse dock via Escape key"
   - Expand, then `fireEvent.keyDown(document, { key: 'Escape' })` → `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`
 
-- [ ] **TC-07** — Pressing Escape when collapsed has no effect
+- [x] **TC-07** — Pressing Escape when collapsed has no effect
   - Spec: "Escape key does nothing when dock is already collapsed"
   - `fireEvent.keyDown(document, { key: 'Escape' })` → no error; `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`; `expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()`
 
 #### Pin control
 
-- [ ] **TC-08** — Pin button has `aria-pressed="false"` when not pinned
+- [x] **TC-08** — Pin button has `aria-pressed="false"` when not pinned
   - Spec: "Pin button reports pressed state"
   - Expand → `expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute('aria-pressed', 'false')`
 
-- [ ] **TC-09** — Clicking pin sets `aria-pressed="true"` and calls `LocalStore.set`
+- [x] **TC-09** — Clicking pin sets `aria-pressed="true"` and calls `LocalStore.set`
   - Spec: "Pin button toggles to pinned state"
   - Expand, click pin → `expect(pinButton).toHaveAttribute('aria-pressed', 'true')` and `expect(LocalStore.set).toHaveBeenCalledWith('campaign-chat-pin', true)`
 
-- [ ] **TC-10** — Clicking pin again sets `aria-pressed="false"` and calls `LocalStore.remove`
+- [x] **TC-10** — Clicking pin again sets `aria-pressed="false"` and calls `LocalStore.remove`
   - Spec: "Pin button toggles to unpinned state"
   - Expand, pin, unpin → `expect(pinButton).toHaveAttribute('aria-pressed', 'false')` and `expect(LocalStore.remove).toHaveBeenCalledWith('campaign-chat-pin')`
 
-- [ ] **TC-11** — Unpinning while expanded does not collapse the drawer
+- [x] **TC-11** — Unpinning while expanded does not collapse the drawer
   - Spec: "Unpinning while expanded does not collapse the drawer"
   - Expand, pin, unpin → `expect(screen.getByRole('complementary')).toBeInTheDocument()`
 
 #### Accessibility
 
-- [ ] **TC-12** — Drawer has `role="complementary"` and `aria-label="Campaign Chat"`
+- [x] **TC-12** — Drawer has `role="complementary"` and `aria-label="Campaign Chat"`
   - Spec: "Drawer has complementary landmark and label"
   - Expand → `expect(screen.getByRole('complementary', { name: 'Campaign Chat' })).toBeInTheDocument()`
 
-- [ ] **TC-13** — Pill button is keyboard-activatable (Enter/Space)
+- [x] **TC-13** — Pill button is keyboard-activatable (Enter/Space)
   - Spec: "Pill button is focusable and activatable"
   - `userEvent.type(pill, '{enter}')` → drawer appears; collapse; `userEvent.type(pill, ' ')` → drawer appears
 
 ### Task 2 — `app/layout.tsx` mount
 
-- [ ] **TC-14** — `CampaignChat` import and usage compile without type errors
+- [x] **TC-14** — `CampaignChat` import and usage compile without type errors
   - Spec: "No layout regression"
-  - `npx tsc --noEmit` — zero errors after adding import and `<CampaignChat />` to `app/layout.tsx`
+  - `npm run typecheck` — zero errors after adding import and `<CampaignChat />` to `app/layout.tsx`
 
 ### Task 3 — Non-functional
 
-- [ ] **TC-15** — Full unit suite passes after changes
+- [x] **TC-15** — Full unit suite passes after changes
   - Spec: "Existing tests pass after layout change"
-  - `npm test` — zero test regressions
+  - `npm run test:unit` — zero test regressions
 
-- [ ] **TC-16** — Build succeeds
+- [x] **TC-16** — Build succeeds
   - `npm run build` — exits 0

--- a/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/tests.md
+++ b/openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/tests.md
@@ -1,0 +1,111 @@
+---
+name: tests
+description: Tests for the campaign-chat-dock-shell change
+---
+
+# Tests
+
+## Overview
+
+Tests for `CampaignChat` — the collapsible/pinnable chat dock shell. All work follows strict TDD: write a failing test, write the minimum code to pass it, then refactor.
+
+Test file: `tests/unit/components/CampaignChat.test.tsx`
+
+`LocalStore` is mocked at the module level for all tests:
+```ts
+jest.mock('@/lib/offline/LocalStore', () => ({
+  LocalStore: {
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+```
+
+## Testing Steps
+
+For each task, follow the TDD cycle:
+1. **Write a failing test** — run `npm test -- --testPathPattern=CampaignChat`, confirm it fails
+2. **Write minimum implementation** — make the test pass
+3. **Refactor** — clean up while keeping tests green
+
+---
+
+## Test Cases
+
+### Task 1 — `CampaignChat` component
+
+#### Render and initial state
+
+- [ ] **TC-01** — Pill button present on render
+  - Spec: "Pill present on initial render"
+  - `render(<CampaignChat />)` → `expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()`
+
+- [ ] **TC-02** — Drawer absent on initial render (no pin stored)
+  - Spec: "Drawer absent on initial render (default collapsed)"
+  - Mock `LocalStore.get` returning `null` → `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`
+
+- [ ] **TC-03** — Drawer present on mount when pin is stored
+  - Spec: "Dock opens on mount when pin is stored"
+  - Mock `LocalStore.get` returning `true` → `expect(screen.getByRole('complementary', { name: /campaign chat/i })).toBeInTheDocument()`
+
+#### Expand / collapse
+
+- [ ] **TC-04** — Clicking pill expands the drawer
+  - Spec: "Expand dock by clicking the pill"
+  - `userEvent.click(pill)` → `expect(screen.getByRole('complementary')).toBeInTheDocument()`
+
+- [ ] **TC-05** — Clicking close button collapses the drawer
+  - Spec: "Collapse dock by clicking the close button"
+  - Expand, then `userEvent.click(getByRole('button', { name: /collapse/i }))` → `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`
+
+- [ ] **TC-06** — Pressing Escape collapses the drawer
+  - Spec: "Collapse dock via Escape key"
+  - Expand, then `fireEvent.keyDown(document, { key: 'Escape' })` → `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`
+
+- [ ] **TC-07** — Pressing Escape when collapsed has no effect
+  - Spec: "Escape key does nothing when dock is already collapsed"
+  - `fireEvent.keyDown(document, { key: 'Escape' })` → no error; `expect(screen.queryByRole('complementary')).not.toBeInTheDocument()`; `expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()`
+
+#### Pin control
+
+- [ ] **TC-08** — Pin button has `aria-pressed="false"` when not pinned
+  - Spec: "Pin button reports pressed state"
+  - Expand → `expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute('aria-pressed', 'false')`
+
+- [ ] **TC-09** — Clicking pin sets `aria-pressed="true"` and calls `LocalStore.set`
+  - Spec: "Pin button toggles to pinned state"
+  - Expand, click pin → `expect(pinButton).toHaveAttribute('aria-pressed', 'true')` and `expect(LocalStore.set).toHaveBeenCalledWith('campaign-chat-pin', true)`
+
+- [ ] **TC-10** — Clicking pin again sets `aria-pressed="false"` and calls `LocalStore.remove`
+  - Spec: "Pin button toggles to unpinned state"
+  - Expand, pin, unpin → `expect(pinButton).toHaveAttribute('aria-pressed', 'false')` and `expect(LocalStore.remove).toHaveBeenCalledWith('campaign-chat-pin')`
+
+- [ ] **TC-11** — Unpinning while expanded does not collapse the drawer
+  - Spec: "Unpinning while expanded does not collapse the drawer"
+  - Expand, pin, unpin → `expect(screen.getByRole('complementary')).toBeInTheDocument()`
+
+#### Accessibility
+
+- [ ] **TC-12** — Drawer has `role="complementary"` and `aria-label="Campaign Chat"`
+  - Spec: "Drawer has complementary landmark and label"
+  - Expand → `expect(screen.getByRole('complementary', { name: 'Campaign Chat' })).toBeInTheDocument()`
+
+- [ ] **TC-13** — Pill button is keyboard-activatable (Enter/Space)
+  - Spec: "Pill button is focusable and activatable"
+  - `userEvent.type(pill, '{enter}')` → drawer appears; collapse; `userEvent.type(pill, ' ')` → drawer appears
+
+### Task 2 — `app/layout.tsx` mount
+
+- [ ] **TC-14** — `CampaignChat` import and usage compile without type errors
+  - Spec: "No layout regression"
+  - `npx tsc --noEmit` — zero errors after adding import and `<CampaignChat />` to `app/layout.tsx`
+
+### Task 3 — Non-functional
+
+- [ ] **TC-15** — Full unit suite passes after changes
+  - Spec: "Existing tests pass after layout change"
+  - `npm test` — zero test regressions
+
+- [ ] **TC-16** — Build succeeds
+  - `npm run build` — exits 0

--- a/openspec/specs/campaign-chat-dock/spec.md
+++ b/openspec/specs/campaign-chat-dock/spec.md
@@ -1,8 +1,10 @@
-## ADDED Requirements
+# Campaign Chat Dock — Specification
 
-This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+This document is the canonical specification for the `CampaignChat` dock shell feature (Phase 4c). Implementation: `lib/components/CampaignChat.tsx`, mounted globally in `app/layout.tsx`. Design rationale: `openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md`.
 
-### Requirement: ADDED CampaignChat dock shell renders globally
+---
+
+## Requirement: CampaignChat dock shell renders globally
 
 The system SHALL render a `CampaignChat` component on every page of the application via `app/layout.tsx`.
 
@@ -20,7 +22,7 @@ The system SHALL render a `CampaignChat` component on every page of the applicat
 
 ---
 
-### Requirement: ADDED Collapse/expand toggle
+## Requirement: Collapse/expand toggle
 
 The system SHALL toggle between collapsed (pill) and expanded (drawer) states on user interaction.
 
@@ -50,7 +52,7 @@ The system SHALL toggle between collapsed (pill) and expanded (drawer) states on
 
 ---
 
-### Requirement: ADDED Pin-open control persisted to LocalStore
+## Requirement: Pin-open control persisted to LocalStore
 
 The system SHALL persist the pin preference using `LocalStore` under the key `campaign-chat-pin`, and restore it on mount.
 
@@ -86,7 +88,7 @@ The system SHALL persist the pin preference using `LocalStore` under the key `ca
 
 ---
 
-### Requirement: ADDED Keyboard accessibility
+## Requirement: Keyboard accessibility
 
 The system SHALL be fully operable via keyboard with appropriate ARIA attributes.
 
@@ -110,36 +112,9 @@ The system SHALL be fully operable via keyboard with appropriate ARIA attributes
 
 ---
 
-## MODIFIED Requirements
+## Non-Functional Requirements
 
-No existing requirements are modified by this change.
-
----
-
-## REMOVED Requirements
-
-No existing requirements are removed by this change.
-
----
-
-## Traceability
-
-- Proposal element "Corner pill, `fixed bottom-4 right-4 z-40`" → Requirement: ADDED CampaignChat dock shell renders globally
-- Proposal element "Expanded drawer `w-80 h-[33vh]`" → Requirement: ADDED Collapse/expand toggle
-- Proposal element "Pin persisted via LocalStore" → Requirement: ADDED Pin-open control persisted to LocalStore
-- Proposal element "Keyboard accessible" → Requirement: ADDED Keyboard accessibility
-- Design decision D2 (always render) → Requirement: ADDED CampaignChat dock shell renders globally → Task: mount in `app/layout.tsx`
-- Design decision D3 (LocalStore) → Requirement: ADDED Pin-open control persisted to LocalStore → Task: implement pin toggle in `CampaignChat`
-- Design decision D5 (unpin = don't collapse) → Scenario: Unpinning while expanded does not collapse the drawer
-- Design decision D6 (Escape always collapses) → Scenario: Collapse dock via Escape key
-- Requirement: ADDED CampaignChat dock shell renders globally → Task: create `lib/components/CampaignChat.tsx`, modify `app/layout.tsx`
-- Requirement: ADDED Keyboard accessibility → Task: add ARIA attributes and Escape handler to `CampaignChat`
-
----
-
-## Non-Functional Acceptance Criteria
-
-### Requirement: Reliability — SSR safety
+### Reliability — SSR safety
 
 #### Scenario: No localStorage access during server render
 
@@ -147,7 +122,7 @@ No existing requirements are removed by this change.
 - **When** the module is imported and the component tree is server-rendered
 - **Then** no `localStorage` access is attempted (verified by `LocalStore`'s `isBrowser()` guard and `useEffect`-gated mount logic)
 
-### Requirement: Reliability — no layout regression
+### Reliability — no layout regression
 
 #### Scenario: Existing tests pass after layout change
 
@@ -155,6 +130,21 @@ No existing requirements are removed by this change.
 - **When** the full unit and integration test suite is run
 - **Then** no previously passing test fails (the dock is `fixed`-positioned and out of document flow)
 
-### Requirement: Security
+### Security
 
-See functional scenarios above — no authentication, authorization, or sensitive data is involved in this component. The dock renders static UI with no user-supplied input beyond button clicks.
+No authentication, authorization, or sensitive data is involved in this component. The dock renders static UI with no user-supplied input beyond button clicks.
+
+---
+
+## Traceability
+
+- Corner pill (`fixed bottom-4 right-4 z-40`) → Requirement: CampaignChat dock shell renders globally
+- Expanded drawer (`w-80 h-[33vh]`) → Requirement: Collapse/expand toggle
+- Pin persisted via LocalStore → Requirement: Pin-open control persisted to LocalStore
+- Keyboard accessible → Requirement: Keyboard accessibility
+- Design D2 (always render) → Requirement: dock renders globally → `app/layout.tsx`
+- Design D3 (LocalStore key `campaign-chat-pin`) → Requirement: pin persisted → `CampaignChat` pin toggle
+- Design D5 (unpin = don't collapse) → Scenario: Unpinning while expanded does not collapse
+- Design D6 (Escape always collapses) → Scenario: Collapse dock via Escape key
+- Implementation: `lib/components/CampaignChat.tsx`, `app/layout.tsx`
+- Tests: `tests/unit/components/CampaignChat.test.tsx`

--- a/openspec/specs/campaign-chat-dock/spec.md
+++ b/openspec/specs/campaign-chat-dock/spec.md
@@ -1,0 +1,160 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `design.md` document, not a replacement.
+
+### Requirement: ADDED CampaignChat dock shell renders globally
+
+The system SHALL render a `CampaignChat` component on every page of the application via `app/layout.tsx`.
+
+#### Scenario: Pill present on initial render
+
+- **Given** the application is loaded on any route
+- **When** the page renders
+- **Then** a button with accessible name matching `/chat/i` is present in the document
+
+#### Scenario: Drawer absent on initial render (default collapsed)
+
+- **Given** `LocalStore` has no stored pin preference
+- **When** the component mounts
+- **Then** the element with `role="complementary"` and `aria-label="Campaign Chat"` is not present in the document
+
+---
+
+### Requirement: ADDED Collapse/expand toggle
+
+The system SHALL toggle between collapsed (pill) and expanded (drawer) states on user interaction.
+
+#### Scenario: Expand dock by clicking the pill
+
+- **Given** the dock is in collapsed state
+- **When** the user clicks the pill button
+- **Then** the element with `role="complementary"` and `aria-label="Campaign Chat"` is present in the document
+
+#### Scenario: Collapse dock by clicking the close button
+
+- **Given** the dock is in expanded state
+- **When** the user clicks the close button (accessible name `/close/i` or `/collapse/i`)
+- **Then** the element with `role="complementary"` is removed from the document
+
+#### Scenario: Collapse dock via Escape key
+
+- **Given** the dock is in expanded state
+- **When** the user presses the Escape key
+- **Then** the element with `role="complementary"` is removed from the document
+
+#### Scenario: Escape key does nothing when dock is already collapsed
+
+- **Given** the dock is in collapsed state
+- **When** the user presses the Escape key
+- **Then** no error occurs and the dock remains collapsed
+
+---
+
+### Requirement: ADDED Pin-open control persisted to LocalStore
+
+The system SHALL persist the pin preference using `LocalStore` under the key `campaign-chat-pin`, and restore it on mount.
+
+#### Scenario: Pin button toggles to pinned state
+
+- **Given** the dock is expanded and not pinned
+- **When** the user clicks the pin button
+- **Then** the pin button has `aria-pressed="true"` and `LocalStore.set` is called with key `campaign-chat-pin` and value `true`
+
+#### Scenario: Pin button toggles to unpinned state
+
+- **Given** the dock is expanded and pinned (`aria-pressed="true"`)
+- **When** the user clicks the pin button
+- **Then** the pin button has `aria-pressed="false"` and `LocalStore.remove` is called with key `campaign-chat-pin`
+
+#### Scenario: Dock opens on mount when pin is stored
+
+- **Given** `LocalStore.get('campaign-chat-pin')` returns `true`
+- **When** the component mounts
+- **Then** the element with `role="complementary"` is present in the document (drawer expanded)
+
+#### Scenario: Dock starts collapsed when pin is not stored
+
+- **Given** `LocalStore.get('campaign-chat-pin')` returns `null`
+- **When** the component mounts
+- **Then** the element with `role="complementary"` is not present in the document
+
+#### Scenario: Unpinning while expanded does not collapse the drawer
+
+- **Given** the dock is expanded and pinned
+- **When** the user clicks the pin button to unpin
+- **Then** the element with `role="complementary"` is still present in the document (drawer remains expanded)
+
+---
+
+### Requirement: ADDED Keyboard accessibility
+
+The system SHALL be fully operable via keyboard with appropriate ARIA attributes.
+
+#### Scenario: Pill button is focusable and activatable
+
+- **Given** the dock is collapsed
+- **When** the user focuses the pill button and presses Enter or Space
+- **Then** the drawer expands (same result as click)
+
+#### Scenario: Drawer has complementary landmark and label
+
+- **Given** the dock is expanded
+- **When** the DOM is queried
+- **Then** an element with `role="complementary"` and `aria-label="Campaign Chat"` is present
+
+#### Scenario: Pin button reports pressed state
+
+- **Given** the dock is expanded
+- **When** the DOM is queried
+- **Then** the pin button has `aria-pressed` attribute reflecting current pin state (`"true"` when pinned, `"false"` when not pinned)
+
+---
+
+## MODIFIED Requirements
+
+No existing requirements are modified by this change.
+
+---
+
+## REMOVED Requirements
+
+No existing requirements are removed by this change.
+
+---
+
+## Traceability
+
+- Proposal element "Corner pill, `fixed bottom-4 right-4 z-40`" → Requirement: ADDED CampaignChat dock shell renders globally
+- Proposal element "Expanded drawer `w-80 h-[33vh]`" → Requirement: ADDED Collapse/expand toggle
+- Proposal element "Pin persisted via LocalStore" → Requirement: ADDED Pin-open control persisted to LocalStore
+- Proposal element "Keyboard accessible" → Requirement: ADDED Keyboard accessibility
+- Design decision D2 (always render) → Requirement: ADDED CampaignChat dock shell renders globally → Task: mount in `app/layout.tsx`
+- Design decision D3 (LocalStore) → Requirement: ADDED Pin-open control persisted to LocalStore → Task: implement pin toggle in `CampaignChat`
+- Design decision D5 (unpin = don't collapse) → Scenario: Unpinning while expanded does not collapse the drawer
+- Design decision D6 (Escape always collapses) → Scenario: Collapse dock via Escape key
+- Requirement: ADDED CampaignChat dock shell renders globally → Task: create `lib/components/CampaignChat.tsx`, modify `app/layout.tsx`
+- Requirement: ADDED Keyboard accessibility → Task: add ARIA attributes and Escape handler to `CampaignChat`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability — SSR safety
+
+#### Scenario: No localStorage access during server render
+
+- **Given** the component is rendered in a Node.js (non-browser) environment
+- **When** the module is imported and the component tree is server-rendered
+- **Then** no `localStorage` access is attempted (verified by `LocalStore`'s `isBrowser()` guard and `useEffect`-gated mount logic)
+
+### Requirement: Reliability — no layout regression
+
+#### Scenario: Existing tests pass after layout change
+
+- **Given** `<CampaignChat />` is added to `app/layout.tsx`
+- **When** the full unit and integration test suite is run
+- **Then** no previously passing test fails (the dock is `fixed`-positioned and out of document flow)
+
+### Requirement: Security
+
+See functional scenarios above — no authentication, authorization, or sensitive data is involved in this component. The dock renders static UI with no user-supplied input beyond button clicks.

--- a/openspec/specs/campaign-chat-dock/spec.md
+++ b/openspec/specs/campaign-chat-dock/spec.md
@@ -139,7 +139,7 @@ No authentication, authorization, or sensitive data is involved in this componen
 ## Traceability
 
 - Corner pill (`fixed bottom-4 right-4 z-40`) → Requirement: CampaignChat dock shell renders globally
-- Expanded drawer (`w-80 h-[33vh]`) → Requirement: Collapse/expand toggle
+- Expanded drawer (`w-80`, height `33vh` via inline style) → Requirement: Collapse/expand toggle
 - Pin persisted via LocalStore → Requirement: Pin-open control persisted to LocalStore
 - Keyboard accessible → Requirement: Keyboard accessibility
 - Design D2 (always render) → Requirement: dock renders globally → `app/layout.tsx`


### PR DESCRIPTION
Archives the completed `campaign-chat-dock-shell` change after PR #403 merged.

- Moves `openspec/changes/campaign-chat-dock-shell/` → `openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/`
- Creates canonical spec at `openspec/specs/campaign-chat-dock/spec.md`