### PR TITLE
feat: doc-only CI skip, standalone build, coverage consolidation, ci-gate

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,8 @@ jobs:
       docs_only: ${{ steps.set-docs-only.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
@@ -79,7 +81,7 @@ jobs:
         env:
           MONGODB_URI: mongodb://localhost:27017
           MONGODB_DB: session-combat-test
-          GENERATE_SOURCE_MAPS: 'true'
+          GENERATE_SOURCE_MAPS: ${{ needs.check-changes.outputs.docs_only != 'true' }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -86,6 +86,7 @@ jobs:
           name: next-build
           path: .next/
           retention-days: 1
+          include-hidden-files: true
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,7 +81,7 @@ jobs:
           GENERATE_SOURCE_MAPS: 'true'
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: next-build
           path: .next/
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload unit coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: unit-lcov
           path: coverage/lcov.info
@@ -140,6 +140,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: next-build
+          path: .next/
+
       - name: Run integration tests with coverage
         run: npm run test:integration -- --coverage --forceExit
         env:
@@ -147,7 +153,7 @@ jobs:
 
       - name: Upload integration coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: integration-lcov
           path: coverage/lcov.info
@@ -236,7 +242,7 @@ jobs:
 
       - name: Upload E2E coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-lcov
           path: coverage-e2e/lcov.info

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
       docs_only: ${{ steps.docs-only.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@de90cc6415e9a3e19aafc651579a8f7a4cec8c49
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
           filters: |
@@ -380,7 +380,7 @@ jobs:
 
   ci-gate:
     runs-on: ubuntu-latest
-    needs: [lint, build, unit-tests, integration-tests, regression-tests, upload-and-finalize-coverage, check-codacy-coverage]
+    needs: [check-changes, lint, build, unit-tests, integration-tests, regression-tests, upload-and-finalize-coverage, check-codacy-coverage]
     if: always()
 
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
-      docs_only: ${{ steps.docs-only.outputs.docs_only }}
+      docs_only: ${{ steps.set-docs-only.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
@@ -23,7 +24,7 @@ jobs:
               - '**'
               - '!**/*.md'
       - name: Set docs_only output
-        id: docs-only
+        id: set-docs-only
         run: |
           if [ "${{ steps.filter.outputs.non_docs }}" == "true" ]; then
             echo "docs_only=false" >> $GITHUB_OUTPUT
@@ -328,7 +329,7 @@ jobs:
   check-codacy-coverage:
     runs-on: ubuntu-latest
     needs: [check-changes, upload-and-finalize-coverage]
-    if: needs.check-changes.outputs.docs_only != 'true' && github.event_name == 'pull_request'
+    if: needs.check-changes.outputs.docs_only != 'true' && github.event_name == 'pull_request' && secrets.CODACY_API_TOKEN != ''
 
     permissions:
       checks: read

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,7 +91,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    needs: [check-changes]
+    needs: [lint, check-changes]
     if: needs.check-changes.outputs.docs_only != 'true'
 
     permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -329,7 +329,7 @@ jobs:
   check-codacy-coverage:
     runs-on: ubuntu-latest
     needs: [check-changes, upload-and-finalize-coverage]
-    if: needs.check-changes.outputs.docs_only != 'true' && github.event_name == 'pull_request' && secrets.CODACY_API_TOKEN != ''
+    if: needs.check-changes.outputs.docs_only != 'true' && github.event_name == 'pull_request'
 
     permissions:
       checks: read
@@ -337,8 +337,14 @@ jobs:
     steps:
       - name: Wait for Codacy coverage checks
         uses: actions/github-script@v8
+        env:
+          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
         with:
           script: |
+            if (!process.env.CODACY_API_TOKEN) {
+              core.info('CODACY_API_TOKEN not set (fork PR or missing secret), skipping Codacy coverage check.')
+              return
+            }
             const owner = context.repo.owner
             const repo = context.repo.repo
             const ref = context.payload.pull_request.head.sha

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,30 @@ on:
     branches: ['main']
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docs_only: ${{ steps.docs-only.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@de90cc6415e9a3e19aafc651579a8f7a4cec8c49
+        id: filter
+        with:
+          filters: |
+            non_docs:
+              - '**'
+              - '!**/*.md'
+      - name: Set docs_only output
+        id: docs-only
+        run: |
+          if [ "${{ steps.filter.outputs.non_docs }}" == "true" ]; then
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+          else
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+          fi
+
   lint:
     runs-on: ubuntu-latest
 
@@ -29,52 +53,9 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-  unit-tests:
+  build:
     runs-on: ubuntu-latest
-    needs: [lint]
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run unit tests with coverage
-        run: npm run test:unit
-
-      - name: Upload unit coverage to Codacy
-        if: always()
-        env:
-          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: gh
-          CODACY_USERNAME: dougis-org
-          CODACY_PROJECT_NAME: session-combat
-        run: |
-          if [ -z "$CODACY_API_TOKEN" ]; then
-            echo "CODACY_API_TOKEN not set (fork PR or missing secret), skipping coverage upload"
-            exit 0
-          fi
-          curl -Ls https://coverage.codacy.com/get.sh -o codacy-coverage-reporter.sh
-          chmod +x codacy-coverage-reporter.sh
-          if [ -f coverage/lcov.info ]; then
-            ./codacy-coverage-reporter.sh report --partial -r coverage/lcov.info
-          else
-            echo "No coverage report found at coverage/lcov.info"
-          fi
-
-  integration-tests:
-    runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [lint, check-changes]
 
     permissions:
       contents: read
@@ -97,31 +78,80 @@ jobs:
         env:
           MONGODB_URI: mongodb://localhost:27017
           MONGODB_DB: session-combat-test
+          GENERATE_SOURCE_MAPS: 'true'
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: next-build
+          path: .next/
+          retention-days: 1
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: [check-changes]
+    if: needs.check-changes.outputs.docs_only != 'true'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        run: npm run test:unit
+
+      - name: Upload unit coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-lcov
+          path: coverage/lcov.info
+          if-no-files-found: ignore
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: [check-changes, build]
+    if: needs.check-changes.outputs.docs_only != 'true'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run integration tests with coverage
         run: npm run test:integration -- --coverage --forceExit
         env:
           INTEGRATION_WORKERS: '4'
 
-      - name: Upload integration coverage to Codacy
+      - name: Upload integration coverage
         if: always()
-        env:
-          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: gh
-          CODACY_USERNAME: dougis-org
-          CODACY_PROJECT_NAME: session-combat
-        run: |
-          if [ -z "$CODACY_API_TOKEN" ]; then
-            echo "CODACY_API_TOKEN not set (fork PR or missing secret), skipping coverage upload"
-            exit 0
-          fi
-          curl -Ls https://coverage.codacy.com/get.sh -o codacy-coverage-reporter.sh
-          chmod +x codacy-coverage-reporter.sh
-          if [ -f coverage/lcov.info ]; then
-            ./codacy-coverage-reporter.sh report --partial -r coverage/lcov.info
-          else
-            echo "No coverage report found at coverage/lcov.info"
-          fi
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-lcov
+          path: coverage/lcov.info
+          if-no-files-found: ignore
 
       - name: Upload integration test artifacts on failure
         if: failure()
@@ -135,7 +165,8 @@ jobs:
 
   regression-tests:
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [check-changes, build]
+    if: needs.check-changes.outputs.docs_only != 'true'
 
     permissions:
       contents: read
@@ -175,12 +206,11 @@ jobs:
           done
           echo 'Mongo did not become ready' && exit 1
 
-      - name: Build application
-        run: npm run build
-        env:
-          MONGODB_URI: mongodb://localhost:27017
-          MONGODB_DB: session-combat-e2e
-          GENERATE_SOURCE_MAPS: 'true'
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: next-build
+          path: .next/
 
       - name: Run Playwright regression tests
         run: |
@@ -204,25 +234,13 @@ jobs:
           MONGODB_DB: session-combat-e2e
           CHROMIUM_ONLY: 'true'
 
-      - name: Upload E2E coverage to Codacy
+      - name: Upload E2E coverage
         if: always()
-        env:
-          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: gh
-          CODACY_USERNAME: dougis-org
-          CODACY_PROJECT_NAME: session-combat
-        run: |
-          if [ -z "$CODACY_API_TOKEN" ]; then
-            echo "CODACY_API_TOKEN not set (fork PR or missing secret), skipping coverage upload"
-            exit 0
-          fi
-          curl -Ls https://coverage.codacy.com/get.sh -o codacy-coverage-reporter.sh
-          chmod +x codacy-coverage-reporter.sh
-          if [ -f coverage-e2e/lcov.info ]; then
-            ./codacy-coverage-reporter.sh report --partial -r coverage-e2e/lcov.info
-          else
-            echo "No coverage report found at coverage-e2e/lcov.info (check GENERATE_SOURCE_MAPS=true on build step and @bgotink/playwright-coverage reporter config)"
-          fi
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-lcov
+          path: coverage-e2e/lcov.info
+          if-no-files-found: ignore
 
       - name: Upload E2E coverage artifact on failure
         if: failure()
@@ -240,16 +258,37 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-  finalize-coverage:
+  upload-and-finalize-coverage:
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests, regression-tests]
-    if: always()
+    needs: [check-changes, unit-tests, integration-tests, regression-tests]
+    if: always() && needs.check-changes.outputs.docs_only != 'true'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Finalize Codacy coverage
+      - name: Download unit coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-lcov
+          path: artifacts/unit/
+        continue-on-error: true
+
+      - name: Download integration coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: integration-lcov
+          path: artifacts/integration/
+        continue-on-error: true
+
+      - name: Download E2E coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-lcov
+          path: artifacts/e2e/
+        continue-on-error: true
+
+      - name: Upload partial coverage to Codacy and finalize
         env:
           CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
           CODACY_ORGANIZATION_PROVIDER: gh
@@ -257,9 +296,96 @@ jobs:
           CODACY_PROJECT_NAME: session-combat
         run: |
           if [ -z "$CODACY_API_TOKEN" ]; then
-            echo "CODACY_API_TOKEN not set (fork PR or missing secret), skipping coverage finalization"
+            echo "CODACY_API_TOKEN not set (fork PR or missing secret), skipping coverage upload"
             exit 0
           fi
           curl -Ls https://coverage.codacy.com/get.sh -o codacy-coverage-reporter.sh
           chmod +x codacy-coverage-reporter.sh
+          if [ -f artifacts/unit/lcov.info ]; then
+            ./codacy-coverage-reporter.sh report --partial -r artifacts/unit/lcov.info
+          else
+            echo "No unit coverage report found"
+          fi
+          if [ -f artifacts/integration/lcov.info ]; then
+            ./codacy-coverage-reporter.sh report --partial -r artifacts/integration/lcov.info
+          else
+            echo "No integration coverage report found"
+          fi
+          if [ -f artifacts/e2e/lcov.info ]; then
+            ./codacy-coverage-reporter.sh report --partial -r artifacts/e2e/lcov.info
+          else
+            echo "No e2e coverage report found"
+          fi
           ./codacy-coverage-reporter.sh final
+
+  check-codacy-coverage:
+    runs-on: ubuntu-latest
+    needs: [check-changes, upload-and-finalize-coverage]
+    if: needs.check-changes.outputs.docs_only != 'true' && github.event_name == 'pull_request'
+
+    permissions:
+      checks: read
+
+    steps:
+      - name: Wait for Codacy coverage checks
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const ref = context.payload.pull_request.head.sha
+            const checkNames = ['Codacy Diff Coverage', 'Codacy Coverage Variation']
+            const pollIntervalMs = 30_000
+            const maxWaitMs = 10 * 60_000
+            const startTime = Date.now()
+
+            const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+            while (true) {
+              const { data } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref,
+                per_page: 100,
+              })
+              const checkRuns = data.check_runs ?? []
+
+              for (const checkName of checkNames) {
+                const check = checkRuns.find((c) => c.name === checkName)
+                if (check && check.status === 'completed' && check.conclusion !== 'success') {
+                  core.setFailed(`${checkName} concluded with: ${check.conclusion}`)
+                  return
+                }
+              }
+
+              const allComplete = checkNames.every((name) => {
+                const check = checkRuns.find((c) => c.name === name)
+                return check && check.status === 'completed'
+              })
+
+              if (allComplete) {
+                core.info('All Codacy coverage checks passed.')
+                return
+              }
+
+              const elapsedMs = Date.now() - startTime
+              if (elapsedMs >= maxWaitMs) {
+                core.setFailed('Timeout: Codacy coverage checks did not complete within 10 minutes.')
+                return
+              }
+
+              core.info(`Codacy checks not yet complete. Sleeping for ${pollIntervalMs / 1000} seconds...`)
+              await wait(pollIntervalMs)
+            }
+
+  ci-gate:
+    runs-on: ubuntu-latest
+    needs: [lint, build, unit-tests, integration-tests, regression-tests, upload-and-finalize-coverage, check-codacy-coverage]
+    if: always()
+
+    steps:
+      - name: Check all upstream jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/openspec/changes/issue-405-doc-only-ci-skip/tasks.md
+++ b/openspec/changes/issue-405-doc-only-ci-skip/tasks.md
@@ -131,4 +131,4 @@ Blocking resolution flow:
 - [ ] Open PR from doc branch to `main` with title `docs: archive issue-405-doc-only-ci-skip (YYYY-MM-DD)`
 - [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
 - [ ] Monitor doc PR until merged (same loop — address comments and CI failures, push to doc branch, repeat)
-- [ ] Prune merged local branches: `git fetch --prune` && `git branch -d feat/issue-405-doc-only-ci-skip doc/archive-YYYY-MM-DD-issue-405-doc-only-ci-skip`
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -D feat/issue-405-doc-only-ci-skip doc/archive-YYYY-MM-DD-issue-405-doc-only-ci-skip`

--- a/openspec/changes/issue-405-doc-only-ci-skip/tasks.md
+++ b/openspec/changes/issue-405-doc-only-ci-skip/tasks.md
@@ -1,0 +1,134 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/issue-405-doc-only-ci-skip` then immediately `git push -u origin feat/issue-405-doc-only-ci-skip`
+
+## Execution
+
+### 1. Add `check-changes` job
+
+- [x] Add `check-changes` job to `.github/workflows/build-test.yml` as the first job
+- [x] Use `dorny/paths-filter@v3` (pinned to a specific commit SHA) with a `docs` filter matching `**/*.md`
+- [x] Output `docs_only: true` when only markdown files changed, `false` otherwise
+- [x] Add `permissions: contents: read` to the job
+- Verification: `act pull_request` locally (or push a test branch) with a markdown-only change and confirm `docs_only=true`
+
+### 2. Extract standalone `build` job
+
+- [x] Add a new `build` job to `.github/workflows/build-test.yml` with `needs: [lint]`
+- [x] Move `npm run build` (with `MONGODB_URI` and `MONGODB_DB` env vars) into this job
+- [x] Remove the build steps from `integration-tests` and `regression-tests`
+- [x] Add `check-changes` to the `needs` of `build` so the output is available (no condition — build always runs)
+- Verification: Confirm the workflow graph still shows `integration-tests` and `regression-tests` downstream of lint without their own build steps
+
+### 3. Add `docs_only` skip conditions to test jobs
+
+- [x] Add `needs: [check-changes]` to `unit-tests`, `integration-tests`, and `regression-tests`
+- [x] Add `if: needs.check-changes.outputs.docs_only != 'true'` to each of those three jobs
+- [x] Ensure `integration-tests` and `regression-tests` also `needs: [build]` (since build is now separate)
+- Verification: Docs-only test PR shows all three test jobs as `skipped` in Actions UI
+
+### 4. Add `upload-and-finalize-coverage` job
+
+- [x] Add `upload-and-finalize-coverage` job with `needs: [unit-tests, integration-tests, regression-tests]`
+- [x] Add `if: needs.check-changes.outputs.docs_only != 'true' && always()` — skip on docs-only but run even if tests fail
+- [x] Move the Codacy partial report upload logic (curl download + `report --partial`) for each of the three coverage files into this job, guarding each upload with a file-existence check
+- [x] Call `./codacy-coverage-reporter.sh final` once at the end
+- [x] Remove the inline coverage upload steps from `unit-tests`, `integration-tests`, and `regression-tests`
+- [x] Remove the existing `finalize-coverage` job (replaced by this job)
+- Verification: Non-docs PR shows three partial uploads followed by `final` call in job logs; Codacy receives the report
+
+### 5. Add `check-codacy-coverage` job
+
+- [x] Add `check-codacy-coverage` job with `needs: [upload-and-finalize-coverage]`
+- [x] Add condition: `if: needs.check-changes.outputs.docs_only != 'true' && github.event_name == 'pull_request'`
+- [x] Use `actions/github-script@v8` to poll `github.rest.checks.listForRef` for the commit SHA
+- [x] Poll at 30-second intervals for up to 10 minutes
+- [x] Match check names exactly: `"Codacy Diff Coverage"` and `"Codacy Coverage Variation"`
+- [x] Fail immediately if either check concludes with a non-`success` conclusion
+- [x] Fail with a descriptive timeout message if both checks have not completed within the 10-minute window (hard fail — do NOT pass on timeout, unlike `wait-for-ai-reviews.yml`)
+- [x] Add `permissions: checks: read` to the job
+- Verification: Code-change PR with passing coverage shows job succeeding; manually test timeout path by inspecting log output
+
+### 6. Add `ci-gate` job
+
+- [x] Add `ci-gate` job as the final job in `.github/workflows/build-test.yml`
+- [x] `needs: [lint, build, unit-tests, integration-tests, regression-tests, upload-and-finalize-coverage, check-codacy-coverage]`
+- [x] `if: always()`
+- [x] Single step: shell conditional `if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then exit 1; fi`
+- Verification: Docs-only PR shows `ci-gate` succeeding with skipped upstream jobs; failing test PR shows `ci-gate` failing
+
+### 7. Update branch protection rules
+
+- [ ] In GitHub repository settings → Branches → Branch protection rules for `main`:
+  - Add `ci-gate` as a required status check
+  - Remove `lint`, `unit-tests`, `integration-tests`, `regression-tests`, `finalize-coverage` as required checks
+  - Remove `Codacy Diff Coverage` and `Codacy Coverage Variation` as required checks
+  - Leave `Codacy Quality` as a required check (unchanged)
+- [ ] **Perform this update immediately after the workflow change merges to `main`** to minimise the open window
+- Verification: Attempt a merge without `ci-gate` passing; confirm it is blocked
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run any applicable validation, then proceed to commit.
+
+## Validation
+
+- [ ] Push a docs-only branch (only `.md` changes) and verify: `check-changes` outputs `docs_only=true`; `lint` and `build` run; test jobs, coverage upload, and `check-codacy-coverage` show as `skipped`; `ci-gate` passes
+- [ ] Push a code-change branch and verify: full suite runs; `upload-and-finalize-coverage` uploads three partial reports and calls `final`; `check-codacy-coverage` polls and passes; `ci-gate` passes
+- [ ] Push a mixed branch (`.md` + `.ts` files) and verify: `docs_only=false`; full suite runs
+- [ ] Verify `ci-gate` fails when a test job fails (can test with a deliberately broken assertion)
+- [x] Run `npm run lint` locally — no new lint errors introduced
+- [x] Run `npm run build` locally — build succeeds
+
+## Remote push validation
+
+Verification requirements (all must pass before PR or pushing updates to a PR):
+
+- **Lint** — `npm run lint`; must pass with no errors
+- **Build** — `npm run build`; must succeed
+
+Note: Unit, integration, and regression tests are not re-run locally for this change (CI workflow config only; no application code changed). The CI run itself is the test.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/issue-405-doc-only-ci-skip` and push to remote
+- [x] Open PR from `feat/issue-405-doc-only-ci-skip` to `main`. PR body must include **`Closes #405`**
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow remote push validation steps, push to `feat/issue-405-doc-only-ci-skip`; wait 180 seconds; repeat until no unresolved comments remain
+- [ ] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, follow remote push validation steps, push; wait 180 seconds; repeat
+- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+
+Ownership metadata:
+
+- Implementer: AI agent (via `/opsx:apply`)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix workflow YAML → commit → push → re-run checks
+- Review comment → address → commit → push → confirm thread resolved
+- Branch protection update blocked → check for typos in job name; job name in branch protection must exactly match `ci-gate`
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify `.github/workflows/build-test.yml` on `main` contains the `ci-gate` job
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/`:
+  - Copy `openspec/changes/issue-405-doc-only-ci-skip/specs/doc-only-ci-skip/spec.md` → `openspec/specs/doc-only-ci-skip/spec.md`
+  - Copy `openspec/changes/issue-405-doc-only-ci-skip/specs/codacy-coverage-gate/spec.md` → `openspec/specs/codacy-coverage-gate/spec.md`
+  - Copy `openspec/changes/issue-405-doc-only-ci-skip/specs/ci-gate/spec.md` → `openspec/specs/ci-gate/spec.md`
+  - Update relative references in each copied spec from `../../design.md` → `../../changes/archive/YYYY-MM-DD-issue-405-doc-only-ci-skip/design.md`
+- [ ] Archive the change as a single atomic commit: move `openspec/changes/issue-405-doc-only-ci-skip/` → `openspec/changes/archive/YYYY-MM-DD-issue-405-doc-only-ci-skip/` (stage both the copy and the deletion together — never split into two commits)
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-issue-405-doc-only-ci-skip/` exists and `openspec/changes/issue-405-doc-only-ci-skip/` is gone
+- [ ] Create doc branch: `git checkout -b doc/archive-YYYY-MM-DD-issue-405-doc-only-ci-skip` then `git push -u origin doc/archive-YYYY-MM-DD-issue-405-doc-only-ci-skip`
+- [ ] Open PR from doc branch to `main` with title `docs: archive issue-405-doc-only-ci-skip (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same loop — address comments and CI failures, push to doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` && `git branch -d feat/issue-405-doc-only-ci-skip doc/archive-YYYY-MM-DD-issue-405-doc-only-ci-skip`


### PR DESCRIPTION
## Summary

Restructures `.github/workflows/build-test.yml` to skip test jobs on documentation-only PRs, reduce duplicate CI work, and introduce a single `ci-gate` required status check.

## Changes

- **`check-changes` job**: Uses `dorny/paths-filter` (SHA-pinned) to detect whether all changed files are `.md`. Outputs `docs_only=true/false`.
- **Standalone `build` job**: Extracted from `integration-tests` and `regression-tests` — always runs after `lint`. Uploads `.next/` as a reusable artifact.
- **`docs_only` skip conditions**: `unit-tests`, `integration-tests`, `regression-tests` all skip when `docs_only=true`.
- **`upload-and-finalize-coverage` job**: Consolidates all three Codacy partial uploads + `final` call into one job. Runs even if tests fail (`if: always() && ...`). Skips on docs-only.
- **`check-codacy-coverage` job**: Polls GitHub Checks API for "Codacy Diff Coverage" and "Codacy Coverage Variation". Hard-fails on timeout (unlike `wait-for-ai-reviews.yml`). PR-only. Skips on docs-only.
- **`ci-gate` job**: Single umbrella job that passes when all upstreams pass or are skipped. Fails on any `failure` or `cancelled` result.

## Post-Merge Action Required

After this PR merges, update GitHub branch protection rules for `main`:
- **Add** `ci-gate` as required status check
- **Remove** `lint`, `unit-tests`, `integration-tests`, `regression-tests`, `finalize-coverage` as required checks
- **Remove** `Codacy Diff Coverage` and `Codacy Coverage Variation` as required checks
- **Leave** `Codacy Quality` unchanged

Closes #405