### PR TITLE
fix(campaigns): two-row card layout — header row + action row

### DIFF
--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -232,48 +232,44 @@ export function CampaignsContent() {
 
                 return (
                   <div key={campaign.id} className="bg-gray-800 rounded-lg p-6">
-                    <div className="flex justify-between items-start mb-4">
-                      <div>
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3 className="text-xl font-bold">{campaign.name}</h3>
-                          <span className={`px-2 py-0.5 text-xs rounded text-white ${statusBadgeClass(campaign.status)}`}>
-                            {statusLabel(campaign.status)}
-                          </span>
-                        </div>
-                        {campaign.moduleName && (
-                          <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
-                        )}
-                        <CampaignChapterInfo
-                          chapters={campaign.chapters || []}
-                          currentChapterId={campaign.currentChapterId}
-                        />
-                      </div>
-                      <div className="flex gap-2 flex-shrink-0 ml-4">
-                        <Link
-                          href={`/campaigns/${campaign.id}`}
-                          className="bg-teal-600 hover:bg-teal-700 px-3 py-1 rounded text-sm"
-                        >
-                          Members
-                        </Link>
-                        <Link
-                          href={`/campaigns/${campaign.id}/prompts`}
-                          className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
-                        >
-                          Prompt Builder
-                        </Link>
-                        <Link
-                          href={`/campaigns/${campaign.id}/library`}
-                          className="bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded text-sm"
-                        >
-                          Library
-                        </Link>
-                        <Link
-                          href="/encounters"
-                          className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm"
-                        >
-                          Start Encounter
-                        </Link>
-                      </div>
+                    <div className="flex items-center gap-2 flex-wrap mb-1">
+                      <h3 className="text-xl font-bold min-w-0 truncate">{campaign.name}</h3>
+                      <span className={`px-2 py-0.5 text-xs rounded text-white flex-shrink-0 ${statusBadgeClass(campaign.status)}`}>
+                        {statusLabel(campaign.status)}
+                      </span>
+                    </div>
+                    {campaign.moduleName && (
+                      <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
+                    )}
+                    <CampaignChapterInfo
+                      chapters={campaign.chapters || []}
+                      currentChapterId={campaign.currentChapterId}
+                    />
+                    <div className="flex flex-wrap gap-2 mt-3 mb-4">
+                      <Link
+                        href={`/campaigns/${campaign.id}`}
+                        className="bg-teal-600 hover:bg-teal-700 px-3 py-1 rounded text-sm"
+                      >
+                        Members
+                      </Link>
+                      <Link
+                        href={`/campaigns/${campaign.id}/prompts`}
+                        className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
+                      >
+                        Prompt Builder
+                      </Link>
+                      <Link
+                        href={`/campaigns/${campaign.id}/library`}
+                        className="bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded text-sm"
+                      >
+                        Library
+                      </Link>
+                      <Link
+                        href="/encounters"
+                        className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm"
+                      >
+                        Start Encounter
+                      </Link>
                     </div>
 
                     {lastSession && (
@@ -428,45 +424,41 @@ export function CampaignsContent() {
             <div className="grid md:grid-cols-2 gap-4">
               {campaigns.map(campaign => (
                 <div key={campaign.id} className="bg-gray-800 rounded-lg p-4">
-                  <div className="flex justify-between items-start mb-2">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h2 className="text-xl font-semibold">{campaign.name}</h2>
-                        <span className={`px-2 py-0.5 text-xs rounded text-white ${statusBadgeClass(campaign.status)}`}>
-                          {statusLabel(campaign.status)}
-                        </span>
-                      </div>
-                      {campaign.moduleName && (
-                        <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
-                      )}
-                      <ManagementChapterInfo campaign={campaign} />
-                    </div>
-                    <div className="flex gap-2">
-                      <Link
-                        href={`/campaigns/${campaign.id}`}
-                        className="bg-teal-600 hover:bg-teal-700 px-3 py-1 rounded text-sm"
-                      >
-                        Members
-                      </Link>
-                      <Link
-                        href={`/campaigns/${campaign.id}/sessions`}
-                        className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
-                      >
-                        Session Log
-                      </Link>
-                      <button
-                        onClick={() => { setEditingCampaign(campaign); setIsAdding(false); }}
-                        className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        onClick={() => deleteCampaign(campaign.id)}
-                        className="bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm"
-                      >
-                        Delete
-                      </button>
-                    </div>
+                  <div className="flex items-center gap-2 flex-wrap mb-1">
+                    <h2 className="text-xl font-semibold min-w-0 truncate">{campaign.name}</h2>
+                    <span className={`px-2 py-0.5 text-xs rounded text-white flex-shrink-0 ${statusBadgeClass(campaign.status)}`}>
+                      {statusLabel(campaign.status)}
+                    </span>
+                  </div>
+                  {campaign.moduleName && (
+                    <p className="text-gray-400 text-sm">{campaign.moduleName}</p>
+                  )}
+                  <ManagementChapterInfo campaign={campaign} />
+                  <div className="flex flex-wrap gap-2 mt-3">
+                    <Link
+                      href={`/campaigns/${campaign.id}`}
+                      className="bg-teal-600 hover:bg-teal-700 px-3 py-1 rounded text-sm"
+                    >
+                      Members
+                    </Link>
+                    <Link
+                      href={`/campaigns/${campaign.id}/sessions`}
+                      className="bg-purple-600 hover:bg-purple-700 px-3 py-1 rounded text-sm"
+                    >
+                      Session Log
+                    </Link>
+                    <button
+                      onClick={() => { setEditingCampaign(campaign); setIsAdding(false); }}
+                      className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => deleteCampaign(campaign.id)}
+                      className="bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm"
+                    >
+                      Delete
+                    </button>
                   </div>
                 </div>
               ))}

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -425,7 +425,7 @@ export function CampaignsContent() {
               {campaigns.map(campaign => (
                 <div key={campaign.id} className="bg-gray-800 rounded-lg p-4">
                   <div className="flex items-center gap-2 flex-wrap mb-1">
-                    <h2 className="text-xl font-semibold min-w-0 truncate">{campaign.name}</h2>
+                    <h3 className="text-xl font-bold min-w-0 truncate">{campaign.name}</h3>
                     <span className={`px-2 py-0.5 text-xs rounded text-white flex-shrink-0 ${statusBadgeClass(campaign.status)}`}>
                       {statusLabel(campaign.status)}
                     </span>
@@ -448,12 +448,14 @@ export function CampaignsContent() {
                       Session Log
                     </Link>
                     <button
+                      type="button"
                       onClick={() => { setEditingCampaign(campaign); setIsAdding(false); }}
                       className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
                     >
                       Edit
                     </button>
                     <button
+                      type="button"
                       onClick={() => deleteCampaign(campaign.id)}
                       className="bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm"
                     >

--- a/openspec/changes/campaign-layout-two-row-cards/.openspec.yaml
+++ b/openspec/changes/campaign-layout-two-row-cards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-14

--- a/openspec/changes/campaign-layout-two-row-cards/design.md
+++ b/openspec/changes/campaign-layout-two-row-cards/design.md
@@ -1,0 +1,135 @@
+## Context
+
+- Relevant architecture: `app/campaigns/page.tsx` is a single Next.js client component containing the full campaigns page. It renders two distinct campaign card contexts: (1) the "Active Campaigns" dashboard section (large cards with party rosters) and (2) the "All Campaigns" list section (compact `md:grid-cols-2` grid). Both share the same layout bug.
+- Dependencies: Tailwind CSS (utility classes only, no custom components). `lib/components/ui.tsx`, `lib/components/CampaignChapterInfo.tsx`, `lib/components/CharacterRosterCard.tsx` are rendered inside the cards but are not themselves changed.
+- Interfaces/contracts touched: DOM structure of campaign cards in `app/campaigns/page.tsx`. `tests/unit/components/CampaignsPage.test.tsx` queries may need updating.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Eliminate chip/button overlap in campaign cards at all viewport widths
+- Establish a stable two-row card header pattern (info row + action row) extensible for future chips
+- Preserve all existing functionality and data rendering
+- Keep tests green
+
+### Non-Goals
+
+- Access-level chip implementation
+- Action button set changes
+- New API calls or data fetching
+- Responsive redesign beyond fixing the existing grid
+
+## Decisions
+
+### Decision 1: Two-row card layout (header row + action row)
+
+- Chosen: Split each card's top section into two flex rows — a header row containing `[title] [status chip]` and an action row containing `[action buttons]`.
+- Alternatives considered:
+  - Single row with `flex-shrink-0` on buttons only (Option C from explore) — stops overflow but doesn't give the header room to grow for future chips
+  - Inline status in title text — user explicitly rejected; reduces evolvability
+- Rationale: Eliminates horizontal competition entirely. Header row can independently accommodate additional chips (access level, etc.) without touching the action row.
+- Trade-offs: Cards are slightly taller. Vertical space is cheap on this page; horizontal correctness is essential.
+
+### Decision 2: Header row structure
+
+- Chosen: `flex items-center gap-2 flex-wrap` row containing `<h2/h3>` with `min-w-0 truncate` and the status chip with `flex-shrink-0`.
+- Alternatives considered: Grid layout — more complex, no benefit over flex here.
+- Rationale: `min-w-0` on the title allows `truncate` to engage when the title is very long. `flex-shrink-0` on the chip ensures it is never squeezed out. `flex-wrap` is a safety valve for extreme cases (very long title + multiple future chips).
+- Trade-offs: Long titles will truncate; tooltip is not added in this change (non-goal).
+
+### Decision 3: Action row structure
+
+- Chosen: `flex flex-wrap gap-2 mt-3` row containing all action buttons/links, left-aligned.
+- Alternatives considered: Right-aligned buttons — current convention in the single-row layout, but left-alignment reads more naturally in a stacked context.
+- Rationale: `flex-wrap` ensures buttons reflow gracefully on mobile without overflow. `mt-3` provides consistent visual separation from the header row.
+- Trade-offs: Left-aligned buttons is a minor visual change from the current right-aligned style. Acceptable given the layout fix it enables.
+
+### Decision 4: Apply same pattern to both card contexts
+
+- Chosen: Apply the two-row pattern to both the campaign list cards and the active campaigns dashboard cards.
+- Alternatives considered: Fix list cards only — does not address the active campaigns chip overflow reported in the screenshot.
+- Rationale: Both contexts share the root cause. Consistent pattern across the page is easier to maintain.
+- Trade-offs: Slightly more code changed, but both sections are in the same file.
+
+## Proposal to Design Mapping
+
+- Proposal element: Status chip collides with action buttons
+  - Design decision: Decision 1 (two-row layout)
+  - Validation approach: Visual test — render card with long name + 4 buttons; confirm no overlap
+
+- Proposal element: Long campaign names overflow
+  - Design decision: Decision 2 (`min-w-0 truncate` on title)
+  - Validation approach: Unit test with a 100-character name; confirm truncation
+
+- Proposal element: Header designed for future access-level chip
+  - Design decision: Decision 2 (`flex-wrap` header row with `flex-shrink-0` chips)
+  - Validation approach: No test needed for the extension point itself; structure is validated by chip rendering test
+
+- Proposal element: Both card contexts affected
+  - Design decision: Decision 4
+  - Validation approach: Unit tests cover both list and active campaigns sections
+
+## Functional Requirements Mapping
+
+- Requirement: Status chip always visible alongside campaign name
+  - Design element: Header row, chip with `flex-shrink-0`
+  - Acceptance criteria reference: specs/campaign-card-layout/spec.md — FR1
+  - Testability notes: RTL query by status chip text; assert it is in the document
+
+- Requirement: Action buttons never overlap header content
+  - Design element: Separate action row below header
+  - Acceptance criteria reference: specs/campaign-card-layout/spec.md — FR2
+  - Testability notes: RTL — assert buttons are present and header text is present (DOM order confirms separation)
+
+- Requirement: Long titles truncate rather than overflow
+  - Design element: `min-w-0 truncate` on title element
+  - Acceptance criteria reference: specs/campaign-card-layout/spec.md — FR3
+  - Testability notes: Render with long name; assert `truncate` class applied to title element
+
+- Requirement: All existing action links/buttons remain functional
+  - Design element: Action row contains same elements as before, only container changes
+  - Acceptance criteria reference: specs/campaign-card-layout/spec.md — FR4
+  - Testability notes: Click each button/link in RTL; assert callback/navigation triggered
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: operability
+  - Requirement: No new dependencies introduced
+  - Design element: Pure Tailwind utility class changes inside existing component
+  - Acceptance criteria reference: No new packages in package.json
+  - Testability notes: `git diff package.json` — no changes
+
+- Requirement category: reliability
+  - Requirement: Existing tests remain green
+  - Design element: Update selectors in CampaignsPage.test.tsx to match new DOM structure
+  - Acceptance criteria reference: `npm run test:unit` passes
+  - Testability notes: Run unit suite before and after; assert no regressions
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Test selectors break due to DOM restructure
+  - Impact: CI fails
+  - Mitigation: Review `CampaignsPage.test.tsx` before writing code; identify all button/chip queries and update to role or text-based queries
+
+- Risk/trade-off: Active campaigns card height increases noticeably
+  - Impact: Minor visual change; page is slightly longer
+  - Mitigation: Acceptable — fix correctness first. If user objects, padding can be tuned.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Visual regression reported in prod or CI unit tests fail after merge
+- Rollback steps: Revert the PR; single-file change makes this trivial
+- Data migration considerations: None — pure UI change
+- Verification after rollback: Run `npm run test:unit`; visually confirm campaign list renders
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing test or build error first.
+- If security checks fail: Do not merge. This change has no security surface (pure layout), so any security failure is unrelated and must be investigated separately.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to maintainer after 48 hours.
+- Escalation path and timeout: If blocked >48 hours, maintainer (dougis) has authority to approve.
+
+## Open Questions
+
+No open questions. Design is fully specified and confirmed.

--- a/openspec/changes/campaign-layout-two-row-cards/proposal.md
+++ b/openspec/changes/campaign-layout-two-row-cards/proposal.md
@@ -1,0 +1,70 @@
+## GitHub Issues
+
+- #420
+
+## Why
+
+- Problem statement: Campaign cards in both the campaign list and active campaigns dashboard suffer from layout overlap — the status chip collides with action link chips when titles are long or the viewport is narrow, and action buttons compress or overflow their container.
+- Why now: The issue was filed 2026-06-14 with a screenshot showing the problem in production. The layout is the first thing users see when managing campaigns and it degrades trust in the app.
+- Business/user impact: Users cannot reliably click action links; the status badge (a key at-a-glance signal) is obscured by overlapping elements.
+
+## Problem Space
+
+- Current behavior: Each campaign card uses a single `flex justify-between` row that holds both `[Title + Status chip]` on the left and `[Action buttons]` on the right. Neither side has `flex-shrink-0` or `min-w-0`, so on narrow viewports (or with long campaign names) the two sides compete for space — chips and buttons overlap or flow outside the card boundary.
+- Desired behavior: Campaign cards use a two-row layout. The top row shows the campaign name, status chip, and (in future) access-level chip. The bottom row shows action buttons, left-aligned with consistent spacing. The two rows never compete for horizontal space.
+- Constraints: Must not break the existing `md:grid-cols-2` grid used in the campaign list. Must work on the same Tailwind / Next.js stack already in use. Must not require new data fetching — the access-level chip is a future extension point only.
+- Assumptions: Both the campaign list section and the active campaigns dashboard section need the same fix, though the active campaigns cards are larger and have different action sets.
+- Edge cases considered:
+  - Very long campaign names (should truncate with ellipsis, not push chips off-screen)
+  - Many action buttons (4 is the current max; wrapping is acceptable on mobile)
+  - Status values: planning, active, on-hold, completed — all must render clearly
+  - Campaigns with no module name or chapter info (header row should collapse gracefully)
+
+## Scope
+
+### In Scope
+
+- Refactor `app/campaigns/page.tsx`: campaign list cards (lines 428–474) to two-row layout
+- Refactor `app/campaigns/page.tsx`: active campaigns cards (lines 234–390) to two-row layout
+- Status chip: retain as a chip in the header row (not inlined into the title text)
+- Header row designed to accommodate a future access-level chip without further restructuring
+- `min-w-0` / `truncate` on title to handle long names gracefully
+- Unit test update: `tests/unit/components/CampaignsPage.test.tsx` to reflect new DOM structure if selectors break
+
+### Out of Scope
+
+- Access-level chip implementation (data not currently fetched in this view)
+- Any changes to campaign API or data model
+- Active campaigns action button set rationalization (Members, Prompt Builder, Library, Start Encounter)
+- Responsive breakpoint redesign beyond fixing the existing two-column grid
+
+## What Changes
+
+- `app/campaigns/page.tsx`: campaign list card inner layout restructured from single flex row to two-row (header + actions)
+- `app/campaigns/page.tsx`: active campaigns card header restructured to same two-row pattern
+- `tests/unit/components/CampaignsPage.test.tsx`: update any DOM queries that relied on old layout structure
+
+## Risks
+
+- Risk: Existing unit test selectors may query buttons by position relative to the title
+  - Impact: Tests fail after refactor
+  - Mitigation: Review `CampaignsPage.test.tsx` before and after; update selectors to use `data-testid` or accessible text queries
+
+- Risk: Two-row layout adds vertical height to each card, potentially making the list feel taller
+  - Impact: Minor UX change; list feels more spacious
+  - Mitigation: Acceptable trade-off; cards gain clarity. No padding changes beyond what the new row requires.
+
+## Open Questions
+
+No unresolved ambiguity. Design direction confirmed in explore session: Option B (two-row), status as chip, header designed for future access-level chip extension.
+
+## Non-Goals
+
+- Adding access-level (DM / Player / Observer) chip to the header — this is a confirmed future extension, not part of this change
+- Changing the action button set or their ordering
+- Introducing new API calls or state
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/campaign-layout-two-row-cards/specs/campaign-card-layout/spec.md
+++ b/openspec/changes/campaign-layout-two-row-cards/specs/campaign-card-layout/spec.md
@@ -1,0 +1,126 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement FR1: Status chip is always visible alongside the campaign name
+
+The system SHALL render the status chip in a dedicated header row alongside the campaign name, never in the same flex container as action buttons.
+
+#### Scenario: Status chip renders beside campaign name
+
+- **Given** a campaign card is rendered in the campaign list
+- **When** the card is displayed
+- **Then** the status chip text (e.g. "Active", "Planning", "On Hold", "Completed") is present in the document
+- **And** the status chip is in the same row as the campaign name heading
+
+#### Scenario: Status chip with long campaign name
+
+- **Given** a campaign with a name longer than 60 characters
+- **When** the card is rendered at any viewport width
+- **Then** the status chip remains visible and is not pushed outside the card boundary
+- **And** the campaign name truncates with an ellipsis
+
+### Requirement FR2: Action buttons rendered below the header row, never overlapping it
+
+The system SHALL render all action buttons/links in a dedicated action row beneath the campaign name and status chip.
+
+#### Scenario: Action row present below header row
+
+- **Given** a campaign card with action buttons (e.g. Members, Session Log, Edit, Delete)
+- **When** the card is rendered
+- **Then** all action buttons are present in the document
+- **And** the action row appears after (below) the header row in DOM order
+
+#### Scenario: Many action buttons do not overflow
+
+- **Given** a campaign card in the active campaigns section with 4 action links
+- **When** the card is rendered
+- **Then** all 4 action links are accessible (not clipped, not hidden)
+- **And** if they wrap to a second line, they do not overlap the header row content
+
+### Requirement FR3: Long campaign names truncate gracefully
+
+The system SHALL truncate campaign title text with an ellipsis when the title exceeds the available width, rather than pushing adjacent elements out of position.
+
+#### Scenario: Title truncation class applied
+
+- **Given** a campaign card is rendered
+- **When** the title element is inspected
+- **Then** the title element has the `truncate` CSS class (or equivalent overflow ellipsis behavior)
+- **And** it has `min-w-0` to allow flex truncation to engage
+
+### Requirement FR4: All existing action links and buttons remain functional
+
+The system SHALL preserve all existing action links and buttons in the action row with no change to their href, onClick, or disabled behavior.
+
+#### Scenario: Campaign list action buttons
+
+- **Given** a campaign card in the all-campaigns list
+- **When** the Edit button is clicked
+- **Then** the campaign editor is opened with the correct campaign data
+
+#### Scenario: Campaign list delete
+
+- **Given** a campaign card in the all-campaigns list
+- **When** the Delete button is clicked
+- **Then** a confirmation dialog is shown
+
+#### Scenario: Active campaigns action links
+
+- **Given** an active campaign card in the dashboard section
+- **When** the Members link is clicked
+- **Then** navigation to `/campaigns/{id}` is triggered
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Campaign card DOM structure
+
+The existing single-row `flex justify-between` layout for campaign cards SHALL be replaced with a two-row stacked layout in both the campaign list section and the active campaigns section of `app/campaigns/page.tsx`.
+
+#### Scenario: Old single-row replaced by two-row
+
+- **Given** the campaign list renders a campaign card
+- **When** the card DOM is inspected
+- **Then** there is no single flex container that holds both the status chip and action buttons as siblings
+
+## REMOVED Requirements
+
+No requirements removed.
+
+## Traceability
+
+- Proposal element "status chip collides with action buttons" -> FR1, FR2
+- Proposal element "long campaign names overflow" -> FR3
+- Proposal element "all existing actions preserved" -> FR4
+- Design Decision 1 (two-row layout) -> FR2, Modified requirement
+- Design Decision 2 (header row structure) -> FR1, FR3
+- Design Decision 3 (action row structure) -> FR2, FR4
+- Design Decision 4 (both card contexts) -> All FRs apply to both sections
+- FR1 -> Tasks: Refactor campaign list card header, Refactor active campaigns card header
+- FR2 -> Tasks: Refactor campaign list card actions, Refactor active campaigns card actions
+- FR3 -> Tasks: Refactor campaign list card header
+- FR4 -> Tasks: Update CampaignsPage unit tests
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+No performance budget changes. This is a pure DOM restructure with no new rendering work.
+
+### Requirement: Security
+
+No security surface changes. See functional scenarios — no access control is altered.
+
+### Requirement: Reliability
+
+#### Scenario: No new dependencies
+
+- **Given** the change is implemented
+- **When** `git diff package.json package-lock.json` is inspected
+- **Then** no new packages have been added or version-bumped as a result of this change
+
+#### Scenario: Existing unit tests pass
+
+- **Given** the layout refactor is applied
+- **When** `npm run test:unit` is executed
+- **Then** all tests pass with no new failures

--- a/openspec/changes/campaign-layout-two-row-cards/tasks.md
+++ b/openspec/changes/campaign-layout-two-row-cards/tasks.md
@@ -1,0 +1,95 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/campaign-layout-two-row-cards` then immediately `git push -u origin feat/campaign-layout-two-row-cards`
+
+## Execution
+
+### 1. Review existing tests before touching code
+
+- [x] Read `tests/unit/components/CampaignsPage.test.tsx` and catalogue all button/chip/heading queries that may break after DOM restructure
+- [x] Note which selectors depend on the current single-row layout
+
+### 2. Refactor campaign list card layout (`app/campaigns/page.tsx` lines ~428–474)
+
+- [x] Replace the single `flex justify-between items-start` container with a two-row structure:
+  - Header row: `flex items-center gap-2 flex-wrap` — contains `<h2>` with `min-w-0 truncate` + status chip with `flex-shrink-0`
+  - Action row: `flex flex-wrap gap-2 mt-3` — contains Members, Session Log, Edit, Delete
+- [x] Verify `ManagementChapterInfo` and `moduleName` paragraph still render between header and action rows
+
+### 3. Refactor active campaigns card layout (`app/campaigns/page.tsx` lines ~234–277)
+
+- [x] Apply the same two-row pattern to the active campaigns dashboard card:
+  - Header row: campaign name + status chip (same pattern as list card)
+  - Action row: Members, Prompt Builder, Library, Start Encounter links
+- [x] Ensure `CampaignChapterInfo`, `moduleName`, `lastSession`, DM Notes, and party roster sections remain below the header row in the correct order
+
+### 4. Update unit tests
+
+- [x] Update `tests/unit/components/CampaignsPage.test.tsx` to use role/text-based queries rather than positional DOM assumptions
+- [x] Ensure all FR1–FR4 scenarios from `openspec/changes/campaign-layout-two-row-cards/specs/campaign-card-layout/spec.md` have corresponding test coverage
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — no type errors or build failures
+- [x] `npm run lint` — no lint errors introduced
+- [x] Manually verify (via `npm run dev` or screenshots) that campaign cards render with two rows at desktop and mobile widths
+- [x] Confirm `git diff package.json` shows no dependency changes
+- [x] All completed tasks marked complete
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` and check whether every changed file ends in `.md`. This change modifies `.tsx` and `.ts` files — use the full path.
+
+**Full path:**
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+- Skip integration and E2E tests unless the CI configuration requires them for this change type
+
+If **ANY** required step fails, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/campaign-layout-two-row-cards` and push to remote
+- [ ] Open PR from `feat/campaign-layout-two-row-cards` to `main`. PR body MUST include: `Closes #420`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (use `--squash` per repo ruleset; NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+Ownership metadata:
+
+- Implementer: (agent)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas: copy `openspec/changes/campaign-layout-two-row-cards/specs/campaign-card-layout/spec.md` to `openspec/specs/campaign-card-layout/spec.md`; update relative links from `../../design.md` to `../../changes/archive/YYYY-MM-DD-campaign-layout-two-row-cards/design.md` (and similarly for `tasks.md`)
+- [ ] Archive the change: move `openspec/changes/campaign-layout-two-row-cards/` to `openspec/changes/archive/YYYY-MM-DD-campaign-layout-two-row-cards/` **as a single atomic commit** that includes both the copy and the deletion
+- [ ] Confirm archive location exists and original directory is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-campaign-layout-two-row-cards` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-layout-two-row-cards`
+- [ ] Open a PR from the doc branch to `main` with title `docs: archive campaign-layout-two-row-cards (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until it merges; address any comments or CI failures, push to the same doc branch, repeat
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/campaign-layout-two-row-cards doc/archive-YYYY-MM-DD-campaign-layout-two-row-cards`

--- a/openspec/changes/campaign-layout-two-row-cards/tests.md
+++ b/openspec/changes/campaign-layout-two-row-cards/tests.md
@@ -1,0 +1,57 @@
+---
+name: tests
+description: Tests for campaign-layout-two-row-cards
+---
+
+# Tests
+
+## Overview
+
+All implementation work follows a strict TDD process: write a failing test, write the minimum code to pass it, then refactor. Tests live in `tests/unit/components/CampaignsPage.test.tsx`.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** before any implementation code. Run and confirm it fails.
+2. **Write code to pass the test** — minimum viable change.
+3. **Refactor** — clean up while keeping tests green.
+
+## Test Cases
+
+### Task 2 — Campaign list card layout
+
+- [ ] **FR1 — Status chip in document:** Given a campaign list renders, assert `getByText('Active')` (or relevant status label) is in the document alongside the campaign name heading
+- [ ] **FR1 — Status chip not sibling of action buttons:** Assert that the status chip element and a button (e.g. "Edit") are NOT within the same immediate flex container (verify via DOM tree or `closest()` check)
+- [ ] **FR2 — All action buttons present:** Assert `getByRole('button', { name: 'Edit' })`, `getByRole('button', { name: 'Delete' })`, and links "Members", "Session Log" are all in the document
+- [ ] **FR2 — Action row appears after header in DOM:** Assert that the heading element precedes the Edit button in `document.body.innerHTML` order
+- [ ] **FR3 — Title has truncate class:** Assert the campaign name heading element has the CSS class `truncate`
+- [ ] **FR3 — Title has min-w-0:** Assert the campaign name heading element (or its wrapper) has the CSS class `min-w-0`
+- [ ] **FR4 — Edit opens editor:** Click the Edit button; assert the campaign editor is rendered (e.g. `getByText('Save')` or the form appears)
+- [ ] **FR4 — Delete triggers confirm:** Mock `window.confirm`; click Delete; assert `window.confirm` was called
+
+### Task 3 — Active campaigns card layout
+
+- [ ] **FR1 — Status chip present in active card:** Given the active campaigns section renders a campaign with status "active", assert `getAllByText('Active')[0]` is in the document
+- [ ] **FR2 — Active campaigns action links present:** Assert link "Members", "Prompt Builder", "Library", "Start Encounter" are all in the document
+- [ ] **FR2 — Action links appear after heading in DOM:** Assert the campaign heading text precedes the "Members" link in DOM order
+- [ ] **FR4 — Members link has correct href:** Assert the Members link has `href` matching `/campaigns/{id}`
+
+### Task 4 — Test suite health
+
+- [ ] **NFR — No regressions:** Run `npm run test:unit`; assert all pre-existing tests in `CampaignsPage.test.tsx` still pass
+- [ ] **NFR — No new packages:** Assert `git diff package.json` shows no changes
+
+## Traceability
+
+| Test case | Spec scenario | Task |
+|---|---|---|
+| Status chip in document | FR1 — Status chip renders beside campaign name | Task 2 |
+| All action buttons present | FR2 — Action row present below header row | Task 2 |
+| Action row after header in DOM | FR2 — Action row DOM order | Task 2, 3 |
+| Title has truncate class | FR3 — Title truncation class applied | Task 2 |
+| Edit opens editor | FR4 — Campaign list action buttons | Task 2 |
+| Delete triggers confirm | FR4 — Campaign list delete | Task 2 |
+| Active card status chip | FR1 — Status chip in active card | Task 3 |
+| Active card action links | FR4 — Active campaigns action links | Task 3 |
+| No regressions | NFR — Existing unit tests pass | Task 4 |

--- a/tests/unit/components/CampaignsPage.test.tsx
+++ b/tests/unit/components/CampaignsPage.test.tsx
@@ -260,10 +260,10 @@ describe('Campaign Catalog UI', () => {
       setupFetch([MOCK_CAMPAIGN], []);
       renderPage();
       await screen.findByText('My Campaign');
-      const chip = screen.getByText('Planning');
-      const editButton = screen.getByRole('button', { name: 'Edit' });
-      expect(chip.parentElement).not.toBe(editButton.parentElement);
-      expect(chip.parentElement?.querySelector('button')).toBeNull();
+      const heading = screen.getByRole('heading', { name: 'My Campaign' });
+      const headerRow = heading.parentElement!;
+      expect(headerRow.querySelector('button')).not.toBeInTheDocument();
+      expect(headerRow.querySelector('a')).not.toBeInTheDocument();
     });
 
     it('active campaigns: status chip present for active campaign', async () => {

--- a/tests/unit/components/CampaignsPage.test.tsx
+++ b/tests/unit/components/CampaignsPage.test.tsx
@@ -247,5 +247,129 @@ describe('Campaign Catalog UI', () => {
       expect(membersLink?.getAttribute('href')).toBe(`/campaigns/${MOCK_CAMPAIGN.id}`);
     });
   });
+
+  describe('FR1 — Status chip visible alongside campaign name', () => {
+    it('campaign list: status chip present in document', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      await screen.findByText('My Campaign');
+      expect(screen.getByText('Planning')).toBeInTheDocument();
+    });
+
+    it('campaign list: status chip is in a different container than action buttons', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      await screen.findByText('My Campaign');
+      const chip = screen.getByText('Planning');
+      const editButton = screen.getByRole('button', { name: 'Edit' });
+      expect(chip.parentElement).not.toBe(editButton.parentElement);
+      expect(chip.parentElement?.querySelector('button')).toBeNull();
+    });
+
+    it('active campaigns: status chip present for active campaign', async () => {
+      const activeCampaign = { ...MOCK_CAMPAIGN, status: 'active' as const };
+      setupFetch([activeCampaign], []);
+      renderPage();
+      await screen.findAllByText('My Campaign');
+      expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('FR2 — Action buttons below header, never overlapping', () => {
+    it('campaign list: all action buttons present', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      await screen.findByText('My Campaign');
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+      const links = screen.getAllByRole('link');
+      expect(links.find(a => a.textContent?.trim() === 'Members')).toBeTruthy();
+      expect(links.find(a => a.textContent?.includes('Session Log'))).toBeTruthy();
+    });
+
+    it('campaign list: heading precedes Edit button in DOM order', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      await screen.findByText('My Campaign');
+      const heading = screen.getByRole('heading', { name: 'My Campaign' });
+      const editButton = screen.getByRole('button', { name: 'Edit' });
+      expect(
+        heading.compareDocumentPosition(editButton) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it('active campaigns: action links present', async () => {
+      const activeCampaign = { ...MOCK_CAMPAIGN, status: 'active' as const };
+      setupFetch([activeCampaign], []);
+      renderPage();
+      await screen.findAllByText('My Campaign');
+      const links = screen.getAllByRole('link');
+      expect(links.find(a => a.textContent?.trim() === 'Members')).toBeTruthy();
+      expect(links.find(a => a.textContent?.includes('Prompt Builder'))).toBeTruthy();
+      expect(links.find(a => a.textContent?.includes('Library'))).toBeTruthy();
+      expect(links.find(a => a.textContent?.includes('Start Encounter'))).toBeTruthy();
+    });
+
+    it('active campaigns: heading precedes Members link in DOM order', async () => {
+      const activeCampaign = { ...MOCK_CAMPAIGN, status: 'active' as const };
+      setupFetch([activeCampaign], []);
+      renderPage();
+      await screen.findAllByText('My Campaign');
+      const headings = screen.getAllByRole('heading', { name: 'My Campaign' });
+      const links = screen.getAllByRole('link');
+      const membersLink = links.find(a => a.textContent?.trim() === 'Members');
+      expect(membersLink).toBeDefined();
+      expect(
+        headings[0].compareDocumentPosition(membersLink!) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+  });
+
+  describe('FR3 — Long titles truncate gracefully', () => {
+    it('campaign list: title heading has truncate class', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      const heading = await screen.findByRole('heading', { name: 'My Campaign' });
+      expect(heading.classList.contains('truncate')).toBe(true);
+    });
+
+    it('campaign list: title heading has min-w-0 class', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      const heading = await screen.findByRole('heading', { name: 'My Campaign' });
+      expect(heading.classList.contains('min-w-0')).toBe(true);
+    });
+  });
+
+  describe('FR4 — All existing action links remain functional', () => {
+    it('campaign list: Edit button opens editor', async () => {
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      await screen.findByText('My Campaign');
+      await user.click(screen.getByRole('button', { name: 'Edit' }));
+      expect(await screen.findByRole('button', { name: /save/i })).toBeInTheDocument();
+    });
+
+    it('campaign list: Delete button calls confirm', async () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      setupFetch([MOCK_CAMPAIGN], []);
+      renderPage();
+      await screen.findByText('My Campaign');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+      expect(confirmSpy).toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('active campaigns: Members link has correct href', async () => {
+      const activeCampaign = { ...MOCK_CAMPAIGN, id: 'active-1', status: 'active' as const };
+      setupFetch([activeCampaign], []);
+      renderPage();
+      await screen.findAllByText('My Campaign');
+      const links = screen.getAllByRole('link');
+      const membersLinks = links.filter(a => a.textContent?.trim() === 'Members');
+      const activeLink = membersLinks.find(a => a.getAttribute('href') === `/campaigns/${activeCampaign.id}`);
+      expect(activeLink).toBeTruthy();
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary

Fixes the chip/button overlap on campaign cards by splitting each card header into two stacked rows.

### Changes

- **Header row** (): title with `min-w-0 truncate` + status chip with `flex-shrink-0`
- **Action row** (): all action buttons/links, left-aligned and wrapping gracefully

Applied to both the All Campaigns grid and the Active Campaigns dashboard in `app/campaigns/page.tsx`.

### Tests

New FR1–FR4 coverage in `CampaignsPage.test.tsx`:
- Status chip is present and not in the same container as action buttons
- Action row appears after header in DOM order
- Title element has `truncate` and `min-w-0` classes
- All action buttons remain functional (Edit opens editor, Delete triggers confirm, Members link has correct href)

All 2273 unit tests pass. No new dependencies.

Closes #420