### PR TITLE
fix: upgrade testcontainers to v12 and ts-jest to v29.4.11 to resolve CVEs

### DIFF
--- a/openspec/changes/fix-audit-cves/tasks.md
+++ b/openspec/changes/fix-audit-cves/tasks.md
@@ -51,7 +51,7 @@ Use the project's documented commands for each of the above (see project README 
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
 - [ ] Commit all changes to the working branch and push to remote
 - [ ] Open PR from working branch to `main`. **If this change is issue-driven, the PR body MUST explicitly state "Closes #241".**
 - [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)

--- a/tests/unit/components/SharedCharactersPanel.test.tsx
+++ b/tests/unit/components/SharedCharactersPanel.test.tsx
@@ -164,7 +164,7 @@ describe('SharedCharactersPanel', () => {
       if (url === `/api/campaigns/${CAMPAIGN_ID}/members/me`) return jsonResponse(ACTIVE_PLAYER);
       if (url === `/api/campaigns/${CAMPAIGN_ID}/characters` && !options?.method) return jsonResponse([SHARE_X]);
       if (url === `/api/campaigns/${CAMPAIGN_ID}/characters/char-x` && options?.method === 'DELETE') {
-        return new FetchResponse(undefined, { status: 204 }) as unknown as Response;
+        return new FetchResponse(null, { status: 204 });
       }
       return jsonResponse({ error: 'Not found' }, 404);
     });


### PR DESCRIPTION
## Summary

Upgrades test-only dependencies to resolve HIGH CVEs reported by `npm audit --audit-level=high`:

- `@testcontainers/mongodb`: `^10.3.1` → `^12.0.1`
- `@testcontainers/postgresql`: `^10.3.1` → `^12.0.1`
- `ts-jest`: `^29.4.6` → `^29.4.11`

Also bumps Node.js in CI workflows from 20 to 22.19.0 to support `undici` v8 (required by testcontainers v12), and adds Jest `transformIgnorePatterns` for ESM compatibility.

All existing tests (unit, integration, E2E) pass with the upgraded dependencies.

Closes #241