### PR TITLE
docs(multi-user-campaigns): sync status with GitHub issue states (2026-06-13)

### DIFF
--- a/docs/multi-user-campaigns/02-invite-and-accept.md
+++ b/docs/multi-user-campaigns/02-invite-and-accept.md
@@ -5,8 +5,8 @@ or decline. Membership only becomes `active` on acceptance.
 
 **Depends on:** Phase 1 (1c search, 1d members, 1e access). ✅ Phase 1 complete.
 
-> **Tracking:** epic [#294](https://github.com/dougis-org/session-combat/issues/294) — OPEN
-> **Status:** All 4 sub-issues CLOSED ✅ — Phase 2 complete. Epic #294 pending close.
+> **Tracking:** epic [#294](https://github.com/dougis-org/session-combat/issues/294) — CLOSED ✅
+> **Status:** All 4 sub-issues CLOSED ✅ — Phase 2 complete.
 
 ## Membership lifecycle
 

--- a/docs/multi-user-campaigns/03-cross-user-characters.md
+++ b/docs/multi-user-campaigns/03-cross-user-characters.md
@@ -7,7 +7,7 @@ own them.
 **Depends on:** Phase 1 (1e access). ✅ Phase 1 complete. Benefits from Phase 2 (active members exist),
 but the data layer can be built against memberships directly.
 
-> **Tracking:** epic [#295](https://github.com/dougis-org/session-combat/issues/295) — OPEN
+> **Tracking:** epic [#295](https://github.com/dougis-org/session-combat/issues/295) — CLOSED ✅
 > **Status:** 2 of 2 sub-issues closed. **Phase 3 complete.**
 
 ## How a player's character reaches a DM's party

--- a/docs/multi-user-campaigns/README.md
+++ b/docs/multi-user-campaigns/README.md
@@ -1,6 +1,6 @@
 # Multi-User Campaigns
 
-> Status: **In Progress** · Owner: DM (campaign owner) · Last updated: 2026-06-09
+> Status: **In Progress** · Owner: DM (campaign owner) · Last updated: 2026-06-13
 > Phase 1 ✅ complete · Phase 2 ✅ complete · Phase 3 ✅ complete · Phases 4–7 🟡 not started
 
 This initiative turns campaigns from a single-owner artifact into a shared space


### PR DESCRIPTION
Automated documentation status sync.

Updates issue status markers (✅/🔄/🟡), refreshes epic tracking blockquotes, and corrects per-phase doc headings to reflect current GitHub issue states.

Changes:
- `README.md`: bumped Last updated date to 2026-06-13
- `02-invite-and-accept.md`: epic #294 tracking updated from OPEN → CLOSED ✅
- `03-cross-user-characters.md`: epic #295 tracking updated from OPEN → CLOSED ✅

All changes are doc-only (no code).