### PR TITLE
feat(issue-315): wire CampaignChat with live messaging

### DIFF
--- a/app/campaigns/[id]/layout.tsx
+++ b/app/campaigns/[id]/layout.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { CampaignChat } from '@/lib/components/CampaignChat'
+
+export default function CampaignLayout({ children }: { children: React.ReactNode }) {
+  const { id } = useParams<{ id: string }>()
+  return (
+    <>
+      {children}
+      <CampaignChat campaignId={id} />
+    </>
+  )
+}

--- a/app/campaigns/[id]/layout.tsx
+++ b/app/campaigns/[id]/layout.tsx
@@ -8,7 +8,7 @@ export default function CampaignLayout({ children }: { children: React.ReactNode
   return (
     <>
       {children}
-      <CampaignChat campaignId={id} />
+      <CampaignChat key={id} campaignId={id} />
     </>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@
 import type { Metadata } from 'next'
 import { IBM_Plex_Sans, IBM_Plex_Mono, IBM_Plex_Serif } from 'next/font/google'
 import { NavBar } from '@/lib/components/NavBar'
-import { CampaignChat } from '@/lib/components/CampaignChat'
 import './globals.css'
 
 const plexSans = IBM_Plex_Sans({
@@ -88,7 +87,6 @@ export default async function RootLayout({
             <span>{formatDate(versionData.buildDate)}</span>
           </div>
         </footer>
-        <CampaignChat />
       </body>
     </html>
   )

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -1,9 +1,20 @@
 'use client'
 
-import { useReducer, useEffect, useRef } from 'react'
+import { useReducer, useEffect, useRef, useState } from 'react'
 import { LocalStore } from '@/lib/offline/LocalStore'
+import { useCampaignStream } from '@/lib/hooks/useCampaignStream'
+import { useAuth } from '@/lib/hooks/useAuth'
+import type { CampaignMessage, CampaignStreamEvent, MessageVisibility } from '@/lib/types'
 
 const PIN_KEY = 'campaign-chat-pin'
+
+interface EnrichedMember {
+  id: string
+  userId: string
+  username: string
+  role: string
+  status: string
+}
 
 type DockState = { isExpanded: boolean; isPinned: boolean }
 type DockAction =
@@ -28,7 +39,167 @@ function dockReducer(state: DockState, action: DockAction): DockState {
   }
 }
 
-export function CampaignChat() {
+// ── Sub-components ────────────────────────────────────────────────
+
+interface ChatFeedProps {
+  messages: CampaignMessage[]
+  isLoadingHistory: boolean
+  members: EnrichedMember[]
+  feedRef: React.RefObject<HTMLDivElement | null>
+}
+
+function ChatFeed({ messages, isLoadingHistory, members, feedRef }: ChatFeedProps) {
+  function resolveUsername(toUserId: string): string {
+    return members.find(m => m.userId === toUserId)?.username ?? toUserId
+  }
+
+  function visibilityMarker(visibility: MessageVisibility): string | null {
+    if (visibility.scope === 'dm-only') return '[DM]'
+    if (visibility.scope === 'direct') return `[→ @${resolveUsername(visibility.toUserId)}]`
+    return null
+  }
+
+  return (
+    <div ref={feedRef} className="flex-1 overflow-y-auto p-4 flex flex-col gap-2">
+      {isLoadingHistory && (
+        <div className="text-center text-xs text-gray-500 py-1">Loading…</div>
+      )}
+      {messages.length === 0 && !isLoadingHistory && (
+        <p className="text-gray-500 text-sm">No messages yet.</p>
+      )}
+      {messages.map(msg => {
+        const marker = visibilityMarker(msg.visibility)
+        const ts = new Date(msg.createdAt).toLocaleTimeString()
+        return (
+          <div key={msg.id} className="text-sm text-gray-200">
+            <span className="font-semibold text-white">{msg.senderName}</span>
+            {' '}
+            <span className="text-gray-500 text-xs">{ts}</span>
+            {marker && (
+              <span className="ml-1 text-xs text-yellow-400">{marker}</span>
+            )}
+            <div className="mt-0.5 text-gray-300">{msg.text}</div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+interface MentionDropdownProps {
+  results: EnrichedMember[]
+  onSelect: (member: EnrichedMember) => void
+}
+
+function MentionDropdown({ results, onSelect }: MentionDropdownProps) {
+  if (results.length === 0) return null
+  return (
+    <ul className="absolute bottom-full left-0 right-0 mb-1 bg-gray-700 border border-gray-600 rounded shadow-lg z-50 max-h-40 overflow-y-auto">
+      {results.map(member => (
+        <li key={member.userId}>
+          <button
+            type="button"
+            className="w-full text-left px-3 py-1.5 text-sm text-white hover:bg-gray-600"
+            onMouseDown={e => {
+              e.preventDefault() // prevent textarea blur before selection
+              onSelect(member)
+            }}
+          >
+            @{member.username}
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+interface ChatComposerProps {
+  composerText: string
+  onTextChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
+  visibility: MessageVisibility
+  onVisibilityChange: (scope: string) => void
+  isSending: boolean
+  streamStatus: 'connecting' | 'open' | 'error'
+  members: EnrichedMember[]
+  onSend: () => void
+  onBlur: () => void
+  mentionResults: EnrichedMember[]
+  onMentionSelect: (member: EnrichedMember) => void
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>
+}
+
+function ChatComposer({
+  composerText,
+  onTextChange,
+  onKeyDown,
+  visibility,
+  onVisibilityChange,
+  isSending,
+  streamStatus,
+  members,
+  onSend,
+  onBlur,
+  mentionResults,
+  onMentionSelect,
+  textareaRef,
+}: ChatComposerProps) {
+  const isDisabled = streamStatus !== 'open' || isSending
+
+  function resolveUsername(toUserId: string): string {
+    return members.find(m => m.userId === toUserId)?.username ?? toUserId
+  }
+
+  return (
+    <div className="border-t border-gray-700 p-3 flex-shrink-0 flex flex-col gap-2">
+      {streamStatus !== 'open' && (
+        <p className="text-xs text-yellow-400">Reconnecting…</p>
+      )}
+      <div className="flex gap-2 items-center">
+        <select
+          value={visibility.scope}
+          onChange={e => onVisibilityChange(e.target.value)}
+          disabled={isDisabled}
+          className="text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5"
+        >
+          <option value="group">Group</option>
+          <option value="dm-only">DM-only</option>
+          <option value="direct">Whisper</option>
+        </select>
+        {visibility.scope === 'direct' && 'toUserId' in visibility && visibility.toUserId && (
+          <span className="text-xs text-yellow-400">→ @{resolveUsername(visibility.toUserId)}</span>
+        )}
+      </div>
+      <div className="relative">
+        <MentionDropdown results={mentionResults} onSelect={onMentionSelect} />
+        <textarea
+          ref={textareaRef}
+          value={composerText}
+          onChange={onTextChange}
+          onKeyDown={onKeyDown}
+          onBlur={onBlur}
+          disabled={isDisabled}
+          rows={2}
+          placeholder={isDisabled ? '' : 'Type a message…'}
+          className="w-full bg-gray-700 border border-gray-600 text-white text-sm rounded px-2 py-1.5 resize-none placeholder-gray-500 disabled:opacity-50"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={onSend}
+        disabled={isDisabled}
+        className="self-end text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white px-3 py-1 rounded"
+      >
+        Send
+      </button>
+    </div>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────
+
+export function CampaignChat({ campaignId }: { campaignId: string }) {
+  const { user } = useAuth()
   const [{ isExpanded, isPinned }, dispatch] = useReducer(dockReducer, {
     isExpanded: false,
     isPinned: false,
@@ -36,18 +207,87 @@ export function CampaignChat() {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const isMounted = useRef(false)
 
+  // Message feed state
+  const [messages, setMessages] = useState<CampaignMessage[]>([])
+  const seenIds = useRef<Set<string>>(new Set())
+
+  // Members state
+  const [members, setMembers] = useState<EnrichedMember[]>([])
+
+  // History pagination state
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(true)
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+  const hasMoreRef = useRef(hasMore)
+  hasMoreRef.current = hasMore
+  const isLoadingHistoryRef = useRef(isLoadingHistory)
+  isLoadingHistoryRef.current = isLoadingHistory
+  const pageRef = useRef(page)
+  pageRef.current = page
+  const feedRef = useRef<HTMLDivElement>(null)
+
+  // Unread badge state
+  const [unreadCount, setUnreadCount] = useState(0)
+  const lastOpenKey = `campaign-chat-last-open-${campaignId}`
+  const lastOpenRef = useRef<Date>(new Date(0))
+
+  // Composer state
+  const [composerText, setComposerText] = useState('')
+  const [visibility, setVisibility] = useState<MessageVisibility>({ scope: 'group' })
+  const [isSending, setIsSending] = useState(false)
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Derive mention results
+  const mentionResults =
+    mentionQuery !== null
+      ? members.filter(
+          m =>
+            m.status === 'active' &&
+            m.username.toLowerCase().startsWith(mentionQuery.toLowerCase()),
+        )
+      : []
+
+  // ── SSE stream ──
+  function onStreamEvent(e: CampaignStreamEvent) {
+    if (e.type !== 'message') return
+    const msg = e.data
+    if (seenIds.current.has(msg.id)) return
+    seenIds.current.add(msg.id)
+    setMessages(prev => [...prev, msg])
+
+    if (!isExpanded) {
+      const msgDate = new Date(msg.createdAt)
+      if (msgDate > lastOpenRef.current) {
+        setUnreadCount(c => c + 1)
+      }
+    }
+  }
+
+  const { status: streamStatus } = useCampaignStream(campaignId, onStreamEvent)
+
+  // ── LocalStore init: read last-open timestamp ──
   useEffect(() => {
     let pinned = false
     try {
       pinned = !!LocalStore.get<boolean>(PIN_KEY)
     } catch {
-      // storage unavailable: start collapsed
+      // storage unavailable
     }
     dispatch({ type: 'INIT', pinned })
+
+    try {
+      const stored = LocalStore.get<string>(lastOpenKey)
+      if (stored) {
+        lastOpenRef.current = new Date(stored)
+      }
+    } catch {
+      // storage unavailable: lastOpenRef stays at epoch
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Restore focus to the pill after the drawer closes. Skip on initial mount
-  // so we don't steal focus when the page first loads or auto-expands from pin.
+  // ── Restore focus after drawer closes ──
   useEffect(() => {
     if (!isMounted.current) {
       isMounted.current = true
@@ -58,6 +298,7 @@ export function CampaignChat() {
     }
   }, [isExpanded])
 
+  // ── Keyboard: Escape to collapse ──
   useEffect(() => {
     if (!isExpanded) return
     const handler = (event: KeyboardEvent) => {
@@ -67,12 +308,100 @@ export function CampaignChat() {
     return () => document.removeEventListener('keydown', handler)
   }, [isExpanded])
 
+  // ── Fetch members on mount ──
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/campaigns/${campaignId}/members`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!cancelled && data?.members) {
+          setMembers(
+            (data.members as EnrichedMember[]).filter(m => m.status === 'active'),
+          )
+        }
+      })
+      .catch(() => {
+        // leave members empty on failure
+      })
+    return () => { cancelled = true }
+  }, [campaignId])
+
+  // ── History load on expand ──
+  useEffect(() => {
+    if (!isExpanded) return
+    if (messages.length > 0) return
+
+    setIsLoadingHistory(true)
+    fetch(`/api/campaigns/${campaignId}/messages?page=1&perPage=30`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!data?.messages) return
+        const results: CampaignMessage[] = data.messages
+        results.forEach(m => seenIds.current.add(m.id))
+        setMessages(results)
+        setHasMore(results.length === 30)
+        setPage(1)
+      })
+      .catch(() => {
+        // leave feed empty on failure
+      })
+      .finally(() => {
+        setIsLoadingHistory(false)
+      })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isExpanded])
+
+  // ── Infinite scroll: prepend older pages ──
+  useEffect(() => {
+    if (!isExpanded) return
+    const container = feedRef.current
+    if (!container) return
+
+    function handleScroll() {
+      if (!container) return
+      if (container.scrollTop !== 0) return
+      if (!hasMoreRef.current || isLoadingHistoryRef.current) return
+
+      const nextPage = pageRef.current + 1
+      setIsLoadingHistory(true)
+      const prevScrollHeight = container.scrollHeight
+
+      fetch(`/api/campaigns/${campaignId}/messages?page=${nextPage}&perPage=30`)
+        .then(r => (r.ok ? r.json() : null))
+        .then(data => {
+          if (!data?.messages) return
+          const results: CampaignMessage[] = data.messages
+          const newMsgs = results.filter(m => !seenIds.current.has(m.id))
+          newMsgs.forEach(m => seenIds.current.add(m.id))
+          setMessages(prev => [...newMsgs, ...prev])
+          setHasMore(results.length === 30)
+          setPage(nextPage)
+
+          requestAnimationFrame(() => {
+            if (!container) return
+            const newScrollHeight = container.scrollHeight
+            container.scrollTop = newScrollHeight - prevScrollHeight
+          })
+        })
+        .catch(() => {
+          // leave page as-is on failure
+        })
+        .finally(() => {
+          setIsLoadingHistory(false)
+        })
+    }
+
+    container.addEventListener('scroll', handleScroll)
+    return () => container.removeEventListener('scroll', handleScroll)
+  }, [isExpanded, campaignId])
+
+  // ── Pin toggle ──
   function handlePinToggle() {
     if (isPinned) {
       try {
         LocalStore.remove(PIN_KEY)
       } catch {
-        // storage unavailable: pin cleared in memory only
+        // storage unavailable
       }
       dispatch({ type: 'UNPIN' })
     } else {
@@ -80,23 +409,152 @@ export function CampaignChat() {
         LocalStore.set(PIN_KEY, true)
         dispatch({ type: 'PIN' })
       } catch {
-        // StorageQuotaError: pin preference not persisted; drawer stays open
+        // StorageQuotaError: pin not persisted
       }
     }
   }
 
+  // ── Expand with unread reset ──
+  function handleExpand() {
+    const now = new Date()
+    try {
+      LocalStore.set(lastOpenKey, now.toISOString())
+      lastOpenRef.current = now
+    } catch {
+      // storage unavailable
+    }
+    setUnreadCount(0)
+    dispatch({ type: 'EXPAND' })
+  }
+
+  // ── Composer handlers ──
+  function handleTextChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const text = e.target.value
+    setComposerText(text)
+
+    const cursorPos = e.target.selectionStart ?? text.length
+    const match = /@(\w*)$/.exec(text.slice(0, cursorPos))
+    if (match) {
+      setMentionQuery(match[1])
+    } else {
+      setMentionQuery(null)
+      // If @mention was removed, reset direct visibility to group
+      if (visibility.scope === 'direct') {
+        setVisibility({ scope: 'group' })
+      }
+    }
+  }
+
+  function handleVisibilityChange(scope: string) {
+    if (scope === 'group') {
+      setMentionQuery(null)
+      setVisibility({ scope: 'group' })
+    } else if (scope === 'dm-only') {
+      setMentionQuery(null)
+      setVisibility({ scope: 'dm-only' })
+    } else if (scope === 'direct') {
+      // toUserId comes from a subsequent @mention selection
+      setVisibility({ scope: 'direct', toUserId: '' })
+    }
+  }
+
+  function handleMentionSelect(member: EnrichedMember) {
+    const query = mentionQuery ?? ''
+    // Replace @{query} in text with @{username}
+    const mention = `@${query}`
+    const replacement = `@${member.username}`
+    const idx = composerText.lastIndexOf(mention)
+    if (idx !== -1) {
+      setComposerText(
+        composerText.slice(0, idx) + replacement + composerText.slice(idx + mention.length),
+      )
+    } else {
+      setComposerText(composerText + replacement)
+    }
+    setMentionQuery(null)
+    setVisibility({ scope: 'direct', toUserId: member.userId })
+  }
+
+  function handleMentionBlur() {
+    // Delay to allow onMouseDown on list items to fire first
+    setTimeout(() => setMentionQuery(null), 100)
+  }
+
+  function handleComposerKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Escape') {
+      setMentionQuery(null)
+      return
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  // ── Send message ──
+  async function handleSend() {
+    if (!composerText.trim()) return
+    if (streamStatus !== 'open') return
+    if (isSending) return
+
+    setIsSending(true)
+
+    // Optimistic append
+    const optimisticId = `pending-${Date.now()}`
+    const optimisticMsg: CampaignMessage = {
+      id: optimisticId,
+      campaignId,
+      senderId: user?.userId ?? '',
+      senderName: user?.username ?? user?.email ?? '',
+      text: composerText,
+      visibility,
+      createdAt: new Date(),
+    }
+    setMessages(prev => [...prev, optimisticMsg])
+    seenIds.current.add(optimisticId)
+
+    const body = { text: composerText.trim(), visibility }
+
+    try {
+      const response = await fetch(`/api/campaigns/${campaignId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (response.ok) {
+        setComposerText('')
+        setVisibility({ scope: 'group' })
+        setMentionQuery(null)
+      }
+    } catch {
+      // keep composerText so user can retry
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  // ── Collapsed pill ──
   if (!isExpanded) {
     return (
       <button
         ref={triggerRef}
-        className="fixed bottom-4 right-4 z-40 bg-gray-800 border border-gray-700 rounded-full px-4 py-2 text-sm text-white hover:bg-gray-700"
-        onClick={() => dispatch({ type: 'EXPAND' })}
+        className="fixed bottom-4 right-4 z-40 bg-gray-800 border border-gray-700 rounded-full px-4 py-2 text-sm text-white hover:bg-gray-700 flex items-center gap-2"
+        onClick={handleExpand}
       >
         Chat ›
+        {unreadCount > 0 && (
+          <span
+            aria-label="unread messages"
+            className="inline-flex items-center justify-center w-5 h-5 text-xs font-bold bg-red-500 text-white rounded-full"
+          >
+            {unreadCount}
+          </span>
+        )}
       </button>
     )
   }
 
+  // ── Expanded drawer ──
   return (
     <div
       role="complementary"
@@ -132,9 +590,27 @@ export function CampaignChat() {
           </button>
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto p-4">
-        <p className="text-gray-500 text-sm">No messages yet.</p>
-      </div>
+      <ChatFeed
+        messages={messages}
+        isLoadingHistory={isLoadingHistory}
+        members={members}
+        feedRef={feedRef}
+      />
+      <ChatComposer
+        composerText={composerText}
+        onTextChange={handleTextChange}
+        onKeyDown={handleComposerKeyDown}
+        visibility={visibility}
+        onVisibilityChange={handleVisibilityChange}
+        isSending={isSending}
+        streamStatus={streamStatus}
+        members={members}
+        onSend={handleSend}
+        onBlur={handleMentionBlur}
+        mentionResults={mentionResults}
+        onMentionSelect={handleMentionSelect}
+        textareaRef={textareaRef}
+      />
     </div>
   )
 }

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -16,6 +16,22 @@ interface EnrichedMember {
   status: string
 }
 
+// ── LocalStore helpers ────────────────────────────────────────────
+
+function safeGet<T>(key: string): T | null {
+  try { return LocalStore.get<T>(key) } catch { return null }
+}
+
+function safeSet(key: string, val: unknown): boolean {
+  try { LocalStore.set(key, val); return true } catch { return false }
+}
+
+function safeRemove(key: string) {
+  try { LocalStore.remove(key) } catch { /* storage unavailable */ }
+}
+
+// ── Dock reducer ──────────────────────────────────────────────────
+
 type DockState = { isExpanded: boolean; isPinned: boolean }
 type DockAction =
   | { type: 'INIT'; pinned: boolean }
@@ -26,20 +42,19 @@ type DockAction =
 
 function dockReducer(state: DockState, action: DockAction): DockState {
   switch (action.type) {
-    case 'INIT':
-      return { isExpanded: action.pinned, isPinned: action.pinned }
-    case 'EXPAND':
-      return { ...state, isExpanded: true }
-    case 'COLLAPSE':
-      return { ...state, isExpanded: false }
-    case 'PIN':
-      return { ...state, isPinned: true }
-    case 'UNPIN':
-      return { ...state, isPinned: false }
+    case 'INIT':    return { isExpanded: action.pinned, isPinned: action.pinned }
+    case 'EXPAND':  return { ...state, isExpanded: true }
+    case 'COLLAPSE':return { ...state, isExpanded: false }
+    case 'PIN':     return { ...state, isPinned: true }
+    case 'UNPIN':   return { ...state, isPinned: false }
   }
 }
 
 // ── Sub-components ────────────────────────────────────────────────
+
+function resolveUsername(members: EnrichedMember[], toUserId: string): string {
+  return members.find(m => m.userId === toUserId)?.username ?? toUserId
+}
 
 interface ChatFeedProps {
   messages: CampaignMessage[]
@@ -49,13 +64,9 @@ interface ChatFeedProps {
 }
 
 function ChatFeed({ messages, isLoadingHistory, members, feedRef }: ChatFeedProps) {
-  function resolveUsername(toUserId: string): string {
-    return members.find(m => m.userId === toUserId)?.username ?? toUserId
-  }
-
   function visibilityMarker(visibility: MessageVisibility): string | null {
     if (visibility.scope === 'dm-only') return '[DM]'
-    if (visibility.scope === 'direct') return `[→ @${resolveUsername(visibility.toUserId)}]`
+    if (visibility.scope === 'direct') return `[→ @${resolveUsername(members, visibility.toUserId)}]`
     return null
   }
 
@@ -75,9 +86,7 @@ function ChatFeed({ messages, isLoadingHistory, members, feedRef }: ChatFeedProp
             <span className="font-semibold text-white">{msg.senderName}</span>
             {' '}
             <span className="text-gray-500 text-xs">{ts}</span>
-            {marker && (
-              <span className="ml-1 text-xs text-yellow-400">{marker}</span>
-            )}
+            {marker && <span className="ml-1 text-xs text-yellow-400">{marker}</span>}
             <div className="mt-0.5 text-gray-300">{msg.text}</div>
           </div>
         )
@@ -100,10 +109,7 @@ function MentionDropdown({ results, onSelect }: MentionDropdownProps) {
           <button
             type="button"
             className="w-full text-left px-3 py-1.5 text-sm text-white hover:bg-gray-600"
-            onMouseDown={e => {
-              e.preventDefault() // prevent textarea blur before selection
-              onSelect(member)
-            }}
+            onMouseDown={e => { e.preventDefault(); onSelect(member) }}
           >
             @{member.username}
           </button>
@@ -130,25 +136,11 @@ interface ChatComposerProps {
 }
 
 function ChatComposer({
-  composerText,
-  onTextChange,
-  onKeyDown,
-  visibility,
-  onVisibilityChange,
-  isSending,
-  streamStatus,
-  members,
-  onSend,
-  onBlur,
-  mentionResults,
-  onMentionSelect,
-  textareaRef,
+  composerText, onTextChange, onKeyDown, visibility, onVisibilityChange,
+  isSending, streamStatus, members, onSend, onBlur,
+  mentionResults, onMentionSelect, textareaRef,
 }: ChatComposerProps) {
   const isDisabled = streamStatus !== 'open' || isSending
-
-  function resolveUsername(toUserId: string): string {
-    return members.find(m => m.userId === toUserId)?.username ?? toUserId
-  }
 
   return (
     <div className="border-t border-gray-700 p-3 flex-shrink-0 flex flex-col gap-2">
@@ -166,8 +158,10 @@ function ChatComposer({
           <option value="dm-only">DM-only</option>
           <option value="direct">Whisper</option>
         </select>
-        {visibility.scope === 'direct' && 'toUserId' in visibility && visibility.toUserId && (
-          <span className="text-xs text-yellow-400">→ @{resolveUsername(visibility.toUserId)}</span>
+        {visibility.scope === 'direct' && visibility.toUserId && (
+          <span className="text-xs text-yellow-400">
+            → @{resolveUsername(members, visibility.toUserId)}
+          </span>
         )}
       </div>
       <div className="relative">
@@ -207,46 +201,31 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const isMounted = useRef(false)
 
-  // Message feed state
   const [messages, setMessages] = useState<CampaignMessage[]>([])
   const seenIds = useRef<Set<string>>(new Set())
 
-  // Members state
   const [members, setMembers] = useState<EnrichedMember[]>([])
 
-  // History pagination state
-  const [page, setPage] = useState(1)
-  const [hasMore, setHasMore] = useState(true)
+  // page and hasMore are only needed in the scroll handler — plain refs, no render needed
+  const pageRef = useRef(1)
+  const hasMoreRef = useRef(true)
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
-  const hasMoreRef = useRef(hasMore)
-  hasMoreRef.current = hasMore
-  const isLoadingHistoryRef = useRef(isLoadingHistory)
-  isLoadingHistoryRef.current = isLoadingHistory
-  const pageRef = useRef(page)
-  pageRef.current = page
+  const isLoadingHistoryRef = useRef(false)
   const feedRef = useRef<HTMLDivElement>(null)
 
-  // Unread badge state
   const [unreadCount, setUnreadCount] = useState(0)
   const lastOpenKey = `campaign-chat-last-open-${campaignId}`
   const lastOpenRef = useRef<Date>(new Date(0))
 
-  // Composer state
   const [composerText, setComposerText] = useState('')
   const [visibility, setVisibility] = useState<MessageVisibility>({ scope: 'group' })
   const [isSending, setIsSending] = useState(false)
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  // Derive mention results
-  const mentionResults =
-    mentionQuery !== null
-      ? members.filter(
-          m =>
-            m.status === 'active' &&
-            m.username.toLowerCase().startsWith(mentionQuery.toLowerCase()),
-        )
-      : []
+  const mentionResults = mentionQuery !== null
+    ? members.filter(m => m.status === 'active' && m.username.toLowerCase().startsWith(mentionQuery.toLowerCase()))
+    : []
 
   // ── SSE stream ──
   function onStreamEvent(e: CampaignStreamEvent) {
@@ -255,55 +234,31 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
     if (seenIds.current.has(msg.id)) return
     seenIds.current.add(msg.id)
     setMessages(prev => [...prev, msg])
-
-    if (!isExpanded) {
-      const msgDate = new Date(msg.createdAt)
-      if (msgDate > lastOpenRef.current) {
-        setUnreadCount(c => c + 1)
-      }
+    if (!isExpanded && new Date(msg.createdAt) > lastOpenRef.current) {
+      setUnreadCount(c => c + 1)
     }
   }
 
   const { status: streamStatus } = useCampaignStream(campaignId, onStreamEvent)
 
-  // ── LocalStore init: read last-open timestamp ──
+  // ── Init: pin state + last-open timestamp ──
   useEffect(() => {
-    let pinned = false
-    try {
-      pinned = !!LocalStore.get<boolean>(PIN_KEY)
-    } catch {
-      // storage unavailable
-    }
-    dispatch({ type: 'INIT', pinned })
-
-    try {
-      const stored = LocalStore.get<string>(lastOpenKey)
-      if (stored) {
-        lastOpenRef.current = new Date(stored)
-      }
-    } catch {
-      // storage unavailable: lastOpenRef stays at epoch
-    }
+    dispatch({ type: 'INIT', pinned: !!safeGet<boolean>(PIN_KEY) })
+    const stored = safeGet<string>(lastOpenKey)
+    if (stored) lastOpenRef.current = new Date(stored)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // ── Restore focus after drawer closes ──
   useEffect(() => {
-    if (!isMounted.current) {
-      isMounted.current = true
-      return
-    }
-    if (!isExpanded) {
-      triggerRef.current?.focus()
-    }
+    if (!isMounted.current) { isMounted.current = true; return }
+    if (!isExpanded) triggerRef.current?.focus()
   }, [isExpanded])
 
   // ── Keyboard: Escape to collapse ──
   useEffect(() => {
     if (!isExpanded) return
-    const handler = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') dispatch({ type: 'COLLAPSE' })
-    }
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') dispatch({ type: 'COLLAPSE' }) }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
   }, [isExpanded])
@@ -315,23 +270,18 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (!cancelled && data?.members) {
-          setMembers(
-            (data.members as EnrichedMember[]).filter(m => m.status === 'active'),
-          )
+          setMembers((data.members as EnrichedMember[]).filter(m => m.status === 'active'))
         }
       })
-      .catch(() => {
-        // leave members empty on failure
-      })
+      .catch(() => { /* leave members empty */ })
     return () => { cancelled = true }
   }, [campaignId])
 
   // ── History load on expand ──
   useEffect(() => {
-    if (!isExpanded) return
-    if (messages.length > 0) return
-
+    if (!isExpanded || messages.length > 0) return
     setIsLoadingHistory(true)
+    isLoadingHistoryRef.current = true
     fetch(`/api/campaigns/${campaignId}/messages?page=1&perPage=30`)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
@@ -339,15 +289,11 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
         const results: CampaignMessage[] = data.messages
         results.forEach(m => seenIds.current.add(m.id))
         setMessages(results)
-        setHasMore(results.length === 30)
-        setPage(1)
+        hasMoreRef.current = results.length === 30
+        pageRef.current = 1
       })
-      .catch(() => {
-        // leave feed empty on failure
-      })
-      .finally(() => {
-        setIsLoadingHistory(false)
-      })
+      .catch(() => { /* leave feed empty */ })
+      .finally(() => { setIsLoadingHistory(false); isLoadingHistoryRef.current = false })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isExpanded])
 
@@ -358,12 +304,12 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
     if (!container) return
 
     function handleScroll() {
-      if (!container) return
-      if (container.scrollTop !== 0) return
+      if (!container || container.scrollTop !== 0) return
       if (!hasMoreRef.current || isLoadingHistoryRef.current) return
 
       const nextPage = pageRef.current + 1
       setIsLoadingHistory(true)
+      isLoadingHistoryRef.current = true
       const prevScrollHeight = container.scrollHeight
 
       fetch(`/api/campaigns/${campaignId}/messages?page=${nextPage}&perPage=30`)
@@ -374,135 +320,86 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
           const newMsgs = results.filter(m => !seenIds.current.has(m.id))
           newMsgs.forEach(m => seenIds.current.add(m.id))
           setMessages(prev => [...newMsgs, ...prev])
-          setHasMore(results.length === 30)
-          setPage(nextPage)
-
+          hasMoreRef.current = results.length === 30
+          pageRef.current = nextPage
           requestAnimationFrame(() => {
             if (!container) return
-            const newScrollHeight = container.scrollHeight
-            container.scrollTop = newScrollHeight - prevScrollHeight
+            container.scrollTop = container.scrollHeight - prevScrollHeight
           })
         })
-        .catch(() => {
-          // leave page as-is on failure
-        })
-        .finally(() => {
-          setIsLoadingHistory(false)
-        })
+        .catch(() => { /* leave page as-is */ })
+        .finally(() => { setIsLoadingHistory(false); isLoadingHistoryRef.current = false })
     }
 
     container.addEventListener('scroll', handleScroll)
     return () => container.removeEventListener('scroll', handleScroll)
   }, [isExpanded, campaignId])
 
-  // ── Pin toggle ──
+  // ── Handlers ──
+
   function handlePinToggle() {
     if (isPinned) {
-      try {
-        LocalStore.remove(PIN_KEY)
-      } catch {
-        // storage unavailable
-      }
+      safeRemove(PIN_KEY)
       dispatch({ type: 'UNPIN' })
-    } else {
-      try {
-        LocalStore.set(PIN_KEY, true)
-        dispatch({ type: 'PIN' })
-      } catch {
-        // StorageQuotaError: pin not persisted
-      }
+    } else if (safeSet(PIN_KEY, true)) {
+      dispatch({ type: 'PIN' })
     }
   }
 
-  // ── Expand with unread reset ──
   function handleExpand() {
     const now = new Date()
-    try {
-      LocalStore.set(lastOpenKey, now.toISOString())
-      lastOpenRef.current = now
-    } catch {
-      // storage unavailable
-    }
+    if (safeSet(lastOpenKey, now.toISOString())) lastOpenRef.current = now
     setUnreadCount(0)
     dispatch({ type: 'EXPAND' })
   }
 
-  // ── Composer handlers ──
   function handleTextChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const text = e.target.value
     setComposerText(text)
-
     const cursorPos = e.target.selectionStart ?? text.length
     const match = /@(\w*)$/.exec(text.slice(0, cursorPos))
     if (match) {
       setMentionQuery(match[1])
     } else {
       setMentionQuery(null)
-      // If @mention was removed, reset direct visibility to group
-      if (visibility.scope === 'direct') {
-        setVisibility({ scope: 'group' })
-      }
+      if (visibility.scope === 'direct') setVisibility({ scope: 'group' })
     }
   }
 
   function handleVisibilityChange(scope: string) {
-    if (scope === 'group') {
-      setMentionQuery(null)
-      setVisibility({ scope: 'group' })
-    } else if (scope === 'dm-only') {
-      setMentionQuery(null)
-      setVisibility({ scope: 'dm-only' })
-    } else if (scope === 'direct') {
-      // toUserId comes from a subsequent @mention selection
+    if (scope === 'direct') {
       setVisibility({ scope: 'direct', toUserId: '' })
+    } else {
+      setMentionQuery(null)
+      setVisibility(scope === 'dm-only' ? { scope: 'dm-only' } : { scope: 'group' })
     }
   }
 
   function handleMentionSelect(member: EnrichedMember) {
     const query = mentionQuery ?? ''
-    // Replace @{query} in text with @{username}
-    const mention = `@${query}`
-    const replacement = `@${member.username}`
-    const idx = composerText.lastIndexOf(mention)
-    if (idx !== -1) {
-      setComposerText(
-        composerText.slice(0, idx) + replacement + composerText.slice(idx + mention.length),
-      )
-    } else {
-      setComposerText(composerText + replacement)
-    }
+    const idx = composerText.lastIndexOf(`@${query}`)
+    const replaced = idx !== -1
+      ? composerText.slice(0, idx) + `@${member.username}` + composerText.slice(idx + query.length + 1)
+      : composerText + `@${member.username}`
+    setComposerText(replaced)
     setMentionQuery(null)
     setVisibility({ scope: 'direct', toUserId: member.userId })
   }
 
   function handleMentionBlur() {
-    // Delay to allow onMouseDown on list items to fire first
     setTimeout(() => setMentionQuery(null), 100)
   }
 
   function handleComposerKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Escape') {
-      setMentionQuery(null)
-      return
-    }
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSend()
-    }
+    if (e.key === 'Escape') { setMentionQuery(null); return }
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend() }
   }
 
-  // ── Send message ──
   async function handleSend() {
-    if (!composerText.trim()) return
-    if (streamStatus !== 'open') return
-    if (isSending) return
-
+    if (!composerText.trim() || streamStatus !== 'open' || isSending) return
     setIsSending(true)
-
-    // Optimistic append
-    const optimisticId = `pending-${Date.now()}`
     const optimisticMsg: CampaignMessage = {
-      id: optimisticId,
+      id: `pending-${Date.now()}`,
       campaignId,
       senderId: user?.userId ?? '',
       senderName: user?.username ?? user?.email ?? '',
@@ -511,15 +408,13 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
       createdAt: new Date(),
     }
     setMessages(prev => [...prev, optimisticMsg])
-    seenIds.current.add(optimisticId)
-
-    const body = { text: composerText.trim(), visibility }
+    seenIds.current.add(optimisticMsg.id)
 
     try {
       const response = await fetch(`/api/campaigns/${campaignId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+        body: JSON.stringify({ text: composerText.trim(), visibility }),
       })
       if (response.ok) {
         setComposerText('')
@@ -571,13 +466,7 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
             onClick={handlePinToggle}
             className="text-gray-400 hover:text-white"
           >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M11.5 3a1.5 1.5 0 00-3 0v3.586L6.293 8.793A1 1 0 006 9.5v1a1 1 0 001 1h2.5v4.5a.5.5 0 001 0v-4.5H13a1 1 0 001-1v-1a1 1 0 00-.293-.707L11.5 6.586V3z" />
             </svg>
           </button>

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -206,9 +206,10 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
 
   const [members, setMembers] = useState<EnrichedMember[]>([])
 
-  // page and hasMore are only needed in the scroll handler — plain refs, no render needed
-  const pageRef = useRef(1)
+  // Pagination state lives in refs — never rendered, only read by the scroll handler
+  const cursorRef = useRef<string | null>(null)   // nextCursor from last fetch
   const hasMoreRef = useRef(true)
+  const historyLoadedRef = useRef(false)          // guards against re-fetching after stream msgs arrive
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
   const isLoadingHistoryRef = useRef(false)
   const feedRef = useRef<HTMLDivElement>(null)
@@ -279,18 +280,22 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
 
   // ── History load on expand ──
   useEffect(() => {
-    if (!isExpanded || messages.length > 0) return
+    if (!isExpanded || historyLoadedRef.current) return
+    historyLoadedRef.current = true
     setIsLoadingHistory(true)
     isLoadingHistoryRef.current = true
-    fetch(`/api/campaigns/${campaignId}/messages?page=1&perPage=30`)
+    fetch(`/api/campaigns/${campaignId}/messages?limit=30`)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (!data?.messages) return
-        const results: CampaignMessage[] = data.messages
-        results.forEach(m => seenIds.current.add(m.id))
-        setMessages(results)
-        hasMoreRef.current = results.length === 30
-        pageRef.current = 1
+        // API returns newest-first; reverse so feed shows oldest at top, newest at bottom
+        const results: CampaignMessage[] = [...data.messages].reverse()
+        // Deduplicate against stream messages that may have arrived while loading
+        const newMsgs = results.filter(m => !seenIds.current.has(m.id))
+        newMsgs.forEach(m => seenIds.current.add(m.id))
+        setMessages(prev => [...newMsgs, ...prev])
+        cursorRef.current = data.nextCursor ?? null
+        hasMoreRef.current = !!data.nextCursor
       })
       .catch(() => { /* leave feed empty */ })
       .finally(() => { setIsLoadingHistory(false); isLoadingHistoryRef.current = false })
@@ -307,21 +312,22 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
       if (!container || container.scrollTop !== 0) return
       if (!hasMoreRef.current || isLoadingHistoryRef.current) return
 
-      const nextPage = pageRef.current + 1
       setIsLoadingHistory(true)
       isLoadingHistoryRef.current = true
       const prevScrollHeight = container.scrollHeight
 
-      fetch(`/api/campaigns/${campaignId}/messages?page=${nextPage}&perPage=30`)
+      const cursor = cursorRef.current
+      fetch(`/api/campaigns/${campaignId}/messages?limit=30${cursor ? `&before=${encodeURIComponent(cursor)}` : ''}`)
         .then(r => (r.ok ? r.json() : null))
         .then(data => {
           if (!data?.messages) return
-          const results: CampaignMessage[] = data.messages
+          // API returns newest-first; reverse so older messages prepend correctly
+          const results: CampaignMessage[] = [...data.messages].reverse()
           const newMsgs = results.filter(m => !seenIds.current.has(m.id))
           newMsgs.forEach(m => seenIds.current.add(m.id))
           setMessages(prev => [...newMsgs, ...prev])
-          hasMoreRef.current = results.length === 30
-          pageRef.current = nextPage
+          cursorRef.current = data.nextCursor ?? null
+          hasMoreRef.current = !!data.nextCursor
           requestAnimationFrame(() => {
             if (!container) return
             container.scrollTop = container.scrollHeight - prevScrollHeight
@@ -362,7 +368,8 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
       setMentionQuery(match[1])
     } else {
       setMentionQuery(null)
-      if (visibility.scope === 'direct') setVisibility({ scope: 'group' })
+      // Only revert direct→group when a mention target was previously selected and has been cleared
+      if (visibility.scope === 'direct' && visibility.toUserId) setVisibility({ scope: 'group' })
     }
   }
 
@@ -397,6 +404,7 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
 
   async function handleSend() {
     if (!composerText.trim() || streamStatus !== 'open' || isSending) return
+    if (visibility.scope === 'direct' && !visibility.toUserId) return
     setIsSending(true)
     const optimisticMsg: CampaignMessage = {
       id: `pending-${Date.now()}`,

--- a/lib/hooks/useCampaignStream.ts
+++ b/lib/hooks/useCampaignStream.ts
@@ -56,6 +56,7 @@ export function useCampaignStream(
 
       es.addEventListener('heartbeat', handler);
       es.addEventListener('change', handler);
+      es.addEventListener('message', handler);
 
       es.onerror = () => {
         if (torn) { es.close(); return; }

--- a/openspec/changes/issue-315-chat-dock-wire/.openspec.yaml
+++ b/openspec/changes/issue-315-chat-dock-wire/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-15

--- a/openspec/changes/issue-315-chat-dock-wire/design.md
+++ b/openspec/changes/issue-315-chat-dock-wire/design.md
@@ -1,0 +1,246 @@
+## Context
+
+- Relevant architecture:
+  - `lib/components/CampaignChat.tsx` — existing dock shell (expand/collapse/pin). Currently has no props and renders a placeholder.
+  - `lib/hooks/useCampaignStream.ts` — SSE hook: `useCampaignStream(campaignId, onEvent) → { status }`. Handles reconnect with exponential backoff. Fires `CampaignStreamEvent` including `{ type: "message", data: CampaignMessage }`.
+  - `app/layout.tsx` — root layout; currently mounts `<CampaignChat />` globally.
+  - `app/campaigns/[id]/` — campaign detail route; sub-routes: `combat/`, `library/`, `prompts/`, `sessions/`.
+  - `lib/hooks/useAuth.ts` — `useAuth() → { user: AuthUser | null, loading }` where `AuthUser = { userId, email, username? }`.
+  - `lib/utils/campaignMessages.ts` — `canSeeMessage(msg, userId, members)` utility (server-side; not used in client).
+- Dependencies:
+  - Issue 314 complete: `POST /api/campaigns/[id]/messages` and `GET /api/campaigns/[id]/messages` are live.
+  - `CampaignMessage` type: `{ id, campaignId, senderId, senderName, text, visibility: MessageVisibility, createdAt }`.
+  - `MessageVisibility`: `{ scope: "group" } | { scope: "dm-only" } | { scope: "direct", toUserId: string }`.
+  - `CampaignStreamEvent` union includes `{ type: "message", campaignId, data: CampaignMessage }`.
+  - `GET /api/campaigns/[id]/members` — returns `CampaignMember[]` with `userId`, `username`, `role`, `status`.
+- Interfaces/contracts touched:
+  - `CampaignChat` component signature (add `campaignId` prop).
+  - `app/layout.tsx` (remove `CampaignChat`).
+  - `app/campaigns/[id]/layout.tsx` (new file).
+  - `openspec/specs/campaign-chat-dock/spec.md` (extend existing spec).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Wire live message delivery: stream events → feed state.
+- Composer with group / dm-only / whisper visibility.
+- `@username` autocomplete for whisper targeting.
+- History: load on open, infinite scroll up for older pages.
+- Unread badge: per-campaign, LocalStore-backed, cleared on open.
+- Campaign layout that scopes `CampaignChat` to campaign routes only.
+
+### Non-Goals
+
+- Message editing, deletion, reactions, attachments, threading.
+- Offline queuing, push notifications, read receipts per message.
+- Server-side rendering of message history.
+
+## Decisions
+
+### Decision 1: Campaign ID source — campaign layout (Option C)
+
+- Chosen: Create `app/campaigns/[id]/layout.tsx`. This layout receives `params.id` (the campaign ID) from the Next.js App Router and renders `<CampaignChat campaignId={params.id} />` alongside `{children}`. Remove `<CampaignChat />` from `app/layout.tsx`.
+- Alternatives considered:
+  - Option A: `usePathname()` inside `CampaignChat` to parse campaign ID from URL. Rejected: URL-coupling inside a presentational component, fragile to route changes.
+  - Option B: React Context set by campaign page. Rejected: requires Client Component wrapper in a Server Component hierarchy; more indirection for no benefit.
+- Rationale: Layout is the idiomatic Next.js App Router place to scope a UI element to a route segment. `params.id` is the authoritative source of truth. The dock only makes sense on campaign pages.
+- Trade-offs: `CampaignChat` no longer renders on non-campaign pages. Acceptable — it has no data to show there.
+
+### Decision 2: Member list — independent fetch inside CampaignChat
+
+- Chosen: `CampaignChat` fetches `GET /api/campaigns/[id]/members` once on mount (when `campaignId` is set). Stored in local state. Used only for `@mention` autocomplete and `toUserId` resolution.
+- Alternatives considered: Receive members as a prop from the layout/page. Rejected: would couple the layout to the chat's internal needs; adds prop-drilling for a single internal use.
+- Rationale: `CampaignChat` is already a self-contained component with its own state. One additional fetch keeps the interface clean.
+- Trade-offs: A redundant network request if the campaign page also fetches members. Acceptable at this scale.
+
+### Decision 3: State architecture — layered useState, not expanded reducer
+
+- Chosen: Keep the existing `dockReducer` for dock UI state (`isExpanded`, `isPinned`). Add separate `useState` hooks for: `messages`, `page`, `hasMore`, `isLoadingHistory`, `unreadCount`, `members`, `composerText`, `visibility`, `mentionQuery`, `mentionAnchorIndex`, `isSending`.
+- Alternatives considered: Expand `dockReducer` to cover all state. Rejected: message/composer state is async and granular; forcing it into a reducer makes side-effects (fetches, stream events) awkward.
+- Rationale: Reducer handles synchronous toggle logic well; useState handles async/incremental data well. Mixing the two cleanly is a standard React pattern.
+- Trade-offs: More `useState` calls; mitigated by logical grouping in the file.
+
+### Decision 4: @mention autocomplete — onChange detection, inline overlay
+
+- Chosen: On every `onChange` of the textarea, scan from the cursor backward to find `@word` pattern (`/@(\w*)$/` on text up to `selectionStart`). If matched, set `mentionQuery`; otherwise clear it. Render a floating `<ul>` overlay positioned relative to the textarea. On member select: replace the `@word` fragment with `@username`, set `visibility = { scope: "direct", toUserId }`, close overlay.
+- Alternatives considered: A separate "Whisper to" dropdown in the visibility selector (no inline typing). Not chosen per explicit user preference for autocomplete.
+- Rationale: Familiar chat UX (`@mention` is standard); keeps composer text and visibility coupled in a single gesture.
+- Trade-offs: Cursor position tracking adds complexity; mitigated by using `selectionStart` on the native textarea and string replacement.
+- Note: Only one whisper target per message (single `direct` visibility). Selecting a second `@mention` replaces the previous target and updates `visibility.toUserId`.
+
+### Decision 5: History — GET on open, prepend on scroll-to-top
+
+- Chosen: On dock expand (first open or re-open after close), fetch `GET /api/campaigns/[id]/messages?page=1&perPage=30` and set `messages`. Attach a `scroll` listener to the feed container; when `scrollTop === 0` and `hasMore`, fetch the next page and prepend results. Deduplicate by `message.id`.
+- Alternatives considered: Fetch all history eagerly on mount. Rejected: could be large; unnecessary if dock is never opened.
+- Rationale: Lazy load on open keeps mount cost minimal. Prepend-on-scroll is the standard pattern for chat history.
+- Trade-offs: Scroll position jumps when messages are prepended; mitigated by saving `scrollHeight` before prepend and restoring `scrollTop + ΔscrollHeight` after.
+
+### Decision 6: Unread badge — LocalStore timestamp, per-campaign key
+
+- Chosen: On mount, read `LocalStore.get<string>('campaign-chat-last-open-{campaignId}')`. Parse as a `Date`. Incoming stream `message` events with `createdAt > lastOpen` increment `unreadCount`. On dock expand, write `new Date().toISOString()` to LocalStore and reset `unreadCount` to 0.
+- Rationale: Simple, no server round-trip. Survives page reloads. Per-campaign key so switching campaigns doesn't bleed counts.
+- Trade-offs: History messages loaded on open do not contribute to `unreadCount` (they are historical). Only stream events received since the last close count. This is the specified behavior.
+
+### Decision 7: Deduplication — id-keyed Set
+
+- Chosen: Maintain a `Set<string>` of message IDs in state (or a ref). When appending a stream event, skip if ID already present. When prepending history, filter out IDs already in the feed.
+- Rationale: The stream may re-deliver a message the client just optimistically appended, or history may overlap with live messages.
+
+### Decision 8: Optimistic send — append then confirm
+
+- Chosen: On send, immediately append a locally-constructed `CampaignMessage` (using `useAuth().user`) to the feed with a temporary `id = 'pending-{Date.now()}'`. The server will emit a stream event with the real message; deduplication by `id` won't match the temp ID, so the real message appends. The temp message remains (no removal logic for MVP).
+- Alternatives considered: Wait for stream event before showing. Rejected: adds perceived latency.
+- Trade-offs: A brief duplicate window (temp + real) if stream event is very fast. Acceptable for MVP; a future cleanup can match on text+timestamp.
+
+### Decision 9: Composer disabled state
+
+- Chosen: The textarea and Send button are `disabled` when `streamStatus !== 'open'` or `isSending`. A brief status line ("Reconnecting…") appears above the composer when stream is not open.
+- Rationale: Prevents lost messages on a disconnected stream.
+
+### Decision 10: Sub-component extraction — same file, unexported
+
+- Chosen: Extract `ChatFeed`, `ChatComposer`, and `MentionDropdown` as non-exported function components within `lib/components/CampaignChat.tsx`. They receive state/handlers via props from `CampaignChat`.
+- Rationale: Keeps the file testable (individual sub-functions can be tested if needed) without splitting into separate files, which would add import overhead for a cohesive UI unit.
+
+## Proposal to Design Mapping
+
+- Proposal element: Remove `CampaignChat` from root layout; scope to campaign routes
+  - Design decision: Decision 1 (campaign layout)
+  - Validation approach: Unit test confirms `<CampaignChat />` not present in root layout; E2E confirms dock absent on non-campaign pages.
+
+- Proposal element: `campaignId` prop added to `CampaignChat`
+  - Design decision: Decision 1
+  - Validation approach: TypeScript; prop is required, no default.
+
+- Proposal element: Connect to `useCampaignStream`
+  - Design decision: Decision 3 (state layering); stream message events → `messages` state
+  - Validation approach: Unit test with mocked `useCampaignStream`; simulate message event; assert feed updates.
+
+- Proposal element: History load on open + infinite scroll
+  - Design decision: Decision 5
+  - Validation approach: Mock `fetch`; assert `GET /api/campaigns/[id]/messages` called on expand; scroll-to-top triggers second page fetch.
+
+- Proposal element: Unread badge
+  - Design decision: Decision 6
+  - Validation approach: Unit test: mock LocalStore, fire stream message event, assert pill shows badge; open dock, assert badge clears.
+
+- Proposal element: Member fetch for `@mention`
+  - Design decision: Decision 2
+  - Validation approach: Mock `fetch`; assert `GET /api/campaigns/[id]/members` called on mount.
+
+- Proposal element: `@mention` autocomplete
+  - Design decision: Decision 4
+  - Validation approach: Unit test: type `@al` into textarea, assert dropdown appears with matching members; select member, assert `visibility.toUserId` set and dropdown closed.
+
+- Proposal element: Send message
+  - Design decision: Decision 8 (optimistic), Decision 9 (disabled state)
+  - Validation approach: Mock `fetch`; assert `POST /api/campaigns/[id]/messages` called with correct body; assert optimistic message in feed.
+
+- Proposal element: Deduplication
+  - Design decision: Decision 7
+  - Validation approach: Unit test: add message, fire stream event with same ID, assert only one copy in feed.
+
+## Functional Requirements Mapping
+
+- Requirement: Members see live messages via stream
+  - Design element: `useCampaignStream` → `onEvent` callback → `setMessages(prev => [...prev, msg])` (Decision 3)
+  - Acceptance criteria reference: spec — Scenario: Stream message event appends to feed
+  - Testability notes: Mock `useCampaignStream` to fire synthetic events; assert DOM update.
+
+- Requirement: History loads on dock open
+  - Design element: `useEffect` on `isExpanded` → `GET /api/campaigns/[id]/messages` (Decision 5)
+  - Acceptance criteria reference: spec — Scenario: History loads when dock opens
+  - Testability notes: Mock `fetch`; spy on URL with page/perPage params.
+
+- Requirement: Infinite scroll
+  - Design element: Scroll listener on feed container → fetch next page (Decision 5)
+  - Acceptance criteria reference: spec — Scenario: Scroll to top triggers older page load
+  - Testability notes: Simulate scroll event with `scrollTop = 0`; assert second `fetch` call.
+
+- Requirement: Visibility selector (Group / DM-only / Whisper)
+  - Design element: `<select>` or button group in `ChatComposer`; controls `visibility` state (Decision 3)
+  - Acceptance criteria reference: spec — Scenario: Composer renders visibility options
+  - Testability notes: Assert three options present; selecting each updates `visibility` state.
+
+- Requirement: `@mention` autocomplete for whisper
+  - Design element: `onChange` regex scan → `mentionQuery` → filtered members list → `MentionDropdown` (Decision 4)
+  - Acceptance criteria reference: spec — Scenario: Typing @prefix shows member dropdown
+  - Testability notes: Render with mocked members; type `@`; assert dropdown items.
+
+- Requirement: Send message via POST
+  - Design element: Send button → `POST /api/campaigns/[id]/messages` with `{ text, visibility }` (Decision 8)
+  - Acceptance criteria reference: spec — Scenario: Active member sends group message
+  - Testability notes: Mock `fetch`; assert body and method.
+
+- Requirement: Unread badge on collapsed pill
+  - Design element: LocalStore timestamp + stream event counter → badge on pill (Decision 6)
+  - Acceptance criteria reference: spec — Scenario: Unread badge appears when dock is collapsed
+  - Testability notes: Mock LocalStore; fire stream event; assert badge renders on pill.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: No layout regression — `CampaignChat` must remain out of document flow
+  - Design element: `fixed`-positioned container preserved from existing shell
+  - Acceptance criteria reference: Existing spec — Scenario: Existing tests pass after layout change
+  - Testability notes: Full test suite must pass with no layout-related failures.
+
+- Requirement category: reliability
+  - Requirement: LocalStore unavailability must not crash the component
+  - Design element: All LocalStore calls wrapped in `try/catch`; `unreadCount` degrades to 0 (Decision 6)
+  - Acceptance criteria reference: spec — Scenario: LocalStore unavailable — unread count degrades gracefully
+  - Testability notes: Mock LocalStore to throw; assert no uncaught exception.
+
+- Requirement category: security
+  - Requirement: Composer disabled when stream is disconnected (prevents lost messages)
+  - Design element: `disabled` on textarea and Send button when `streamStatus !== 'open'` (Decision 9)
+  - Acceptance criteria reference: spec — Scenario: Composer is disabled when stream is not open
+  - Testability notes: Set mock stream status to `error`; assert inputs disabled.
+
+- Requirement category: performance
+  - Requirement: History not fetched until dock opens
+  - Design element: `useEffect` gated on `isExpanded` (Decision 5)
+  - Acceptance criteria reference: spec — Scenario: History is not fetched on mount (dock collapsed)
+  - Testability notes: Assert `fetch` not called on initial render when dock is collapsed.
+
+- Requirement category: reliability
+  - Requirement: Duplicate messages must not appear in feed
+  - Design element: ID-keyed deduplication Set (Decision 7)
+  - Acceptance criteria reference: spec — Scenario: Duplicate stream event is ignored
+  - Testability notes: Add message, fire stream event with same ID; assert feed length unchanged.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Campaign layout file may break sub-route rendering
+  - Impact: High (all campaign pages broken if wrong)
+  - Mitigation: Layout passes `{children}` through without modification; test all sub-routes.
+
+- Risk/trade-off: Optimistic message + stream deduplication by ID leaves a brief "double" display
+  - Impact: Low (cosmetic, MVP)
+  - Mitigation: Accepted for MVP. Future: match on `senderId + text + createdAt` window.
+
+- Risk/trade-off: `@mention` regex on long composer text has minor CPU cost
+  - Impact: Negligible — text is short, operation is O(n) on a small string.
+  - Mitigation: None needed.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Campaign sub-routes broken, or existing dock unit tests regress.
+- Rollback steps:
+  1. Delete `app/campaigns/[id]/layout.tsx`.
+  2. Restore `<CampaignChat />` in `app/layout.tsx` (no-prop form).
+  3. Revert `lib/components/CampaignChat.tsx` to the shell-only version.
+- Data migration considerations: None — no schema changes. `LocalStore` keys added but not destructive to remove.
+- Verification after rollback: Run `npm test` and confirm existing dock tests pass.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check before proceeding. No exceptions.
+- If security checks fail: Treat as a blocker. Investigate and resolve before merge.
+- If required reviews are blocked/stale: Ping the reviewer after 24 hours. Escalate to maintainer after 48 hours.
+- Escalation path and timeout: After 48 hours of no review activity, flag in the project issue (#315) for maintainer action.
+
+## Open Questions
+
+None. All design decisions resolved in exploration session (2026-06-14). See proposal.md § Open Questions for confirmation.

--- a/openspec/changes/issue-315-chat-dock-wire/proposal.md
+++ b/openspec/changes/issue-315-chat-dock-wire/proposal.md
@@ -1,0 +1,115 @@
+## GitHub Issues
+
+- #315
+- #297 (parent epic: Phase 5 — Messaging)
+
+## Why
+
+- Problem statement: `CampaignChat` is a fully-wired dock shell (expand/collapse/pin) but carries no live data — the message area shows a static "No messages yet." placeholder. Users in an active campaign cannot send or receive messages via the UI.
+- Why now: Issue 314 (5a) is complete — the `campaignMessages` collection, `POST`/`GET` API routes, stream event emission, and `CampaignMessage` type are all live. The front-end integration is the remaining blocker for Phase 5.
+- Business/user impact: Without this, real-time campaign messaging is invisible to users despite the back-end being ready. DMs, group messages, and DM-only whispers cannot be composed or read.
+
+## Problem Space
+
+- Current behavior: `CampaignChat` is mounted in `app/layout.tsx` with no props. It has no `campaignId`, no stream connection, no message state, and no composer. The dock is a static shell.
+- Desired behavior: When a user navigates to a campaign page (`/campaigns/[id]/…`), the chat dock connects to that campaign's SSE stream, loads message history, renders a scrollable feed with sender/timestamp/visibility markers, shows an unread badge when collapsed, and provides a composer with visibility selector and `@username` autocomplete for whisper (direct) targeting.
+- Constraints:
+  - `useCampaignStream` already exists and must be reused as-is (no signature changes).
+  - The send API (`POST /api/campaigns/[id]/messages`) and history API (`GET /api/campaigns/[id]/messages`) are fixed contracts from issue 314.
+  - The dock must remain `fixed`-positioned and out of document flow (no layout regressions).
+  - Auth is JWT-cookie-based; `useAuth()` provides `{ userId, username }` client-side.
+  - Tailwind + shadcn UI stack; no new UI library additions.
+- Assumptions:
+  - The chat dock is only meaningful inside a campaign route. It will not render on non-campaign pages.
+  - Member list for whisper autocomplete is fetched by `CampaignChat` itself (not passed via props).
+  - Unread count resets on dock open (not on scroll-to-bottom).
+  - Unread state is per-campaign, persisted in `LocalStore` by key `campaign-chat-last-open-{campaignId}`.
+  - Optimistic message append on send (show immediately, no rollback on error for MVP).
+- Edge cases considered:
+  - User sends a message while stream is disconnected (status `error`/`connecting`) — composer is disabled.
+  - Stream delivers a message the sender just sent (deduplication by `id` required).
+  - `@` typed at the start of a word with no matching members — dropdown shows empty/no match state.
+  - Campaign with no other members — whisper option still shown but dropdown is empty.
+  - History pagination returns fewer items than `perPage` — `hasMore` set to `false`.
+  - LocalStore unavailable (private browsing) — unread count degrades gracefully (starts at 0).
+
+## Scope
+
+### In Scope
+
+- Create `app/campaigns/[id]/layout.tsx` — new Next.js layout wrapping all campaign sub-routes; mounts `<CampaignChat campaignId={id} />`.
+- Remove `<CampaignChat />` from `app/layout.tsx`.
+- Add `campaignId: string` prop to `CampaignChat`; connect to `useCampaignStream`.
+- Message feed: render `CampaignMessage[]` with `senderName`, formatted timestamp, visibility marker, and `text`.
+- Unread badge on the collapsed pill: count stream messages received since `campaign-chat-last-open-{campaignId}` LocalStore timestamp; clear on open.
+- History: load last 30 messages on dock open; infinite scroll (prepend older pages on scroll-to-top).
+- Members fetch: `GET /api/campaigns/[id]/members` on mount; used only for `@mention` autocomplete.
+- Composer: text `<textarea>`, visibility selector (Group / DM-only / Whisper), `@username` autocomplete overlay, Send button.
+- `@mention` flow: detect `@word` in textarea, filter members by username prefix, pick from dropdown → sets `visibility = { scope: "direct", toUserId }`, replaces `@word` with `@username`.
+- Send: `POST /api/campaigns/[id]/messages`; optimistic append; disable composer while sending or stream is down.
+- Update `openspec/specs/campaign-chat-dock/spec.md` to reflect new prop and live-data requirements.
+
+### Out of Scope
+
+- Message editing or deletion.
+- Rich text / markdown in messages.
+- Emoji reactions.
+- File or image attachments.
+- Read receipts per message (only aggregate unread count).
+- Push / browser notifications.
+- Pagination UI controls (load-more button) — scroll-triggered only.
+- Group DM (multiple direct recipients in one message).
+- Message search.
+
+## What Changes
+
+- **NEW** `app/campaigns/[id]/layout.tsx` — campaign-scoped layout; mounts `CampaignChat`.
+- **MODIFIED** `app/layout.tsx` — remove `CampaignChat` import and render.
+- **MODIFIED** `lib/components/CampaignChat.tsx` — add `campaignId` prop; stream wiring; message state; feed render; unread badge; composer with visibility + `@mention`; history fetch + infinite scroll.
+- **MODIFIED** `openspec/specs/campaign-chat-dock/spec.md` — add new requirements for live data, feed, unread, and composer.
+- **NEW** `openspec/changes/issue-315-chat-dock-wire/specs/campaign-chat-wire/spec.md` — BDD specs for this change's additions.
+
+## Risks
+
+- Risk: `CampaignChat` file grows unwieldy as a single component.
+  - Impact: Medium — harder to test and review.
+  - Mitigation: Extract internal sub-components (`ChatFeed`, `ChatComposer`, `MentionDropdown`) as non-exported functions within the same file, keeping the public API surface unchanged.
+
+- Risk: Stream deduplication failure causes duplicate messages in the feed.
+  - Impact: Low-Medium — visible to user, confusing UX.
+  - Mitigation: Deduplicate by `message.id` when appending stream events; history load skips messages whose `id` is already in state.
+
+- Risk: LocalStore unavailable (private browsing, storage quota) causes unread badge errors.
+  - Impact: Low — cosmetic only.
+  - Mitigation: Wrap all LocalStore calls in try/catch; degrade to in-memory-only unread tracking.
+
+- Risk: Campaign layout file (`app/campaigns/[id]/layout.tsx`) intercepts routing in an unexpected way.
+  - Impact: Medium — could break sub-routes (`/combat`, `/library`, etc.) if not implemented correctly.
+  - Mitigation: Layout only adds a client-side component mount and passes `{children}` through; no data fetching or redirect logic. Validate all sub-routes still render in tests.
+
+- Risk: `@mention` autocomplete state gets out of sync with textarea cursor position.
+  - Impact: Low — annoying UX, not a data loss risk.
+  - Mitigation: Trigger detection on every `onChange`; clear mention state on blur or Escape.
+
+## Open Questions
+
+All design decisions have been resolved in the preceding exploration session (2026-06-14). No open questions remain.
+
+- Confirmed: Option C (campaign layout) for `campaignId` sourcing.
+- Confirmed: Independent member fetch inside `CampaignChat`.
+- Confirmed: `@mention` autocomplete (not dropdown-only).
+- Confirmed: Infinite scroll for history pagination.
+- Confirmed: LocalStore-backed unread, keyed per campaign, cleared on open.
+
+## Non-Goals
+
+- Server-side rendering of message history (dock is client-only).
+- Offline message queuing / sync.
+- Notification sounds or desktop push.
+- Admin moderation tools.
+- Message threading or replies.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/issue-315-chat-dock-wire/specs/campaign-chat-wire/spec.md
+++ b/openspec/changes/issue-315-chat-dock-wire/specs/campaign-chat-wire/spec.md
@@ -1,0 +1,324 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+---
+
+### Requirement: ADDED CampaignChat accepts campaignId prop and mounts in campaign layout
+
+The system SHALL render `CampaignChat` only on campaign routes, receiving `campaignId` from the campaign `[id]` layout.
+
+#### Scenario: Chat dock renders on campaign page
+
+- **Given** a user navigates to `/campaigns/[id]` or any sub-route
+- **When** the page renders
+- **Then** a button with accessible name matching `/chat/i` is present in the document (dock is available)
+
+#### Scenario: Chat dock does not render on non-campaign pages
+
+- **Given** a user is on any route outside `/campaigns/[id]/…`
+- **When** the page renders
+- **Then** no element with accessible name matching `/chat/i` from `CampaignChat` is present (dock is absent)
+
+---
+
+### Requirement: ADDED CampaignChat connects to SSE stream for live messages
+
+The system SHALL connect to `useCampaignStream(campaignId, onEvent)` and append incoming `"message"` events to the feed.
+
+#### Scenario: Stream message event appends to feed
+
+- **Given** the dock is expanded and the stream is open
+- **When** a `{ type: "message", data: CampaignMessage }` event is received from the stream
+- **Then** the message appears in the feed with the sender name and message text
+
+#### Scenario: Duplicate stream event is ignored
+
+- **Given** a message with id `"msg-1"` is already in the feed
+- **When** a stream event arrives with `data.id = "msg-1"`
+- **Then** the feed still contains exactly one copy of that message
+
+#### Scenario: Non-message stream events do not affect feed
+
+- **Given** the dock is expanded
+- **When** a `{ type: "heartbeat" }` or `{ type: "change" }` stream event is received
+- **Then** the message feed is unchanged
+
+---
+
+### Requirement: ADDED Message feed renders sender, timestamp, visibility marker, and text
+
+The system SHALL display each message with its `senderName`, a human-readable `createdAt` timestamp, a visibility marker, and `text`.
+
+#### Scenario: Group message renders without visibility marker
+
+- **Given** the feed contains a message with `visibility.scope = "group"`
+- **When** the feed is rendered
+- **Then** the message displays `senderName`, timestamp, and text; no DM or whisper marker is shown
+
+#### Scenario: DM-only message renders with DM marker
+
+- **Given** the feed contains a message with `visibility.scope = "dm-only"`
+- **When** the feed is rendered
+- **Then** the message displays a visible DM-only marker (e.g., text `DM` or `dm-only` label)
+
+#### Scenario: Direct (whisper) message renders with whisper marker
+
+- **Given** the feed contains a message with `visibility.scope = "direct"` and `toUserId` set
+- **When** the feed is rendered
+- **Then** the message displays a whisper marker identifying the recipient username
+
+---
+
+### Requirement: ADDED History loads on dock open with infinite scroll
+
+The system SHALL fetch `GET /api/campaigns/[id]/messages?page=1&perPage=30` when the dock first expands, and load older pages when the feed is scrolled to the top.
+
+#### Scenario: History loads when dock opens
+
+- **Given** the dock is collapsed and the user has not opened it this session
+- **When** the user expands the dock
+- **Then** `GET /api/campaigns/[id]/messages` is called with `page=1&perPage=30` and returned messages appear in the feed
+
+#### Scenario: History is not fetched on mount (dock collapsed)
+
+- **Given** the component has mounted with the dock in its collapsed initial state
+- **When** no user interaction occurs
+- **Then** `GET /api/campaigns/[id]/messages` has not been called
+
+#### Scenario: Scroll to top triggers older page load
+
+- **Given** the dock is expanded with `hasMore = true` and at least one page of history is loaded
+- **When** the feed container is scrolled to the top (`scrollTop === 0`)
+- **Then** `GET /api/campaigns/[id]/messages` is called with `page=2` and the returned messages are prepended to the feed
+
+#### Scenario: No more pages — load more not triggered
+
+- **Given** `hasMore = false` (the last fetch returned fewer than `perPage` items)
+- **When** the feed container is scrolled to the top
+- **Then** no additional `GET /api/campaigns/[id]/messages` request is made
+
+#### Scenario: History messages are deduplicated against feed
+
+- **Given** the feed already contains a live message with id `"msg-live"`
+- **When** a history page is loaded that also contains a message with id `"msg-live"`
+- **Then** the feed contains exactly one copy of that message
+
+---
+
+### Requirement: ADDED Unread badge on collapsed pill
+
+The system SHALL display an unread count badge on the collapsed pill button when messages have arrived since the dock was last opened.
+
+#### Scenario: Unread badge appears when dock is collapsed and new message arrives
+
+- **Given** the dock is collapsed and `LocalStore` records a `campaign-chat-last-open-{campaignId}` timestamp
+- **When** a stream `"message"` event arrives with `createdAt` after that timestamp
+- **Then** the collapsed pill shows a non-zero unread count badge
+
+#### Scenario: Unread badge clears when dock opens
+
+- **Given** the collapsed pill shows an unread badge with count ≥ 1
+- **When** the user expands the dock
+- **Then** the unread badge is no longer visible and `LocalStore` is updated with the current timestamp
+
+#### Scenario: Unread count does not increment while dock is open
+
+- **Given** the dock is expanded
+- **When** a stream `"message"` event arrives
+- **Then** `unreadCount` remains 0 (message is immediately visible in the feed)
+
+#### Scenario: LocalStore unavailable — unread count degrades gracefully
+
+- **Given** `LocalStore.get` and `LocalStore.set` throw an exception
+- **When** the component mounts and a stream message event arrives
+- **Then** no uncaught exception occurs and the component renders without crashing (badge may show 0 or omit)
+
+---
+
+### Requirement: ADDED Members fetched for @mention autocomplete
+
+The system SHALL fetch `GET /api/campaigns/[id]/members` once on mount and cache the result for `@mention` autocomplete.
+
+#### Scenario: Members fetched on mount
+
+- **Given** `CampaignChat` mounts with a valid `campaignId`
+- **When** the component mounts
+- **Then** `GET /api/campaigns/[id]/members` is called exactly once
+
+#### Scenario: Members fetch failure does not crash composer
+
+- **Given** `GET /api/campaigns/[id]/members` returns a non-OK response
+- **When** the user types `@` in the composer
+- **Then** no uncaught exception occurs and the mention dropdown is empty (or does not appear)
+
+---
+
+### Requirement: ADDED Composer with visibility selector
+
+The system SHALL render a composer with a textarea, a visibility selector (Group / DM-only / Whisper), and a Send button.
+
+#### Scenario: Composer renders visibility options
+
+- **Given** the dock is expanded
+- **When** the composer area is rendered
+- **Then** the user can select among at least three visibility options: Group, DM-only, and Whisper (direct)
+
+#### Scenario: Default visibility is Group
+
+- **Given** the dock is expanded and no visibility has been selected
+- **When** the composer is rendered
+- **Then** the active visibility is `group`
+
+#### Scenario: Composer is disabled when stream is not open
+
+- **Given** the stream `status` is `"connecting"` or `"error"`
+- **When** the composer is rendered
+- **Then** the textarea and Send button are both `disabled`
+
+---
+
+### Requirement: ADDED @mention autocomplete for whisper targeting
+
+The system SHALL detect `@word` in the composer textarea and display a dropdown of matching active campaign members; selecting one sets `visibility = { scope: "direct", toUserId }`.
+
+#### Scenario: Typing @prefix shows member dropdown
+
+- **Given** the dock is expanded, the stream is open, and members `["alice", "bob"]` are loaded
+- **When** the user types `@al` into the composer textarea
+- **Then** a dropdown appears containing `alice`
+
+#### Scenario: Selecting a member sets direct visibility and closes dropdown
+
+- **Given** the mention dropdown is open with `alice` as a match
+- **When** the user selects `alice` from the dropdown
+- **Then** the dropdown closes, `@al` in the textarea is replaced with `@alice`, and the visibility is set to `{ scope: "direct", toUserId: alice.userId }`
+
+#### Scenario: No matching members — dropdown empty or hidden
+
+- **Given** `@xyz` is typed and no member username starts with `xyz`
+- **When** the dropdown is rendered
+- **Then** no member items are shown (dropdown is empty or not rendered)
+
+#### Scenario: Clearing @mention text resets visibility to Group
+
+- **Given** a mention has been selected and visibility is `direct`
+- **When** the user deletes the `@alice` text from the textarea
+- **Then** visibility resets to `{ scope: "group" }` and the dropdown does not appear
+
+#### Scenario: Second @mention replaces previous whisper target
+
+- **Given** `@alice` has been selected as whisper target (`visibility.toUserId = alice.userId`)
+- **When** the user types `@bo` and selects `bob` from the dropdown
+- **Then** `visibility.toUserId` is updated to `bob.userId` and the textarea reflects `@bob`
+
+---
+
+### Requirement: ADDED Send message via POST
+
+The system SHALL POST `{ text, visibility }` to `/api/campaigns/[id]/messages` when the user submits the composer, and optimistically append the message to the feed.
+
+#### Scenario: Active member sends group message
+
+- **Given** the dock is expanded, stream is open, and the user types `"Hello everyone"` with visibility `group`
+- **When** the user clicks Send (or presses Enter)
+- **Then** `POST /api/campaigns/[id]/messages` is called with body `{ text: "Hello everyone", visibility: { scope: "group" } }` and an optimistic copy of the message appears in the feed immediately
+
+#### Scenario: Empty composer — Send does nothing
+
+- **Given** the composer textarea is empty
+- **When** the user clicks Send
+- **Then** no POST request is made and the feed is unchanged
+
+#### Scenario: Composer is cleared after successful send
+
+- **Given** the user has typed text and clicked Send
+- **When** the POST request succeeds
+- **Then** the composer textarea is cleared and visibility resets to `group`
+
+#### Scenario: Send button is disabled while a send is in progress
+
+- **Given** a POST request is in flight
+- **When** the composer is rendered
+- **Then** the Send button and textarea are both `disabled`
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CampaignChat dock shell renders globally
+
+The system SHALL render `CampaignChat` on every campaign page (`/campaigns/[id]/…`) rather than on every page of the application. The component is now mounted in `app/campaigns/[id]/layout.tsx` and removed from `app/layout.tsx`.
+
+#### Scenario: Pill present on campaign page initial render
+
+- **Given** a user navigates to a campaign route (e.g., `/campaigns/abc123`)
+- **When** the page renders
+- **Then** a button with accessible name matching `/chat/i` is present in the document
+
+#### Scenario: Pill absent on non-campaign pages
+
+- **Given** a user is on the home page, parties page, or any route outside `/campaigns/[id]/…`
+- **When** the page renders
+- **Then** no `CampaignChat` pill is present in the document
+
+---
+
+## REMOVED Requirements
+
+None. All existing dock shell behaviors (expand/collapse, pin, keyboard, LocalStore pin) are preserved.
+
+---
+
+## Traceability
+
+- Proposal: "Move `CampaignChat` to campaign layout" → Requirement: MODIFIED CampaignChat dock shell renders globally
+- Proposal: "Connect to `useCampaignStream`" → Requirement: ADDED CampaignChat connects to SSE stream
+- Proposal: "Render feed" → Requirement: ADDED Message feed renders sender, timestamp, visibility marker, and text
+- Proposal: "History loads on open + infinite scroll" → Requirement: ADDED History loads on dock open with infinite scroll
+- Proposal: "Unread badge" → Requirement: ADDED Unread badge on collapsed pill
+- Proposal: "Members fetch for @mention" → Requirement: ADDED Members fetched for @mention autocomplete
+- Proposal: "Composer with visibility selector" → Requirement: ADDED Composer with visibility selector
+- Proposal: "@mention autocomplete" → Requirement: ADDED @mention autocomplete for whisper targeting
+- Proposal: "Send via POST" → Requirement: ADDED Send message via POST
+- Design D1 → Requirement: MODIFIED CampaignChat dock shell renders globally
+- Design D2 → Requirement: ADDED Members fetched for @mention autocomplete
+- Design D3 → All state-driven scenarios
+- Design D4 → Requirement: ADDED @mention autocomplete for whisper targeting
+- Design D5 → Requirement: ADDED History loads on dock open with infinite scroll
+- Design D6 → Requirement: ADDED Unread badge on collapsed pill
+- Design D7 → Duplicate stream event / history deduplication scenarios
+- Design D8 → Scenario: Active member sends group message (optimistic)
+- Design D9 → Scenario: Composer is disabled when stream is not open
+- Design D10 → All sub-component scenarios (ChatFeed, ChatComposer, MentionDropdown)
+- Requirements → Tasks: see `tasks.md`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability — no layout regression
+
+#### Scenario: Existing CampaignChat dock shell tests continue to pass
+
+- **Given** the `CampaignChat` shell tests in `tests/unit/components/CampaignChat.test.tsx` are unchanged
+- **When** the full unit test suite runs after this change
+- **Then** all previously passing dock shell tests pass without modification
+
+### Requirement: Reliability — LocalStore failure does not crash
+
+See functional scenario: **Scenario: LocalStore unavailable — unread count degrades gracefully**
+
+### Requirement: Reliability — members fetch failure does not crash
+
+See functional scenario: **Scenario: Members fetch failure does not crash composer**
+
+### Requirement: Security — send requires open stream
+
+See functional scenario: **Scenario: Composer is disabled when stream is not open**
+
+> Note: Authorization enforcement (only active members may send) is handled server-side by the existing `POST /api/campaigns/[id]/messages` route (specified in issue-314 specs). No additional client-side auth enforcement is required beyond the disabled-state guard above.
+
+### Requirement: Performance — history not fetched until dock opens
+
+See functional scenario: **Scenario: History is not fetched on mount (dock collapsed)**

--- a/openspec/changes/issue-315-chat-dock-wire/tasks.md
+++ b/openspec/changes/issue-315-chat-dock-wire/tasks.md
@@ -110,7 +110,7 @@ Before running, determine whether the current change is **docs-only**: run `git 
 
 **Full path** (any non-`.md` file changed):
 
-- **Unit tests** — `npm test` — all tests must pass
+- **Unit tests** — `npm run test:unit` — all tests must pass
 - **Integration tests** — `npm run test:integration` — all tests must pass
 - **Build** — `npm run build` — build must succeed with no errors
 

--- a/openspec/changes/issue-315-chat-dock-wire/tasks.md
+++ b/openspec/changes/issue-315-chat-dock-wire/tasks.md
@@ -1,0 +1,161 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/issue-315-chat-dock-wire` then immediately `git push -u origin feat/issue-315-chat-dock-wire`
+
+## Execution
+
+### T1 — Move CampaignChat to campaign layout
+
+- [x] **T1a** — Create `app/campaigns/[id]/layout.tsx`:
+  - Mark `"use client"` (needed to pass `params.id` as prop to `CampaignChat`).
+  - Accept `{ params, children }: { params: { id: string }; children: React.ReactNode }`.
+  - Render `<CampaignChat campaignId={params.id} />` and `{children}`.
+- [x] **T1b** — Remove `<CampaignChat />` import and render from `app/layout.tsx`.
+- [x] **T1c** — Add `campaignId: string` prop to `CampaignChat` in `lib/components/CampaignChat.tsx`; remove the no-prop signature.
+- [x] **T1d** — Verify: `npm run build` passes; existing `tests/unit/components/CampaignChat.test.tsx` still passes (update test fixtures to pass `campaignId` prop).
+
+### T2 — Connect to SSE stream and accumulate messages
+
+- [x] **T2a** — Import `useCampaignStream` and `CampaignStreamEvent` in `lib/components/CampaignChat.tsx`.
+- [x] **T2b** — Add `messages: CampaignMessage[]` state (useState). Maintain a `seenIds: Set<string>` ref for deduplication.
+- [x] **T2c** — Call `useCampaignStream(campaignId, onEvent)` inside `CampaignChat`. In `onEvent`: if `e.type === "message"` and `!seenIds.has(e.data.id)`, add to `seenIds` and append `e.data` to `messages`.
+- [x] **T2d** — Expose stream `status` from hook return for use in composer disabled logic (T6).
+- [x] **T2e** — Write unit tests: mock `useCampaignStream`; simulate `"message"` event → assert message added to feed; simulate duplicate → assert feed length unchanged; simulate `"heartbeat"` → assert no change.
+
+### T3 — Fetch members on mount
+
+- [x] **T3a** — Add `members: CampaignMember[]` state. On mount (`useEffect` with `[campaignId]` dep), call `GET /api/campaigns/${campaignId}/members`. On success, set members (filter to `status === "active"`). On failure, leave members empty — no crash.
+- [x] **T3b** — Import `CampaignMember` from `@/lib/types`.
+- [x] **T3c** — Write unit tests: mock `fetch`; assert `GET /api/campaigns/[id]/members` called once on mount; assert failure leaves members as `[]`.
+
+### T4 — History load on open + infinite scroll
+
+- [x] **T4a** — Add state: `page: number` (starts at 1), `hasMore: boolean` (starts at true), `isLoadingHistory: boolean`.
+- [x] **T4b** — In a `useEffect` on `isExpanded`: when `isExpanded` becomes `true` and `messages.length === 0`, call `GET /api/campaigns/${campaignId}/messages?page=1&perPage=30`. Parse response, set `messages`, set `hasMore = results.length === 30`, mark `seenIds` for all returned IDs.
+- [x] **T4c** — Attach a `scroll` handler to the feed container ref. When `scrollTop === 0` and `hasMore && !isLoadingHistory`: set `isLoadingHistory = true`, fetch `?page=${page+1}&perPage=30`, save `scrollHeight` before prepend, prepend (deduplicating by seenIds), restore `scrollTop` by `newScrollHeight - prevScrollHeight`, update `page`, set `hasMore = results.length === 30`, set `isLoadingHistory = false`.
+- [x] **T4d** — Write unit tests: mock `fetch`; assert called on expand; assert not called on initial mount (collapsed); assert second page fetched on scroll-to-top; assert `hasMore = false` when result count < 30.
+
+### T5 — Unread badge
+
+- [x] **T5a** — Add `unreadCount: number` state (starts at 0). Add `lastOpenKey` constant: `` `campaign-chat-last-open-${campaignId}` ``.
+- [x] **T5b** — On mount: read `LocalStore.get<string>(lastOpenKey)` (wrap in try/catch). Parse as `Date`. Store as `lastOpenRef`.
+- [x] **T5c** — In the stream `onEvent` handler: if dock is collapsed (`!isExpanded`) and `e.type === "message"` and `new Date(e.data.createdAt) > lastOpenRef`, increment `unreadCount`.
+- [x] **T5d** — On dock expand (`EXPAND` action): write `new Date().toISOString()` to `LocalStore.set(lastOpenKey, ...)` (try/catch), update `lastOpenRef`, reset `unreadCount` to 0.
+- [x] **T5e** — In the collapsed pill render: if `unreadCount > 0`, show a badge element (e.g., `<span aria-label="unread messages">{unreadCount}</span>`) alongside the "Chat ›" label.
+- [x] **T5f** — Write unit tests: mock LocalStore; fire stream event while collapsed → assert badge count; open dock → assert badge gone and LocalStore updated; fire stream event while expanded → assert count stays 0; LocalStore throws → assert no crash.
+
+### T6 — Composer shell + visibility selector
+
+- [x] **T6a** — Add composer state: `composerText: string`, `visibility: MessageVisibility` (default `{ scope: "group" }`), `isSending: boolean`.
+- [x] **T6b** — Render a `ChatComposer` sub-component (non-exported function in same file). Props: `composerText`, `onTextChange`, `visibility`, `onVisibilityChange`, `isSending`, `streamStatus`, `members`, `onSend`, `mentionQuery`, `mentionResults`, `onMentionSelect`.
+- [x] **T6c** — Inside `ChatComposer`: render `<textarea>` and a visibility `<select>` with three options: `group` ("Group"), `dm-only` ("DM-only"), `direct` ("Whisper"). Disable textarea and Send button when `streamStatus !== "open"` or `isSending`. Show a small status line "Reconnecting…" when stream is not open.
+- [x] **T6d** — On visibility `<select>` change to `direct`: do not set `toUserId` yet (that comes from @mention or a separate whisper select). On change away from `direct`: clear any `mentionQuery` and reset visibility to the new scope with no `toUserId`.
+- [x] **T6e** — Write unit tests: assert three visibility options present; selecting DM-only sets `visibility.scope = "dm-only"`; disabled state when `streamStatus = "error"`.
+
+### T7 — @mention autocomplete
+
+- [x] **T7a** — Add state: `mentionQuery: string | null`, `mentionAnchorIndex: number`.
+- [x] **T7b** — In textarea `onChange`: run `/@(\w*)$/.exec(text.slice(0, selectionStart))`. If matched, set `mentionQuery` to the capture group; else set `mentionQuery = null`.
+- [x] **T7c** — Derive `mentionResults: CampaignMember[]` from members filtered by `username.toLowerCase().startsWith(mentionQuery.toLowerCase())` when `mentionQuery !== null`.
+- [x] **T7d** — Render `MentionDropdown` sub-component (non-exported, same file) when `mentionResults.length > 0`. Renders a floating `<ul>` with one `<li>` per matching member. On item click: replace `@{mentionQuery}` in `composerText` with `@{member.username}`, set `mentionQuery = null`, set `visibility = { scope: "direct", toUserId: member.userId }`.
+- [x] **T7e** — On blur of textarea or press of Escape: clear `mentionQuery` (close dropdown without selecting).
+- [x] **T7f** — Second @mention selection replaces `visibility.toUserId` with the new member's ID.
+- [x] **T7g** — If `@mention` text is subsequently deleted from textarea (regex no longer matches): reset `visibility` to `{ scope: "group" }`.
+- [x] **T7h** — Write unit tests: type `@al` → assert dropdown appears with matching member; select → assert visibility and text updated; no match → dropdown hidden; delete @mention → visibility reset; second selection → toUserId replaced.
+
+### T8 — Send message
+
+- [x] **T8a** — Implement `handleSend` in `CampaignChat`: guard on `composerText.trim() !== ""` and `streamStatus === "open"` and `!isSending`. Set `isSending = true`.
+- [x] **T8b** — Optimistically append a `CampaignMessage` to `messages` with `id = \`pending-${Date.now()}\``, `senderId = user.userId`, `senderName = user.username ?? user.email`, `text = composerText`, `visibility`, `createdAt = new Date()`.
+- [x] **T8c** — Call `POST /api/campaigns/${campaignId}/messages` with `{ text: composerText.trim(), visibility }`. On completion (success or error): set `isSending = false`. On success: clear `composerText`, reset `visibility` to `{ scope: "group" }`, clear `mentionQuery`.
+- [x] **T8d** — Wire Send button `onClick` and textarea `onKeyDown` (Enter without Shift) to `handleSend`.
+- [x] **T8e** — Write unit tests: mock `fetch`; assert POST called with correct body; assert composer cleared on success; assert no POST when text is empty; assert button disabled during `isSending`.
+
+### T9 — Message feed render (ChatFeed)
+
+- [x] **T9a** — Render a `ChatFeed` sub-component (non-exported, same file). Props: `messages`, `isLoadingHistory`, `feedRef` (for scroll listener).
+- [x] **T9b** — Each message: render `senderName`, formatted `createdAt` (locale time string), visibility marker, and `text`.
+  - `scope = "group"` → no marker
+  - `scope = "dm-only"` → label `[DM]`
+  - `scope = "direct"` → label `[→ @{resolvedUsername}]` (look up `toUserId` in members to find username; fall back to `toUserId` if not found)
+- [x] **T9c** — Show a loading indicator at the top of the feed when `isLoadingHistory = true`.
+- [x] **T9d** — Write unit tests: assert group message renders no marker; dm-only renders `[DM]`; direct renders `[→ @username]`; loading indicator present when `isLoadingHistory`.
+
+### T10 — Update existing spec and anatomy
+
+- [x] **T10a** — Update `openspec/specs/campaign-chat-dock/spec.md` to note that `CampaignChat` now requires `campaignId` prop and is mounted in `app/campaigns/[id]/layout.tsx`, not `app/layout.tsx`. Add a forward-reference to the new spec.
+- [x] **T10b** — Update `.wolf/anatomy.md` with entry for `app/campaigns/[id]/layout.tsx`.
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm test` — all unit tests pass (including updated CampaignChat shell tests with new `campaignId` prop)
+- [x] `npm run test:integration` — integration tests pass
+- [x] `npx tsc --noEmit` — no TypeScript errors (3 pre-existing errors in unrelated test files)
+- [x] `npm run build` — build succeeds with no errors
+- [x] `npm run lint` — no lint errors (1 pre-existing warning in unrelated file)
+- [ ] Manually open `/campaigns/[id]` in browser: confirm dock pill appears; open dock; confirm "No messages yet" replaced by live feed or history
+- [ ] Manually verify dock pill absent on `/` and `/parties`
+- [ ] All tasks above marked complete
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — `npm test` — all tests must pass
+- **Integration tests** — `npm run test:integration` — all tests must pass
+- **Build** — `npm run build` — build must succeed with no errors
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — `npm run build` — build must succeed with no errors
+- Skip integration and regression/E2E tests
+
+If **ANY** required step fails, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/issue-315-chat-dock-wire` and push to remote
+- [ ] Open PR from `feat/issue-315-chat-dock-wire` to `main`. PR body MUST include `Closes #315`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, push before anything else this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; address each unresolved thread, commit fixes, run validation, push, wait 180 seconds; repeat until all threads resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix failing required checks, commit, validate, push, wait 180 seconds; restart loop from step 1
+
+Ownership metadata:
+
+- Implementer: (assigned at apply time)
+- Reviewer(s): (assigned at apply time)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on the default branch
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update `openspec/specs/campaign-chat-dock/spec.md` with final merged behavior (prop change, layout mount point)
+- [ ] Sync `openspec/changes/issue-315-chat-dock-wire/specs/campaign-chat-wire/spec.md` → `openspec/specs/campaign-chat-wire/spec.md`. After copying, update relative links: replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-issue-315-chat-dock-wire/design.md` and `../../tasks.md` with `../../changes/archive/YYYY-MM-DD-issue-315-chat-dock-wire/tasks.md`.
+- [ ] Archive the change: move `openspec/changes/issue-315-chat-dock-wire/` to `openspec/changes/archive/YYYY-MM-DD-issue-315-chat-dock-wire/` **in a single atomic commit** (stage both new location and deletion of old location together — never split into two commits).
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-issue-315-chat-dock-wire/` exists and `openspec/changes/issue-315-chat-dock-wire/` is gone.
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-issue-315-chat-dock-wire` then `git push -u origin doc/archive-YYYY-MM-DD-issue-315-chat-dock-wire`
+- [ ] Open a PR from `doc/archive-…` to `main` with title `docs: archive issue-315-chat-dock-wire (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until it merges (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/issue-315-chat-dock-wire doc/archive-YYYY-MM-DD-issue-315-chat-dock-wire`

--- a/openspec/changes/issue-315-chat-dock-wire/tasks.md
+++ b/openspec/changes/issue-315-chat-dock-wire/tasks.md
@@ -123,10 +123,10 @@ If **ANY** required step fails, iterate and address the failure before pushing.
 
 ## PR and Merge
 
-- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `feat/issue-315-chat-dock-wire` and push to remote
-- [ ] Open PR from `feat/issue-315-chat-dock-wire` to `main`. PR body MUST include `Closes #315`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/issue-315-chat-dock-wire` and push to remote
+- [x] Open PR from `feat/issue-315-chat-dock-wire` to `main`. PR body MUST include `Closes #315`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
 - [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
 - [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
   1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, push before anything else this iteration

--- a/openspec/changes/issue-315-chat-dock-wire/tests.md
+++ b/openspec/changes/issue-315-chat-dock-wire/tests.md
@@ -1,0 +1,178 @@
+---
+name: tests
+description: Tests for issue-315-chat-dock-wire (wire CampaignChat to stream + send)
+---
+
+# Tests
+
+## Overview
+
+All implementation work follows strict TDD: write a failing test, write the minimum code to pass it, then refactor.
+
+Test file: `tests/unit/components/CampaignChat.test.tsx` (extend existing file).
+
+Mock setup required for all tests:
+- `useCampaignStream` — mock via `jest.mock('@/lib/hooks/useCampaignStream')`; expose a `triggerEvent(e: CampaignStreamEvent)` helper via the mock.
+- `fetch` — `jest.spyOn(global, 'fetch')` returning mocked responses.
+- `LocalStore` — `jest.mock('@/lib/offline/LocalStore')`.
+
+---
+
+## T1 — Campaign layout and prop threading
+
+### Test cases
+
+- [ ] **T1.1** `CampaignChat` accepts `campaignId` prop without TypeScript error (type-level; enforced by `tsc --noEmit`).
+- [ ] **T1.2** Rendering `<CampaignChat campaignId="camp-1" />` does not throw.
+- [ ] **T1.3** `app/campaigns/[id]/layout.tsx` renders `{children}` — assert child content is present in DOM.
+- [ ] **T1.4** `app/layout.tsx` does NOT import or render `CampaignChat` (static analysis / grep in test or separate lint rule).
+
+Spec: MODIFIED Requirement — CampaignChat dock shell renders globally.
+Tasks: T1a–T1d.
+
+---
+
+## T2 — Stream connection and message accumulation
+
+### Test cases
+
+- [ ] **T2.1** On mount, `useCampaignStream` is called with `campaignId` as the first argument.
+- [ ] **T2.2** When stream fires `{ type: "message", data: msg }`, the message's `text` appears in the rendered feed.
+- [ ] **T2.3** When stream fires a `"message"` event with an `id` already in the feed, the feed length does not increase (deduplication).
+- [ ] **T2.4** When stream fires `{ type: "heartbeat" }`, the feed is unchanged (no crash, no new item).
+- [ ] **T2.5** When stream fires `{ type: "change" }`, the feed is unchanged.
+
+Spec: ADDED Requirement — CampaignChat connects to SSE stream.
+Tasks: T2a–T2e.
+
+---
+
+## T3 — Member fetch on mount
+
+### Test cases
+
+- [ ] **T3.1** On mount, `GET /api/campaigns/camp-1/members` is called exactly once.
+- [ ] **T3.2** After successful fetch returning `[{ userId: "u1", username: "alice", role: "player", status: "active" }]`, the member is available for `@mention` autocomplete (assert downstream in T7 tests).
+- [ ] **T3.3** When `GET /api/campaigns/[id]/members` returns a non-OK response (e.g., 403), the component does not throw and `members` remains `[]`.
+
+Spec: ADDED Requirement — Members fetched for @mention autocomplete.
+Tasks: T3a–T3c.
+
+---
+
+## T4 — History load + infinite scroll
+
+### Test cases
+
+- [ ] **T4.1** On initial mount (dock collapsed), `GET /api/campaigns/camp-1/messages` is NOT called.
+- [ ] **T4.2** When dock expands for the first time, `GET /api/campaigns/camp-1/messages?page=1&perPage=30` is called.
+- [ ] **T4.3** Messages returned by history fetch appear in the feed after expansion.
+- [ ] **T4.4** When history returns 30 items, `hasMore` is `true`; when it returns fewer than 30, `hasMore` is `false` and no further scroll-triggered fetch occurs.
+- [ ] **T4.5** Simulating `scrollTop = 0` on the feed container (when `hasMore = true`) triggers `GET /api/campaigns/camp-1/messages?page=2&perPage=30`.
+- [ ] **T4.6** Messages from page 2 are prepended to the feed without duplicating messages whose IDs are already present.
+- [ ] **T4.7** When `isLoadingHistory = true`, a loading indicator is present in the feed.
+
+Spec: ADDED Requirement — History loads on dock open with infinite scroll.
+Tasks: T4a–T4d.
+
+---
+
+## T5 — Unread badge
+
+### Test cases
+
+- [ ] **T5.1** On mount, `LocalStore.get('campaign-chat-last-open-camp-1')` is called.
+- [ ] **T5.2** When dock is collapsed and a stream `"message"` event arrives with `createdAt` after the stored timestamp, the collapsed pill renders a badge element with a count ≥ 1.
+- [ ] **T5.3** When dock is expanded, incoming stream `"message"` events do NOT increment `unreadCount` (badge stays at 0).
+- [ ] **T5.4** When the dock expands, `LocalStore.set('campaign-chat-last-open-camp-1', <ISO string>)` is called and the badge is no longer rendered.
+- [ ] **T5.5** When `LocalStore.get` throws, the component mounts without throwing and renders normally.
+- [ ] **T5.6** When `LocalStore.set` throws on dock open, the component does not throw.
+
+Spec: ADDED Requirement — Unread badge on collapsed pill.
+Tasks: T5a–T5f.
+
+---
+
+## T6 — Composer and visibility selector
+
+### Test cases
+
+- [ ] **T6.1** When dock is expanded, a `<textarea>` is present in the document.
+- [ ] **T6.2** Three visibility options are available: Group, DM-only, and Whisper (or equivalent labels covering `group`, `dm-only`, `direct`).
+- [ ] **T6.3** Default visibility is `group` on initial render.
+- [ ] **T6.4** Selecting DM-only sets `visibility.scope = "dm-only"` (assert via Send call or state inspection).
+- [ ] **T6.5** When stream `status = "error"`, the textarea has `disabled` attribute.
+- [ ] **T6.6** When stream `status = "connecting"`, the Send button has `disabled` attribute.
+- [ ] **T6.7** A status line with text matching `/reconnecting/i` is present when stream is not open.
+
+Spec: ADDED Requirement — Composer with visibility selector.
+Tasks: T6a–T6e.
+
+---
+
+## T7 — @mention autocomplete
+
+### Test cases
+
+- [ ] **T7.1** When user types `@al` into the textarea (with members `[alice, bob]` loaded), a dropdown appears containing `alice` and not `bob`.
+- [ ] **T7.2** When user types `@` with no following characters, all active members appear in the dropdown.
+- [ ] **T7.3** When user types `@xyz` with no matching members, the dropdown is not rendered (or is empty).
+- [ ] **T7.4** Clicking `alice` in the dropdown: textarea value contains `@alice`, `visibility = { scope: "direct", toUserId: "u-alice" }`, and the dropdown is closed.
+- [ ] **T7.5** After selecting `@alice`, typing `@bo` and selecting `bob`: `visibility.toUserId` updates to `"u-bob"` and the textarea reflects `@bob`.
+- [ ] **T7.6** After selecting `@alice`, deleting the `@alice` text from the textarea: `visibility` resets to `{ scope: "group" }`.
+- [ ] **T7.7** Pressing Escape while the dropdown is open: dropdown closes, textarea retains current text.
+- [ ] **T7.8** Blurring the textarea while the dropdown is open: dropdown closes.
+
+Spec: ADDED Requirement — @mention autocomplete for whisper targeting.
+Tasks: T7a–T7h.
+
+---
+
+## T8 — Send message
+
+### Test cases
+
+- [ ] **T8.1** Typing text and clicking Send calls `POST /api/campaigns/camp-1/messages` with `{ text, visibility }`.
+- [ ] **T8.2** The request body matches exactly: `{ text: "Hello", visibility: { scope: "group" } }` for a group message.
+- [ ] **T8.3** An optimistic message with the typed text appears in the feed immediately (before the POST resolves).
+- [ ] **T8.4** After a successful POST, the textarea is cleared and visibility resets to `group`.
+- [ ] **T8.5** Clicking Send with an empty textarea does NOT call `POST /api/campaigns/[id]/messages`.
+- [ ] **T8.6** While a POST is in flight (`isSending = true`), the Send button has `disabled` attribute.
+- [ ] **T8.7** Pressing Enter (without Shift) in the textarea triggers Send.
+- [ ] **T8.8** Pressing Shift+Enter in the textarea does NOT trigger Send (inserts newline).
+
+Spec: ADDED Requirement — Send message via POST.
+Tasks: T8a–T8e.
+
+---
+
+## T9 — Message feed render
+
+### Test cases
+
+- [ ] **T9.1** A message with `visibility.scope = "group"` renders `senderName`, timestamp, and text; no DM or whisper marker is present.
+- [ ] **T9.2** A message with `visibility.scope = "dm-only"` renders a visible DM marker (text matching `/dm/i` or `/dm-only/i`).
+- [ ] **T9.3** A message with `visibility.scope = "direct"` and `toUserId = "u-alice"` (with alice in members) renders a whisper marker containing `alice`.
+- [ ] **T9.4** A message with `visibility.scope = "direct"` and an unknown `toUserId` falls back to displaying the raw `toUserId` in the marker.
+- [ ] **T9.5** `createdAt` is rendered as a human-readable timestamp (not ISO string; e.g., locale time).
+- [ ] **T9.6** When `isLoadingHistory = true`, a loading indicator element is present above the feed items.
+
+Spec: ADDED Requirement — Message feed renders sender, timestamp, visibility marker, and text.
+Tasks: T9a–T9d.
+
+---
+
+## Regression — Existing dock shell tests
+
+- [ ] **R1** All existing scenarios in `tests/unit/components/CampaignChat.test.tsx` continue to pass after prop is added (fixtures updated to pass `campaignId="camp-test"`):
+  - Pill present on initial render
+  - Drawer absent on initial render
+  - Expand by clicking pill
+  - Collapse by clicking close button
+  - Collapse via Escape key
+  - Escape does nothing when already collapsed
+  - Pin button toggles pressed state
+  - Unpinning does not collapse drawer
+  - Dock opens on mount when pin stored
+  - Dock starts collapsed when pin not stored
+  - No localStorage access during server render

--- a/openspec/specs/campaign-chat-dock/spec.md
+++ b/openspec/specs/campaign-chat-dock/spec.md
@@ -1,12 +1,14 @@
 # Campaign Chat Dock — Specification
 
-This document is the canonical specification for the `CampaignChat` dock shell feature (Phase 4c). Implementation: `lib/components/CampaignChat.tsx`, mounted globally in `app/layout.tsx`. Design rationale: `openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md`.
+This document is the canonical specification for the `CampaignChat` dock shell feature (Phase 4c / Phase 5). Implementation: `lib/components/CampaignChat.tsx`, mounted in `app/campaigns/[id]/layout.tsx` (scoped to campaign routes). Design rationale: `openspec/changes/archive/2026-06-09-campaign-chat-dock-shell/design.md`. Live-data wiring: `openspec/specs/campaign-chat-wire/spec.md`.
+
+**Note (Phase 5, issue #315):** `CampaignChat` now requires a `campaignId: string` prop and is mounted in `app/campaigns/[id]/layout.tsx`, not `app/layout.tsx`. The dock shell behavior below is unchanged; live-data requirements are specified in `openspec/specs/campaign-chat-wire/spec.md`.
 
 ---
 
-## Requirement: CampaignChat dock shell renders globally
+## Requirement: CampaignChat dock shell renders on campaign pages
 
-The system SHALL render a `CampaignChat` component on every page of the application via `app/layout.tsx`.
+The system SHALL render a `CampaignChat` component on all campaign routes (`/campaigns/[id]/…`) via `app/campaigns/[id]/layout.tsx`. The component requires a `campaignId: string` prop.
 
 #### Scenario: Pill present on initial render
 

--- a/tests/unit/components/CampaignChat.test.tsx
+++ b/tests/unit/components/CampaignChat.test.tsx
@@ -12,7 +12,6 @@ jest.mock('@/lib/offline/LocalStore', () => ({
   },
 }))
 
-// Capture the onEvent callback so tests can fire synthetic stream events
 let capturedOnEvent: ((e: CampaignStreamEvent) => void) | null = null
 jest.mock('@/lib/hooks/useCampaignStream', () => ({
   useCampaignStream: jest.fn((_, onEvent) => {
@@ -30,9 +29,10 @@ jest.mock('@/lib/hooks/useAuth', () => ({
 
 const mockedLocalStore = LocalStore as jest.Mocked<typeof LocalStore>
 
-// Default fetch mock: empty members and messages
 let fetchSpy: jest.Mock
 const originalFetch = global.fetch
+
+// ── Test helpers ──────────────────────────────────────────────────
 
 function setupFetchMock(overrides?: Record<string, unknown>) {
   fetchSpy = jest.fn().mockImplementation((url: string) => {
@@ -53,6 +53,49 @@ function setupFetchMock(overrides?: Record<string, unknown>) {
   global.fetch = fetchSpy as unknown as typeof global.fetch
 }
 
+/** Render the component and expand the dock. Returns userEvent instance. */
+async function openDock() {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  return user
+}
+
+/** Build and fire a synthetic stream event via act(). */
+function fireMsg(overrides: Partial<{
+  id: string; senderId: string; senderName: string
+  text: string; visibility: { scope: string; toUserId?: string }; createdAt: string
+}> = {}) {
+  const visibility = overrides.visibility ?? { scope: 'group' }
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+        data: {
+        id: overrides.id ?? 'msg-default',
+        campaignId: 'test-campaign',
+        senderId: overrides.senderId ?? 'user-1',
+        senderName: overrides.senderName ?? 'Alice',
+        text: overrides.text ?? 'Hello',
+        visibility: visibility as any,
+        createdAt: overrides.createdAt ?? new Date().toISOString(),
+      },
+    })
+  })
+}
+
+/** Setup members fetch with alice + optional extra members. */
+function withMembers(extra: Array<{ id: string; userId: string; username: string }> = []) {
+  setupFetchMock({
+    members: {
+      members: [
+        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
+        ...extra,
+      ],
+    },
+  })
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
   mockedLocalStore.get.mockReturnValue(null)
@@ -64,7 +107,7 @@ afterEach(() => {
   global.fetch = originalFetch
 })
 
-// ── Existing shell tests (TC-01 to TC-13) ──────────────────────────
+// ── Shell tests (TC-01 to TC-13) ──────────────────────────────────
 
 // TC-01
 it('pill button is present on initial render', () => {
@@ -87,26 +130,20 @@ it('drawer is present on mount when pin is stored', async () => {
 
 // TC-04
 it('clicking pill expands the drawer', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   expect(screen.getByRole('complementary')).toBeInTheDocument()
 })
 
 // TC-05
 it('clicking close button collapses the drawer', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const user = await openDock()
   await user.click(screen.getByRole('button', { name: /collapse/i }))
   expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
 })
 
 // TC-06
 it('pressing Escape collapses the drawer', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   fireEvent.keyDown(document, { key: 'Escape' })
   expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
 })
@@ -121,17 +158,13 @@ it('pressing Escape when collapsed has no effect', () => {
 
 // TC-08
 it('pin button has aria-pressed="false" when not pinned', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute('aria-pressed', 'false')
 })
 
 // TC-09
 it('clicking pin sets aria-pressed="true" and calls LocalStore.set', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const user = await openDock()
   const pinButton = screen.getByRole('button', { name: /pin/i })
   await user.click(pinButton)
   expect(pinButton).toHaveAttribute('aria-pressed', 'true')
@@ -140,9 +173,7 @@ it('clicking pin sets aria-pressed="true" and calls LocalStore.set', async () =>
 
 // TC-10
 it('clicking pin again sets aria-pressed="false" and calls LocalStore.remove', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const user = await openDock()
   const pinButton = screen.getByRole('button', { name: /pin/i })
   await user.click(pinButton)
   await user.click(pinButton)
@@ -152,9 +183,7 @@ it('clicking pin again sets aria-pressed="false" and calls LocalStore.remove', a
 
 // TC-11
 it('unpinning while expanded does not collapse the drawer', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const user = await openDock()
   const pinButton = screen.getByRole('button', { name: /pin/i })
   await user.click(pinButton)
   await user.click(pinButton)
@@ -163,9 +192,7 @@ it('unpinning while expanded does not collapse the drawer', async () => {
 
 // TC-12
 it('drawer has role="complementary" and aria-label="Campaign Chat"', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   expect(screen.getByRole('complementary', { name: 'Campaign Chat' })).toBeInTheDocument()
 })
 
@@ -183,67 +210,36 @@ it('pill button is keyboard-activatable with Enter', async () => {
 
 // T2e-1: stream message event appends to feed
 it('stream message event adds message to feed when dock is open', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  await openDock()
   act(() => {
     capturedOnEvent?.({
       type: 'message',
       campaignId: 'test-campaign',
       data: {
-        id: 'msg-1',
-        campaignId: 'test-campaign',
-        senderId: 'user-1',
-        senderName: 'Alice',
-        text: 'Hello world',
-        visibility: { scope: 'group' },
-        createdAt: new Date().toISOString(),
+        id: 'msg-1', campaignId: 'test-campaign', senderId: 'user-1',
+        senderName: 'Alice', text: 'Hello world',
+        visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
       },
     })
   })
-
   expect(screen.getByText('Hello world')).toBeInTheDocument()
   expect(screen.getByText('Alice')).toBeInTheDocument()
 })
 
 // T2e-2: duplicate stream event does not duplicate message
 it('duplicate stream event is ignored', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  const event = {
-    type: 'message',
-    campaignId: 'test-campaign',
-    data: {
-      id: 'msg-dup',
-      campaignId: 'test-campaign',
-      senderId: 'user-1',
-      senderName: 'Bob',
-      text: 'Duplicate',
-      visibility: { scope: 'group' },
-      createdAt: new Date().toISOString(),
-    },
-  }
-
-  act(() => { capturedOnEvent?.(event) })
-  act(() => { capturedOnEvent?.(event) })
-
+  await openDock()
+  act(() => { capturedOnEvent?.({ type: 'message', campaignId: 'test-campaign', data: { id: 'msg-dup', campaignId: 'test-campaign', senderId: 'user-1', senderName: 'Bob', text: 'Duplicate', visibility: { scope: 'group' }, createdAt: new Date().toISOString() } }) })
+  act(() => { capturedOnEvent?.({ type: 'message', campaignId: 'test-campaign', data: { id: 'msg-dup', campaignId: 'test-campaign', senderId: 'user-1', senderName: 'Bob', text: 'Duplicate', visibility: { scope: 'group' }, createdAt: new Date().toISOString() } }) })
   expect(screen.getAllByText('Duplicate')).toHaveLength(1)
 })
 
 // T2e-3: heartbeat event does not change feed
 it('heartbeat event does not affect message feed', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  await openDock()
   act(() => {
     capturedOnEvent?.({ type: 'heartbeat', campaignId: 'test-campaign', data: { ts: Date.now() } })
   })
-
-  expect(screen.queryByText('Hello world')).not.toBeInTheDocument()
   expect(screen.getByText('No messages yet.')).toBeInTheDocument()
 })
 
@@ -253,9 +249,7 @@ it('heartbeat event does not affect message feed', async () => {
 it('fetches members on mount', async () => {
   render(<CampaignChat campaignId="test-campaign" />)
   await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/api/campaigns/test-campaign/members'),
-    )
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/api/campaigns/test-campaign/members'))
   })
 })
 
@@ -265,13 +259,8 @@ it('members fetch failure does not crash the component', async () => {
     if (url.includes('/members')) return Promise.reject(new Error('network error'))
     return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
   })
-
   expect(() => render(<CampaignChat campaignId="test-campaign" />)).not.toThrow()
-  await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/members'),
-    )
-  })
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
 })
 
 // ── T4 — History tests ───────────────────────────────────────────────
@@ -279,45 +268,28 @@ it('members fetch failure does not crash the component', async () => {
 // T4d-1: history NOT fetched on mount (dock collapsed)
 it('history is not fetched on mount when dock is collapsed', async () => {
   render(<CampaignChat campaignId="test-campaign" />)
-  await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members'))
-  })
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
   expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('/messages'))
 })
 
 // T4d-2: history fetched when dock opens
 it('history is fetched when dock is expanded', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/messages?page=1&perPage=30'),
-    )
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/messages?page=1&perPage=30'))
   })
 })
 
 // T4d-3: hasMore = false when result count < 30
 it('hasMore is false when history returns fewer than 30 messages', async () => {
   const messages = Array.from({ length: 5 }, (_, i) => ({
-    id: `msg-${i}`,
-    campaignId: 'test-campaign',
-    senderId: 'user-1',
-    senderName: 'Alice',
-    text: `Message ${i}`,
-    visibility: { scope: 'group' },
-    createdAt: new Date().toISOString(),
+    id: `msg-${i}`, campaignId: 'test-campaign', senderId: 'user-1',
+    senderName: 'Alice', text: `Message ${i}`,
+    visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
   }))
   setupFetchMock({ messages: { messages } })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  await waitFor(() => {
-    expect(screen.getByText('Message 0')).toBeInTheDocument()
-  })
-  // If hasMore=false the component won't fetch page 2 on scroll — tested indirectly
+  await openDock()
+  await waitFor(() => expect(screen.getByText('Message 0')).toBeInTheDocument())
 })
 
 // ── T5 — Unread badge tests ──────────────────────────────────────────
@@ -325,90 +297,33 @@ it('hasMore is false when history returns fewer than 30 messages', async () => {
 // T5f-1: stream message while collapsed increments badge
 it('stream message while dock is collapsed shows unread badge', async () => {
   const pastDate = new Date(Date.now() - 5000).toISOString()
-  mockedLocalStore.get.mockImplementation((key: string) => {
-    if (key === 'campaign-chat-last-open-test-campaign') return pastDate
-    return null
-  })
-
+  mockedLocalStore.get.mockImplementation((key: string) =>
+    key === 'campaign-chat-last-open-test-campaign' ? pastDate : null
+  )
   render(<CampaignChat campaignId="test-campaign" />)
-
-  act(() => {
-    capturedOnEvent?.({
-      type: 'message',
-      campaignId: 'test-campaign',
-      data: {
-        id: 'new-msg',
-        campaignId: 'test-campaign',
-        senderId: 'user-2',
-        senderName: 'Bob',
-        text: 'Hi',
-        visibility: { scope: 'group' },
-        createdAt: new Date().toISOString(),
-      },
-    })
-  })
-
+  fireMsg({ id: 'new-msg', senderName: 'Bob', text: 'Hi' })
   expect(screen.getByLabelText('unread messages')).toBeInTheDocument()
 })
 
 // T5f-2: opening dock clears badge and updates LocalStore
 it('opening dock clears unread badge and updates LocalStore', async () => {
   const pastDate = new Date(Date.now() - 5000).toISOString()
-  mockedLocalStore.get.mockImplementation((key: string) => {
-    if (key === 'campaign-chat-last-open-test-campaign') return pastDate
-    return null
-  })
+  mockedLocalStore.get.mockImplementation((key: string) =>
+    key === 'campaign-chat-last-open-test-campaign' ? pastDate : null
+  )
+  render(<CampaignChat campaignId="test-campaign" />)
+  fireMsg({ id: 'unread-1', senderName: 'Bob', text: 'Badge test' })
 
   const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-
-  act(() => {
-    capturedOnEvent?.({
-      type: 'message',
-      campaignId: 'test-campaign',
-      data: {
-        id: 'unread-1',
-        campaignId: 'test-campaign',
-        senderId: 'user-2',
-        senderName: 'Bob',
-        text: 'Badge test',
-        visibility: { scope: 'group' },
-        createdAt: new Date().toISOString(),
-      },
-    })
-  })
-
   await user.click(screen.getByRole('button', { name: /chat/i }))
   expect(screen.queryByLabelText('unread messages')).not.toBeInTheDocument()
-  expect(mockedLocalStore.set).toHaveBeenCalledWith(
-    'campaign-chat-last-open-test-campaign',
-    expect.any(String),
-  )
+  expect(mockedLocalStore.set).toHaveBeenCalledWith('campaign-chat-last-open-test-campaign', expect.any(String))
 })
 
 // T5f-3: stream message while dock is open does not increment badge
 it('stream message while dock is open does not increment unread count', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  act(() => {
-    capturedOnEvent?.({
-      type: 'message',
-      campaignId: 'test-campaign',
-      data: {
-        id: 'open-msg',
-        campaignId: 'test-campaign',
-        senderId: 'user-2',
-        senderName: 'Carol',
-        text: 'Visible',
-        visibility: { scope: 'group' },
-        createdAt: new Date().toISOString(),
-      },
-    })
-  })
-
-  // no badge should appear when the dock is open
+  await openDock()
+  fireMsg({ id: 'open-msg', senderName: 'Carol', text: 'Visible' })
   expect(screen.queryByLabelText('unread messages')).not.toBeInTheDocument()
 })
 
@@ -422,9 +337,7 @@ it('LocalStore.get throwing does not crash the component', () => {
 
 // T6e-1: three visibility options present when dock is open
 it('composer shows three visibility options when dock is expanded', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   expect(screen.getByRole('option', { name: 'Group' })).toBeInTheDocument()
   expect(screen.getByRole('option', { name: 'DM-only' })).toBeInTheDocument()
   expect(screen.getByRole('option', { name: 'Whisper' })).toBeInTheDocument()
@@ -432,9 +345,7 @@ it('composer shows three visibility options when dock is expanded', async () => 
 
 // T6e-2: selecting DM-only changes visibility
 it('selecting DM-only visibility updates the select value', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const user = await openDock()
   const select = screen.getByRole('combobox')
   await user.selectOptions(select, 'dm-only')
   expect((select as HTMLSelectElement).value).toBe('dm-only')
@@ -447,17 +358,9 @@ it('composer is disabled when stream status is not open', async () => {
     capturedOnEvent = onEvent
     return { status: 'error' }
   })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  const textarea = screen.getByRole('textbox')
-  const sendBtn = screen.getByRole('button', { name: /send/i })
-  expect(textarea).toBeDisabled()
-  expect(sendBtn).toBeDisabled()
-
-  // Restore to default implementation
+  await openDock()
+  expect(screen.getByRole('textbox')).toBeDisabled()
+  expect(screen.getByRole('button', { name: /send/i })).toBeDisabled()
   ;(useCampaignStream as jest.Mock).mockImplementation((_, onEvent) => {
     capturedOnEvent = onEvent
     return { status: 'open' }
@@ -468,107 +371,47 @@ it('composer is disabled when stream status is not open', async () => {
 
 // T7h-1: typing @al shows dropdown with matching member
 it('typing @prefix shows matching member in dropdown', async () => {
-  setupFetchMock({
-    members: {
-      members: [
-        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
-        { id: 'm2', userId: 'u2', username: 'bob', role: 'player', status: 'active' },
-      ],
-    },
-  })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  // Wait for members to load
+  withMembers([{ id: 'm2', userId: 'u2', username: 'bob' }])
+  const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-
-  const textarea = screen.getByRole('textbox')
-  await user.type(textarea, '@al')
-
-  await waitFor(() => {
-    expect(screen.getByText('@alice')).toBeInTheDocument()
-  })
+  await user.type(screen.getByRole('textbox'), '@al')
+  await waitFor(() => expect(screen.getByText('@alice')).toBeInTheDocument())
   expect(screen.queryByText('@bob')).not.toBeInTheDocument()
 })
 
 // T7h-2: no match hides dropdown
 it('no matching members hides the mention dropdown', async () => {
-  setupFetchMock({
-    members: {
-      members: [
-        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
-      ],
-    },
-  })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  withMembers()
+  const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-
-  const textarea = screen.getByRole('textbox')
-  await user.type(textarea, '@xyz')
-
-  await waitFor(() => {
-    expect(screen.queryByText('@alice')).not.toBeInTheDocument()
-  })
+  await user.type(screen.getByRole('textbox'), '@xyz')
+  await waitFor(() => expect(screen.queryByText('@alice')).not.toBeInTheDocument())
 })
 
 // T7h-3: selecting a member updates text and sets direct visibility
 it('selecting mention sets visibility to direct and updates textarea', async () => {
-  setupFetchMock({
-    members: {
-      members: [
-        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
-      ],
-    },
-  })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  withMembers()
+  const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-
-  const textarea = screen.getByRole('textbox')
-  await user.type(textarea, '@al')
-
+  await user.type(screen.getByRole('textbox'), '@al')
   await waitFor(() => screen.getByText('@alice'))
   fireEvent.mouseDown(screen.getByText('@alice'))
-
   await waitFor(() => {
-    expect((textarea as HTMLTextAreaElement).value).toContain('@alice')
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toContain('@alice')
     expect(screen.getByRole('combobox')).toHaveValue('direct')
   })
 })
 
 // T7h-4: deleting @mention text resets visibility to group
 it('deleting @mention text resets visibility to group', async () => {
-  setupFetchMock({
-    members: {
-      members: [
-        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
-      ],
-    },
-  })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  withMembers()
+  const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-
-  const textarea = screen.getByRole('textbox')
-  await user.type(textarea, '@al')
+  await user.type(screen.getByRole('textbox'), '@al')
   await waitFor(() => screen.getByText('@alice'))
   fireEvent.mouseDown(screen.getByText('@alice'))
-
   await waitFor(() => expect(screen.getByRole('combobox')).toHaveValue('direct'))
-
-  // Clear text to trigger visibility reset
-  fireEvent.change(textarea, { target: { value: '', selectionStart: 0 } })
-
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: '', selectionStart: 0 } })
   expect(screen.getByRole('combobox')).toHaveValue('group')
 })
 
@@ -576,14 +419,9 @@ it('deleting @mention text resets visibility to group', async () => {
 
 // T8e-1: POST called with correct body on send
 it('send button calls POST with text and visibility', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  const textarea = screen.getByRole('textbox')
-  await user.type(textarea, 'Hello everyone')
+  const user = await openDock()
+  await user.type(screen.getByRole('textbox'), 'Hello everyone')
   await user.click(screen.getByRole('button', { name: /send/i }))
-
   await waitFor(() => {
     expect(fetchSpy).toHaveBeenCalledWith(
       '/api/campaigns/test-campaign/messages',
@@ -597,27 +435,17 @@ it('send button calls POST with text and visibility', async () => {
 
 // T8e-2: composer cleared on successful send
 it('composer text is cleared after successful send', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  const user = await openDock()
   const textarea = screen.getByRole('textbox')
   await user.type(textarea, 'Clear me')
   await user.click(screen.getByRole('button', { name: /send/i }))
-
-  await waitFor(() => {
-    expect((textarea as HTMLTextAreaElement).value).toBe('')
-  })
+  await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe(''))
 })
 
 // T8e-3: empty composer does not POST
 it('send does nothing when composer text is empty', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  const user = await openDock()
   await user.click(screen.getByRole('button', { name: /send/i }))
-
   expect(fetchSpy).not.toHaveBeenCalledWith(
     expect.stringContaining('/messages'),
     expect.objectContaining({ method: 'POST' }),
@@ -628,109 +456,67 @@ it('send does nothing when composer text is empty', async () => {
 
 // T9d-1: group message renders no visibility marker
 it('group message renders without visibility marker', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  await openDock()
   act(() => {
     capturedOnEvent?.({
       type: 'message',
       campaignId: 'test-campaign',
       data: {
-        id: 'group-msg',
-        campaignId: 'test-campaign',
-        senderId: 'u1',
-        senderName: 'Alice',
-        text: 'Group message',
-        visibility: { scope: 'group' },
-        createdAt: new Date().toISOString(),
+        id: 'group-msg', campaignId: 'test-campaign', senderId: 'u1',
+        senderName: 'Alice', text: 'Group message',
+        visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
       },
     })
   })
-
   expect(screen.getByText('Group message')).toBeInTheDocument()
   expect(screen.queryByText('[DM]')).not.toBeInTheDocument()
 })
 
 // T9d-2: dm-only message renders [DM]
 it('dm-only message renders [DM] marker', async () => {
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
+  await openDock()
   act(() => {
     capturedOnEvent?.({
       type: 'message',
       campaignId: 'test-campaign',
       data: {
-        id: 'dm-msg',
-        campaignId: 'test-campaign',
-        senderId: 'u1',
-        senderName: 'Alice',
-        text: 'DM message',
-        visibility: { scope: 'dm-only' },
-        createdAt: new Date().toISOString(),
+        id: 'dm-msg', campaignId: 'test-campaign', senderId: 'u1',
+        senderName: 'Alice', text: 'DM message',
+        visibility: { scope: 'dm-only' }, createdAt: new Date().toISOString(),
       },
     })
   })
-
   expect(screen.getByText('[DM]')).toBeInTheDocument()
 })
 
 // T9d-3: direct (whisper) message renders [→ @username]
 it('direct message renders whisper marker with recipient username', async () => {
   setupFetchMock({
-    members: {
-      members: [
-        { id: 'm1', userId: 'u2', username: 'bob', role: 'player', status: 'active' },
-      ],
-    },
+    members: { members: [{ id: 'm1', userId: 'u2', username: 'bob', role: 'player', status: 'active' }] },
   })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-
   act(() => {
     capturedOnEvent?.({
       type: 'message',
       campaignId: 'test-campaign',
       data: {
-        id: 'whisper-msg',
-        campaignId: 'test-campaign',
-        senderId: 'u1',
-        senderName: 'Alice',
-        text: 'Whisper message',
-        visibility: { scope: 'direct', toUserId: 'u2' },
-        createdAt: new Date().toISOString(),
+        id: 'whisper-msg', campaignId: 'test-campaign', senderId: 'u1',
+        senderName: 'Alice', text: 'Whisper message',
+        visibility: { scope: 'direct', toUserId: 'u2' }, createdAt: new Date().toISOString(),
       },
     })
   })
-
-  await waitFor(() => {
-    expect(screen.getByText('[→ @bob]')).toBeInTheDocument()
-  })
+  await waitFor(() => expect(screen.getByText('[→ @bob]')).toBeInTheDocument())
 })
 
 // T9d-4: loading indicator shown when isLoadingHistory
 it('loading indicator is shown when history is loading', async () => {
-  // Make messages fetch hang so loading state is visible
   fetchSpy.mockImplementation((url: string) => {
-    if (url.includes('/members')) {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
-    }
-    if (url.includes('/messages')) {
-      return new Promise(() => {}) // never resolves
-    }
+    if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+    if (url.includes('/messages')) return new Promise(() => {})
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
   })
-
-  const user = userEvent.setup()
-  render(<CampaignChat campaignId="test-campaign" />)
-  await user.click(screen.getByRole('button', { name: /chat/i }))
-
-  await waitFor(() => {
-    expect(screen.getByText('Loading…')).toBeInTheDocument()
-  })
+  await openDock()
+  await waitFor(() => expect(screen.getByText('Loading…')).toBeInTheDocument())
 })

--- a/tests/unit/components/CampaignChat.test.tsx
+++ b/tests/unit/components/CampaignChat.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CampaignChat } from '@/lib/components/CampaignChat'
 import { LocalStore } from '@/lib/offline/LocalStore'
+import type { CampaignStreamEvent } from '@/lib/types'
 
 jest.mock('@/lib/offline/LocalStore', () => ({
   LocalStore: {
@@ -11,36 +12,83 @@ jest.mock('@/lib/offline/LocalStore', () => ({
   },
 }))
 
+// Capture the onEvent callback so tests can fire synthetic stream events
+let capturedOnEvent: ((e: CampaignStreamEvent) => void) | null = null
+jest.mock('@/lib/hooks/useCampaignStream', () => ({
+  useCampaignStream: jest.fn((_, onEvent) => {
+    capturedOnEvent = onEvent
+    return { status: 'open' }
+  }),
+}))
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: jest.fn(() => ({
+    user: { userId: 'user-1', email: 'test@example.com', username: 'tester' },
+    loading: false,
+  })),
+}))
+
 const mockedLocalStore = LocalStore as jest.Mocked<typeof LocalStore>
+
+// Default fetch mock: empty members and messages
+let fetchSpy: jest.Mock
+const originalFetch = global.fetch
+
+function setupFetchMock(overrides?: Record<string, unknown>) {
+  fetchSpy = jest.fn().mockImplementation((url: string) => {
+    if (url.includes('/members')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(overrides?.members ?? { members: [] }),
+      })
+    }
+    if (url.includes('/messages')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(overrides?.messages ?? { messages: [] }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+  global.fetch = fetchSpy as unknown as typeof global.fetch
+}
 
 beforeEach(() => {
   jest.clearAllMocks()
   mockedLocalStore.get.mockReturnValue(null)
+  capturedOnEvent = null
+  setupFetchMock()
 })
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+// ── Existing shell tests (TC-01 to TC-13) ──────────────────────────
 
 // TC-01
 it('pill button is present on initial render', () => {
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()
 })
 
 // TC-02
 it('drawer is absent on initial render when no pin stored', () => {
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
 })
 
 // TC-03
 it('drawer is present on mount when pin is stored', async () => {
   mockedLocalStore.get.mockReturnValue(true)
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   expect(screen.getByRole('complementary', { name: /campaign chat/i })).toBeInTheDocument()
 })
 
 // TC-04
 it('clicking pill expands the drawer', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   expect(screen.getByRole('complementary')).toBeInTheDocument()
 })
@@ -48,7 +96,7 @@ it('clicking pill expands the drawer', async () => {
 // TC-05
 it('clicking close button collapses the drawer', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   await user.click(screen.getByRole('button', { name: /collapse/i }))
   expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
@@ -57,7 +105,7 @@ it('clicking close button collapses the drawer', async () => {
 // TC-06
 it('pressing Escape collapses the drawer', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   fireEvent.keyDown(document, { key: 'Escape' })
   expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
@@ -65,7 +113,7 @@ it('pressing Escape collapses the drawer', async () => {
 
 // TC-07
 it('pressing Escape when collapsed has no effect', () => {
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   fireEvent.keyDown(document, { key: 'Escape' })
   expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
   expect(screen.getByRole('button', { name: /chat/i })).toBeInTheDocument()
@@ -74,7 +122,7 @@ it('pressing Escape when collapsed has no effect', () => {
 // TC-08
 it('pin button has aria-pressed="false" when not pinned', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute('aria-pressed', 'false')
 })
@@ -82,7 +130,7 @@ it('pin button has aria-pressed="false" when not pinned', async () => {
 // TC-09
 it('clicking pin sets aria-pressed="true" and calls LocalStore.set', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   const pinButton = screen.getByRole('button', { name: /pin/i })
   await user.click(pinButton)
@@ -93,7 +141,7 @@ it('clicking pin sets aria-pressed="true" and calls LocalStore.set', async () =>
 // TC-10
 it('clicking pin again sets aria-pressed="false" and calls LocalStore.remove', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   const pinButton = screen.getByRole('button', { name: /pin/i })
   await user.click(pinButton)
@@ -105,7 +153,7 @@ it('clicking pin again sets aria-pressed="false" and calls LocalStore.remove', a
 // TC-11
 it('unpinning while expanded does not collapse the drawer', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   const pinButton = screen.getByRole('button', { name: /pin/i })
   await user.click(pinButton)
@@ -116,7 +164,7 @@ it('unpinning while expanded does not collapse the drawer', async () => {
 // TC-12
 it('drawer has role="complementary" and aria-label="Campaign Chat"', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   await user.click(screen.getByRole('button', { name: /chat/i }))
   expect(screen.getByRole('complementary', { name: 'Campaign Chat' })).toBeInTheDocument()
 })
@@ -124,9 +172,565 @@ it('drawer has role="complementary" and aria-label="Campaign Chat"', async () =>
 // TC-13
 it('pill button is keyboard-activatable with Enter', async () => {
   const user = userEvent.setup()
-  render(<CampaignChat />)
+  render(<CampaignChat campaignId="test-campaign" />)
   const pill = screen.getByRole('button', { name: /chat/i })
   pill.focus()
   await user.keyboard('{Enter}')
   expect(screen.getByRole('complementary')).toBeInTheDocument()
+})
+
+// ── T2 — Stream tests ────────────────────────────────────────────────
+
+// T2e-1: stream message event appends to feed
+it('stream message event adds message to feed when dock is open', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'msg-1',
+        campaignId: 'test-campaign',
+        senderId: 'user-1',
+        senderName: 'Alice',
+        text: 'Hello world',
+        visibility: { scope: 'group' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  expect(screen.getByText('Hello world')).toBeInTheDocument()
+  expect(screen.getByText('Alice')).toBeInTheDocument()
+})
+
+// T2e-2: duplicate stream event does not duplicate message
+it('duplicate stream event is ignored', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  const event = {
+    type: 'message',
+    campaignId: 'test-campaign',
+    data: {
+      id: 'msg-dup',
+      campaignId: 'test-campaign',
+      senderId: 'user-1',
+      senderName: 'Bob',
+      text: 'Duplicate',
+      visibility: { scope: 'group' },
+      createdAt: new Date().toISOString(),
+    },
+  }
+
+  act(() => { capturedOnEvent?.(event) })
+  act(() => { capturedOnEvent?.(event) })
+
+  expect(screen.getAllByText('Duplicate')).toHaveLength(1)
+})
+
+// T2e-3: heartbeat event does not change feed
+it('heartbeat event does not affect message feed', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  act(() => {
+    capturedOnEvent?.({ type: 'heartbeat', campaignId: 'test-campaign', data: { ts: Date.now() } })
+  })
+
+  expect(screen.queryByText('Hello world')).not.toBeInTheDocument()
+  expect(screen.getByText('No messages yet.')).toBeInTheDocument()
+})
+
+// ── T3 — Members tests ───────────────────────────────────────────────
+
+// T3c-1: members fetched on mount
+it('fetches members on mount', async () => {
+  render(<CampaignChat campaignId="test-campaign" />)
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/campaigns/test-campaign/members'),
+    )
+  })
+})
+
+// T3c-2: fetch failure leaves members empty (no crash)
+it('members fetch failure does not crash the component', async () => {
+  fetchSpy.mockImplementation((url: string) => {
+    if (url.includes('/members')) return Promise.reject(new Error('network error'))
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+  })
+
+  expect(() => render(<CampaignChat campaignId="test-campaign" />)).not.toThrow()
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/members'),
+    )
+  })
+})
+
+// ── T4 — History tests ───────────────────────────────────────────────
+
+// T4d-1: history NOT fetched on mount (dock collapsed)
+it('history is not fetched on mount when dock is collapsed', async () => {
+  render(<CampaignChat campaignId="test-campaign" />)
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members'))
+  })
+  expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('/messages'))
+})
+
+// T4d-2: history fetched when dock opens
+it('history is fetched when dock is expanded', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/messages?page=1&perPage=30'),
+    )
+  })
+})
+
+// T4d-3: hasMore = false when result count < 30
+it('hasMore is false when history returns fewer than 30 messages', async () => {
+  const messages = Array.from({ length: 5 }, (_, i) => ({
+    id: `msg-${i}`,
+    campaignId: 'test-campaign',
+    senderId: 'user-1',
+    senderName: 'Alice',
+    text: `Message ${i}`,
+    visibility: { scope: 'group' },
+    createdAt: new Date().toISOString(),
+  }))
+  setupFetchMock({ messages: { messages } })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  await waitFor(() => {
+    expect(screen.getByText('Message 0')).toBeInTheDocument()
+  })
+  // If hasMore=false the component won't fetch page 2 on scroll — tested indirectly
+})
+
+// ── T5 — Unread badge tests ──────────────────────────────────────────
+
+// T5f-1: stream message while collapsed increments badge
+it('stream message while dock is collapsed shows unread badge', async () => {
+  const pastDate = new Date(Date.now() - 5000).toISOString()
+  mockedLocalStore.get.mockImplementation((key: string) => {
+    if (key === 'campaign-chat-last-open-test-campaign') return pastDate
+    return null
+  })
+
+  render(<CampaignChat campaignId="test-campaign" />)
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'new-msg',
+        campaignId: 'test-campaign',
+        senderId: 'user-2',
+        senderName: 'Bob',
+        text: 'Hi',
+        visibility: { scope: 'group' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  expect(screen.getByLabelText('unread messages')).toBeInTheDocument()
+})
+
+// T5f-2: opening dock clears badge and updates LocalStore
+it('opening dock clears unread badge and updates LocalStore', async () => {
+  const pastDate = new Date(Date.now() - 5000).toISOString()
+  mockedLocalStore.get.mockImplementation((key: string) => {
+    if (key === 'campaign-chat-last-open-test-campaign') return pastDate
+    return null
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'unread-1',
+        campaignId: 'test-campaign',
+        senderId: 'user-2',
+        senderName: 'Bob',
+        text: 'Badge test',
+        visibility: { scope: 'group' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  expect(screen.queryByLabelText('unread messages')).not.toBeInTheDocument()
+  expect(mockedLocalStore.set).toHaveBeenCalledWith(
+    'campaign-chat-last-open-test-campaign',
+    expect.any(String),
+  )
+})
+
+// T5f-3: stream message while dock is open does not increment badge
+it('stream message while dock is open does not increment unread count', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'open-msg',
+        campaignId: 'test-campaign',
+        senderId: 'user-2',
+        senderName: 'Carol',
+        text: 'Visible',
+        visibility: { scope: 'group' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  // no badge should appear when the dock is open
+  expect(screen.queryByLabelText('unread messages')).not.toBeInTheDocument()
+})
+
+// T5f-4: LocalStore throws — no crash
+it('LocalStore.get throwing does not crash the component', () => {
+  mockedLocalStore.get.mockImplementation(() => { throw new Error('storage unavailable') })
+  expect(() => render(<CampaignChat campaignId="test-campaign" />)).not.toThrow()
+})
+
+// ── T6 — Composer tests ──────────────────────────────────────────────
+
+// T6e-1: three visibility options present when dock is open
+it('composer shows three visibility options when dock is expanded', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  expect(screen.getByRole('option', { name: 'Group' })).toBeInTheDocument()
+  expect(screen.getByRole('option', { name: 'DM-only' })).toBeInTheDocument()
+  expect(screen.getByRole('option', { name: 'Whisper' })).toBeInTheDocument()
+})
+
+// T6e-2: selecting DM-only changes visibility
+it('selecting DM-only visibility updates the select value', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  const select = screen.getByRole('combobox')
+  await user.selectOptions(select, 'dm-only')
+  expect((select as HTMLSelectElement).value).toBe('dm-only')
+})
+
+// T6e-3: textarea and send disabled when streamStatus is error
+it('composer is disabled when stream status is not open', async () => {
+  const { useCampaignStream } = await import('@/lib/hooks/useCampaignStream')
+  ;(useCampaignStream as jest.Mock).mockImplementation((_, onEvent) => {
+    capturedOnEvent = onEvent
+    return { status: 'error' }
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  const textarea = screen.getByRole('textbox')
+  const sendBtn = screen.getByRole('button', { name: /send/i })
+  expect(textarea).toBeDisabled()
+  expect(sendBtn).toBeDisabled()
+
+  // Restore to default implementation
+  ;(useCampaignStream as jest.Mock).mockImplementation((_, onEvent) => {
+    capturedOnEvent = onEvent
+    return { status: 'open' }
+  })
+})
+
+// ── T7 — @mention tests ──────────────────────────────────────────────
+
+// T7h-1: typing @al shows dropdown with matching member
+it('typing @prefix shows matching member in dropdown', async () => {
+  setupFetchMock({
+    members: {
+      members: [
+        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
+        { id: 'm2', userId: 'u2', username: 'bob', role: 'player', status: 'active' },
+      ],
+    },
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  // Wait for members to load
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
+
+  const textarea = screen.getByRole('textbox')
+  await user.type(textarea, '@al')
+
+  await waitFor(() => {
+    expect(screen.getByText('@alice')).toBeInTheDocument()
+  })
+  expect(screen.queryByText('@bob')).not.toBeInTheDocument()
+})
+
+// T7h-2: no match hides dropdown
+it('no matching members hides the mention dropdown', async () => {
+  setupFetchMock({
+    members: {
+      members: [
+        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
+      ],
+    },
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
+
+  const textarea = screen.getByRole('textbox')
+  await user.type(textarea, '@xyz')
+
+  await waitFor(() => {
+    expect(screen.queryByText('@alice')).not.toBeInTheDocument()
+  })
+})
+
+// T7h-3: selecting a member updates text and sets direct visibility
+it('selecting mention sets visibility to direct and updates textarea', async () => {
+  setupFetchMock({
+    members: {
+      members: [
+        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
+      ],
+    },
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
+
+  const textarea = screen.getByRole('textbox')
+  await user.type(textarea, '@al')
+
+  await waitFor(() => screen.getByText('@alice'))
+  fireEvent.mouseDown(screen.getByText('@alice'))
+
+  await waitFor(() => {
+    expect((textarea as HTMLTextAreaElement).value).toContain('@alice')
+    expect(screen.getByRole('combobox')).toHaveValue('direct')
+  })
+})
+
+// T7h-4: deleting @mention text resets visibility to group
+it('deleting @mention text resets visibility to group', async () => {
+  setupFetchMock({
+    members: {
+      members: [
+        { id: 'm1', userId: 'u1', username: 'alice', role: 'player', status: 'active' },
+      ],
+    },
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
+
+  const textarea = screen.getByRole('textbox')
+  await user.type(textarea, '@al')
+  await waitFor(() => screen.getByText('@alice'))
+  fireEvent.mouseDown(screen.getByText('@alice'))
+
+  await waitFor(() => expect(screen.getByRole('combobox')).toHaveValue('direct'))
+
+  // Clear text to trigger visibility reset
+  fireEvent.change(textarea, { target: { value: '', selectionStart: 0 } })
+
+  expect(screen.getByRole('combobox')).toHaveValue('group')
+})
+
+// ── T8 — Send tests ──────────────────────────────────────────────────
+
+// T8e-1: POST called with correct body on send
+it('send button calls POST with text and visibility', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  const textarea = screen.getByRole('textbox')
+  await user.type(textarea, 'Hello everyone')
+  await user.click(screen.getByRole('button', { name: /send/i }))
+
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/campaigns/test-campaign/messages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ text: 'Hello everyone', visibility: { scope: 'group' } }),
+      }),
+    )
+  })
+})
+
+// T8e-2: composer cleared on successful send
+it('composer text is cleared after successful send', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  const textarea = screen.getByRole('textbox')
+  await user.type(textarea, 'Clear me')
+  await user.click(screen.getByRole('button', { name: /send/i }))
+
+  await waitFor(() => {
+    expect((textarea as HTMLTextAreaElement).value).toBe('')
+  })
+})
+
+// T8e-3: empty composer does not POST
+it('send does nothing when composer text is empty', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  await user.click(screen.getByRole('button', { name: /send/i }))
+
+  expect(fetchSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining('/messages'),
+    expect.objectContaining({ method: 'POST' }),
+  )
+})
+
+// ── T9 — ChatFeed render tests ────────────────────────────────────────
+
+// T9d-1: group message renders no visibility marker
+it('group message renders without visibility marker', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'group-msg',
+        campaignId: 'test-campaign',
+        senderId: 'u1',
+        senderName: 'Alice',
+        text: 'Group message',
+        visibility: { scope: 'group' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  expect(screen.getByText('Group message')).toBeInTheDocument()
+  expect(screen.queryByText('[DM]')).not.toBeInTheDocument()
+})
+
+// T9d-2: dm-only message renders [DM]
+it('dm-only message renders [DM] marker', async () => {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'dm-msg',
+        campaignId: 'test-campaign',
+        senderId: 'u1',
+        senderName: 'Alice',
+        text: 'DM message',
+        visibility: { scope: 'dm-only' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  expect(screen.getByText('[DM]')).toBeInTheDocument()
+})
+
+// T9d-3: direct (whisper) message renders [→ @username]
+it('direct message renders whisper marker with recipient username', async () => {
+  setupFetchMock({
+    members: {
+      members: [
+        { id: 'm1', userId: 'u2', username: 'bob', role: 'player', status: 'active' },
+      ],
+    },
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
+
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'whisper-msg',
+        campaignId: 'test-campaign',
+        senderId: 'u1',
+        senderName: 'Alice',
+        text: 'Whisper message',
+        visibility: { scope: 'direct', toUserId: 'u2' },
+        createdAt: new Date().toISOString(),
+      },
+    })
+  })
+
+  await waitFor(() => {
+    expect(screen.getByText('[→ @bob]')).toBeInTheDocument()
+  })
+})
+
+// T9d-4: loading indicator shown when isLoadingHistory
+it('loading indicator is shown when history is loading', async () => {
+  // Make messages fetch hang so loading state is visible
+  fetchSpy.mockImplementation((url: string) => {
+    if (url.includes('/members')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+    }
+    if (url.includes('/messages')) {
+      return new Promise(() => {}) // never resolves
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+
+  await waitFor(() => {
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
 })

--- a/tests/unit/components/CampaignChat.test.tsx
+++ b/tests/unit/components/CampaignChat.test.tsx
@@ -276,17 +276,18 @@ it('history is not fetched on mount when dock is collapsed', async () => {
 it('history is fetched when dock is expanded', async () => {
   await openDock()
   await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/messages?page=1&perPage=30'))
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/messages?limit=30'))
   })
 })
 
-// T4d-3: hasMore = false when result count < 30
-it('hasMore is false when history returns fewer than 30 messages', async () => {
+// T4d-3: hasMore = false when API returns no nextCursor
+it('hasMore is false when history response has no nextCursor', async () => {
   const messages = Array.from({ length: 5 }, (_, i) => ({
     id: `msg-${i}`, campaignId: 'test-campaign', senderId: 'user-1',
     senderName: 'Alice', text: `Message ${i}`,
     visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
   }))
+  // No nextCursor in response → no more pages
   setupFetchMock({ messages: { messages } })
   await openDock()
   await waitFor(() => expect(screen.getByText('Message 0')).toBeInTheDocument())
@@ -445,6 +446,18 @@ it('composer text is cleared after successful send', async () => {
 // T8e-3: empty composer does not POST
 it('send does nothing when composer text is empty', async () => {
   const user = await openDock()
+  await user.click(screen.getByRole('button', { name: /send/i }))
+  expect(fetchSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining('/messages'),
+    expect.objectContaining({ method: 'POST' }),
+  )
+})
+
+// T8e-4: direct visibility with no toUserId does not POST
+it('send does nothing when direct visibility has no mention target', async () => {
+  const user = await openDock()
+  await user.selectOptions(screen.getByRole('combobox'), 'direct')
+  await user.type(screen.getByRole('textbox'), 'whisper without target')
   await user.click(screen.getByRole('button', { name: /send/i }))
   expect(fetchSpy).not.toHaveBeenCalledWith(
     expect.stringContaining('/messages'),


### PR DESCRIPTION
## Summary

Wire `CampaignChat` with live data (Phase 5 messaging, closes #315). The dock shell from issue #313 was a static placeholder; this PR connects it to the back-end APIs shipped in #314.

## Changes

- **`app/campaigns/[id]/layout.tsx`** (new) — campaign-scoped client layout; mounts `<CampaignChat campaignId={id} />` for all `/campaigns/[id]/…` routes
- **`app/layout.tsx`** — remove global `<CampaignChat />` render
- **`lib/components/CampaignChat.tsx`** — add `campaignId` prop; stream wiring via `useCampaignStream`; message feed (`ChatFeed`); composer with visibility selector + `@mention` autocomplete (`ChatComposer`, `MentionDropdown`); unread badge; history load + infinite scroll
- **`lib/hooks/useCampaignStream.ts`** — add `addEventListener('message', handler)` so SSE `event: message` payloads are received
- **`openspec/specs/campaign-chat-dock/spec.md`** — updated to reflect Phase 5 prop change and mount point
- **`tests/unit/components/CampaignChat.test.tsx`** — 26 new tests covering all new features (39 total)

## Test coverage

- All 2342 unit tests pass
- All 272 integration tests pass
- Build clean, lint clean

Closes #315