### PR TITLE
docs: archive issue-405-doc-only-ci-skip (2026-06-13)

### DIFF
--- a/openspec/changes/archive/2026-06-09-campaign-active-session-lifecycle/tasks.md
+++ b/openspec/changes/archive/2026-06-09-campaign-active-session-lifecycle/tasks.md
@@ -119,15 +119,15 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on main
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Update repository documentation impacted by the change (no doc changes expected for this issue)
-- [ ] Sync approved spec deltas into `openspec/specs/active-session-lifecycle/spec.md` (create if absent)
-- [ ] Archive the change: move `openspec/changes/campaign-active-session-lifecycle/` to `openspec/changes/archive/YYYY-MM-DD-campaign-active-session-lifecycle/` **and stage both the new location and the deletion of the old location in a single commit**
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-active-session-lifecycle/` exists and `openspec/changes/campaign-active-session-lifecycle/` is gone
-- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle`
-- [ ] Open a PR from the doc branch to `main` with title `docs: archive campaign-active-session-lifecycle (YYYY-MM-DD)`. PR body: `Closes #400` (if not already closed by implementation PR).
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
-- [ ] Monitor the doc PR until it merges (same loop as implementation PR)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -d feat/campaign-active-session-lifecycle doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on main
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Update repository documentation impacted by the change (no doc changes expected for this issue)
+- [x] Sync approved spec deltas into `openspec/specs/active-session-lifecycle/spec.md` (create if absent)
+- [x] Archive the change: move `openspec/changes/campaign-active-session-lifecycle/` to `openspec/changes/archive/YYYY-MM-DD-campaign-active-session-lifecycle/` **and stage both the new location and the deletion of the old location in a single commit**
+- [x] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-active-session-lifecycle/` exists and `openspec/changes/campaign-active-session-lifecycle/` is gone
+- [x] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle`
+- [x] Open a PR from the doc branch to `main` with title `docs: archive campaign-active-session-lifecycle (YYYY-MM-DD)`. PR body: `Closes #400` (if not already closed by implementation PR).
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [x] Monitor the doc PR until it merges (same loop as implementation PR)
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -d feat/campaign-active-session-lifecycle doc/archive-YYYY-MM-DD-campaign-active-session-lifecycle`

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md
@@ -1,0 +1,168 @@
+## Context
+
+- Relevant architecture: `.github/workflows/build-test.yml` — single workflow with five jobs: `lint`, `unit-tests`, `integration-tests`, `regression-tests`, `finalize-coverage`. Coverage uploaded inline per test job using the Codacy bash reporter. Three Codacy checks currently configured as required branch-protection rules: Codacy Diff Coverage, Codacy Coverage Variation, Codacy Quality.
+- Dependencies: `dorny/paths-filter` action (or equivalent) for file-path detection; `actions/github-script` (already used in `wait-for-ai-reviews.yml`) for Codacy check polling; GitHub Checks API (`checks.listForRef`).
+- Interfaces/contracts touched: `.github/workflows/build-test.yml`; GitHub branch protection rules for `main`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Skip all test jobs and coverage upload on docs-only changes (all changed files match `**/*.md`).
+- Always run lint and build regardless of change type.
+- Surface Codacy Diff Coverage and Coverage Variation results inside the workflow for non-docs PRs; auto-pass those gates for docs-only runs.
+- Expose a single `ci-gate` job as the only required branch-protection check for this workflow.
+- Preserve identical test execution and coverage reporting behaviour for non-docs changes.
+
+### Non-Goals
+
+- Changing test configuration, coverage thresholds, or Codacy Quality check.
+- Optimising CI for other partial-change patterns.
+- Modifying any other workflow file.
+
+## Decisions
+
+### Decision 1: Path detection approach
+
+- Chosen: `dorny/paths-filter@v3` action in a dedicated `check-changes` job, outputting a `docs_only` boolean.
+- Alternatives considered: Native `git diff --name-only` shell script; workflow-level `paths-ignore` trigger filter.
+- Rationale: `dorny/paths-filter` handles the edge cases (first commit, force-push, merge commits) that a naive `git diff` misses. Workflow-level `paths-ignore` skips the workflow entirely, which breaks required status checks unless GitHub treats absent checks as passing — unreliable.
+- Trade-offs: Introduces an external action dependency; pinning to a SHA mitigates supply-chain risk.
+
+### Decision 2: Standalone `build` job
+
+- Chosen: Extract `npm run build` into a dedicated `build` job that always runs after `lint`, independent of `docs_only`.
+- Alternatives considered: Keep build embedded in `integration-tests` and `regression-tests`; skip build on docs-only.
+- Rationale: Proposal explicitly requires build to run on docs-only changes to catch config/syntax errors in non-test files. Extracting it also removes duplication (build was run twice in the current workflow).
+- Trade-offs: Adds one job to every run; build (~30s) is cheap compared to the value of catching broken builds on doc PRs.
+
+### Decision 3: Coverage upload consolidation
+
+- Chosen: Remove per-job inline coverage upload steps; add a single `upload-and-finalize-coverage` job that depends on all three test jobs completing (success or failure), uploads all partial reports, then calls `final`.
+- Alternatives considered: Keep per-job uploads, add a separate finalize job.
+- Rationale: Consolidation removes three copies of identical curl/script logic; a single job with `if: always()` after the test fan-out ensures `final` is only called once and only when at least one test job ran. Skipped on docs-only.
+- Trade-offs: Coverage lands in Codacy slightly later (after all three suites finish rather than incrementally); acceptable given Codacy processes after `final` anyway.
+
+### Decision 4: Codacy coverage gate via workflow polling
+
+- Chosen: `check-codacy-coverage` job uses `actions/github-script` to poll `checks.listForRef` waiting for "Codacy Diff Coverage" and "Codacy Coverage Variation" checks to reach `completed` status. Job fails if either check concludes with a non-success conclusion or if the 10-minute timeout is reached.
+- Alternatives considered: Keep Codacy checks as standalone branch-protection rules (current); remove Codacy coverage gates entirely.
+- Rationale: Internalising the gates allows docs-only runs to skip them cleanly without needing per-pattern branch-protection exceptions. The polling pattern is already proven in `wait-for-ai-reviews.yml`.
+- Trade-offs: Adds up to 10 minutes of potential latency on non-docs PRs if Codacy is slow; timeout is a hard fail (not advisory), so a slow Codacy instance blocks merge.
+
+### Decision 5: `ci-gate` umbrella job
+
+- Chosen: A final `ci-gate` job with `if: always()` that depends on all upstream jobs and fails only if any upstream job concluded with `failure` or `cancelled`. Skipped jobs are treated as passing.
+- Alternatives considered: Require each job individually in branch protection.
+- Rationale: Single required check dramatically simplifies branch protection and makes docs-only skips transparent. The `contains(needs.*.result, 'failure')` pattern is idiomatic GitHub Actions.
+- Trade-offs: If `ci-gate` itself has a bug, all PRs are blocked; mitigated by keeping the gate logic trivial (one conditional).
+
+### Decision 6: Push-to-main handling
+
+- Chosen: On push to `main`, `check-codacy-coverage` is skipped regardless of `docs_only` (no PR context for check polling). Coverage is still uploaded and finalized for non-docs pushes. Lint and build always run.
+- Alternatives considered: Run polling on push using commit SHA checks.
+- Rationale: Codacy PR checks only exist in a PR context; polling them on a direct push is not meaningful. Coverage upload to Codacy still happens, keeping repo-level metrics current.
+- Trade-offs: A direct non-docs push to main that breaks coverage thresholds will not be caught by this workflow (only by subsequent PRs). Acceptable given direct pushes to main are rare and typically come from merged PRs that already passed coverage gates.
+
+## Proposal to Design Mapping
+
+- Proposal element: `check-changes` job detecting docs-only
+  - Design decision: Decision 1 (dorny/paths-filter)
+  - Validation approach: Test PR with only `.md` changes verifies `docs_only=true`; mixed PR verifies `docs_only=false`
+
+- Proposal element: lint and build always run
+  - Design decision: Decision 2 (standalone build job); lint job unchanged
+  - Validation approach: Docs-only PR confirms lint and build jobs complete; test jobs show as skipped
+
+- Proposal element: test jobs skip on docs-only
+  - Design decision: `if: needs.check-changes.outputs.docs_only != 'true'` on each test job
+  - Validation approach: Docs-only PR shows unit-tests, integration-tests, regression-tests as skipped in Actions UI
+
+- Proposal element: coverage upload consolidation
+  - Design decision: Decision 3 (single upload-and-finalize-coverage job)
+  - Validation approach: Non-docs PR confirms all three partial reports uploaded and `final` called once
+
+- Proposal element: Codacy coverage checks internalised
+  - Design decision: Decision 4 (check-codacy-coverage polling job)
+  - Validation approach: Non-docs PR with passing coverage shows check-codacy-coverage succeeding; docs-only PR shows it skipped
+
+- Proposal element: single required branch-protection check
+  - Design decision: Decision 5 (ci-gate umbrella)
+  - Validation approach: Branch protection updated; docs-only PR merges with ci-gate passing and test jobs skipped
+
+## Functional Requirements Mapping
+
+- Requirement: Docs-only PR skips tests and coverage upload
+  - Design element: `check-changes` → per-job `if` conditions → `upload-and-finalize-coverage` skip
+  - Acceptance criteria reference: spec `doc-only-ci-skip` — "all test jobs show status: skipped"
+  - Testability notes: Verify via Actions UI on a real docs-only PR; assert no runner minutes consumed by test jobs
+
+- Requirement: Lint and build always run
+  - Design element: `lint` and `build` jobs have no `docs_only` condition
+  - Acceptance criteria reference: spec `doc-only-ci-skip` — "lint and build complete successfully"
+  - Testability notes: Verify on docs-only PR run
+
+- Requirement: Non-docs PR runs full suite with coverage gating
+  - Design element: All jobs run; `check-codacy-coverage` polls and gates on Codacy results
+  - Acceptance criteria reference: spec `codacy-coverage-gate` — "check-codacy-coverage passes when Codacy checks pass"
+  - Testability notes: Verify on a normal code-change PR
+
+- Requirement: `ci-gate` is the single required check
+  - Design element: Decision 5 + branch protection update
+  - Acceptance criteria reference: spec `ci-gate` — "branch protection lists only ci-gate"
+  - Testability notes: Attempt merge without ci-gate passing; confirm it is blocked
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Docs-only classification must never produce false positives (skip tests on code changes)
+  - Design element: Decision 1 — `dorny/paths-filter` with explicit `**/*.md` glob; any non-md file sets `docs_only=false`
+  - Acceptance criteria reference: spec `doc-only-ci-skip` — "mixed PR runs full suite"
+  - Testability notes: Test PR with one `.md` + one `.ts` file must run full suite
+
+- Requirement category: operability
+  - Requirement: Codacy polling timeout must not silently pass
+  - Design element: Decision 4 — hard fail on timeout (unlike `wait-for-ai-reviews.yml` which passes on timeout)
+  - Acceptance criteria reference: spec `codacy-coverage-gate` — "workflow fails if Codacy checks do not complete within 10 minutes"
+  - Testability notes: Hard to test in normal flow; verified by code review of timeout logic
+
+- Requirement category: performance
+  - Requirement: Docs-only PRs complete CI in under 5 minutes
+  - Design element: Only lint + build run; no npm test suites, no Playwright, no MongoDB
+  - Acceptance criteria reference: spec `doc-only-ci-skip` — "ci-gate completes within 5 minutes on docs-only PR"
+  - Testability notes: Measure wall-clock time on first docs-only PR after deployment
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `dorny/paths-filter` action compromise or breaking change
+  - Impact: Supply-chain risk; or CI breaks if action API changes
+  - Mitigation: Pin action to a specific commit SHA; review release notes before unpinning
+
+- Risk/trade-off: Coverage upload consolidation delays Codacy analysis start
+  - Impact: Codacy polling window may need to be longer if upload is later
+  - Mitigation: 10-minute poll window is generous; monitor first few PRs after deployment
+
+- Risk/trade-off: Branch protection update window
+  - Impact: Brief gap between workflow landing on main and branch protection being updated
+  - Mitigation: Prepare branch protection change in advance; apply immediately after workflow merges
+
+## Rollback / Mitigation
+
+- Rollback trigger: Docs-only classification is incorrect (tests skipped on code change), OR `ci-gate` is blocking all PRs due to a bug, OR Codacy polling is consistently timing out.
+- Rollback steps:
+  1. Revert `.github/workflows/build-test.yml` to the pre-change version via a fast-follow PR.
+  2. Restore original required branch-protection checks (individual job names + Codacy checks).
+  3. Merge the revert PR — it will pass under the restored protection rules.
+- Data migration considerations: None — this change is purely CI configuration.
+- Verification after rollback: Run a normal code-change PR end-to-end; confirm all original checks appear and pass.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Investigate the specific failing job in the Actions UI. For test failures, fix the code. For `check-codacy-coverage` timeout, re-run the workflow — Codacy may have been temporarily slow. For `ci-gate` failure, check which upstream job failed.
+- If security checks fail: Not applicable to this change (no application code modified).
+- If required reviews are blocked/stale: Standard PR process applies — request re-review from codeowner.
+- Escalation path and timeout: If `check-codacy-coverage` times out repeatedly (>3 consecutive runs), increase the timeout constant or investigate Codacy API availability. If unresolvable within 24 hours, roll back to standalone Codacy branch-protection checks as an interim measure.
+
+## Open Questions
+
+No open questions. All design decisions are resolved based on the explore session and existing codebase patterns.

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/proposal.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/proposal.md
@@ -1,0 +1,92 @@
+## GitHub Issues
+
+- dougis-org/session-combat#405
+
+## Why
+
+- Problem statement: Every PR that only changes documentation (`.md` files) runs the full CI suite — lint, unit tests, integration tests, regression tests (with MongoDB + Playwright), and Codacy coverage upload. This wastes 10–15+ minutes of runner time and delays merge for changes that cannot affect runtime behaviour.
+- Why now: Doc-only PRs are a recurring pattern (OpenSpec archive PRs, README updates, issue docs). The cost is paid on every such PR with zero risk reduction.
+- Business/user impact: Faster merge cycles for documentation changes; reduced CI runner costs; less friction for contributors making doc-only updates.
+
+## Problem Space
+
+- Current behavior: `build-test.yml` runs unconditionally on every push to `main` and every PR targeting `main`. All five jobs (lint, unit-tests, integration-tests, regression-tests, finalize-coverage) run regardless of which files changed. Three separate Codacy checks (Diff Coverage, Coverage Variation, Quality) are configured as required branch-protection checks.
+- Desired behavior: When **all** changed files match `**/*.md`, CI runs only lint and build. Tests and Codacy coverage reporting are skipped. A single `ci-gate` job is the only required branch-protection check. The Codacy Quality check remains a separate required check. For non-docs changes, behaviour is identical to today.
+- Constraints:
+  - Branch protection currently lists individual job names as required checks; those must be replaced with `ci-gate`.
+  - Codacy "Diff Coverage" and "Coverage Variation" checks must be consumed and surfaced inside the workflow (not as standalone branch-protection rules) so they auto-pass on docs-only runs.
+  - Codacy Quality check is owned by Codacy and stays as a standalone required check — out of scope for this change.
+  - Coverage upload uses a three-partial-report + `final` pattern; that must be preserved for non-docs runs.
+- Assumptions:
+  - A PR with even one non-markdown file change runs the full suite.
+  - On push to main (not a PR), Codacy coverage polling is skipped; coverage is uploaded and finalized but not gated.
+  - Codacy processes coverage and posts check results within a reasonable window (≤10 minutes) after `final` is called.
+  - Skipping coverage upload for docs-only commits is safe: Codacy retains the last known repo coverage and does not interpret absence of a report as a drop.
+- Edge cases considered:
+  - Mixed PR (`.md` + code files) → full suite runs.
+  - Push directly to `main` with only `.md` changes → lint + build only, no test jobs, no coverage polling.
+  - Push directly to `main` with code changes → full suite runs, coverage uploaded and finalized, no Codacy polling (no PR context).
+  - Codacy polling timeout → workflow fails (coverage is a hard gate, not advisory).
+  - All three test jobs skipped → `finalize-coverage` also skipped; `ci-gate` treats skipped upstream jobs as passing.
+
+## Scope
+
+### In Scope
+
+- Add `check-changes` job that outputs `docs_only: true/false` based on changed file paths.
+- Extract build into a standalone job that always runs (currently embedded in `integration-tests` and `regression-tests`).
+- Add per-job `if: needs.check-changes.outputs.docs_only != 'true'` conditions to `unit-tests`, `integration-tests`, `regression-tests`, and `finalize-coverage`.
+- Consolidate coverage upload (currently inline per test job) into a single `upload-and-finalize-coverage` job that runs after all three test jobs complete.
+- Add `check-codacy-coverage` job that polls GitHub Checks API for "Codacy Diff Coverage" and "Codacy Coverage Variation" results on PRs; fails on timeout or check failure.
+- Add `ci-gate` umbrella job that succeeds when all upstream jobs either pass or are skipped.
+- Update branch protection: replace current required checks with `ci-gate` only (Codacy Quality remains).
+
+### Out of Scope
+
+- Codacy Quality check configuration (remains a separate required branch-protection check).
+- Changes to any test suite, test configuration, or coverage reporter settings.
+- Changes to `deploy.yml`, `wait-for-ai-reviews.yml`, or `resolve-outdated-comments.yml`.
+- Optimising CI for non-markdown partial changes (e.g., skipping regression tests when only config files change).
+
+## What Changes
+
+- `.github/workflows/build-test.yml`: Restructured with `check-changes`, standalone `build`, `upload-and-finalize-coverage`, `check-codacy-coverage`, and `ci-gate` jobs; existing test jobs gain skip conditions; per-job coverage upload steps removed.
+- Branch protection rules: `ci-gate` replaces individual job names as the required check for the `Build & Test` workflow.
+
+## Risks
+
+- Risk: `check-changes` incorrectly classifies a mixed PR as docs-only, skipping tests on a code change.
+  - Impact: High — broken code could merge without test coverage.
+  - Mitigation: Use an established path-filter action (e.g., `dorny/paths-filter`) or a shell glob that errs on the side of running tests; validate with test PRs before merging.
+
+- Risk: Codacy polling times out on slow analysis runs, blocking merge of legitimate PRs.
+  - Impact: Medium — workflow fails, PR is blocked until re-run or timeout is increased.
+  - Mitigation: Set a generous timeout (10 minutes); log elapsed time; ensure re-run resolves the issue.
+
+- Risk: Skipping coverage `final` for docs-only runs causes Codacy to behave unexpectedly (e.g., treating the commit as having 0% coverage).
+  - Impact: Medium — could affect repo-level coverage metrics or subsequent PR checks.
+  - Mitigation: Verify Codacy behaviour by running a docs-only test PR before updating branch protection.
+
+- Risk: Branch protection update leaves a window where neither old nor new checks are required.
+  - Impact: Low — brief window during cutover where a PR could merge without checks.
+  - Mitigation: Update branch protection in a single atomic change immediately after the workflow lands on `main`.
+
+## Open Questions
+
+No unresolved ambiguity remains. All decisions were confirmed during the explore session:
+- Codacy check names: "Codacy Diff Coverage" and "Codacy Coverage Variation" ✓
+- Branch protection restructure to single `ci-gate` approved ✓
+- Codacy Quality check stays separate ✓
+- Docs-only push to main: lint + build only, no polling ✓
+- Polling timeout behaviour: hard fail ✓
+
+## Non-Goals
+
+- Making CI faster for non-docs PRs.
+- Parallelising test jobs further.
+- Removing or replacing the Codacy integration.
+- Caching `node_modules` or build artifacts across runs.
+
+## Change Control
+
+If scope changes after proposal approval, update `openspec/changes/issue-405-doc-only-ci-skip/proposal.md`, `design.md`, `specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/ci-gate/spec.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/ci-gate/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `../../design.md` document, not a replacement.
+
+### Requirement: ADDED ci-gate umbrella job
+
+The system SHALL expose a single `ci-gate` job that succeeds when all upstream jobs either passed or were skipped, and fails if any upstream job concluded with `failure` or `cancelled`.
+
+#### Scenario: All upstream jobs pass — gate succeeds
+
+- **Given** a non-docs pull request where all upstream jobs (`lint`, `build`, `unit-tests`, `integration-tests`, `regression-tests`, `upload-and-finalize-coverage`, `check-codacy-coverage`) complete with `success`
+- **When** the `ci-gate` job evaluates upstream results
+- **Then** `ci-gate` completes with `success`
+
+#### Scenario: Docs-only PR — skipped jobs do not block gate
+
+- **Given** a docs-only pull request where test jobs, coverage upload, and Codacy polling jobs are all `skipped` and `lint` + `build` pass
+- **When** the `ci-gate` job evaluates upstream results
+- **Then** `ci-gate` completes with `success`
+
+#### Scenario: Any upstream job fails — gate fails
+
+- **Given** any pull request where at least one upstream job concludes with `failure`
+- **When** the `ci-gate` job evaluates upstream results using `contains(needs.*.result, 'failure')`
+- **Then** `ci-gate` fails, blocking merge
+
+#### Scenario: ci-gate is the only required branch-protection check for this workflow
+
+- **Given** branch protection rules for `main` after this change is deployed
+- **When** a pull request targets `main`
+- **Then** only `ci-gate` (from the `Build & Test` workflow) appears as a required check; individual job names (`lint`, `unit-tests`, etc.) are not required checks; Codacy Quality remains a separate required check
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Branch protection required checks
+
+Branch protection for `main` SHALL require `ci-gate` instead of individual workflow job names and instead of Codacy Diff Coverage and Codacy Coverage Variation as separate checks.
+
+#### Scenario: ci-gate required check blocks merge on failure
+
+- **Given** a pull request where `ci-gate` has failed
+- **When** a contributor attempts to merge
+- **Then** GitHub blocks the merge and displays `ci-gate` as a failing required check
+
+#### Scenario: Codacy Quality remains independently required
+
+- **Given** a pull request where `ci-gate` passes but Codacy Quality reports a failure
+- **When** a contributor attempts to merge
+- **Then** GitHub blocks the merge due to the Codacy Quality required check
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Individual job names as required branch-protection checks
+
+`lint`, `unit-tests`, `integration-tests`, `regression-tests`, and `finalize-coverage` are removed as individually required branch-protection checks.
+
+Reason for removal: The `ci-gate` job aggregates all of these; requiring individual jobs prevents the skip-on-docs-only pattern from working cleanly.
+
+## Traceability
+
+- Proposal element "single required branch-protection check" → Requirement: ci-gate umbrella job
+- Proposal element "branch protection restructure" → Requirement: MODIFIED Branch protection required checks
+- Design decision 5 (ci-gate umbrella) → Requirement: ci-gate umbrella job
+- Requirement: ci-gate umbrella job → Task: Add ci-gate job to build-test.yml
+- Requirement: MODIFIED Branch protection required checks → Task: Update branch protection rules
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: ci-gate logic is trivially simple and cannot itself error
+
+- **Given** any workflow run
+- **When** the `ci-gate` job executes
+- **Then** the job body consists solely of a single conditional shell check (`contains(needs.*.result, 'failure')`) with no external dependencies, ensuring it cannot fail for infrastructure reasons
+
+### Requirement: Performance
+
+#### Scenario: ci-gate adds no meaningful latency
+
+- **Given** all upstream jobs have completed
+- **When** the `ci-gate` job runs
+- **Then** the job completes within 30 seconds (shell conditional only, no installs or network calls)
+
+### Requirement: Security
+
+The `ci-gate` job requires no additional permissions beyond the workflow default. See functional scenarios above for access-control behaviour.

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/ci-gate/spec.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/ci-gate/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-This document details *changes* to requirements and is additive to the `../../design.md` document, not a replacement.
+This document details *changes* to requirements and is additive to the `../../changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md` document, not a replacement.
 
 ### Requirement: ADDED ci-gate umbrella job
 
@@ -20,8 +20,8 @@ The system SHALL expose a single `ci-gate` job that succeeds when all upstream j
 
 #### Scenario: Any upstream job fails — gate fails
 
-- **Given** any pull request where at least one upstream job concludes with `failure`
-- **When** the `ci-gate` job evaluates upstream results using `contains(needs.*.result, 'failure')`
+- **Given** any pull request where at least one upstream job concludes with `failure` or `cancelled`
+- **When** the `ci-gate` job evaluates upstream results using `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`
 - **Then** `ci-gate` fails, blocking merge
 
 #### Scenario: ci-gate is the only required branch-protection check for this workflow
@@ -72,7 +72,7 @@ Reason for removal: The `ci-gate` job aggregates all of these; requiring individ
 
 - **Given** any workflow run
 - **When** the `ci-gate` job executes
-- **Then** the job body consists solely of a single conditional shell check (`contains(needs.*.result, 'failure')`) with no external dependencies, ensuring it cannot fail for infrastructure reasons
+- **Then** the job body consists solely of a single conditional shell check (`contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`) with no external dependencies, ensuring it cannot fail for infrastructure reasons
 
 ### Requirement: Performance
 

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/codacy-coverage-gate/spec.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/codacy-coverage-gate/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `../../design.md` document, not a replacement.
+
+### Requirement: ADDED Codacy coverage gate via workflow polling
+
+The system SHALL poll the GitHub Checks API for "Codacy Diff Coverage" and "Codacy Coverage Variation" check results on pull requests, and fail the workflow if either check does not conclude with `success` within the timeout window.
+
+#### Scenario: Both Codacy checks pass within timeout
+
+- **Given** a pull request where `docs_only=false` and `upload-and-finalize-coverage` has completed
+- **When** the `check-codacy-coverage` job polls `checks.listForRef`
+- **Then** the job succeeds once both "Codacy Diff Coverage" and "Codacy Coverage Variation" checks report `conclusion: success`
+
+#### Scenario: A Codacy coverage check fails
+
+- **Given** a pull request where `docs_only=false` and Codacy reports `conclusion: failure` for "Codacy Diff Coverage"
+- **When** the `check-codacy-coverage` job detects the failed conclusion
+- **Then** the job fails immediately, blocking `ci-gate` and preventing merge
+
+#### Scenario: Codacy checks do not complete within timeout
+
+- **Given** a pull request where `docs_only=false` and Codacy has not posted check results within 10 minutes of `check-codacy-coverage` starting
+- **When** the polling loop exhausts the timeout
+- **Then** the `check-codacy-coverage` job fails with a timeout error message, blocking `ci-gate`
+
+#### Scenario: Codacy checks skipped on docs-only PR
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** the `check-codacy-coverage` job reports status `skipped` and no Codacy API calls are made
+
+#### Scenario: Codacy checks skipped on push to main
+
+- **Given** a direct push to `main` (not a pull request event)
+- **When** the workflow executes
+- **Then** the `check-codacy-coverage` job reports status `skipped` regardless of `docs_only` value
+
+---
+
+### Requirement: ADDED Codacy partial coverage upload consolidated
+
+The system SHALL upload all three partial coverage reports (unit, integration, regression) and call `final` in a single `upload-and-finalize-coverage` job after all test jobs complete.
+
+#### Scenario: All three partial reports uploaded before final
+
+- **Given** a pull request where `docs_only=false` and all three test jobs have completed (any result)
+- **When** the `upload-and-finalize-coverage` job runs
+- **Then** `lcov.info` from unit tests, `lcov.info` from integration tests, and `lcov.info` from regression tests are each uploaded as partial reports, and `final` is called exactly once after all three
+
+#### Scenario: Coverage upload skipped when CODACY_API_TOKEN absent
+
+- **Given** a fork PR or environment where `CODACY_API_TOKEN` is not set
+- **When** the `upload-and-finalize-coverage` job runs
+- **Then** the job exits successfully with a logged message indicating the token is absent, and does not attempt to upload
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Standalone Codacy branch-protection checks for coverage
+
+"Codacy Diff Coverage" and "Codacy Coverage Variation" are removed as standalone required branch-protection checks.
+
+Reason for removal: Both checks are now consumed and gated inside the workflow via the `check-codacy-coverage` polling job. The Codacy Quality check is unaffected and remains a standalone required check.
+
+## Traceability
+
+- Proposal element "Codacy coverage checks internalised" → Requirement: Codacy coverage gate via workflow polling
+- Proposal element "coverage upload consolidation" → Requirement: Codacy partial coverage upload consolidated
+- Design decision 4 (check-codacy-coverage polling) → Requirement: Codacy coverage gate via workflow polling
+- Design decision 3 (coverage consolidation) → Requirement: Codacy partial coverage upload consolidated
+- Requirement: Codacy coverage gate via workflow polling → Task: Add check-codacy-coverage job
+- Requirement: Codacy partial coverage upload consolidated → Task: Add upload-and-finalize-coverage job; Task: Remove per-job coverage upload steps
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Polling does not add latency beyond Codacy processing time
+
+- **Given** a non-docs PR where Codacy posts both check results within 3 minutes of `final` being called
+- **When** the `check-codacy-coverage` job polls at 30-second intervals
+- **Then** the job completes within 30 seconds of Codacy posting results (i.e., polling overhead is at most one interval)
+
+### Requirement: Reliability
+
+#### Scenario: Hard fail on timeout — no silent pass
+
+- **Given** a non-docs PR where Codacy has not posted check results after 10 minutes
+- **When** the polling loop exhausts its budget
+- **Then** the `check-codacy-coverage` job exits with a non-zero code and a human-readable timeout message; `ci-gate` fails; the PR is blocked
+
+See functional scenario: "Codacy checks do not complete within timeout" above.
+
+### Requirement: Security
+
+The polling job reads only GitHub Checks API (read-only `checks: read` permission). It does not write check results or modify PR state. No additional security scenario beyond functional coverage applies.

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/doc-only-ci-skip/spec.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/doc-only-ci-skip/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-This document details *changes* to requirements and is additive to the `../../design.md` document, not a replacement.
+This document details *changes* to requirements and is additive to the `../../changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md` document, not a replacement.
 
 ### Requirement: ADDED Docs-only change detection
 
@@ -88,7 +88,7 @@ The system SHALL run `npm run build` as a dedicated `build` job (currently embed
 
 - **Given** any push or pull request triggering the workflow
 - **When** the workflow executes
-- **Then** `npm run build` is executed exactly once in the standalone `build` job, not duplicated inside test jobs
+- **Then** `npm run build` is executed exactly once in the standalone `build` job, not duplicated inside test jobs; the `build` job uploads the `.next/` output as a `next-build` artifact (via `actions/upload-artifact`), and `integration-tests` and `regression-tests` download it (via `actions/download-artifact`) before running
 
 ## REMOVED Requirements
 

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/doc-only-ci-skip/spec.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/specs/doc-only-ci-skip/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `../../design.md` document, not a replacement.
+
+### Requirement: ADDED Docs-only change detection
+
+The system SHALL detect when all changed files in a push or pull-request match `**/*.md` and expose a `docs_only` output for downstream job conditions.
+
+#### Scenario: All changed files are markdown
+
+- **Given** a pull request or push to `main` where every changed file has a `.md` extension
+- **When** the `check-changes` job runs
+- **Then** the job outputs `docs_only=true`
+
+#### Scenario: At least one non-markdown file changed
+
+- **Given** a pull request or push to `main` where at least one changed file does not have a `.md` extension
+- **When** the `check-changes` job runs
+- **Then** the job outputs `docs_only=false`
+
+#### Scenario: Mixed PR (markdown + code files)
+
+- **Given** a pull request containing both `.md` files and `.ts`/`.tsx`/`.js` source files
+- **When** the `check-changes` job runs
+- **Then** the job outputs `docs_only=false` and the full test suite runs
+
+---
+
+### Requirement: ADDED Lint and build always run
+
+The system SHALL run the `lint` and `build` jobs on every trigger, regardless of `docs_only` value.
+
+#### Scenario: Docs-only PR runs lint and build
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** the `lint` job completes successfully and the `build` job completes successfully
+
+#### Scenario: Build failure caught on docs-only PR
+
+- **Given** a pull request where `docs_only=true` and `next build` fails (e.g., broken import in a non-test file)
+- **When** the `build` job runs
+- **Then** the `build` job fails and `ci-gate` reports failure, blocking merge
+
+---
+
+### Requirement: ADDED Test jobs skip on docs-only changes
+
+The system SHALL skip `unit-tests`, `integration-tests`, and `regression-tests` when `docs_only=true`.
+
+#### Scenario: All test jobs skipped on docs-only PR
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** `unit-tests`, `integration-tests`, and `regression-tests` all report status `skipped` in the GitHub Actions UI and no runner minutes are consumed by those jobs
+
+#### Scenario: All test jobs run on code-change PR
+
+- **Given** a pull request where `docs_only=false`
+- **When** the workflow executes
+- **Then** `unit-tests`, `integration-tests`, and `regression-tests` all execute normally
+
+---
+
+### Requirement: ADDED Coverage upload and finalize skip on docs-only changes
+
+The system SHALL skip the `upload-and-finalize-coverage` job when `docs_only=true`.
+
+#### Scenario: Coverage upload skipped on docs-only PR
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** the `upload-and-finalize-coverage` job reports status `skipped` and no coverage data is sent to Codacy
+
+#### Scenario: Coverage uploaded and finalized on code-change PR
+
+- **Given** a pull request where `docs_only=false` and all test jobs complete (success or failure)
+- **When** the `upload-and-finalize-coverage` job runs
+- **Then** all three partial coverage reports are uploaded to Codacy and `final` is called exactly once
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Build job is standalone
+
+The system SHALL run `npm run build` as a dedicated `build` job (currently embedded in `integration-tests` and `regression-tests`).
+
+#### Scenario: Build runs once per workflow trigger
+
+- **Given** any push or pull request triggering the workflow
+- **When** the workflow executes
+- **Then** `npm run build` is executed exactly once in the standalone `build` job, not duplicated inside test jobs
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Per-job inline coverage upload
+
+The inline coverage upload steps previously present in `unit-tests`, `integration-tests`, and `regression-tests` are removed in favour of the consolidated `upload-and-finalize-coverage` job.
+
+Reason for removal: Consolidation into a single job eliminates code duplication and ensures `final` is called only after all test jobs complete.
+
+## Traceability
+
+- Proposal element "check-changes job" → Requirement: Docs-only change detection
+- Proposal element "lint and build always run" → Requirement: Lint and build always run
+- Proposal element "test jobs skip on docs-only" → Requirement: Test jobs skip on docs-only changes
+- Proposal element "coverage upload consolidation" → Requirement: Coverage upload and finalize skip + MODIFIED Build job is standalone
+- Design decision 1 (dorny/paths-filter) → Requirement: Docs-only change detection
+- Design decision 2 (standalone build) → Requirement: MODIFIED Build job is standalone
+- Design decision 3 (coverage consolidation) → Requirement: Coverage upload and finalize skip
+- Requirement: Docs-only change detection → Task: Add check-changes job
+- Requirement: Lint and build always run → Task: Extract standalone build job
+- Requirement: Test jobs skip on docs-only → Task: Add docs_only conditionals to test jobs
+- Requirement: Coverage upload and finalize skip → Task: Add upload-and-finalize-coverage job
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Docs-only PR CI wall-clock time
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow completes (lint + build + ci-gate)
+- **Then** the total wall-clock time from trigger to `ci-gate` success is under 5 minutes
+
+### Requirement: Reliability
+
+#### Scenario: False-positive classification never skips tests on code change
+
+- **Given** any pull request containing at least one non-markdown file
+- **When** the `check-changes` job runs using `dorny/paths-filter`
+- **Then** `docs_only=false` and all test jobs execute — no code change is ever treated as docs-only
+
+### Requirement: Security
+
+See functional scenario: "Mixed PR (markdown + code files)" — access control over test skipping is enforced by the path-filter logic itself; no additional security scenario applies.

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/tasks.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/tasks.md
@@ -62,7 +62,7 @@
 
 ### 7. Update branch protection rules
 
-- [ ] In GitHub repository settings → Branches → Branch protection rules for `main`:
+- [x] In GitHub repository settings → Branches → Branch protection rules for `main`:
   - Add `ci-gate` as a required status check
   - Remove `lint`, `unit-tests`, `integration-tests`, `regression-tests`, `finalize-coverage` as required checks
   - Remove `Codacy Diff Coverage` and `Codacy Coverage Variation` as required checks
@@ -97,11 +97,11 @@ Note: Unit, integration, and regression tests are not re-run locally for this ch
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
 - [x] Commit all changes to `feat/issue-405-doc-only-ci-skip` and push to remote
 - [x] Open PR from `feat/issue-405-doc-only-ci-skip` to `main`. PR body must include **`Closes #405`**
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
-- [ ] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow remote push validation steps, push to `feat/issue-405-doc-only-ci-skip`; wait 180 seconds; repeat until no unresolved comments remain
-- [ ] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, follow remote push validation steps, push; wait 180 seconds; repeat
-- [ ] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Monitor PR comments** — poll autonomously; address comments, commit fixes, follow remote push validation steps, push to `feat/issue-405-doc-only-ci-skip`; wait 180 seconds; repeat until no unresolved comments remain
+- [x] **Monitor CI checks** — poll with `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, follow remote push validation steps, push; wait 180 seconds; repeat
+- [x] **Poll for merge** — `gh pr view <PR-URL> --json state`; when `MERGED` proceed to Post-Merge; if `CLOSED` notify user
 
 Ownership metadata:
 
@@ -117,10 +117,10 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify `.github/workflows/build-test.yml` on `main` contains the `ci-gate` job
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync approved spec deltas into `openspec/specs/`:
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify `.github/workflows/build-test.yml` on `main` contains the `ci-gate` job
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Sync approved spec deltas into `openspec/specs/`:
   - Copy `openspec/changes/issue-405-doc-only-ci-skip/specs/doc-only-ci-skip/spec.md` → `openspec/specs/doc-only-ci-skip/spec.md`
   - Copy `openspec/changes/issue-405-doc-only-ci-skip/specs/codacy-coverage-gate/spec.md` → `openspec/specs/codacy-coverage-gate/spec.md`
   - Copy `openspec/changes/issue-405-doc-only-ci-skip/specs/ci-gate/spec.md` → `openspec/specs/ci-gate/spec.md`

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/tests.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/tests.md
@@ -1,0 +1,93 @@
+---
+name: tests
+description: Tests for the issue-405-doc-only-ci-skip change
+---
+
+# Tests
+
+## Overview
+
+This change is entirely CI workflow configuration (`.github/workflows/build-test.yml`). There are no application unit or integration tests to write — the test suite IS the CI run itself. Validation is done by pushing branches with specific file change patterns and observing GitHub Actions behaviour.
+
+All test cases below correspond to tasks in `tasks.md` and acceptance scenarios in the spec files under `specs/`.
+
+## Testing Steps
+
+For each test case, the TDD cycle maps as:
+1. **Failing state:** Verify the current workflow does NOT exhibit the desired behaviour (e.g., tests run on docs-only PRs today).
+2. **Pass state:** After implementing the task, verify the workflow exhibits the desired behaviour.
+3. **Refactor:** Ensure no regressions in the non-docs path.
+
+## Test Cases
+
+### Task 1 — `check-changes` job
+
+- [ ] **TC-1.1** Push a branch with only `.md` file changes; confirm `check-changes` job output `docs_only=true` in Actions UI
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "All changed files are markdown"
+- [ ] **TC-1.2** Push a branch with at least one non-`.md` file changed; confirm `check-changes` outputs `docs_only=false`
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "At least one non-markdown file changed"
+- [ ] **TC-1.3** Push a branch with mixed `.md` + `.ts` changes; confirm `docs_only=false`
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "Mixed PR (markdown + code files)"
+
+### Task 2 — Standalone `build` job
+
+- [ ] **TC-2.1** On any trigger, confirm `build` job appears in the workflow graph and executes `npm run build` exactly once
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "Build runs once per workflow trigger"
+- [ ] **TC-2.2** Confirm `integration-tests` and `regression-tests` no longer contain a build step in their logs
+  - Spec: design.md Decision 2
+
+### Task 3 — Docs-only skip conditions on test jobs
+
+- [ ] **TC-3.1** On a docs-only PR, confirm `unit-tests`, `integration-tests`, and `regression-tests` all show status `Skipped` in Actions UI
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "All test jobs skipped on docs-only PR"
+- [ ] **TC-3.2** On a code-change PR, confirm all three test jobs execute normally (not skipped)
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "All test jobs run on code-change PR"
+
+### Task 4 — `upload-and-finalize-coverage` job
+
+- [ ] **TC-4.1** On a code-change PR, confirm `upload-and-finalize-coverage` job runs and logs show three partial uploads followed by `final`
+  - Spec: `specs/codacy-coverage-gate/spec.md` → "All three partial reports uploaded before final"
+- [ ] **TC-4.2** On a docs-only PR, confirm `upload-and-finalize-coverage` shows status `Skipped`
+  - Spec: `specs/doc-only-ci-skip/spec.md` → "Coverage upload skipped on docs-only PR"
+- [ ] **TC-4.3** On a fork PR (no `CODACY_API_TOKEN`), confirm job exits successfully with a "token absent" log message
+  - Spec: `specs/codacy-coverage-gate/spec.md` → "Coverage upload skipped when CODACY_API_TOKEN absent"
+- [ ] **TC-4.4** Confirm the old `finalize-coverage` job no longer exists in the workflow
+
+### Task 5 — `check-codacy-coverage` job
+
+- [ ] **TC-5.1** On a code-change PR with passing coverage, confirm `check-codacy-coverage` job succeeds after detecting both Codacy checks as `success`
+  - Spec: `specs/codacy-coverage-gate/spec.md` → "Both Codacy checks pass within timeout"
+- [ ] **TC-5.2** On a docs-only PR, confirm `check-codacy-coverage` shows status `Skipped`
+  - Spec: `specs/codacy-coverage-gate/spec.md` → "Codacy checks skipped on docs-only PR"
+- [ ] **TC-5.3** On a direct push to `main` (not a PR), confirm `check-codacy-coverage` shows status `Skipped`
+  - Spec: `specs/codacy-coverage-gate/spec.md` → "Codacy checks skipped on push to main"
+- [ ] **TC-5.4** (Code review only — hard to trigger in practice) Inspect polling logic to confirm a non-`success` Codacy conclusion causes immediate job failure, and timeout causes hard fail (not pass)
+  - Spec: `specs/codacy-coverage-gate/spec.md` → "A Codacy coverage check fails" and "Codacy checks do not complete within timeout"
+
+### Task 6 — `ci-gate` job
+
+- [ ] **TC-6.1** On a docs-only PR where lint and build pass and test jobs are skipped, confirm `ci-gate` succeeds
+  - Spec: `specs/ci-gate/spec.md` → "Docs-only PR — skipped jobs do not block gate"
+- [ ] **TC-6.2** On a code-change PR where all jobs pass, confirm `ci-gate` succeeds
+  - Spec: `specs/ci-gate/spec.md` → "All upstream jobs pass — gate succeeds"
+- [ ] **TC-6.3** Push a branch with a deliberately failing test; confirm `ci-gate` fails
+  - Spec: `specs/ci-gate/spec.md` → "Any upstream job fails — gate fails"
+- [ ] **TC-6.4** Confirm `ci-gate` completes in under 30 seconds once upstream jobs are done
+  - Spec: `specs/ci-gate/spec.md` NFAC → "ci-gate adds no meaningful latency"
+
+### Task 7 — Branch protection update
+
+- [ ] **TC-7.1** After updating branch protection, confirm `ci-gate` appears as a required check on a new PR
+  - Spec: `specs/ci-gate/spec.md` → "ci-gate is the only required branch-protection check for this workflow"
+- [ ] **TC-7.2** Confirm `lint`, `unit-tests`, `integration-tests`, `regression-tests` do NOT appear as individually required checks
+  - Spec: `specs/ci-gate/spec.md` → REMOVED "Individual job names as required branch-protection checks"
+- [ ] **TC-7.3** Confirm `Codacy Quality` still appears as a required check and is independent of `ci-gate`
+  - Spec: `specs/ci-gate/spec.md` → "Codacy Quality remains independently required"
+- [ ] **TC-7.4** Confirm `Codacy Diff Coverage` and `Codacy Coverage Variation` are NOT standalone required checks
+  - Spec: `specs/codacy-coverage-gate/spec.md` → REMOVED "Standalone Codacy branch-protection checks for coverage"
+
+## Regression Coverage
+
+- [ ] **REG-1** A normal code-change PR runs full suite end-to-end and merges successfully — identical behaviour to pre-change
+- [ ] **REG-2** A docs-only PR (e.g., an OpenSpec archive PR containing only `.md` files) completes CI in under 5 minutes
+  - Spec: `specs/doc-only-ci-skip/spec.md` NFAC → "Docs-only PR CI wall-clock time"

--- a/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/tests.md
+++ b/openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/tests.md
@@ -22,72 +22,72 @@ For each test case, the TDD cycle maps as:
 
 ### Task 1 — `check-changes` job
 
-- [ ] **TC-1.1** Push a branch with only `.md` file changes; confirm `check-changes` job output `docs_only=true` in Actions UI
+- [x] **TC-1.1** Push a branch with only `.md` file changes; confirm `check-changes` job output `docs_only=true` in Actions UI
   - Spec: `specs/doc-only-ci-skip/spec.md` → "All changed files are markdown"
-- [ ] **TC-1.2** Push a branch with at least one non-`.md` file changed; confirm `check-changes` outputs `docs_only=false`
+- [x] **TC-1.2** Push a branch with at least one non-`.md` file changed; confirm `check-changes` outputs `docs_only=false`
   - Spec: `specs/doc-only-ci-skip/spec.md` → "At least one non-markdown file changed"
-- [ ] **TC-1.3** Push a branch with mixed `.md` + `.ts` changes; confirm `docs_only=false`
+- [x] **TC-1.3** Push a branch with mixed `.md` + `.ts` changes; confirm `docs_only=false`
   - Spec: `specs/doc-only-ci-skip/spec.md` → "Mixed PR (markdown + code files)"
 
 ### Task 2 — Standalone `build` job
 
-- [ ] **TC-2.1** On any trigger, confirm `build` job appears in the workflow graph and executes `npm run build` exactly once
+- [x] **TC-2.1** On any trigger, confirm `build` job appears in the workflow graph and executes `npm run build` exactly once
   - Spec: `specs/doc-only-ci-skip/spec.md` → "Build runs once per workflow trigger"
-- [ ] **TC-2.2** Confirm `integration-tests` and `regression-tests` no longer contain a build step in their logs
+- [x] **TC-2.2** Confirm `integration-tests` and `regression-tests` no longer contain a build step in their logs
   - Spec: design.md Decision 2
 
 ### Task 3 — Docs-only skip conditions on test jobs
 
-- [ ] **TC-3.1** On a docs-only PR, confirm `unit-tests`, `integration-tests`, and `regression-tests` all show status `Skipped` in Actions UI
+- [x] **TC-3.1** On a docs-only PR, confirm `unit-tests`, `integration-tests`, and `regression-tests` all show status `Skipped` in Actions UI
   - Spec: `specs/doc-only-ci-skip/spec.md` → "All test jobs skipped on docs-only PR"
-- [ ] **TC-3.2** On a code-change PR, confirm all three test jobs execute normally (not skipped)
+- [x] **TC-3.2** On a code-change PR, confirm all three test jobs execute normally (not skipped)
   - Spec: `specs/doc-only-ci-skip/spec.md` → "All test jobs run on code-change PR"
 
 ### Task 4 — `upload-and-finalize-coverage` job
 
-- [ ] **TC-4.1** On a code-change PR, confirm `upload-and-finalize-coverage` job runs and logs show three partial uploads followed by `final`
+- [x] **TC-4.1** On a code-change PR, confirm `upload-and-finalize-coverage` job runs and logs show three partial uploads followed by `final`
   - Spec: `specs/codacy-coverage-gate/spec.md` → "All three partial reports uploaded before final"
-- [ ] **TC-4.2** On a docs-only PR, confirm `upload-and-finalize-coverage` shows status `Skipped`
+- [x] **TC-4.2** On a docs-only PR, confirm `upload-and-finalize-coverage` shows status `Skipped`
   - Spec: `specs/doc-only-ci-skip/spec.md` → "Coverage upload skipped on docs-only PR"
-- [ ] **TC-4.3** On a fork PR (no `CODACY_API_TOKEN`), confirm job exits successfully with a "token absent" log message
+- [x] **TC-4.3** On a fork PR (no `CODACY_API_TOKEN`), confirm job exits successfully with a "token absent" log message
   - Spec: `specs/codacy-coverage-gate/spec.md` → "Coverage upload skipped when CODACY_API_TOKEN absent"
-- [ ] **TC-4.4** Confirm the old `finalize-coverage` job no longer exists in the workflow
+- [x] **TC-4.4** Confirm the old `finalize-coverage` job no longer exists in the workflow
 
 ### Task 5 — `check-codacy-coverage` job
 
-- [ ] **TC-5.1** On a code-change PR with passing coverage, confirm `check-codacy-coverage` job succeeds after detecting both Codacy checks as `success`
+- [x] **TC-5.1** On a code-change PR with passing coverage, confirm `check-codacy-coverage` job succeeds after detecting both Codacy checks as `success`
   - Spec: `specs/codacy-coverage-gate/spec.md` → "Both Codacy checks pass within timeout"
-- [ ] **TC-5.2** On a docs-only PR, confirm `check-codacy-coverage` shows status `Skipped`
+- [x] **TC-5.2** On a docs-only PR, confirm `check-codacy-coverage` shows status `Skipped`
   - Spec: `specs/codacy-coverage-gate/spec.md` → "Codacy checks skipped on docs-only PR"
-- [ ] **TC-5.3** On a direct push to `main` (not a PR), confirm `check-codacy-coverage` shows status `Skipped`
+- [x] **TC-5.3** On a direct push to `main` (not a PR), confirm `check-codacy-coverage` shows status `Skipped`
   - Spec: `specs/codacy-coverage-gate/spec.md` → "Codacy checks skipped on push to main"
-- [ ] **TC-5.4** (Code review only — hard to trigger in practice) Inspect polling logic to confirm a non-`success` Codacy conclusion causes immediate job failure, and timeout causes hard fail (not pass)
+- [x] **TC-5.4** (Code review only — hard to trigger in practice) Inspect polling logic to confirm a non-`success` Codacy conclusion causes immediate job failure, and timeout causes hard fail (not pass)
   - Spec: `specs/codacy-coverage-gate/spec.md` → "A Codacy coverage check fails" and "Codacy checks do not complete within timeout"
 
 ### Task 6 — `ci-gate` job
 
-- [ ] **TC-6.1** On a docs-only PR where lint and build pass and test jobs are skipped, confirm `ci-gate` succeeds
+- [x] **TC-6.1** On a docs-only PR where lint and build pass and test jobs are skipped, confirm `ci-gate` succeeds
   - Spec: `specs/ci-gate/spec.md` → "Docs-only PR — skipped jobs do not block gate"
-- [ ] **TC-6.2** On a code-change PR where all jobs pass, confirm `ci-gate` succeeds
+- [x] **TC-6.2** On a code-change PR where all jobs pass, confirm `ci-gate` succeeds
   - Spec: `specs/ci-gate/spec.md` → "All upstream jobs pass — gate succeeds"
-- [ ] **TC-6.3** Push a branch with a deliberately failing test; confirm `ci-gate` fails
+- [x] **TC-6.3** Push a branch with a deliberately failing test; confirm `ci-gate` fails
   - Spec: `specs/ci-gate/spec.md` → "Any upstream job fails — gate fails"
-- [ ] **TC-6.4** Confirm `ci-gate` completes in under 30 seconds once upstream jobs are done
+- [x] **TC-6.4** Confirm `ci-gate` completes in under 30 seconds once upstream jobs are done
   - Spec: `specs/ci-gate/spec.md` NFAC → "ci-gate adds no meaningful latency"
 
 ### Task 7 — Branch protection update
 
-- [ ] **TC-7.1** After updating branch protection, confirm `ci-gate` appears as a required check on a new PR
+- [x] **TC-7.1** After updating branch protection, confirm `ci-gate` appears as a required check on a new PR
   - Spec: `specs/ci-gate/spec.md` → "ci-gate is the only required branch-protection check for this workflow"
-- [ ] **TC-7.2** Confirm `lint`, `unit-tests`, `integration-tests`, `regression-tests` do NOT appear as individually required checks
+- [x] **TC-7.2** Confirm `lint`, `unit-tests`, `integration-tests`, `regression-tests` do NOT appear as individually required checks
   - Spec: `specs/ci-gate/spec.md` → REMOVED "Individual job names as required branch-protection checks"
-- [ ] **TC-7.3** Confirm `Codacy Quality` still appears as a required check and is independent of `ci-gate`
+- [x] **TC-7.3** Confirm `Codacy Quality` still appears as a required check and is independent of `ci-gate`
   - Spec: `specs/ci-gate/spec.md` → "Codacy Quality remains independently required"
-- [ ] **TC-7.4** Confirm `Codacy Diff Coverage` and `Codacy Coverage Variation` are NOT standalone required checks
+- [x] **TC-7.4** Confirm `Codacy Diff Coverage` and `Codacy Coverage Variation` are NOT standalone required checks
   - Spec: `specs/codacy-coverage-gate/spec.md` → REMOVED "Standalone Codacy branch-protection checks for coverage"
 
 ## Regression Coverage
 
-- [ ] **REG-1** A normal code-change PR runs full suite end-to-end and merges successfully — identical behaviour to pre-change
-- [ ] **REG-2** A docs-only PR (e.g., an OpenSpec archive PR containing only `.md` files) completes CI in under 5 minutes
+- [x] **REG-1** A normal code-change PR runs full suite end-to-end and merges successfully — identical behaviour to pre-change
+- [x] **REG-2** A docs-only PR (e.g., an OpenSpec archive PR containing only `.md` files) completes CI in under 5 minutes
   - Spec: `specs/doc-only-ci-skip/spec.md` NFAC → "Docs-only PR CI wall-clock time"

--- a/openspec/specs/ci-gate/spec.md
+++ b/openspec/specs/ci-gate/spec.md
@@ -20,8 +20,8 @@ The system SHALL expose a single `ci-gate` job that succeeds when all upstream j
 
 #### Scenario: Any upstream job fails — gate fails
 
-- **Given** any pull request where at least one upstream job concludes with `failure`
-- **When** the `ci-gate` job evaluates upstream results using `contains(needs.*.result, 'failure')`
+- **Given** any pull request where at least one upstream job concludes with `failure` or `cancelled`
+- **When** the `ci-gate` job evaluates upstream results using `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`
 - **Then** `ci-gate` fails, blocking merge
 
 #### Scenario: ci-gate is the only required branch-protection check for this workflow
@@ -72,7 +72,7 @@ Reason for removal: The `ci-gate` job aggregates all of these; requiring individ
 
 - **Given** any workflow run
 - **When** the `ci-gate` job executes
-- **Then** the job body consists solely of a single conditional shell check (`contains(needs.*.result, 'failure')`) with no external dependencies, ensuring it cannot fail for infrastructure reasons
+- **Then** the job body consists solely of a single conditional shell check (`contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`) with no external dependencies, ensuring it cannot fail for infrastructure reasons
 
 ### Requirement: Performance
 

--- a/openspec/specs/ci-gate/spec.md
+++ b/openspec/specs/ci-gate/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `../../changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md` document, not a replacement.
+
+### Requirement: ADDED ci-gate umbrella job
+
+The system SHALL expose a single `ci-gate` job that succeeds when all upstream jobs either passed or were skipped, and fails if any upstream job concluded with `failure` or `cancelled`.
+
+#### Scenario: All upstream jobs pass — gate succeeds
+
+- **Given** a non-docs pull request where all upstream jobs (`lint`, `build`, `unit-tests`, `integration-tests`, `regression-tests`, `upload-and-finalize-coverage`, `check-codacy-coverage`) complete with `success`
+- **When** the `ci-gate` job evaluates upstream results
+- **Then** `ci-gate` completes with `success`
+
+#### Scenario: Docs-only PR — skipped jobs do not block gate
+
+- **Given** a docs-only pull request where test jobs, coverage upload, and Codacy polling jobs are all `skipped` and `lint` + `build` pass
+- **When** the `ci-gate` job evaluates upstream results
+- **Then** `ci-gate` completes with `success`
+
+#### Scenario: Any upstream job fails — gate fails
+
+- **Given** any pull request where at least one upstream job concludes with `failure`
+- **When** the `ci-gate` job evaluates upstream results using `contains(needs.*.result, 'failure')`
+- **Then** `ci-gate` fails, blocking merge
+
+#### Scenario: ci-gate is the only required branch-protection check for this workflow
+
+- **Given** branch protection rules for `main` after this change is deployed
+- **When** a pull request targets `main`
+- **Then** only `ci-gate` (from the `Build & Test` workflow) appears as a required check; individual job names (`lint`, `unit-tests`, etc.) are not required checks; Codacy Quality remains a separate required check
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Branch protection required checks
+
+Branch protection for `main` SHALL require `ci-gate` instead of individual workflow job names and instead of Codacy Diff Coverage and Codacy Coverage Variation as separate checks.
+
+#### Scenario: ci-gate required check blocks merge on failure
+
+- **Given** a pull request where `ci-gate` has failed
+- **When** a contributor attempts to merge
+- **Then** GitHub blocks the merge and displays `ci-gate` as a failing required check
+
+#### Scenario: Codacy Quality remains independently required
+
+- **Given** a pull request where `ci-gate` passes but Codacy Quality reports a failure
+- **When** a contributor attempts to merge
+- **Then** GitHub blocks the merge due to the Codacy Quality required check
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Individual job names as required branch-protection checks
+
+`lint`, `unit-tests`, `integration-tests`, `regression-tests`, and `finalize-coverage` are removed as individually required branch-protection checks.
+
+Reason for removal: The `ci-gate` job aggregates all of these; requiring individual jobs prevents the skip-on-docs-only pattern from working cleanly.
+
+## Traceability
+
+- Proposal element "single required branch-protection check" → Requirement: ci-gate umbrella job
+- Proposal element "branch protection restructure" → Requirement: MODIFIED Branch protection required checks
+- Design decision 5 (ci-gate umbrella) → Requirement: ci-gate umbrella job
+- Requirement: ci-gate umbrella job → Task: Add ci-gate job to build-test.yml
+- Requirement: MODIFIED Branch protection required checks → Task: Update branch protection rules
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: ci-gate logic is trivially simple and cannot itself error
+
+- **Given** any workflow run
+- **When** the `ci-gate` job executes
+- **Then** the job body consists solely of a single conditional shell check (`contains(needs.*.result, 'failure')`) with no external dependencies, ensuring it cannot fail for infrastructure reasons
+
+### Requirement: Performance
+
+#### Scenario: ci-gate adds no meaningful latency
+
+- **Given** all upstream jobs have completed
+- **When** the `ci-gate` job runs
+- **Then** the job completes within 30 seconds (shell conditional only, no installs or network calls)
+
+### Requirement: Security
+
+The `ci-gate` job requires no additional permissions beyond the workflow default. See functional scenarios above for access-control behaviour.

--- a/openspec/specs/codacy-coverage-gate/spec.md
+++ b/openspec/specs/codacy-coverage-gate/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `../../changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md` document, not a replacement.
+
+### Requirement: ADDED Codacy coverage gate via workflow polling
+
+The system SHALL poll the GitHub Checks API for "Codacy Diff Coverage" and "Codacy Coverage Variation" check results on pull requests, and fail the workflow if either check does not conclude with `success` within the timeout window.
+
+#### Scenario: Both Codacy checks pass within timeout
+
+- **Given** a pull request where `docs_only=false` and `upload-and-finalize-coverage` has completed
+- **When** the `check-codacy-coverage` job polls `checks.listForRef`
+- **Then** the job succeeds once both "Codacy Diff Coverage" and "Codacy Coverage Variation" checks report `conclusion: success`
+
+#### Scenario: A Codacy coverage check fails
+
+- **Given** a pull request where `docs_only=false` and Codacy reports `conclusion: failure` for "Codacy Diff Coverage"
+- **When** the `check-codacy-coverage` job detects the failed conclusion
+- **Then** the job fails immediately, blocking `ci-gate` and preventing merge
+
+#### Scenario: Codacy checks do not complete within timeout
+
+- **Given** a pull request where `docs_only=false` and Codacy has not posted check results within 10 minutes of `check-codacy-coverage` starting
+- **When** the polling loop exhausts the timeout
+- **Then** the `check-codacy-coverage` job fails with a timeout error message, blocking `ci-gate`
+
+#### Scenario: Codacy checks skipped on docs-only PR
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** the `check-codacy-coverage` job reports status `skipped` and no Codacy API calls are made
+
+#### Scenario: Codacy checks skipped on push to main
+
+- **Given** a direct push to `main` (not a pull request event)
+- **When** the workflow executes
+- **Then** the `check-codacy-coverage` job reports status `skipped` regardless of `docs_only` value
+
+---
+
+### Requirement: ADDED Codacy partial coverage upload consolidated
+
+The system SHALL upload all three partial coverage reports (unit, integration, regression) and call `final` in a single `upload-and-finalize-coverage` job after all test jobs complete.
+
+#### Scenario: All three partial reports uploaded before final
+
+- **Given** a pull request where `docs_only=false` and all three test jobs have completed (any result)
+- **When** the `upload-and-finalize-coverage` job runs
+- **Then** `lcov.info` from unit tests, `lcov.info` from integration tests, and `lcov.info` from regression tests are each uploaded as partial reports, and `final` is called exactly once after all three
+
+#### Scenario: Coverage upload skipped when CODACY_API_TOKEN absent
+
+- **Given** a fork PR or environment where `CODACY_API_TOKEN` is not set
+- **When** the `upload-and-finalize-coverage` job runs
+- **Then** the job exits successfully with a logged message indicating the token is absent, and does not attempt to upload
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Standalone Codacy branch-protection checks for coverage
+
+"Codacy Diff Coverage" and "Codacy Coverage Variation" are removed as standalone required branch-protection checks.
+
+Reason for removal: Both checks are now consumed and gated inside the workflow via the `check-codacy-coverage` polling job. The Codacy Quality check is unaffected and remains a standalone required check.
+
+## Traceability
+
+- Proposal element "Codacy coverage checks internalised" → Requirement: Codacy coverage gate via workflow polling
+- Proposal element "coverage upload consolidation" → Requirement: Codacy partial coverage upload consolidated
+- Design decision 4 (check-codacy-coverage polling) → Requirement: Codacy coverage gate via workflow polling
+- Design decision 3 (coverage consolidation) → Requirement: Codacy partial coverage upload consolidated
+- Requirement: Codacy coverage gate via workflow polling → Task: Add check-codacy-coverage job
+- Requirement: Codacy partial coverage upload consolidated → Task: Add upload-and-finalize-coverage job; Task: Remove per-job coverage upload steps
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Polling does not add latency beyond Codacy processing time
+
+- **Given** a non-docs PR where Codacy posts both check results within 3 minutes of `final` being called
+- **When** the `check-codacy-coverage` job polls at 30-second intervals
+- **Then** the job completes within 30 seconds of Codacy posting results (i.e., polling overhead is at most one interval)
+
+### Requirement: Reliability
+
+#### Scenario: Hard fail on timeout — no silent pass
+
+- **Given** a non-docs PR where Codacy has not posted check results after 10 minutes
+- **When** the polling loop exhausts its budget
+- **Then** the `check-codacy-coverage` job exits with a non-zero code and a human-readable timeout message; `ci-gate` fails; the PR is blocked
+
+See functional scenario: "Codacy checks do not complete within timeout" above.
+
+### Requirement: Security
+
+The polling job reads only GitHub Checks API (read-only `checks: read` permission). It does not write check results or modify PR state. No additional security scenario beyond functional coverage applies.

--- a/openspec/specs/doc-only-ci-skip/spec.md
+++ b/openspec/specs/doc-only-ci-skip/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the `../../changes/archive/2026-06-13-issue-405-doc-only-ci-skip/design.md` document, not a replacement.
+
+### Requirement: ADDED Docs-only change detection
+
+The system SHALL detect when all changed files in a push or pull-request match `**/*.md` and expose a `docs_only` output for downstream job conditions.
+
+#### Scenario: All changed files are markdown
+
+- **Given** a pull request or push to `main` where every changed file has a `.md` extension
+- **When** the `check-changes` job runs
+- **Then** the job outputs `docs_only=true`
+
+#### Scenario: At least one non-markdown file changed
+
+- **Given** a pull request or push to `main` where at least one changed file does not have a `.md` extension
+- **When** the `check-changes` job runs
+- **Then** the job outputs `docs_only=false`
+
+#### Scenario: Mixed PR (markdown + code files)
+
+- **Given** a pull request containing both `.md` files and `.ts`/`.tsx`/`.js` source files
+- **When** the `check-changes` job runs
+- **Then** the job outputs `docs_only=false` and the full test suite runs
+
+---
+
+### Requirement: ADDED Lint and build always run
+
+The system SHALL run the `lint` and `build` jobs on every trigger, regardless of `docs_only` value.
+
+#### Scenario: Docs-only PR runs lint and build
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** the `lint` job completes successfully and the `build` job completes successfully
+
+#### Scenario: Build failure caught on docs-only PR
+
+- **Given** a pull request where `docs_only=true` and `next build` fails (e.g., broken import in a non-test file)
+- **When** the `build` job runs
+- **Then** the `build` job fails and `ci-gate` reports failure, blocking merge
+
+---
+
+### Requirement: ADDED Test jobs skip on docs-only changes
+
+The system SHALL skip `unit-tests`, `integration-tests`, and `regression-tests` when `docs_only=true`.
+
+#### Scenario: All test jobs skipped on docs-only PR
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** `unit-tests`, `integration-tests`, and `regression-tests` all report status `skipped` in the GitHub Actions UI and no runner minutes are consumed by those jobs
+
+#### Scenario: All test jobs run on code-change PR
+
+- **Given** a pull request where `docs_only=false`
+- **When** the workflow executes
+- **Then** `unit-tests`, `integration-tests`, and `regression-tests` all execute normally
+
+---
+
+### Requirement: ADDED Coverage upload and finalize skip on docs-only changes
+
+The system SHALL skip the `upload-and-finalize-coverage` job when `docs_only=true`.
+
+#### Scenario: Coverage upload skipped on docs-only PR
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow executes
+- **Then** the `upload-and-finalize-coverage` job reports status `skipped` and no coverage data is sent to Codacy
+
+#### Scenario: Coverage uploaded and finalized on code-change PR
+
+- **Given** a pull request where `docs_only=false` and all test jobs complete (success or failure)
+- **When** the `upload-and-finalize-coverage` job runs
+- **Then** all three partial coverage reports are uploaded to Codacy and `final` is called exactly once
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Build job is standalone
+
+The system SHALL run `npm run build` as a dedicated `build` job (currently embedded in `integration-tests` and `regression-tests`).
+
+#### Scenario: Build runs once per workflow trigger
+
+- **Given** any push or pull request triggering the workflow
+- **When** the workflow executes
+- **Then** `npm run build` is executed exactly once in the standalone `build` job, not duplicated inside test jobs
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Per-job inline coverage upload
+
+The inline coverage upload steps previously present in `unit-tests`, `integration-tests`, and `regression-tests` are removed in favour of the consolidated `upload-and-finalize-coverage` job.
+
+Reason for removal: Consolidation into a single job eliminates code duplication and ensures `final` is called only after all test jobs complete.
+
+## Traceability
+
+- Proposal element "check-changes job" → Requirement: Docs-only change detection
+- Proposal element "lint and build always run" → Requirement: Lint and build always run
+- Proposal element "test jobs skip on docs-only" → Requirement: Test jobs skip on docs-only changes
+- Proposal element "coverage upload consolidation" → Requirement: Coverage upload and finalize skip + MODIFIED Build job is standalone
+- Design decision 1 (dorny/paths-filter) → Requirement: Docs-only change detection
+- Design decision 2 (standalone build) → Requirement: MODIFIED Build job is standalone
+- Design decision 3 (coverage consolidation) → Requirement: Coverage upload and finalize skip
+- Requirement: Docs-only change detection → Task: Add check-changes job
+- Requirement: Lint and build always run → Task: Extract standalone build job
+- Requirement: Test jobs skip on docs-only → Task: Add docs_only conditionals to test jobs
+- Requirement: Coverage upload and finalize skip → Task: Add upload-and-finalize-coverage job
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Docs-only PR CI wall-clock time
+
+- **Given** a pull request where `docs_only=true`
+- **When** the workflow completes (lint + build + ci-gate)
+- **Then** the total wall-clock time from trigger to `ci-gate` success is under 5 minutes
+
+### Requirement: Reliability
+
+#### Scenario: False-positive classification never skips tests on code change
+
+- **Given** any pull request containing at least one non-markdown file
+- **When** the `check-changes` job runs using `dorny/paths-filter`
+- **Then** `docs_only=false` and all test jobs execute — no code change is ever treated as docs-only
+
+### Requirement: Security
+
+See functional scenario: "Mixed PR (markdown + code files)" — access control over test skipping is enforced by the path-filter logic itself; no additional security scenario applies.

--- a/openspec/specs/doc-only-ci-skip/spec.md
+++ b/openspec/specs/doc-only-ci-skip/spec.md
@@ -88,7 +88,7 @@ The system SHALL run `npm run build` as a dedicated `build` job (currently embed
 
 - **Given** any push or pull request triggering the workflow
 - **When** the workflow executes
-- **Then** `npm run build` is executed exactly once in the standalone `build` job, not duplicated inside test jobs
+- **Then** `npm run build` is executed exactly once in the standalone `build` job, not duplicated inside test jobs; the `build` job uploads the `.next/` output as a `next-build` artifact (via `actions/upload-artifact`), and `integration-tests` and `regression-tests` download it (via `actions/download-artifact`) before running
 
 ## REMOVED Requirements
 


### PR DESCRIPTION
Archives the completed `issue-405-doc-only-ci-skip` OpenSpec change and syncs approved specs to `openspec/specs/`.

- Moves `openspec/changes/issue-405-doc-only-ci-skip/` → `openspec/changes/archive/2026-06-13-issue-405-doc-only-ci-skip/`
- Adds `openspec/specs/doc-only-ci-skip/spec.md`
- Adds `openspec/specs/codacy-coverage-gate/spec.md`
- Adds `openspec/specs/ci-gate/spec.md`