### PR TITLE
docs: archive flatten-eslint-next-config (2026-06-15)

### DIFF
--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/design.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/design.md
@@ -60,7 +60,7 @@ Note: `globals` has two installed copies — v14.0.0 at the top level and v16.4.
 
 - Proposal element: Replace `eslint-config-next/core-web-vitals` import
   - Design decision: Decision 1 (inline flat config)
-  - Validation approach: Run `npx eslint --print-config src/app/page.tsx` before and after; diff must show no rule changes
+  - Validation approach: Run `npx eslint --print-config app/page.tsx` before and after; diff must show no rule changes
 
 - Proposal element: Promote seven plugins to direct devDependencies
   - Design decision: Decision 2 (pin to exact installed versions)

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/design.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/design.md
@@ -1,0 +1,134 @@
+## Context
+
+- Relevant architecture: `eslint.config.mjs` is the single ESLint flat-config entry point for the project. Codacy's ESLint9 analysis tool mounts project source files at `/src` and runs its own sandboxed Node environment; it does not have access to the project's `node_modules` tree unless packages are listed as direct dependencies that Codacy can resolve.
+- Dependencies: `eslint-config-next@16.2.6` is currently the only direct ESLint dependency in `devDependencies`. It wraps seven underlying plugins transitively. All seven plugins are already present in `node_modules`.
+- Interfaces/contracts touched: `eslint.config.mjs` (ESLint config entry point), `package.json` (devDependencies).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Eliminate the `eslint-config-next` import from `eslint.config.mjs` so Codacy's container can run ESLint without missing-package errors
+- Preserve the exact same rule set, severity levels, plugins, globals, parser, and ignores as the current config produces
+- Make all ESLint plugin dependencies explicit in `package.json`
+
+### Non-Goals
+
+- Changing any ESLint rule or severity
+- Upgrading plugin versions beyond what is already installed
+- Modifying Codacy configuration files or `.codacy/` directory
+- Adding TypeScript project-aware linting
+
+## Decisions
+
+### Decision 1: Inline the flat config rather than using a Codacy-specific shim
+
+- Chosen: Rewrite `eslint.config.mjs` with direct plugin imports expanding the full config inline
+- Alternatives considered: (a) Add a separate `.codacy/eslint.config.mjs` with no Next.js deps — keeps main config intact but creates drift; (b) Configure Codacy to skip ESLint — removes analysis entirely
+- Rationale: A single source of truth for ESLint config is correct. The inlined config runs identically locally, in CI, and in Codacy.
+- Trade-offs: The `eslint.config.mjs` grows from 33 lines to ~80 lines; this is acceptable one-time verbosity for a permanent fix.
+
+### Decision 2: Pin newly direct deps to currently installed versions
+
+- Chosen: Pin each of the seven plugins to the exact version already in `node_modules` (see version table below)
+- Alternatives considered: Use caret ranges (`^`) and let npm resolve — risks pulling in different versions than what `eslint-config-next` uses today
+- Rationale: Zero behaviour change is the explicit constraint. Pinning guarantees the same rule implementations.
+- Trade-offs: Upgrading these plugins in the future requires a deliberate version bump; this is the desired outcome.
+
+**Version table (pin targets):**
+
+| Package | Version |
+|---|---|
+| `@next/eslint-plugin-next` | `16.2.6` |
+| `eslint-plugin-react` | `7.37.5` |
+| `eslint-plugin-react-hooks` | `7.0.1` |
+| `typescript-eslint` | `8.57.0` |
+| `eslint-plugin-import` | `2.32.0` |
+| `eslint-plugin-jsx-a11y` | `6.10.2` |
+| `globals` | `16.4.0` |
+
+Note: `globals` has two installed copies — v14.0.0 at the top level and v16.4.0 nested under `eslint-config-next/node_modules/`. The inlined config must use v16.4.0 (matching what `eslint-config-next` actually used), so `globals` is pinned to `16.4.0` as a new direct dep.
+
+### Decision 3: Merge ignores from the unpacked config and existing `eslint.config.mjs`
+
+- Chosen: Combine the ignores from `eslint-config-next`'s built-in ignores (`.next/**`, `out/**`, `build/**`, `next-env.d.ts`) with the project-specific ignores already in `eslint.config.mjs` (`coverage/**`, `coverage-e2e/**`, `playwright-report/**`, `.codacy/**`, `docs/**`) into one ignores block
+- Alternatives considered: Keep them as two separate config objects — functionally equivalent but slightly more verbose
+- Rationale: A single ignores block is easier to audit
+- Trade-offs: None
+
+## Proposal to Design Mapping
+
+- Proposal element: Replace `eslint-config-next/core-web-vitals` import
+  - Design decision: Decision 1 (inline flat config)
+  - Validation approach: Run `npx eslint --print-config src/app/page.tsx` before and after; diff must show no rule changes
+
+- Proposal element: Promote seven plugins to direct devDependencies
+  - Design decision: Decision 2 (pin to exact installed versions)
+  - Validation approach: `npm ls @next/eslint-plugin-next eslint-plugin-react` shows single resolved version matching pinned value
+
+- Proposal element: `globals` version split
+  - Design decision: Decision 2 (pin to v16.4.0)
+  - Validation approach: `node -e "require('globals')"` resolves v16 after install
+
+- Proposal element: Ignores consolidation
+  - Design decision: Decision 3 (merge into one block)
+  - Validation approach: `npx eslint coverage/` returns "no files matched" (still ignored)
+
+## Functional Requirements Mapping
+
+- Requirement: ESLint config must load without errors in Codacy's sandboxed container
+  - Design element: Direct plugin imports (Decision 1)
+  - Acceptance criteria reference: specs/eslint-config.md — "config loads without missing-package error"
+  - Testability notes: Verify locally with `npx eslint .`; Codacy result verified after merge
+
+- Requirement: Rule set must be identical before and after
+  - Design element: Exact inline expansion of `eslint-config-next` dist output (Decision 1)
+  - Acceptance criteria reference: specs/eslint-config.md — "resolved rules match pre-change baseline"
+  - Testability notes: `npx eslint --print-config` diff on a representative file
+
+- Requirement: All ignores preserved
+  - Design element: Decision 3 (merged ignores block)
+  - Acceptance criteria reference: specs/eslint-config.md — "previously ignored paths remain ignored"
+  - Testability notes: Run eslint against `coverage/`, `.next/`, `docs/` — all must produce no findings
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: operability
+  - Requirement: `npm install` must complete without version conflicts after dep changes
+  - Design element: Decision 2 (pin exact versions)
+  - Acceptance criteria reference: specs/eslint-config.md — "`npm install` exits 0"
+  - Testability notes: Run `npm install` in a clean checkout after `package.json` changes
+
+- Requirement category: reliability
+  - Requirement: Local ESLint run must produce same findings as before
+  - Design element: Decision 1 + Decision 2
+  - Acceptance criteria reference: specs/eslint-config.md — "no new lint errors introduced"
+  - Testability notes: `npx eslint .` output diff before/after
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Inlined config diverges from future `eslint-config-next` updates
+  - Impact: Project misses upstream rule improvements automatically
+  - Mitigation: This is an accepted trade-off; the project can periodically review `eslint-config-next` changelogs and update manually
+
+- Risk/trade-off: `globals` v16 introduces API differences vs v14
+  - Impact: `globals.browser` / `globals.node` could have different key sets, changing available globals
+  - Mitigation: Both v14 and v16 expose `browser` and `node` with the same shape; confirmed via inspection
+
+## Rollback / Mitigation
+
+- Rollback trigger: Codacy ESLint still fails after merge, OR `npx eslint .` produces new errors
+- Rollback steps: Revert `eslint.config.mjs` and `package.json` to pre-change state; run `npm install`
+- Data migration considerations: None
+- Verification after rollback: `npx eslint .` exits with same code as before the change
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix lint errors or rule delta before proceeding.
+- If security checks fail: Do not merge. Investigate whether a newly direct dep introduced an advisory.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to maintainer after 48 hours.
+- Escalation path and timeout: If Codacy still fails after merge despite correct deps, fall back to a `.codacy/eslint.config.mjs` shim (out of scope for this change but known fallback).
+
+## Open Questions
+
+No open questions. All design decisions are fully resolved based on inspection of the installed packages.

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/proposal.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/proposal.md
@@ -1,0 +1,67 @@
+## GitHub Issues
+
+- #423
+
+## Why
+
+- Problem statement: Codacy's ESLint9 CI container runs sandboxed without the project's `node_modules`, so `eslint-config-next` is not available at `/src`. The container exits with code 1 before any linting occurs, meaning ESLint analysis is completely absent from Codacy reports.
+- Why now: Issue #423 was filed 2026-06-14. Codacy ESLint analysis has been silently broken; fixing it restores visibility into lint issues in CI.
+- Business/user impact: Without ESLint analysis in Codacy, lint regressions go undetected in code review. Fixing this restores the full quality gate.
+
+## Problem Space
+
+- Current behavior: `eslint.config.mjs` imports `eslint-config-next/core-web-vitals`. Codacy mounts only `/src` (project files) into its ESLint container. The container has its own `node_modules` but not `eslint-config-next`, so the import fails immediately.
+- Desired behavior: `eslint.config.mjs` imports only packages that are direct `devDependencies` of the project. Codacy's container can resolve them through the project's own dependency graph.
+- Constraints: No rule changes — same plugins, same rules, same severity levels, same ignores. The refactor must be a pure structural change.
+- Assumptions: Codacy resolves packages from the project's `node_modules` when they are listed as direct (not transitive) dependencies. The seven underlying plugins are already present in `node_modules` transitively and can be promoted to direct deps without version conflicts.
+- Edge cases considered: The `next/typescript` config block uses `typescript-eslint` parser; this must be preserved. The babel fallback parser options in `languageOptions` are part of the base config and must be kept. Existing ignores in `eslint.config.mjs` (`.codacy/**`, `coverage/**`, etc.) must be merged correctly with the ignores baked into the unpacked config.
+
+## Scope
+
+### In Scope
+
+- Rewrite `eslint.config.mjs` to replace the `eslint-config-next/core-web-vitals` import with direct imports of the seven underlying plugins
+- Add the seven plugins as explicit `devDependencies` in `package.json` (pinned to versions already in `node_modules`)
+- Remove `eslint-config-next` from `devDependencies` (it remains a transitive peer dep of `next`)
+
+### Out of Scope
+
+- Changing any ESLint rules or their severity
+- Upgrading any ESLint plugin versions
+- Adding new ESLint plugins or rules
+- Fixing any pre-existing lint warnings or errors
+- Changes to CI pipelines, Codacy configuration files, or GitHub Actions
+
+## What Changes
+
+- `eslint.config.mjs`: Remove `eslint-config-next/core-web-vitals` import; add direct imports of `@next/eslint-plugin-next`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, `typescript-eslint`, `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `globals`; expand inline flat config matching current behavior exactly
+- `package.json`: Add seven plugins to `devDependencies`; remove `eslint-config-next` from `devDependencies`
+
+## Risks
+
+- Risk: Subtle rule delta between the inlined config and the original `eslint-config-next` output
+  - Impact: Lint errors appear or disappear unexpectedly in CI
+  - Mitigation: Run `eslint .` locally before and after and diff the output; confirm zero rule-level difference
+
+- Risk: Version mismatch when pinning newly direct deps
+  - Impact: `npm install` resolves different versions than currently in `node_modules`
+  - Mitigation: Pin to exact versions already installed (inspected from `node_modules/*/package.json`)
+
+- Risk: Codacy still cannot resolve packages even when direct deps
+  - Impact: Issue #423 remains open
+  - Mitigation: This is the documented Codacy fix pattern; if it fails, the fallback is a `.codacy/eslint.config.mjs` shim with no Next.js-specific rules
+
+## Open Questions
+
+No unresolved ambiguity exists. The seven plugin versions are known from the current lockfile, the rule set is fully enumerated from the compiled `dist/` files, and the Codacy failure mode is confirmed.
+
+## Non-Goals
+
+- Upgrading to a newer version of `eslint-config-next` or any of its plugins
+- Adding TypeScript project-aware linting (`parserOptions.project`)
+- Modifying Codacy configuration or suppressing Codacy findings
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/specs/eslint-config/spec.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/specs/eslint-config/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED ESLint config loads without missing-package error
+
+The system SHALL load `eslint.config.mjs` successfully in environments where only direct `devDependencies` are available (e.g., Codacy's sandboxed ESLint container).
+
+#### Scenario: Config loads in sandboxed environment
+
+- **Given** an environment with only the project's direct `devDependencies` available in `node_modules`
+- **When** ESLint initialises and loads `eslint.config.mjs`
+- **Then** ESLint exits with code 0 (or a lint-finding code, not a config-load error)
+
+#### Scenario: No missing-package error in local environment
+
+- **Given** a developer's local checkout with all deps installed
+- **When** `npx eslint .` is run
+- **Then** the output contains no `Cannot find package` or `MODULE_NOT_FOUND` errors
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED ESLint config produces identical resolved rules
+
+The system SHALL resolve the same set of rules, severity levels, plugins, globals, parser, and file patterns as before the change.
+
+#### Scenario: Resolved config matches pre-change baseline for a TS file
+
+- **Given** `eslint.config.mjs` has been rewritten with direct imports
+- **When** `npx eslint --print-config src/app/page.tsx` is run before and after the change
+- **Then** the printed config diff shows no changes to `rules`, `plugins`, `languageOptions`, or `settings`
+
+#### Scenario: Previously ignored paths remain ignored
+
+- **Given** `eslint.config.mjs` has been rewritten with merged ignores
+- **When** `npx eslint coverage/` or `npx eslint .next/` or `npx eslint docs/` is run
+- **Then** ESLint reports no files matched / exits with no findings for those paths
+
+#### Scenario: `no-restricted-imports` rule preserved for test files
+
+- **Given** `eslint.config.mjs` has been rewritten
+- **When** a file in `tests/` imports from `@jest/globals`
+- **Then** ESLint reports an error for that import (rule is still active)
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Implicit dependency on `eslint-config-next` for ESLint config resolution
+
+Reason for removal: The change replaces the `eslint-config-next` import with direct plugin imports. `eslint-config-next` no longer needs to be a direct `devDependency` for ESLint to work; it remains a transitive peer dep of `next` but is not imported by `eslint.config.mjs`.
+
+---
+
+## Traceability
+
+- Proposal element "Replace eslint-config-next import" → Requirement: MODIFIED (identical resolved rules)
+- Proposal element "Promote seven plugins to direct devDependencies" → Requirement: ADDED (config loads without missing-package error)
+- Proposal element "Remove eslint-config-next from devDependencies" → Requirement: REMOVED
+- Design Decision 1 (inline flat config) → ADDED scenario: Config loads in sandboxed environment
+- Design Decision 2 (pin exact versions) → MODIFIED scenario: Resolved config matches pre-change baseline
+- Design Decision 3 (merge ignores) → MODIFIED scenario: Previously ignored paths remain ignored
+- ADDED requirement → Task: Rewrite `eslint.config.mjs`
+- MODIFIED requirement → Task: Add direct devDependencies to `package.json`
+- REMOVED requirement → Task: Remove `eslint-config-next` from `package.json`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: `npm install` succeeds after dependency changes
+
+- **Given** `package.json` has been updated to add seven direct deps and remove `eslint-config-next`
+- **When** `npm install` is run in a clean checkout
+- **Then** `npm install` exits with code 0 and no peer-dependency warnings related to the changed packages
+
+### Requirement: Reliability
+
+#### Scenario: ESLint run produces no new findings
+
+- **Given** the rewritten `eslint.config.mjs` and updated `package.json`
+- **When** `npx eslint .` is run on the full project
+- **Then** the number and identity of lint findings is identical to a baseline run before the change (no new errors or warnings introduced by the config rewrite itself)
+
+### Requirement: Security
+
+See functional scenarios above — no access-control or token-leakage concerns apply to an ESLint config change.

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/specs/eslint-config/spec.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/specs/eslint-config/spec.md
@@ -29,7 +29,7 @@ The system SHALL resolve the same set of rules, severity levels, plugins, global
 #### Scenario: Resolved config matches pre-change baseline for a TS file
 
 - **Given** `eslint.config.mjs` has been rewritten with direct imports
-- **When** `npx eslint --print-config src/app/page.tsx` is run before and after the change
+- **When** `npx eslint --print-config app/page.tsx` is run before and after the change
 - **Then** the printed config diff shows no changes to `rules`, `plugins`, `languageOptions`, or `settings`
 
 #### Scenario: Previously ignored paths remain ignored

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tasks.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tasks.md
@@ -9,7 +9,7 @@
 
 ### Task 1 — Capture pre-change ESLint baseline
 
-- [x] Run `npx eslint --print-config src/app/page.tsx > /tmp/eslint-before.json` to capture the resolved config for a representative TypeScript file
+- [x] Run `npx eslint --print-config app/page.tsx > /tmp/eslint-before.json` to capture the resolved config for a representative TypeScript file
 - [x] Run `npx eslint . 2>&1 | tee /tmp/eslint-findings-before.txt` to capture current lint findings
 
 ### Task 2 — Add direct devDependencies to `package.json`
@@ -36,7 +36,7 @@
 
 ### Task 4 — Validate against baseline
 
-- [x] Run `npx eslint --print-config src/app/page.tsx > /tmp/eslint-after.json`
+- [x] Run `npx eslint --print-config app/page.tsx > /tmp/eslint-after.json`
 - [x] Diff: `diff /tmp/eslint-before.json /tmp/eslint-after.json` — must produce no output (identical resolved config)
 - [x] Run `npx eslint . 2>&1 | tee /tmp/eslint-findings-after.txt`
 - [x] Diff: `diff /tmp/eslint-findings-before.txt /tmp/eslint-findings-after.txt` — no new errors or warnings introduced by the config change
@@ -49,18 +49,18 @@
 ## Validation
 
 - [x] `npx eslint .` exits without `Cannot find package` or `MODULE_NOT_FOUND` errors
-- [x] `npx eslint --print-config src/app/page.tsx` diff vs baseline is empty
+- [x] `npx eslint --print-config app/page.tsx` diff vs baseline is empty
 - [x] `npm install` exits 0 with no peer-dependency warnings for the changed packages
 - [x] Run type checks: `npm run typecheck` (or equivalent) — must pass
 - [x] Run build: `npm run build` — must succeed
 - [x] All completed tasks marked as complete
-- [ ] All steps in Remote push validation passed
+- [x] All steps in Remote push validation passed
 
 ## Remote push validation
 
 This change modifies `eslint.config.mjs` and `package.json` — non-docs files are changed, so apply the **full path**.
 
-- **Unit tests** — `npm test` (or equivalent); all tests must pass
+- **Unit tests** — `npm run test:unit`; all tests must pass
 - **Integration tests** — run the project's integration test suite; all tests must pass
 - **Build** — `npm run build`; must succeed with no errors
 

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tasks.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tasks.md
@@ -1,0 +1,105 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b fix/flatten-eslint-next-config` then immediately `git push -u origin fix/flatten-eslint-next-config`
+
+## Execution
+
+### Task 1 — Capture pre-change ESLint baseline
+
+- [x] Run `npx eslint --print-config src/app/page.tsx > /tmp/eslint-before.json` to capture the resolved config for a representative TypeScript file
+- [x] Run `npx eslint . 2>&1 | tee /tmp/eslint-findings-before.txt` to capture current lint findings
+
+### Task 2 — Add direct devDependencies to `package.json`
+
+- [x] Add the following to `devDependencies` in `package.json`, pinned to exact versions:
+  - `"@next/eslint-plugin-next": "16.2.6"`
+  - `"eslint-plugin-react": "7.37.5"`
+  - `"eslint-plugin-react-hooks": "7.0.1"`
+  - `"typescript-eslint": "8.57.0"`
+  - `"eslint-plugin-import": "2.32.0"`
+  - `"eslint-plugin-jsx-a11y": "6.10.2"`
+  - `"globals": "16.4.0"`
+- [x] Remove `eslint-config-next` from `devDependencies`
+- [x] Run `npm install` — must exit 0
+
+### Task 3 — Rewrite `eslint.config.mjs`
+
+- [x] Replace the contents of `eslint.config.mjs` with direct plugin imports that expand `eslint-config-next/core-web-vitals` inline:
+  - Import: `@next/eslint-plugin-next`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, `typescript-eslint`, `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `globals`
+  - Spell out the `name: 'next'` flat config block with plugins, languageOptions (globals, parser, parserOptions), settings, and rules exactly as compiled in `node_modules/eslint-config-next/dist/index.js`
+  - Spell out the `name: 'next/typescript'` block (typescript-eslint plugin + parser, `.ts`/`.tsx` files)
+  - Merge ignores: `.next/**`, `out/**`, `build/**`, `next-env.d.ts` (from unpacked config) plus `coverage/**`, `coverage-e2e/**`, `playwright-report/**`, `.codacy/**`, `docs/**` (existing project ignores) into a single ignores block
+  - Preserve the existing `no-restricted-imports` rule for `tests/**` files
+
+### Task 4 — Validate against baseline
+
+- [x] Run `npx eslint --print-config src/app/page.tsx > /tmp/eslint-after.json`
+- [x] Diff: `diff /tmp/eslint-before.json /tmp/eslint-after.json` — must produce no output (identical resolved config)
+- [x] Run `npx eslint . 2>&1 | tee /tmp/eslint-findings-after.txt`
+- [x] Diff: `diff /tmp/eslint-findings-before.txt /tmp/eslint-findings-after.txt` — no new errors or warnings introduced by the config change
+- [x] Run `npx eslint coverage/ .next/ docs/` — must report "no files matched" for all three (ignores still active)
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npx eslint .` exits without `Cannot find package` or `MODULE_NOT_FOUND` errors
+- [x] `npx eslint --print-config src/app/page.tsx` diff vs baseline is empty
+- [x] `npm install` exits 0 with no peer-dependency warnings for the changed packages
+- [x] Run type checks: `npm run typecheck` (or equivalent) — must pass
+- [x] Run build: `npm run build` — must succeed
+- [x] All completed tasks marked as complete
+- [ ] All steps in Remote push validation passed
+
+## Remote push validation
+
+This change modifies `eslint.config.mjs` and `package.json` — non-docs files are changed, so apply the **full path**.
+
+- **Unit tests** — `npm test` (or equivalent); all tests must pass
+- **Integration tests** — run the project's integration test suite; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+
+If **ANY** required step fails, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `fix/flatten-eslint-next-config` and push to remote
+- [x] Open PR from `fix/flatten-eslint-next-config` to `main`. PR body **MUST** include `Closes #423`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
+  1. **Build and tests** — run all steps in Remote push validation; fix any failures, commit, and push before anything else
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; address each unresolved thread, commit fixes, run validation, push, wait 180 seconds
+  3. **CI check failures** — only after all comments resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix failing required checks, commit, run validation, push, wait 180 seconds
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): TBD
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete
+- [ ] Sync approved spec delta: copy `openspec/changes/flatten-eslint-next-config/specs/eslint-config/spec.md` to `openspec/specs/eslint-config/spec.md`; update relative links from `../../design.md` → `../../changes/archive/YYYY-MM-DD-flatten-eslint-next-config/design.md` and `../../tasks.md` → `../../changes/archive/YYYY-MM-DD-flatten-eslint-next-config/tasks.md`
+- [ ] Archive the change: move `openspec/changes/flatten-eslint-next-config/` to `openspec/changes/archive/YYYY-MM-DD-flatten-eslint-next-config/` — stage copy and deletion **in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-flatten-eslint-next-config/` exists and `openspec/changes/flatten-eslint-next-config/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-flatten-eslint-next-config` then `git push -u origin doc/archive-YYYY-MM-DD-flatten-eslint-next-config`
+- [ ] Open PR from `doc/archive-YYYY-MM-DD-flatten-eslint-next-config` to `main` with title `docs: archive flatten-eslint-next-config (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until it merges; address any comments or CI failures, commit to the doc branch, push, repeat
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D fix/flatten-eslint-next-config doc/archive-YYYY-MM-DD-flatten-eslint-next-config`

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tests.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tests.md
@@ -1,0 +1,80 @@
+---
+name: tests
+description: Tests for the flatten-eslint-next-config change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `flatten-eslint-next-config` change. This is a pure configuration refactor — no application code changes — so tests are verification commands rather than unit test files. Each test maps to a task in `tasks.md` and an acceptance scenario in `specs/eslint-config/spec.md`.
+
+All work follows a strict TDD (Test-Driven Development) process: capture a failing baseline first (step 1), apply the change (step 2), then verify all checks pass (step 3).
+
+## Testing Steps
+
+### Phase 1 — Establish failing baseline (before any code changes)
+
+These commands confirm the current broken state (Codacy fails) and capture a known-good local baseline to diff against after the change.
+
+- [ ] **TC-1.1** Confirm `eslint-config-next` is currently imported: `grep 'eslint-config-next' eslint.config.mjs` — must match
+  - Maps to: Task 3 (Rewrite eslint.config.mjs)
+  - Spec scenario: Config loads in sandboxed environment
+
+- [ ] **TC-1.2** Capture resolved-config baseline: `npx eslint --print-config src/app/page.tsx > /tmp/eslint-before.json`
+  - Maps to: Task 1 (Capture pre-change ESLint baseline)
+  - Spec scenario: Resolved config matches pre-change baseline
+
+- [ ] **TC-1.3** Capture lint-findings baseline: `npx eslint . 2>&1 | tee /tmp/eslint-findings-before.txt`
+  - Maps to: Task 1
+  - Spec scenario: ESLint run produces no new findings
+
+### Phase 2 — Implement the change (Tasks 2 & 3)
+
+Write the change, then verify each test goes from fail → pass.
+
+### Phase 3 — Verify all tests pass (after change)
+
+- [ ] **TC-3.1** `eslint-config-next` import is gone: `grep 'eslint-config-next' eslint.config.mjs` — must produce no output
+  - Maps to: Task 3
+  - Spec scenario: Config loads in sandboxed environment
+
+- [ ] **TC-3.2** All seven plugins are directly imported: `grep -E '@next/eslint-plugin-next|eslint-plugin-react|eslint-plugin-react-hooks|typescript-eslint|eslint-plugin-import|eslint-plugin-jsx-a11y|globals' eslint.config.mjs | wc -l` — must be ≥ 7
+  - Maps to: Task 3
+  - Spec scenario: Config loads in sandboxed environment
+
+- [ ] **TC-3.3** `npm install` exits 0 after `package.json` changes: `npm install` — exit code must be 0
+  - Maps to: Task 2 (Add direct devDependencies)
+  - Spec scenario (NFAC): `npm install` succeeds after dependency changes
+
+- [ ] **TC-3.4** Seven new deps appear in `package.json` devDependencies: `node -e "const d=require('./package.json').devDependencies; ['@next/eslint-plugin-next','eslint-plugin-react','eslint-plugin-react-hooks','typescript-eslint','eslint-plugin-import','eslint-plugin-jsx-a11y','globals'].forEach(p => console.log(p, d[p] || 'MISSING'))"` — all must show a version, none `MISSING`
+  - Maps to: Task 2
+  - Spec scenario (NFAC): `npm install` succeeds after dependency changes
+
+- [ ] **TC-3.5** `eslint-config-next` is absent from `package.json` devDependencies: `node -e "console.log(require('./package.json').devDependencies['eslint-config-next'] || 'absent')"` — must print `absent`
+  - Maps to: Task 2
+  - Spec scenario: REMOVED — implicit dependency on eslint-config-next
+
+- [ ] **TC-3.6** ESLint loads without missing-package error: `npx eslint . 2>&1 | grep -c 'Cannot find package\|MODULE_NOT_FOUND'` — must print `0`
+  - Maps to: Task 3
+  - Spec scenario: No missing-package error in local environment
+
+- [ ] **TC-3.7** Resolved config is identical to baseline: `npx eslint --print-config src/app/page.tsx > /tmp/eslint-after.json && diff /tmp/eslint-before.json /tmp/eslint-after.json` — diff must be empty
+  - Maps to: Task 4 (Validate against baseline)
+  - Spec scenario: Resolved config matches pre-change baseline for a TS file
+
+- [ ] **TC-3.8** No new lint findings introduced: `npx eslint . 2>&1 | tee /tmp/eslint-findings-after.txt && diff /tmp/eslint-findings-before.txt /tmp/eslint-findings-after.txt` — diff must be empty
+  - Maps to: Task 4
+  - Spec scenario: ESLint run produces no new findings
+
+- [ ] **TC-3.9** Previously ignored paths are still ignored — `npx eslint coverage/` reports no files matched, same for `npx eslint .next/` and `npx eslint docs/`
+  - Maps to: Task 4
+  - Spec scenario: Previously ignored paths remain ignored
+
+- [ ] **TC-3.10** `no-restricted-imports` rule is still active for test files: create a temp file `tests/tmp-lint-test.ts` containing `import {} from '@jest/globals';`, run `npx eslint tests/tmp-lint-test.ts`, confirm it reports the restriction error, then delete the temp file
+  - Maps to: Task 3 (preserve existing rule)
+  - Spec scenario: `no-restricted-imports` rule preserved for test files
+
+- [ ] **TC-3.11** Build passes: `npm run build` — must exit 0
+  - Maps to: Validation
+  - Spec scenario (NFAC): Operability — `npm install` / build succeeds

--- a/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tests.md
+++ b/openspec/changes/archive/2026-06-15-flatten-eslint-next-config/tests.md
@@ -17,15 +17,15 @@ All work follows a strict TDD (Test-Driven Development) process: capture a faili
 
 These commands confirm the current broken state (Codacy fails) and capture a known-good local baseline to diff against after the change.
 
-- [ ] **TC-1.1** Confirm `eslint-config-next` is currently imported: `grep 'eslint-config-next' eslint.config.mjs` — must match
+- [x] **TC-1.1** Confirm `eslint-config-next` is currently imported: `grep 'eslint-config-next' eslint.config.mjs` — must match
   - Maps to: Task 3 (Rewrite eslint.config.mjs)
   - Spec scenario: Config loads in sandboxed environment
 
-- [ ] **TC-1.2** Capture resolved-config baseline: `npx eslint --print-config src/app/page.tsx > /tmp/eslint-before.json`
+- [x] **TC-1.2** Capture resolved-config baseline: `npx eslint --print-config app/page.tsx > /tmp/eslint-before.json`
   - Maps to: Task 1 (Capture pre-change ESLint baseline)
   - Spec scenario: Resolved config matches pre-change baseline
 
-- [ ] **TC-1.3** Capture lint-findings baseline: `npx eslint . 2>&1 | tee /tmp/eslint-findings-before.txt`
+- [x] **TC-1.3** Capture lint-findings baseline: `npx eslint . 2>&1 | tee /tmp/eslint-findings-before.txt`
   - Maps to: Task 1
   - Spec scenario: ESLint run produces no new findings
 
@@ -35,46 +35,46 @@ Write the change, then verify each test goes from fail → pass.
 
 ### Phase 3 — Verify all tests pass (after change)
 
-- [ ] **TC-3.1** `eslint-config-next` import is gone: `grep 'eslint-config-next' eslint.config.mjs` — must produce no output
+- [x] **TC-3.1** `eslint-config-next` import is gone: `grep 'eslint-config-next' eslint.config.mjs` — must produce no output
   - Maps to: Task 3
   - Spec scenario: Config loads in sandboxed environment
 
-- [ ] **TC-3.2** All seven plugins are directly imported: `grep -E '@next/eslint-plugin-next|eslint-plugin-react|eslint-plugin-react-hooks|typescript-eslint|eslint-plugin-import|eslint-plugin-jsx-a11y|globals' eslint.config.mjs | wc -l` — must be ≥ 7
+- [x] **TC-3.2** All seven plugins are directly imported: `grep -E '@next/eslint-plugin-next|eslint-plugin-react|eslint-plugin-react-hooks|typescript-eslint|eslint-plugin-import|eslint-plugin-jsx-a11y|globals' eslint.config.mjs | wc -l` — must be ≥ 7
   - Maps to: Task 3
   - Spec scenario: Config loads in sandboxed environment
 
-- [ ] **TC-3.3** `npm install` exits 0 after `package.json` changes: `npm install` — exit code must be 0
+- [x] **TC-3.3** `npm install` exits 0 after `package.json` changes: `npm install` — exit code must be 0
   - Maps to: Task 2 (Add direct devDependencies)
   - Spec scenario (NFAC): `npm install` succeeds after dependency changes
 
-- [ ] **TC-3.4** Seven new deps appear in `package.json` devDependencies: `node -e "const d=require('./package.json').devDependencies; ['@next/eslint-plugin-next','eslint-plugin-react','eslint-plugin-react-hooks','typescript-eslint','eslint-plugin-import','eslint-plugin-jsx-a11y','globals'].forEach(p => console.log(p, d[p] || 'MISSING'))"` — all must show a version, none `MISSING`
+- [x] **TC-3.4** Seven new deps appear in `package.json` devDependencies: `node -e "const d=require('./package.json').devDependencies; ['@next/eslint-plugin-next','eslint-plugin-react','eslint-plugin-react-hooks','typescript-eslint','eslint-plugin-import','eslint-plugin-jsx-a11y','globals'].forEach(p => console.log(p, d[p] || 'MISSING'))"` — all must show a version, none `MISSING`
   - Maps to: Task 2
   - Spec scenario (NFAC): `npm install` succeeds after dependency changes
 
-- [ ] **TC-3.5** `eslint-config-next` is absent from `package.json` devDependencies: `node -e "console.log(require('./package.json').devDependencies['eslint-config-next'] || 'absent')"` — must print `absent`
+- [x] **TC-3.5** `eslint-config-next` is absent from `package.json` devDependencies: `node -e "console.log(require('./package.json').devDependencies['eslint-config-next'] || 'absent')"` — must print `absent`
   - Maps to: Task 2
   - Spec scenario: REMOVED — implicit dependency on eslint-config-next
 
-- [ ] **TC-3.6** ESLint loads without missing-package error: `npx eslint . 2>&1 | grep -c 'Cannot find package\|MODULE_NOT_FOUND'` — must print `0`
+- [x] **TC-3.6** ESLint loads without missing-package error: `npx eslint . 2>&1 | grep -c 'Cannot find package\|MODULE_NOT_FOUND'` — must print `0`
   - Maps to: Task 3
   - Spec scenario: No missing-package error in local environment
 
-- [ ] **TC-3.7** Resolved config is identical to baseline: `npx eslint --print-config src/app/page.tsx > /tmp/eslint-after.json && diff /tmp/eslint-before.json /tmp/eslint-after.json` — diff must be empty
+- [x] **TC-3.7** Resolved config is identical to baseline: `npx eslint --print-config app/page.tsx > /tmp/eslint-after.json && diff /tmp/eslint-before.json /tmp/eslint-after.json` — diff must be empty
   - Maps to: Task 4 (Validate against baseline)
   - Spec scenario: Resolved config matches pre-change baseline for a TS file
 
-- [ ] **TC-3.8** No new lint findings introduced: `npx eslint . 2>&1 | tee /tmp/eslint-findings-after.txt && diff /tmp/eslint-findings-before.txt /tmp/eslint-findings-after.txt` — diff must be empty
+- [x] **TC-3.8** No new lint findings introduced: `npx eslint . 2>&1 | tee /tmp/eslint-findings-after.txt && diff /tmp/eslint-findings-before.txt /tmp/eslint-findings-after.txt` — diff must be empty
   - Maps to: Task 4
   - Spec scenario: ESLint run produces no new findings
 
-- [ ] **TC-3.9** Previously ignored paths are still ignored — `npx eslint coverage/` reports no files matched, same for `npx eslint .next/` and `npx eslint docs/`
+- [x] **TC-3.9** Previously ignored paths are still ignored — `npx eslint coverage/` reports no files matched, same for `npx eslint .next/` and `npx eslint docs/`
   - Maps to: Task 4
   - Spec scenario: Previously ignored paths remain ignored
 
-- [ ] **TC-3.10** `no-restricted-imports` rule is still active for test files: create a temp file `tests/tmp-lint-test.ts` containing `import {} from '@jest/globals';`, run `npx eslint tests/tmp-lint-test.ts`, confirm it reports the restriction error, then delete the temp file
+- [x] **TC-3.10** `no-restricted-imports` rule is still active for test files: create a temp file `tests/tmp-lint-test.ts` containing `import {} from '@jest/globals';`, run `npx eslint tests/tmp-lint-test.ts`, confirm it reports the restriction error, then delete the temp file
   - Maps to: Task 3 (preserve existing rule)
   - Spec scenario: `no-restricted-imports` rule preserved for test files
 
-- [ ] **TC-3.11** Build passes: `npm run build` — must exit 0
+- [x] **TC-3.11** Build passes: `npm run build` — must exit 0
   - Maps to: Validation
   - Spec scenario (NFAC): Operability — `npm install` / build succeeds

--- a/openspec/specs/eslint-config/spec.md
+++ b/openspec/specs/eslint-config/spec.md
@@ -29,7 +29,7 @@ The system SHALL resolve the same set of rules, severity levels, plugins, global
 #### Scenario: Resolved config matches pre-change baseline for a TS file
 
 - **Given** `eslint.config.mjs` has been rewritten with direct imports
-- **When** `npx eslint --print-config src/app/page.tsx` is run before and after the change
+- **When** `npx eslint --print-config app/page.tsx` is run before and after the change
 - **Then** the printed config diff shows no changes to `rules`, `plugins`, `languageOptions`, or `settings`
 
 #### Scenario: Previously ignored paths remain ignored

--- a/openspec/specs/eslint-config/spec.md
+++ b/openspec/specs/eslint-config/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-06-15-flatten-eslint-next-config/design.md) document, not a replacement.
+
+### Requirement: ADDED ESLint config loads without missing-package error
+
+The system SHALL load `eslint.config.mjs` successfully in environments where only direct `devDependencies` are available (e.g., Codacy's sandboxed ESLint container).
+
+#### Scenario: Config loads in sandboxed environment
+
+- **Given** an environment with only the project's direct `devDependencies` available in `node_modules`
+- **When** ESLint initialises and loads `eslint.config.mjs`
+- **Then** ESLint exits with code 0 (or a lint-finding code, not a config-load error)
+
+#### Scenario: No missing-package error in local environment
+
+- **Given** a developer's local checkout with all deps installed
+- **When** `npx eslint .` is run
+- **Then** the output contains no `Cannot find package` or `MODULE_NOT_FOUND` errors
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED ESLint config produces identical resolved rules
+
+The system SHALL resolve the same set of rules, severity levels, plugins, globals, parser, and file patterns as before the change.
+
+#### Scenario: Resolved config matches pre-change baseline for a TS file
+
+- **Given** `eslint.config.mjs` has been rewritten with direct imports
+- **When** `npx eslint --print-config src/app/page.tsx` is run before and after the change
+- **Then** the printed config diff shows no changes to `rules`, `plugins`, `languageOptions`, or `settings`
+
+#### Scenario: Previously ignored paths remain ignored
+
+- **Given** `eslint.config.mjs` has been rewritten with merged ignores
+- **When** `npx eslint coverage/` or `npx eslint .next/` or `npx eslint docs/` is run
+- **Then** ESLint reports no files matched / exits with no findings for those paths
+
+#### Scenario: `no-restricted-imports` rule preserved for test files
+
+- **Given** `eslint.config.mjs` has been rewritten
+- **When** a file in `tests/` imports from `@jest/globals`
+- **Then** ESLint reports an error for that import (rule is still active)
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Implicit dependency on `eslint-config-next` for ESLint config resolution
+
+Reason for removal: The change replaces the `eslint-config-next` import with direct plugin imports. `eslint-config-next` no longer needs to be a direct `devDependency` for ESLint to work; it remains a transitive peer dep of `next` but is not imported by `eslint.config.mjs`.
+
+---
+
+## Traceability
+
+- Proposal element "Replace eslint-config-next import" → Requirement: MODIFIED (identical resolved rules)
+- Proposal element "Promote seven plugins to direct devDependencies" → Requirement: ADDED (config loads without missing-package error)
+- Proposal element "Remove eslint-config-next from devDependencies" → Requirement: REMOVED
+- Design Decision 1 (inline flat config) → ADDED scenario: Config loads in sandboxed environment
+- Design Decision 2 (pin exact versions) → MODIFIED scenario: Resolved config matches pre-change baseline
+- Design Decision 3 (merge ignores) → MODIFIED scenario: Previously ignored paths remain ignored
+- ADDED requirement → Task: Rewrite `eslint.config.mjs`
+- MODIFIED requirement → Task: Add direct devDependencies to `package.json`
+- REMOVED requirement → Task: Remove `eslint-config-next` from `package.json`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Operability
+
+#### Scenario: `npm install` succeeds after dependency changes
+
+- **Given** `package.json` has been updated to add seven direct deps and remove `eslint-config-next`
+- **When** `npm install` is run in a clean checkout
+- **Then** `npm install` exits with code 0 and no peer-dependency warnings related to the changed packages
+
+### Requirement: Reliability
+
+#### Scenario: ESLint run produces no new findings
+
+- **Given** the rewritten `eslint.config.mjs` and updated `package.json`
+- **When** `npx eslint .` is run on the full project
+- **Then** the number and identity of lint findings is identical to a baseline run before the change (no new errors or warnings introduced by the config rewrite itself)
+
+### Requirement: Security
+
+See functional scenarios above — no access-control or token-leakage concerns apply to an ESLint config change.


### PR DESCRIPTION
Archives the completed flatten-eslint-next-config change and syncs the approved spec to `openspec/specs/eslint-config/spec.md`.