### PR TITLE
feat: 4b — client useCampaignStream hook (Phase 4 real-time transport)

### DIFF
--- a/lib/hooks/useCampaignStream.ts
+++ b/lib/hooks/useCampaignStream.ts
@@ -5,7 +5,7 @@ import type { CampaignStreamEvent } from '@/lib/types';
 
 type Status = 'connecting' | 'open' | 'error';
 
-// Use a local constant so tests don't need a real EventSource global for static values
+// Local constant avoids reading EventSource.CLOSED, which requires a real EventSource global
 const CLOSED = 2;
 
 export function useCampaignStream(
@@ -29,7 +29,7 @@ export function useCampaignStream(
       const es = new globalThis.EventSource(`/api/campaigns/${encodeURIComponent(campaignId)}/stream`);
       currentEs = es;
 
-      if (!torn) setStatus('connecting');
+      setStatus('connecting');
 
       es.onopen = () => {
         if (torn) { es.close(); return; }

--- a/lib/hooks/useCampaignStream.ts
+++ b/lib/hooks/useCampaignStream.ts
@@ -13,7 +13,13 @@ export function useCampaignStream(
   onEvent: (e: CampaignStreamEvent) => void,
 ): { status: Status } {
   const [status, setStatus] = useState<Status>('connecting');
-  // Store onEvent in a ref to avoid stale closures without triggering reconnect (Decision 3)
+  // Reset status synchronously during render when campaignId changes (avoids stale 'open' flash)
+  const [prevCampaignId, setPrevCampaignId] = useState(campaignId);
+  if (campaignId !== prevCampaignId) {
+    setPrevCampaignId(campaignId);
+    setStatus('connecting');
+  }
+  // Store onEvent in a ref to avoid stale closures without triggering reconnect (Decision 1)
   const onEventRef = useRef(onEvent);
   useLayoutEffect(() => { onEventRef.current = onEvent; });
 

--- a/openspec/changes/client-use-campaign-stream-hook/.openspec.yaml
+++ b/openspec/changes/client-use-campaign-stream-hook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-14

--- a/openspec/changes/client-use-campaign-stream-hook/design.md
+++ b/openspec/changes/client-use-campaign-stream-hook/design.md
@@ -1,0 +1,128 @@
+## Context
+
+- Relevant architecture: Next.js app with `"use client"` components. Real-time data flows via SSE (`text/event-stream`) from `GET /api/campaigns/[id]/stream` (issue #311). The hook lives in `lib/hooks/` alongside `useAuth`, `useCombat`, etc.
+- Dependencies: `react` (useEffect, useLayoutEffect, useRef, useState); `CampaignStreamEvent` union type from `lib/types.ts`; browser `EventSource` API (accessed via `globalThis` for test isolation).
+- Interfaces/contracts touched: `CampaignStreamEvent` in `lib/types.ts`; the hook's public API `useCampaignStream(campaignId, onEvent) → { status }`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Wrap `EventSource` so components subscribe to a campaign SSE stream with a single hook call.
+- Expose `status: 'connecting' | 'open' | 'error'` for UI feedback.
+- Reconnect automatically with exponential backoff (1s base, ×2 per failure, cap 30s, reset on success).
+- Dispatch typed `CampaignStreamEvent` objects to caller via `onEvent`.
+- Tear down cleanly (close ES, cancel pending timer) on unmount or `campaignId` change.
+
+### Non-Goals
+
+- Manual reconnect API.
+- Retry count or error details in returned state.
+- End-to-end integration test (deferred to 4a).
+
+## Decisions
+
+### Decision 1: `onEvent` stored in a ref (not a dep)
+
+- Chosen: Keep `onEvent` in a `useRef`, synced via `useLayoutEffect` on every render.
+- Alternatives considered: Include `onEvent` in `useEffect` dependency array (causes reconnect on every render if caller uses an inline function).
+- Rationale: Avoids spurious reconnects while still always calling the latest handler.
+- Trade-offs: `useLayoutEffect` fires synchronously after DOM mutation — correct in this case since it must update before the event fires.
+
+### Decision 2: `globalThis.EventSource` (not bare `EventSource`)
+
+- Chosen: Construct `EventSource` via `globalThis.EventSource`.
+- Alternatives considered: Import a polyfill; use bare `EventSource`.
+- Rationale: Allows Jest tests to swap in `MockEventSource` without a real browser environment. Bare `EventSource` fails in JSDOM.
+- Trade-offs: Slightly non-idiomatic; the comment in the file explains why.
+
+### Decision 3: Explicit backoff only on `CLOSED` state; browser-managed on `CONNECTING`
+
+- Chosen: In `onerror`, branch on `es.readyState`. If `CLOSED`, close and schedule explicit reconnect with backoff. If `CONNECTING`, browser is handling it — only update status to `'connecting'`.
+- Alternatives considered: Always schedule explicit reconnect regardless of readyState.
+- Rationale: Avoids racing with the browser's own retry, which fires first for transient drops. HTTP-level failures (CLOSED) require an explicit new `EventSource`.
+- Trade-offs: Two distinct reconnect paths; both are unit-tested (T3-1 vs T3-6).
+
+### Decision 4: `encodeURIComponent` on `campaignId`
+
+- Chosen: URL-encode `campaignId` when constructing the EventSource URL.
+- Alternatives considered: Trust callers to pass safe IDs.
+- Rationale: Defends against IDs containing slashes or spaces; test T1-3b covers this.
+- Trade-offs: None meaningful.
+
+## Proposal to Design Mapping
+
+- Proposal element: Auto-reconnect/backoff
+  - Design decision: Decision 3 (explicit backoff on CLOSED; browser-managed on CONNECTING)
+  - Validation approach: T3-1 through T3-6 unit tests
+
+- Proposal element: Connection state
+  - Design decision: `status` state var with `'connecting' | 'open' | 'error'`
+  - Validation approach: T1-1, T1-2, T3-1, T3-6
+
+- Proposal element: Typed event dispatch
+  - Design decision: `CampaignStreamEvent` union in `lib/types.ts`; dispatched via `onEventRef`
+  - Validation approach: T2-3, T2-4, T2-5
+
+- Proposal element: Stale closure avoidance
+  - Design decision: Decision 1 (onEvent ref)
+  - Validation approach: T2-5
+
+- Proposal element: Clean teardown
+  - Design decision: `torn` flag + `currentEs?.close()` + `clearTimeout(timerId)` in cleanup
+  - Validation approach: T4-1, T4-2, T4-3
+
+## Functional Requirements Mapping
+
+- Requirement: Hook connects to `/api/campaigns/[id]/stream`
+  - Design element: `new globalThis.EventSource(...)` with URL-encoded campaignId
+  - Acceptance criteria reference: T1-3, T1-3b
+  - Testability notes: MockEventSource records the URL passed to constructor
+
+- Requirement: Reconnects after CLOSED error with backoff
+  - Design element: `onerror` CLOSED branch; `delay` var doubling up to 30s
+  - Acceptance criteria reference: T3-1 through T3-5
+  - Testability notes: jest fake timers advance backoff intervals
+
+- Requirement: Tears down on unmount
+  - Design element: useEffect cleanup closes ES and clears timer
+  - Acceptance criteria reference: T4-1, T4-2, T4-3
+  - Testability notes: MockEventSource.close is a jest.fn(); timer checked with runAllTimers
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Reconnect cap prevents runaway retry storms
+  - Design element: `Math.min(delay * 2, 30_000)` cap
+  - Acceptance criteria reference: T3-4
+  - Testability notes: Advance fake timers through 5 failures, verify 30s cap
+
+- Requirement category: testability
+  - Requirement: All branches exercised without a real browser
+  - Design element: `globalThis.EventSource` swap; `MockEventSource` in test setup
+  - Acceptance criteria reference: All T1–T4 tests
+  - Testability notes: beforeEach replaces globalThis.EventSource; afterEach restores it
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `CampaignStreamEvent` type is minimal (`heartbeat | change`) and will need extension as 4a defines more event names.
+  - Impact: Callers may receive events they cannot discriminate until the type is updated.
+  - Mitigation: Discriminated union is open for extension; adding variants is non-breaking.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Hook causes regressions in existing component behaviour.
+- Rollback steps: Revert the hook file; the type extension to `lib/types.ts` is additive and safe to leave.
+- Data migration considerations: None (client-only, no persistent state).
+- Verification after rollback: Run full test suite; verify no import errors.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Read failure logs via `gh run view --log-failed`, fix in code, re-push.
+- If security checks fail: Treat as a blocking CI failure; investigate dependency advisories.
+- If required reviews are blocked/stale: Address all unresolved review threads; resolve via GraphQL mutation if auto-resolve hasn't fired after 3-minute wait.
+- Escalation path and timeout: If blocked for > 24 h with no reviewer response, ping the team in the PR and flag to the project maintainer.
+
+## Open Questions
+
+- No unresolved questions. All design decisions are already implemented and tested.

--- a/openspec/changes/client-use-campaign-stream-hook/proposal.md
+++ b/openspec/changes/client-use-campaign-stream-hook/proposal.md
@@ -1,0 +1,62 @@
+## GitHub Issues
+
+- #312
+
+## Why
+
+- Problem statement: The multi-user campaign real-time transport (Phase 4) requires a client-side hook to consume the SSE stream from the server endpoint, manage connection lifecycle, and deliver typed events to React components.
+- Why now: Phase 1 is complete; 4b and 4c have no upstream dependencies and can proceed immediately. The hook is already implemented and fully tested.
+- Business/user impact: Unblocks all UI components that need to react to live campaign updates (chat, combat state changes, etc.).
+
+## Problem Space
+
+- Current behavior: No client-side SSE consumer exists; components cannot receive real-time campaign events.
+- Desired behavior: A React hook `useCampaignStream(campaignId, onEvent)` wraps `EventSource`, manages reconnect/backoff, exposes connection state, and dispatches typed `CampaignStreamEvent` objects to callers. Tears down cleanly on unmount or `campaignId` change.
+- Constraints: Must work in the Next.js `"use client"` context; `EventSource` must be accessed via `globalThis` to remain test-friendly. Reconnect uses exponential backoff (1s base, 2× per failure, capped at 30s); resets to 1s after successful reconnect.
+- Assumptions: The SSE endpoint (`GET /api/campaigns/[id]/stream`) is defined in issue #311 (4a); end-to-end testing against a live endpoint is deferred to 4a.
+- Edge cases considered: unmount during connecting state, unmount while a reconnect timer is pending, campaignId change while open, stale `onEvent` closure (handled via ref).
+
+## Scope
+
+### In Scope
+
+- `lib/hooks/useCampaignStream.ts` — the hook implementation
+- `tests/unit/hooks/useCampaignStream.test.ts` — unit tests covering T1–T4
+- `lib/types.ts` — `CampaignStreamEvent` union type (`heartbeat | change`)
+
+### Out of Scope
+
+- SSE server endpoint (issue #311, 4a)
+- End-to-end integration test against a live stream (deferred to 4a)
+- `CampaignChat` dock UI shell (issue #313, 4c)
+- Data wiring / product features
+
+## What Changes
+
+- `lib/hooks/useCampaignStream.ts` added: wraps `EventSource` with auto-reconnect/backoff, connection state (`connecting | open | error`), and typed event dispatch via `onEventRef`.
+- `lib/types.ts` extended: `CampaignStreamEvent` union type added.
+- `tests/unit/hooks/useCampaignStream.test.ts` added: 19 tests across T1 (connection lifecycle), T2 (event dispatch), T3 (reconnect behaviour), T4 (teardown).
+
+## Risks
+
+- Risk: `CampaignStreamEvent` type evolves as 4a defines more event types.
+  - Impact: Callers receive `unknown` data until type is updated.
+  - Mitigation: Type is a discriminated union; adding new variants is non-breaking for existing callers.
+
+- Risk: End-to-end reconnect behaviour untested until 4a lands.
+  - Impact: Edge cases in browser reconnect vs. explicit backoff may surface in production.
+  - Mitigation: Unit tests cover all known branches; 4a will add integration coverage.
+
+## Open Questions
+
+- No unresolved ambiguity. The hook is implemented and all 19 unit tests pass. End-to-end testing is explicitly deferred to issue #311 per the issue's stated scope.
+
+## Non-Goals
+
+- Providing a manual-reconnect API (e.g. `reconnect()` callback) — not required by any consumer today.
+- Retry count or last-error details in the returned state — not required by 4c.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/client-use-campaign-stream-hook/specs/use-campaign-stream-hook/spec.md
+++ b/openspec/changes/client-use-campaign-stream-hook/specs/use-campaign-stream-hook/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED useCampaignStream hook
+
+The system SHALL provide a React hook `useCampaignStream(campaignId, onEvent)` that wraps `EventSource`, manages connection lifecycle, and dispatches typed `CampaignStreamEvent` objects.
+
+#### Scenario: Initial connection
+
+- **Given** a component mounts and calls `useCampaignStream('c1', onEvent)`
+- **When** the hook initialises
+- **Then** an `EventSource` is constructed for `/api/campaigns/c1/stream` and `status` is `'connecting'`
+
+#### Scenario: Successful open
+
+- **Given** the hook has constructed an `EventSource`
+- **When** the server accepts the connection and `onopen` fires
+- **Then** `status` becomes `'open'`
+
+#### Scenario: campaignId URL-encoding
+
+- **Given** a campaignId containing special characters (e.g. `'campaign/with spaces'`)
+- **When** the hook constructs the `EventSource`
+- **Then** the URL uses `encodeURIComponent(campaignId)`, i.e. `/api/campaigns/campaign%2Fwith%20spaces/stream`
+
+#### Scenario: campaignId change
+
+- **Given** the hook is connected to campaign `'a'`
+- **When** `campaignId` prop changes to `'b'`
+- **Then** the previous `EventSource` is closed, a new one opens for campaign `'b'`, and `status` resets to `'connecting'`
+
+### Requirement: ADDED typed event dispatch
+
+The system SHALL parse SSE frames and invoke `onEvent` with a typed `CampaignStreamEvent` for `heartbeat` and `change` event types.
+
+#### Scenario: heartbeat event received
+
+- **Given** the connection is open
+- **When** the server sends a `heartbeat` SSE frame with `data: {"type":"heartbeat","campaignId":"c1","data":{"ts":1000}}`
+- **Then** `onEvent` is called once with `{ type: 'heartbeat', campaignId: 'c1', data: { ts: 1000 } }`
+
+#### Scenario: change event received
+
+- **Given** the connection is open
+- **When** the server sends a `change` SSE frame
+- **Then** `onEvent` is called with the parsed `CampaignStreamEvent` object
+
+#### Scenario: malformed payload ignored
+
+- **Given** the connection is open
+- **When** the server sends an SSE frame with non-JSON data
+- **Then** `onEvent` is not called and no error is thrown
+
+#### Scenario: stale closure avoided
+
+- **Given** the hook is open and the caller passes a new `onEvent` function without changing `campaignId`
+- **When** a subsequent event arrives
+- **Then** the updated `onEvent` is called, the old one is not, and no new `EventSource` is created
+
+### Requirement: ADDED auto-reconnect with exponential backoff
+
+The system SHALL automatically reconnect after HTTP-level failures, with backoff starting at 1 s, doubling per failure, capped at 30 s, and resetting to 1 s after a successful open.
+
+#### Scenario: first reconnect after CLOSED error
+
+- **Given** the connection closes with `readyState === CLOSED`
+- **When** `onerror` fires
+- **Then** `status` becomes `'error'` and a new `EventSource` is created after 1000 ms
+
+#### Scenario: backoff doubles on second failure
+
+- **Given** the first reconnect attempt also fails with `CLOSED`
+- **When** `onerror` fires again
+- **Then** the next reconnect is scheduled for 2000 ms
+
+#### Scenario: backoff is capped at 30 s
+
+- **Given** multiple failures have driven delay to 16 s
+- **When** another failure occurs
+- **Then** the next reconnect is scheduled for exactly 30 000 ms (not 32 000)
+
+#### Scenario: backoff resets after success
+
+- **Given** a reconnect attempt succeeds (`onopen` fires)
+- **When** a subsequent failure occurs
+- **Then** the next reconnect delay is 1000 ms (reset)
+
+#### Scenario: browser-managed reconnect (CONNECTING state)
+
+- **Given** the connection enters `readyState === CONNECTING` during `onerror` (transient drop, browser retrying)
+- **When** `onerror` fires
+- **Then** `status` becomes `'connecting'`, no explicit reconnect timer is scheduled, and no new `EventSource` is created
+
+### Requirement: ADDED clean teardown
+
+The system SHALL close the `EventSource` and cancel any pending reconnect timer when the hook unmounts or `campaignId` changes.
+
+#### Scenario: unmount while open
+
+- **Given** the hook is in `status === 'open'`
+- **When** the component unmounts
+- **Then** `EventSource.close()` is called
+
+#### Scenario: unmount during pending reconnect
+
+- **Given** a reconnect timer is pending after a CLOSED error
+- **When** the component unmounts before the timer fires
+- **Then** the timer is cancelled and no new `EventSource` is created
+
+#### Scenario: unmount before onopen
+
+- **Given** the hook has constructed an `EventSource` but `onopen` has not fired
+- **When** the component unmounts
+- **Then** `EventSource.close()` is called and no error is thrown
+
+## MODIFIED Requirements
+
+None — this is a new capability.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element: Auto-reconnect/backoff → Requirement: ADDED auto-reconnect with exponential backoff
+- Proposal element: Typed event dispatch → Requirement: ADDED typed event dispatch
+- Proposal element: Connection state → `status` state in hook (covered by connection lifecycle scenarios)
+- Proposal element: Clean teardown → Requirement: ADDED clean teardown
+- Design Decision 1 (onEvent ref) → Scenario: stale closure avoided
+- Design Decision 2 (globalThis.EventSource) → testability NFR
+- Design Decision 3 (CLOSED vs CONNECTING branch) → Scenarios: first reconnect after CLOSED, browser-managed reconnect
+- Design Decision 4 (URL encoding) → Scenario: campaignId URL-encoding
+- Requirement: ADDED useCampaignStream hook → Tasks: T-1 (types), T-2 (hook), T-3 (tests)
+- Requirement: ADDED typed event dispatch → Tasks: T-3 (T2 test suite)
+- Requirement: ADDED auto-reconnect → Tasks: T-3 (T3 test suite)
+- Requirement: ADDED clean teardown → Tasks: T-3 (T4 test suite)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Reconnect storm prevention
+
+- **Given** the connection has failed six consecutive times (delays: 1s, 2s, 4s, 8s, 16s, then capped)
+- **When** the sixth failure occurs
+- **Then** the next reconnect fires at exactly 30 000 ms (cap enforced)
+
+### Requirement: Testability
+
+- All hook behaviour is exercised without a real browser via `MockEventSource` substituted on `globalThis.EventSource`.
+- See functional scenarios above for coverage of all branches (T1–T4).
+
+### Requirement: Security
+
+- The hook passes only `campaignId` (URL-encoded) in the `EventSource` URL; no credentials or tokens are embedded in the URL.
+- Authentication is enforced server-side by the SSE endpoint (assertCampaignAccess — see issue #311); the hook is not responsible for access control.

--- a/openspec/changes/client-use-campaign-stream-hook/specs/use-campaign-stream-hook/spec.md
+++ b/openspec/changes/client-use-campaign-stream-hook/specs/use-campaign-stream-hook/spec.md
@@ -141,11 +141,7 @@ None.
 
 ### Requirement: Reliability
 
-#### Scenario: Reconnect storm prevention
-
-- **Given** the connection has failed six consecutive times (delays: 1s, 2s, 4s, 8s, 16s, then capped)
-- **When** the sixth failure occurs
-- **Then** the next reconnect fires at exactly 30 000 ms (cap enforced)
+*See functional scenario: "Scenario: backoff is capped at 30 s" — reconnect storm prevention is fully specified there.*
 
 ### Requirement: Testability
 

--- a/openspec/changes/client-use-campaign-stream-hook/tasks.md
+++ b/openspec/changes/client-use-campaign-stream-hook/tasks.md
@@ -1,0 +1,97 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/client-use-campaign-stream-hook` then immediately `git push -u origin feat/client-use-campaign-stream-hook`
+
+## Execution
+
+- [x] **T-1 — Add `CampaignStreamEvent` type to `lib/types.ts`**
+  - Add a discriminated union: `{ type: 'heartbeat'; campaignId: string; data: { ts: number } } | { type: 'change'; campaignId: string; data: Record<string, unknown> }`
+  - BDD/TDD: write failing test that imports and uses the type; confirm type-check fails before the type exists; add the type; confirm it passes.
+
+- [x] **T-2 — Implement `useCampaignStream` hook in `lib/hooks/useCampaignStream.ts`**
+  - Hook signature: `useCampaignStream(campaignId: string, onEvent: (e: CampaignStreamEvent) => void): { status: Status }`
+  - `Status = 'connecting' | 'open' | 'error'`
+  - Use `useRef` for `onEvent` (Decision 1), `globalThis.EventSource` (Decision 2), explicit backoff on `CLOSED` (Decision 3), `encodeURIComponent` on campaignId (Decision 4).
+  - BDD/TDD: write failing tests (T1-T4) first; implement to green; refactor for clarity.
+
+- [x] **T-3 — Write unit tests in `tests/unit/hooks/useCampaignStream.test.ts`**
+  - T1: connection lifecycle (4 scenarios + URL encoding variant)
+  - T2: event dispatch (5 scenarios including stale closure)
+  - T3: reconnect/backoff (6 scenarios covering CLOSED, CONNECTING, cap, reset)
+  - T4: teardown (3 scenarios: unmount open, unmount during pending reconnect, unmount before open)
+  - All 19 tests must pass before marking complete.
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] Run unit tests: `npx jest tests/unit/hooks/useCampaignStream.test.ts` — all 19 pass
+- [x] Run type checks: `npx tsc --noEmit`
+- [x] Run build: `npm run build`
+- [x] All completed tasks marked as complete
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` (or compare the working branch against the base branch) and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — run the project's unit test suite; all tests must pass
+- **Integration tests** — run the project's integration test suite; all tests must pass
+- **Regression / E2E tests** — run the project's end-to-end or regression test suite; all tests must pass
+- **Build** — run the project's build script; build must succeed with no errors
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — run the project's build script; build must succeed with no errors
+- Skip integration and regression/E2E tests — they are not required when no code changed
+
+If **ANY** required step fails, you **MUST** iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from working branch to `main`. **PR body MUST include `Closes #312`.**
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: AI agent
+- Reviewer(s): project maintainer
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change
+- [ ] Sync approved spec deltas into `openspec/specs/` (global spec). After copying each `spec.md` to `openspec/specs/<cap>/spec.md`, update all relative links that pointed into the change directory so they resolve from the archive location — replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-<name>/design.md`, and similarly for `../../tasks.md` and any other relative paths into the change directory.
+- [ ] Archive the change: move `openspec/changes/client-use-campaign-stream-hook/` to `openspec/changes/archive/YYYY-MM-DD-client-use-campaign-stream-hook/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-client-use-campaign-stream-hook/` exists and `openspec/changes/client-use-campaign-stream-hook/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-client-use-campaign-stream-hook` then `git push -u origin doc/archive-YYYY-MM-DD-client-use-campaign-stream-hook`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-client-use-campaign-stream-hook` to `main` with title `docs: archive client-use-campaign-stream-hook (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/client-use-campaign-stream-hook doc/archive-YYYY-MM-DD-client-use-campaign-stream-hook`
+
+Required cleanup after archive: `git fetch --prune` and `git branch -D feat/client-use-campaign-stream-hook doc/archive-YYYY-MM-DD-client-use-campaign-stream-hook`

--- a/openspec/changes/client-use-campaign-stream-hook/tests.md
+++ b/openspec/changes/client-use-campaign-stream-hook/tests.md
@@ -1,0 +1,64 @@
+---
+name: tests
+description: Tests for the client-use-campaign-stream-hook change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `client-use-campaign-stream-hook` change.
+All work follows a strict TDD process: write a failing test, make it pass, refactor.
+
+The full test suite lives in `tests/unit/hooks/useCampaignStream.test.ts`.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2. **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3. **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### T-1 — `CampaignStreamEvent` type (lib/types.ts)
+
+- [x] T1-type-1: Type compiles correctly — TypeScript accepts a `heartbeat` event shape
+- [x] T1-type-2: Type compiles correctly — TypeScript accepts a `change` event shape
+- [x] T1-type-3: Discriminated union is exhaustive — unknown `type` values are rejected at compile time
+
+### T-2 / T-3 — `useCampaignStream` hook (lib/hooks/useCampaignStream.ts + tests/)
+
+Maps to spec scenarios in `specs/use-campaign-stream-hook/spec.md`.
+
+#### T1 — Connection lifecycle
+
+- [x] T1-1: initial status is `connecting`
+- [x] T1-2: status becomes `open` after `onopen` fires
+- [x] T1-3: `EventSource` constructed with correct URL for a plain campaignId
+- [x] T1-3b: campaignId containing `/` and spaces is URL-encoded in the EventSource URL
+- [x] T1-4: campaignId change closes previous `EventSource` and opens a new one; status resets to `connecting`
+
+#### T2 — Event dispatch
+
+- [x] T2-1: `addEventListener('heartbeat')` is called; `onmessage` is NOT assigned
+- [x] T2-2: `addEventListener('change')` is called
+- [x] T2-3: `heartbeat` SSE frame is parsed and dispatched to `onEvent` with correct shape
+- [x] T2-4: `change` SSE frame is parsed and dispatched to `onEvent` with correct shape
+- [x] T2-5: updated `onEvent` reference receives subsequent events without triggering reconnect (stale closure test)
+
+#### T3 — Reconnect behaviour
+
+- [x] T3-1: `onerror` + `CLOSED` state → status `error`, new `EventSource` created after 1000 ms
+- [x] T3-2: backoff doubles on second failure (2000 ms)
+- [x] T3-3: backoff doubles again on third failure (4000 ms)
+- [x] T3-4: backoff is capped at 30 000 ms after multiple failures
+- [x] T3-5: backoff resets to 1000 ms after a successful `onopen`
+- [x] T3-6: `onerror` + `CONNECTING` state → status `connecting`; no explicit reconnect scheduled; no new `EventSource`
+
+#### T4 — Teardown
+
+- [x] T4-1: `es.close()` called on unmount when status is `open`
+- [x] T4-2: pending reconnect timer is cancelled on unmount before the timer fires
+- [x] T4-3: unmount before `onopen` does not throw; `es.close()` still called

--- a/tests/unit/hooks/useCampaignStream.test.ts
+++ b/tests/unit/hooks/useCampaignStream.test.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createReactRoot, unmountReactRoot } from '../helpers/reactRoot';
 import { useCampaignStream } from '@/lib/hooks/useCampaignStream';
 import type { CampaignStreamEvent } from '@/lib/types';
 
@@ -21,7 +21,7 @@ class MockEventSource {
   onmessage: ((e: MessageEvent) => void) | null = null;
   close = jest.fn(() => { this.readyState = MockEventSource.CLOSED; });
 
-  private listeners: Record<string, Array<(e: MessageEvent) => void>> = {};
+  listeners: Record<string, Array<(e: MessageEvent) => void>> = {};
 
   constructor(url: string) {
     this.url = url;
@@ -57,9 +57,7 @@ type HookProps = { campaignId: string; onEvent: (e: CampaignStreamEvent) => void
 type HookResult = { current: { status: string } };
 
 function renderHook(props: HookProps): { result: HookResult; rerender: (p: HookProps) => void; unmount: () => void } {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
+  const { container, root } = createReactRoot();
   const resultRef: HookResult = { current: { status: 'connecting' } };
   let latestProps = props;
 
@@ -77,7 +75,7 @@ function renderHook(props: HookProps): { result: HookResult; rerender: (p: HookP
       latestProps = newProps;
       act(() => { root.render(React.createElement(Probe)); });
     },
-    unmount: () => { act(() => { root.unmount(); }); container.remove(); },
+    unmount: () => { unmountReactRoot(container, root); },
   };
 }
 
@@ -155,23 +153,14 @@ describe('T1 — Connection lifecycle', () => {
 // ---------------------------------------------------------------------------
 
 describe('T2 — Event dispatch', () => {
-  test('T2-1: addEventListener(heartbeat) called, onmessage not assigned', () => {
+  test('T2-1/T2-2: heartbeat and change listeners registered, onmessage not assigned', () => {
     const onEvent = jest.fn();
     const { unmount } = renderHook({ campaignId: 'c1', onEvent });
     const mockEs = MockEventSource.instances[0];
-    // Verify heartbeat listener was registered (spy on addEventListener calls)
-    const listeners = (mockEs as unknown as Record<string, unknown>)['listeners'] as Record<string, unknown[]>;
+    const listeners = mockEs.listeners;
     expect(listeners['heartbeat']).toHaveLength(1);
-    expect(mockEs.onmessage).toBeNull();
-    unmount();
-  });
-
-  test('T2-2: addEventListener(change) called', () => {
-    const onEvent = jest.fn();
-    const { unmount } = renderHook({ campaignId: 'c1', onEvent });
-    const mockEs = MockEventSource.instances[0];
-    const listeners = (mockEs as unknown as Record<string, unknown>)['listeners'] as Record<string, unknown[]>;
     expect(listeners['change']).toHaveLength(1);
+    expect(mockEs.onmessage).toBeNull();
     unmount();
   });
 


### PR DESCRIPTION
## Summary

Adds the `useCampaignStream` React hook (Phase 4b) — the client-side SSE consumer for the multi-user campaign real-time transport layer.

## What changed

- **`lib/hooks/useCampaignStream.ts`** — React hook wrapping `EventSource` with:
  - Auto-reconnect with exponential backoff (1s base, ×2 per failure, cap 30s, reset on success)
  - Connection state: `'connecting' | 'open' | 'error'`
  - Typed `CampaignStreamEvent` dispatch via `onEvent` ref (avoids stale closures without triggering reconnect)
  - Clean teardown on unmount (closes `EventSource`, cancels pending timer)
- **`lib/types.ts`** — `CampaignStreamEvent` discriminated union type (`heartbeat | change`)
- **`tests/unit/hooks/useCampaignStream.test.ts`** — 18 unit tests across T1–T4 (connection lifecycle, event dispatch, reconnect behaviour, teardown)
- **`openspec/changes/client-use-campaign-stream-hook/`** — Full OpenSpec change artifacts

## Test results

18/18 unit tests pass. Full suite: 2261/2261 pass.

## Acceptance criteria (from #312)

- ✅ Components can subscribe to a campaign and receive typed events
- ✅ Reconnects after transient drops (T3-1 through T3-6)
- ✅ Tears down on unmount (T4-1 through T4-3)

End-to-end integration testing against the live SSE endpoint is deferred to #311 (4a).

Closes #312