### PR TITLE
feat: GridFS attachment upload and serve endpoints

### DIFF
--- a/app/api/campaigns/[id]/attachments/[attachmentId]/route.ts
+++ b/app/api/campaigns/[id]/attachments/[attachmentId]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { assertCampaignAccess } from '@/lib/utils/campaign';
+import { getDatabase } from '@/lib/db';
+import { getAttachmentsBucket, openDownloadStream } from '@/lib/gridfs';
+
+type Params = { id: string; attachmentId: string };
+
+export const GET = withAuthAndParams<Params>(
+  async (_request, auth, { id: campaignId, attachmentId }) => {
+    const access = await assertCampaignAccess(campaignId, auth.userId);
+    if (access instanceof NextResponse) return access;
+
+    const db = await getDatabase();
+    const bucket = getAttachmentsBucket(db);
+
+    let streamResult: Awaited<ReturnType<typeof openDownloadStream>>;
+    try {
+      streamResult = await openDownloadStream(bucket, attachmentId);
+    } catch (err: unknown) {
+      const code = err instanceof Error ? (err as Error & { code?: string }).code : undefined;
+      if (code === 'NOT_FOUND') {
+        return NextResponse.json({ error: 'Not found' }, { status: 404 });
+      }
+      if (code === 'INVALID_ID') {
+        return NextResponse.json({ error: 'Invalid attachmentId' }, { status: 400 });
+      }
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+
+    const { stream, contentType, campaignId: fileCampaignId } = streamResult;
+
+    if (fileCampaignId !== campaignId) {
+      stream.destroy();
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const readableStream = new ReadableStream({
+      start(controller) {
+        stream.on('data', (chunk: Buffer) => controller.enqueue(chunk));
+        stream.on('end', () => controller.close());
+        stream.on('error', (err) => controller.error(err));
+      },
+    });
+
+    return new NextResponse(readableStream, {
+      status: 200,
+      headers: { 'Content-Type': contentType },
+    });
+  },
+);

--- a/app/api/campaigns/[id]/attachments/[attachmentId]/route.ts
+++ b/app/api/campaigns/[id]/attachments/[attachmentId]/route.ts
@@ -41,6 +41,9 @@ export const GET = withAuthAndParams<Params>(
         stream.on('end', () => controller.close());
         stream.on('error', (err) => controller.error(err));
       },
+      cancel() {
+        stream.destroy();
+      },
     });
 
     return new NextResponse(readableStream, {

--- a/app/api/campaigns/[id]/attachments/[attachmentId]/route.ts
+++ b/app/api/campaigns/[id]/attachments/[attachmentId]/route.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream';
 import { NextResponse } from 'next/server';
 import { withAuthAndParams } from '@/lib/middleware';
 import { assertCampaignAccess } from '@/lib/utils/campaign';
@@ -35,18 +36,7 @@ export const GET = withAuthAndParams<Params>(
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
 
-    const readableStream = new ReadableStream({
-      start(controller) {
-        stream.on('data', (chunk: Buffer) => controller.enqueue(chunk));
-        stream.on('end', () => controller.close());
-        stream.on('error', (err) => controller.error(err));
-      },
-      cancel() {
-        stream.destroy();
-      },
-    });
-
-    return new NextResponse(readableStream, {
+    return new NextResponse(Readable.toWeb(stream) as ReadableStream, {
       status: 200,
       headers: { 'Content-Type': contentType },
     });

--- a/app/api/campaigns/[id]/attachments/route.ts
+++ b/app/api/campaigns/[id]/attachments/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { assertCampaignAccess } from '@/lib/utils/campaign';
+import { getDatabase } from '@/lib/db';
+import { getAttachmentsBucket, uploadAttachment, deleteOrphanedAttachments } from '@/lib/gridfs';
+
+type Params = { id: string };
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+export const POST = withAuthAndParams<Params>(async (request, auth, { id: campaignId }) => {
+  const access = await assertCampaignAccess(campaignId, auth.userId);
+  if (access instanceof NextResponse) return access;
+  if (access.role !== 'dm') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid form data' }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'file is required' }, { status: 400 });
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return NextResponse.json({ error: 'Unsupported file type' }, { status: 415 });
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json({ error: 'File exceeds 5 MB limit' }, { status: 413 });
+  }
+
+  const db = await getDatabase();
+  const bucket = getAttachmentsBucket(db);
+
+  await deleteOrphanedAttachments(bucket, campaignId);
+
+  const attachmentId = await uploadAttachment(bucket, file, campaignId);
+  return NextResponse.json({ attachmentId }, { status: 201 });
+});

--- a/app/api/campaigns/[id]/attachments/route.ts
+++ b/app/api/campaigns/[id]/attachments/route.ts
@@ -36,11 +36,16 @@ export const POST = withAuthAndParams<Params>(async (request, auth, { id: campai
     return NextResponse.json({ error: 'File exceeds 5 MB limit' }, { status: 413 });
   }
 
-  const db = await getDatabase();
-  const bucket = getAttachmentsBucket(db);
+  let attachmentId: string;
+  try {
+    const db = await getDatabase();
+    const bucket = getAttachmentsBucket(db);
+    await deleteOrphanedAttachments(bucket, campaignId);
+    attachmentId = await uploadAttachment(bucket, file, campaignId);
+  } catch (err) {
+    console.error('uploadAttachment error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 
-  await deleteOrphanedAttachments(bucket, campaignId);
-
-  const attachmentId = await uploadAttachment(bucket, file, campaignId);
   return NextResponse.json({ attachmentId }, { status: 201 });
 });

--- a/lib/gridfs.ts
+++ b/lib/gridfs.ts
@@ -1,0 +1,74 @@
+import { Db, ObjectId, GridFSBucket, GridFSBucketReadStream } from 'mongodb';
+
+export function getAttachmentsBucket(db: Db): GridFSBucket {
+  return new GridFSBucket(db, { bucketName: 'attachments' });
+}
+
+export async function uploadAttachment(
+  bucket: GridFSBucket,
+  file: File,
+  campaignId: string,
+): Promise<string> {
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const id = new ObjectId();
+
+  await new Promise<void>((resolve, reject) => {
+    const uploadStream = bucket.openUploadStreamWithId(id, file.name, {
+      metadata: {
+        campaignId,
+        status: 'pending',
+        uploadedAt: new Date(),
+        contentType: file.type,
+      },
+    });
+    uploadStream.on('error', reject);
+    uploadStream.on('finish', resolve);
+    uploadStream.end(buffer);
+  });
+
+  return id.toHexString();
+}
+
+export async function openDownloadStream(
+  bucket: GridFSBucket,
+  attachmentId: string,
+): Promise<{ stream: GridFSBucketReadStream; contentType: string; campaignId: string }> {
+  if (!ObjectId.isValid(attachmentId)) {
+    throw Object.assign(new Error('Invalid attachmentId'), { code: 'INVALID_ID' });
+  }
+
+  const oid = new ObjectId(attachmentId);
+  const files = await bucket.find({ _id: oid }).toArray();
+
+  if (files.length === 0) {
+    throw Object.assign(new Error('Attachment not found'), { code: 'NOT_FOUND' });
+  }
+
+  const file = files[0];
+  const contentType = (file.metadata?.contentType as string) ?? 'application/octet-stream';
+  const campaignId = file.metadata?.campaignId as string;
+
+  const stream = bucket.openDownloadStream(oid);
+  return { stream, contentType, campaignId };
+}
+
+export async function deleteOrphanedAttachments(
+  bucket: GridFSBucket,
+  campaignId: string,
+  thresholdMs: number = 24 * 60 * 60 * 1000,
+): Promise<void> {
+  try {
+    const threshold = new Date(Date.now() - thresholdMs);
+    const orphans = await bucket
+      .find({
+        'metadata.campaignId': campaignId,
+        'metadata.status': 'pending',
+        'metadata.uploadedAt': { $lt: threshold },
+      })
+      .toArray();
+
+    await Promise.all(orphans.map((f) => bucket.delete(f._id)));
+  } catch (err) {
+    console.error('deleteOrphanedAttachments error:', err);
+  }
+}

--- a/lib/gridfs.ts
+++ b/lib/gridfs.ts
@@ -29,6 +29,19 @@ export async function uploadAttachment(
   return id.toHexString();
 }
 
+export async function updateAttachmentStatus(
+  db: Db,
+  attachmentId: string,
+  status: string,
+): Promise<void> {
+  if (!ObjectId.isValid(attachmentId)) {
+    throw Object.assign(new Error('Invalid attachmentId'), { code: 'INVALID_ID' });
+  }
+  await db
+    .collection('attachments.files')
+    .updateOne({ _id: new ObjectId(attachmentId) }, { $set: { 'metadata.status': status } });
+}
+
 export async function openDownloadStream(
   bucket: GridFSBucket,
   attachmentId: string,

--- a/lib/gridfs.ts
+++ b/lib/gridfs.ts
@@ -1,5 +1,9 @@
 import { Db, ObjectId, GridFSBucket, GridFSBucketReadStream } from 'mongodb';
 
+function isHexObjectId(id: string): boolean {
+  return /^[0-9a-f]{24}$/i.test(id);
+}
+
 export function getAttachmentsBucket(db: Db): GridFSBucket {
   return new GridFSBucket(db, { bucketName: 'attachments' });
 }
@@ -34,7 +38,7 @@ export async function updateAttachmentStatus(
   attachmentId: string,
   status: string,
 ): Promise<void> {
-  if (!ObjectId.isValid(attachmentId)) {
+  if (!isHexObjectId(attachmentId)) {
     throw Object.assign(new Error('Invalid attachmentId'), { code: 'INVALID_ID' });
   }
   await db
@@ -46,7 +50,7 @@ export async function openDownloadStream(
   bucket: GridFSBucket,
   attachmentId: string,
 ): Promise<{ stream: GridFSBucketReadStream; contentType: string; campaignId: string }> {
-  if (!ObjectId.isValid(attachmentId)) {
+  if (!isHexObjectId(attachmentId)) {
     throw Object.assign(new Error('Invalid attachmentId'), { code: 'INVALID_ID' });
   }
 
@@ -80,7 +84,9 @@ export async function deleteOrphanedAttachments(
       })
       .toArray();
 
-    await Promise.all(orphans.map((f) => bucket.delete(f._id)));
+    for (const orphan of orphans) {
+      await bucket.delete(orphan._id);
+    }
   } catch (err) {
     console.error('deleteOrphanedAttachments error:', err);
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,8 @@ export type MessageVisibility =
   | { scope: "dm-only" }
   | { scope: "direct"; toUserId: string };
 
+export type MessageKind = 'chat' | 'scene';
+
 export interface CampaignMessage {
   _id?: string;
   id: string;
@@ -14,6 +16,8 @@ export interface CampaignMessage {
   text: string;
   visibility: MessageVisibility;
   createdAt: Date;
+  kind?: MessageKind;
+  attachmentId?: string;
 }
 
 export type CampaignStreamEvent =

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,7 @@ export type MessageVisibility =
   | { scope: "dm-only" }
   | { scope: "direct"; toUserId: string };
 
-export type MessageKind = 'chat' | 'scene';
+export type MessageKind = "chat" | "scene";
 
 export interface CampaignMessage {
   _id?: string;

--- a/openspec/changes/gridfs-attachment-upload-serve/tasks.md
+++ b/openspec/changes/gridfs-attachment-upload-serve/tasks.md
@@ -1,0 +1,123 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/gridfs-attachment-upload-serve` then immediately `git push -u origin feat/gridfs-attachment-upload-serve`
+
+## Execution
+
+### T0 — Extend `CampaignMessage` type (`lib/types.ts`)
+
+- [x] Add `export type MessageKind = 'chat' | 'scene';`
+- [x] Add optional fields `kind?: MessageKind` and `attachmentId?: string` to `CampaignMessage`
+- [x] Run `npm run test:unit` — all existing tests must pass (additive change only)
+- [x] Run TypeScript check: `npx tsc --noEmit`
+
+### T1 — Create `lib/gridfs.ts` helper module
+
+- [x] Implement `getAttachmentsBucket(db: Db): GridFSBucket` — returns `new GridFSBucket(db, { bucketName: 'attachments' })`
+- [x] Implement `uploadAttachment(bucket, file: File, campaignId: string): Promise<string>` — streams file to GridFS with metadata `{ campaignId, status: 'pending', uploadedAt: new Date(), contentType: file.type }`, returns hex ObjectId string
+- [x] Implement `openDownloadStream(bucket, attachmentId: string): Promise<{ stream: GridFSBucketReadStream; contentType: string; campaignId: string }>` — opens download stream, reads file metadata, returns stream + stored contentType + metadata.campaignId; throws on not found or invalid id
+- [x] Implement `deleteOrphanedAttachments(bucket, campaignId: string, thresholdMs?: number): Promise<void>` — deletes GridFS files where `metadata.campaignId === campaignId`, `metadata.status === 'pending'`, and `metadata.uploadedAt < now - thresholdMs (default 24h)`; errors are caught and logged (best-effort)
+- [x] Write unit tests at `tests/unit/lib/gridfs.test.ts` covering each function with mocked GridFSBucket
+- [x] Run `npm run test:unit` — all tests pass
+
+### T2 — Create `app/api/campaigns/[id]/attachments/route.ts` (POST — upload)
+
+- [x] Create directory `app/api/campaigns/[id]/attachments/`
+- [x] Use `withAuthAndParams<{ id: string }>` pattern matching existing routes
+- [x] Call `assertCampaignAccess` — check `role === 'dm'`, return 403 otherwise
+- [x] Parse `request.formData()`, extract `file` field — return 400 if missing
+- [x] Validate MIME type against allowlist `['image/jpeg', 'image/png', 'image/webp', 'image/gif']` — return 415 if invalid
+- [x] Validate file size ≤ 5,242,880 bytes (5 MB) — return 413 if exceeded
+- [x] Call `deleteOrphanedAttachments` (fire-and-await, swallow errors)
+- [x] Call `uploadAttachment` — return 201 `{ attachmentId }`
+- [x] Write integration tests at `tests/integration/api/campaigns/[id]/attachments/route.test.ts` covering all scenarios in `specs/gridfs-upload/spec.md`
+- [x] Run `npm run test:unit` and `npm run test:integration` — all pass
+
+### T3 — Create `app/api/campaigns/[id]/attachments/[attachmentId]/route.ts` (GET — serve)
+
+- [x] Create directory `app/api/campaigns/[id]/attachments/[attachmentId]/`
+- [x] Use `withAuthAndParams<{ id: string; attachmentId: string }>` pattern
+- [x] Call `assertCampaignAccess` — any active member (DM or player); return 403 if not member
+- [x] Validate `attachmentId` is a valid hex ObjectId — return 400 if not
+- [x] Call `openDownloadStream` — return 404 if not found
+- [x] Verify `metadata.campaignId === campaignId` from URL — return 404 if mismatch
+- [x] Return streaming `Response` with `Content-Type` from stored metadata
+- [x] Write integration tests at `tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts` covering all scenarios in `specs/gridfs-serve/spec.md`
+- [x] Run `npm run test:unit` and `npm run test:integration` — all pass
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test:unit` — all pass
+- [x] `npm run test:integration` — all pass
+- [x] `npx tsc --noEmit` — no type errors
+- [x] `npm run build` — build succeeds
+- [x] All scenarios in `specs/gridfs-upload/spec.md`, `specs/gridfs-serve/spec.md`, `specs/gridfs-orphan/spec.md`, and `specs/campaign-message-type/spec.md` are covered by tests
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Build** — `npm run build`; build must succeed with no errors
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — `npm run build`; build must succeed with no errors
+- Skip integration tests — not required when no code changed
+
+If **ANY** required step fails, iterate and fix before pushing.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feat/gridfs-attachment-upload-serve` and push to remote
+- [ ] Open PR from `feat/gridfs-attachment-upload-serve` to `main`. PR body MUST include `Closes #318`.
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas into `openspec/specs/`:
+  - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md` → `openspec/specs/gridfs-upload/spec.md`
+  - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md` → `openspec/specs/gridfs-serve/spec.md`
+  - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-orphan/spec.md` → `openspec/specs/gridfs-orphan/spec.md`
+  - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md` → `openspec/specs/campaign-message-type/spec.md`
+  - Update relative links in each copied spec: replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/design.md` and `../../tasks.md` with `../../changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/tasks.md`
+- [ ] Archive the change: move `openspec/changes/gridfs-attachment-upload-serve/` to `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` **in a single atomic commit** (stage both the new location and the deletion of the old location together)
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` exists and `openspec/changes/gridfs-attachment-upload-serve/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-gridfs-attachment-upload-serve` then `git push -u origin doc/archive-gridfs-attachment-upload-serve`
+- [ ] Open a PR from `doc/archive-gridfs-attachment-upload-serve` to `main` with title `docs: archive gridfs-attachment-upload-serve (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until it merges; address any comments or CI failures
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/gridfs-attachment-upload-serve doc/archive-gridfs-attachment-upload-serve`

--- a/tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts
+++ b/tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment node
+ */
+import fetch from "node-fetch";
+import FormData from "form-data";
+import { ObjectId, GridFSBucket } from "mongodb";
+import { connectToDatabase, closeDatabase, getDatabase } from "@/lib/db";
+import { registerTestUser } from "@/tests/integration/helpers/users";
+
+const BASE_URL = () => process.env.TEST_BASE_URL!;
+
+function smallJpeg(): Buffer {
+  return Buffer.from(
+    "ffd8ffe000104a46494600010100000100010000ffdb004300080606070605080707070909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffffc0000b08000100010101011100ffc4001f0000010501010101010100000000000000000102030405060708090a0bffda00080101000000011a00ffda00030101003f00ffa4ffd9",
+    "hex"
+  );
+}
+
+async function addActiveMember(
+  campaignId: string,
+  dmCookie: string,
+  userId: string
+): Promise<void> {
+  const res = await fetch(`${BASE_URL()}/api/campaigns/${campaignId}/members`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: dmCookie },
+    body: JSON.stringify({ userId }),
+  });
+  expect(res.status).toBe(201);
+  const db = await getDatabase();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await db.collection("campaignMembers").updateOne(
+    { campaignId, userId },
+    { $set: { status: "active" } } as any
+  );
+}
+
+async function createCampaign(cookie: string): Promise<string> {
+  const res = await fetch(`${BASE_URL()}/api/campaigns`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: cookie },
+    body: JSON.stringify({ name: "Serve Test Campaign" }),
+  });
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function uploadFile(
+  campaignId: string,
+  cookie: string,
+  mimeType = "image/jpeg"
+): Promise<string> {
+  const form = new FormData();
+  form.append("file", smallJpeg(), { filename: "test.jpg", contentType: mimeType });
+  const res = await fetch(`${BASE_URL()}/api/campaigns/${campaignId}/attachments`, {
+    method: "POST",
+    headers: { ...form.getHeaders(), Cookie: cookie },
+    body: form,
+  });
+  if (res.status !== 201) throw new Error(`Upload failed: ${res.status}`);
+  return ((await res.json()) as { attachmentId: string }).attachmentId;
+}
+
+describe("GET /api/campaigns/[id]/attachments/[attachmentId]", () => {
+  let dmCookie: string;
+  let playerCookie: string;
+  let playerUserId: string;
+  let nonMemberCookie: string;
+  let campaignId: string;
+  let attachmentId: string;
+
+  beforeAll(async () => {
+    await connectToDatabase();
+
+    const dm = await registerTestUser(BASE_URL(), "serve-dm");
+    dmCookie = dm.cookie;
+
+    const player = await registerTestUser(BASE_URL(), "serve-player");
+    playerCookie = player.cookie;
+    playerUserId = player.userId;
+
+    const nonMember = await registerTestUser(BASE_URL(), "serve-nonmember");
+    nonMemberCookie = nonMember.cookie;
+
+    campaignId = await createCampaign(dmCookie);
+    await addActiveMember(campaignId, dmCookie, playerUserId);
+
+    // Upload a file as DM so we have a valid attachmentId
+    attachmentId = await uploadFile(campaignId, dmCookie);
+  }, 30000);
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  const serveUrl = (aid = attachmentId) =>
+    `${BASE_URL()}/api/campaigns/${campaignId}/attachments/${aid}`;
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+
+  it("returns 401 for unauthenticated request", async () => {
+    const res = await fetch(serveUrl());
+    expect(res.status).toBe(401);
+  });
+
+  // ─── Access control ───────────────────────────────────────────────────────
+
+  it("returns 404 for non-member (campaign hidden)", async () => {
+    const res = await fetch(serveUrl(), { headers: { Cookie: nonMemberCookie } });
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Validation ───────────────────────────────────────────────────────────
+
+  it("returns 400 for invalid attachmentId format", async () => {
+    const res = await fetch(
+      `${BASE_URL()}/api/campaigns/${campaignId}/attachments/not-a-valid-objectid`,
+      { headers: { Cookie: dmCookie } }
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid attachmentId");
+  });
+
+  // ─── Not found ────────────────────────────────────────────────────────────
+
+  it("returns 404 for non-existent attachmentId", async () => {
+    const nonExistentId = new ObjectId().toHexString();
+    const res = await fetch(serveUrl(nonExistentId), { headers: { Cookie: dmCookie } });
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Cross-campaign isolation ──────────────────────────────────────────────
+
+  it("returns 404 when attachmentId belongs to a different campaign", async () => {
+    // Create a second campaign and upload a file there
+    const dm2 = await registerTestUser(BASE_URL(), "serve-dm2");
+    const campaign2Id = await createCampaign(dm2.cookie);
+    const otherAttachmentId = await uploadFile(campaign2Id, dm2.cookie);
+
+    // DM of campaign1 tries to access campaign2's attachment via campaign1's URL
+    const res = await fetch(
+      `${BASE_URL()}/api/campaigns/${campaignId}/attachments/${otherAttachmentId}`,
+      { headers: { Cookie: dmCookie } }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Success scenarios ────────────────────────────────────────────────────
+
+  it("returns 200 with image bytes and correct Content-Type for DM", async () => {
+    const res = await fetch(serveUrl(), { headers: { Cookie: dmCookie } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/jpeg");
+    const body = await res.buffer();
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("returns 200 with image bytes for active player member", async () => {
+    const res = await fetch(serveUrl(), { headers: { Cookie: playerCookie } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/jpeg");
+    const body = await res.buffer();
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("preserves the stored Content-Type for a PNG file", async () => {
+    const pngId = await uploadFile(campaignId, dmCookie, "image/png");
+    const res = await fetch(serveUrl(pngId), { headers: { Cookie: dmCookie } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+  });
+});

--- a/tests/integration/api/campaigns/[id]/attachments/route.test.ts
+++ b/tests/integration/api/campaigns/[id]/attachments/route.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @jest-environment node
+ */
+import fetch from "node-fetch";
+import FormData from "form-data";
+import { connectToDatabase, closeDatabase, getDatabase } from "@/lib/db";
+import { registerTestUser } from "@/tests/integration/helpers/users";
+
+const BASE_URL = () => process.env.TEST_BASE_URL!;
+
+function smallJpeg(): Buffer {
+  // Minimal valid JPEG (1x1 pixel, white)
+  return Buffer.from(
+    "ffd8ffe000104a46494600010100000100010000ffdb004300080606070605080707070909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffffc0000b08000100010101011100ffc4001f0000010501010101010100000000000000000102030405060708090a0bffda00080101000000011a00ffda00030101003f00ffa4ffd9",
+    "hex"
+  );
+}
+
+async function addActiveMember(
+  campaignId: string,
+  dmCookie: string,
+  userId: string
+): Promise<void> {
+  const inviteRes = await fetch(`${BASE_URL()}/api/campaigns/${campaignId}/members`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: dmCookie },
+    body: JSON.stringify({ userId }),
+  });
+  expect(inviteRes.status).toBe(201);
+
+  const db = await getDatabase();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await db.collection("campaignMembers").updateOne(
+    { campaignId, userId },
+    { $set: { status: "active" } } as any
+  );
+}
+
+async function createCampaign(cookie: string): Promise<string> {
+  const res = await fetch(`${BASE_URL()}/api/campaigns`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: cookie },
+    body: JSON.stringify({ name: "Attachment Test Campaign" }),
+  });
+  const data = (await res.json()) as { id: string };
+  return data.id;
+}
+
+function makeFormWithFile(mimeType = "image/jpeg", sizeBytes?: number): FormData {
+  const form = new FormData();
+  const content = sizeBytes ? Buffer.alloc(sizeBytes) : smallJpeg();
+  form.append("file", content, { filename: "test.jpg", contentType: mimeType });
+  return form;
+}
+
+describe("POST /api/campaigns/[id]/attachments", () => {
+  let dmCookie: string;
+  let dmUserId: string;
+  let playerCookie: string;
+  let playerUserId: string;
+  let nonMemberCookie: string;
+  let campaignId: string;
+
+  beforeAll(async () => {
+    await connectToDatabase();
+
+    const dm = await registerTestUser(BASE_URL(), "attach-dm");
+    dmCookie = dm.cookie;
+    dmUserId = dm.userId;
+
+    const player = await registerTestUser(BASE_URL(), "attach-player");
+    playerCookie = player.cookie;
+    playerUserId = player.userId;
+
+    const nonMember = await registerTestUser(BASE_URL(), "attach-nonmember");
+    nonMemberCookie = nonMember.cookie;
+
+    campaignId = await createCampaign(dmCookie);
+    await addActiveMember(campaignId, dmCookie, playerUserId);
+  }, 30000);
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  const uploadUrl = () => `${BASE_URL()}/api/campaigns/${campaignId}/attachments`;
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+
+  it("returns 401 for unauthenticated request", async () => {
+    const form = makeFormWithFile();
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: form.getHeaders(),
+      body: form,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  // ─── Access control ───────────────────────────────────────────────────────
+
+  it("returns 403 for player (non-DM) attempting upload", async () => {
+    const form = makeFormWithFile();
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: playerCookie },
+      body: form,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for non-member attempting upload (campaign hidden)", async () => {
+    const form = makeFormWithFile();
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: nonMemberCookie },
+      body: form,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-existent campaign", async () => {
+    const form = makeFormWithFile();
+    const res = await fetch(`${BASE_URL()}/api/campaigns/nonexistent-id/attachments`, {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // ─── Validation ───────────────────────────────────────────────────────────
+
+  it("returns 400 when no file field present", async () => {
+    const form = new FormData();
+    form.append("other", "value");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("file is required");
+  });
+
+  it("returns 415 for unsupported MIME type (PDF)", async () => {
+    const form = makeFormWithFile("application/pdf");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(415);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Unsupported file type");
+  });
+
+  it("returns 413 for file exceeding 5 MB", async () => {
+    const form = makeFormWithFile("image/jpeg", 5 * 1024 * 1024 + 1);
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("File exceeds 5 MB limit");
+  });
+
+  // ─── Success scenarios ────────────────────────────────────────────────────
+
+  it("returns 201 with attachmentId for valid JPEG upload by DM", async () => {
+    const form = makeFormWithFile("image/jpeg");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { attachmentId: string };
+    expect(typeof body.attachmentId).toBe("string");
+    expect(body.attachmentId).toHaveLength(24);
+  });
+
+  it("returns 201 for valid PNG upload", async () => {
+    const form = makeFormWithFile("image/png");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { attachmentId: string };
+    expect(typeof body.attachmentId).toBe("string");
+  });
+
+  it("returns 201 for valid WebP upload", async () => {
+    const form = makeFormWithFile("image/webp");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { attachmentId: string };
+    expect(typeof body.attachmentId).toBe("string");
+  });
+
+  it("returns 201 for valid GIF upload", async () => {
+    const form = makeFormWithFile("image/gif");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { attachmentId: string };
+    expect(typeof body.attachmentId).toBe("string");
+  });
+
+  // ─── Orphan sweep ─────────────────────────────────────────────────────────
+
+  it("sweeps orphaned pending files older than 24h before inserting", async () => {
+    const db = await getDatabase();
+
+    // Insert an orphan: pending + 25h ago
+    const { ObjectId, GridFSBucket } = await import("mongodb");
+    const bucket = new GridFSBucket(db, { bucketName: "attachments" });
+    const orphanId = new ObjectId();
+    const staleDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
+
+    await new Promise<void>((resolve, reject) => {
+      const stream = bucket.openUploadStreamWithId(orphanId, "orphan.jpg", {
+        metadata: {
+          campaignId,
+          status: "pending",
+          uploadedAt: staleDate,
+          contentType: "image/jpeg",
+        },
+      });
+      stream.on("error", reject);
+      stream.on("finish", resolve);
+      stream.end(smallJpeg());
+    });
+
+    // Upload triggers sweep
+    const form = makeFormWithFile("image/jpeg");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(201);
+
+    // Orphan should be gone
+    const files = await bucket.find({ _id: orphanId }).toArray();
+    expect(files).toHaveLength(0);
+  });
+
+  it("does not sweep recent pending files (< 24h old)", async () => {
+    const db = await getDatabase();
+    const { ObjectId, GridFSBucket } = await import("mongodb");
+    const bucket = new GridFSBucket(db, { bucketName: "attachments" });
+    const recentId = new ObjectId();
+    const recentDate = new Date(Date.now() - 1000); // 1 second ago
+
+    await new Promise<void>((resolve, reject) => {
+      const stream = bucket.openUploadStreamWithId(recentId, "recent.jpg", {
+        metadata: {
+          campaignId,
+          status: "pending",
+          uploadedAt: recentDate,
+          contentType: "image/jpeg",
+        },
+      });
+      stream.on("error", reject);
+      stream.on("finish", resolve);
+      stream.end(smallJpeg());
+    });
+
+    const form = makeFormWithFile("image/jpeg");
+    const res = await fetch(uploadUrl(), {
+      method: "POST",
+      headers: { ...form.getHeaders(), Cookie: dmCookie },
+      body: form,
+    });
+    expect(res.status).toBe(201);
+
+    // Recent file should still exist
+    const files = await bucket.find({ _id: recentId }).toArray();
+    expect(files).toHaveLength(1);
+
+    // Cleanup
+    await bucket.delete(recentId);
+  });
+});

--- a/tests/unit/api/campaigns/[id]/attachments/attachmentId.route.test.ts
+++ b/tests/unit/api/campaigns/[id]/attachments/attachmentId.route.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from "next/server";
+import { GET } from "@/app/api/campaigns/[id]/attachments/[attachmentId]/route";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
+import { getDatabase } from "@/lib/db";
+import * as gridfs from "@/lib/gridfs";
+import {
+  MOCK_AUTH,
+  mockAuthState,
+} from "@/tests/unit/helpers/route.test.helpers";
+import { Readable } from "stream";
+
+jest.mock("@/lib/middleware", () =>
+  require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware()
+);
+
+jest.mock("@/lib/utils/campaign", () => ({
+  assertCampaignAccess: jest.fn(),
+}));
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock("@/lib/gridfs", () => ({
+  getAttachmentsBucket: jest.fn(),
+  openDownloadStream: jest.fn(),
+}));
+
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
+const mockedGetDatabase = jest.mocked(getDatabase);
+const mockedGetAttachmentsBucket = jest.mocked(gridfs.getAttachmentsBucket);
+const mockedOpenDownloadStream = jest.mocked(gridfs.openDownloadStream);
+
+const CAMPAIGN_ID = "campaign-1";
+const VALID_ATTACHMENT_ID = "507f1f77bcf86cd799439011";
+const MOCK_BUCKET = {} as any;
+const MEMBER_ACCESS = { campaign: { id: CAMPAIGN_ID } as any, role: "player" as const };
+
+const BASE_URL = `http://localhost/api/campaigns/${CAMPAIGN_ID}/attachments`;
+
+function makeRequest(attachmentId = VALID_ATTACHMENT_ID): Request {
+  return new Request(`${BASE_URL}/${attachmentId}`, { method: "GET" });
+}
+
+function makeReadableStream(content = "image-bytes"): Readable {
+  return Readable.from([Buffer.from(content)]);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthState.payload = MOCK_AUTH;
+  mockedGetDatabase.mockResolvedValue({} as any);
+  mockedGetAttachmentsBucket.mockReturnValue(MOCK_BUCKET);
+});
+
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/campaigns/[id]/attachments/[attachmentId] — auth", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAuthState.payload = null;
+    const req = makeRequest();
+    const res = await GET(req as any, { params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }) });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Campaign access ──────────────────────────────────────────────────────────
+
+describe("GET /api/campaigns/[id]/attachments/[attachmentId] — campaign access", () => {
+  it("returns 404 when assertCampaignAccess returns NextResponse (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(makeRequest() as any, { params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── attachmentId validation ──────────────────────────────────────────────────
+
+describe("GET /api/campaigns/[id]/attachments/[attachmentId] — validation", () => {
+  beforeEach(() => {
+    mockedAssertCampaignAccess.mockResolvedValue(MEMBER_ACCESS);
+  });
+
+  it("returns 400 for invalid attachmentId (INVALID_ID from openDownloadStream)", async () => {
+    const err = Object.assign(new Error("Invalid attachmentId"), { code: "INVALID_ID" });
+    mockedOpenDownloadStream.mockRejectedValue(err);
+    const res = await GET(makeRequest("not-a-valid-id") as any, {
+      params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: "not-a-valid-id" }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid attachmentId" });
+  });
+
+  it("returns 404 when attachment not found (NOT_FOUND from openDownloadStream)", async () => {
+    const err = Object.assign(new Error("Attachment not found"), { code: "NOT_FOUND" });
+    mockedOpenDownloadStream.mockRejectedValue(err);
+    const res = await GET(makeRequest() as any, {
+      params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 for unexpected errors", async () => {
+    mockedOpenDownloadStream.mockRejectedValue(new Error("Unexpected DB error"));
+    const res = await GET(makeRequest() as any, {
+      params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }),
+    });
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Campaign ID mismatch ─────────────────────────────────────────────────────
+
+describe("GET /api/campaigns/[id]/attachments/[attachmentId] — campaignId mismatch", () => {
+  beforeEach(() => {
+    mockedAssertCampaignAccess.mockResolvedValue(MEMBER_ACCESS);
+  });
+
+  it("returns 404 when file belongs to a different campaign", async () => {
+    const stream = makeReadableStream();
+    (stream as any).destroy = jest.fn();
+    mockedOpenDownloadStream.mockResolvedValue({
+      stream: stream as any,
+      contentType: "image/jpeg",
+      campaignId: "other-campaign",
+    });
+    const res = await GET(makeRequest() as any, {
+      params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Successful serve ─────────────────────────────────────────────────────────
+
+describe("GET /api/campaigns/[id]/attachments/[attachmentId] — success", () => {
+  beforeEach(() => {
+    mockedAssertCampaignAccess.mockResolvedValue(MEMBER_ACCESS);
+  });
+
+  it("returns 200 with correct Content-Type header", async () => {
+    const stream = makeReadableStream();
+    mockedOpenDownloadStream.mockResolvedValue({
+      stream: stream as any,
+      contentType: "image/jpeg",
+      campaignId: CAMPAIGN_ID,
+    });
+    const res = await GET(makeRequest() as any, {
+      params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/jpeg");
+  });
+
+  it("returns 200 with PNG content-type", async () => {
+    const stream = makeReadableStream();
+    mockedOpenDownloadStream.mockResolvedValue({
+      stream: stream as any,
+      contentType: "image/png",
+      campaignId: CAMPAIGN_ID,
+    });
+    const res = await GET(makeRequest() as any, {
+      params: Promise.resolve({ id: CAMPAIGN_ID, attachmentId: VALID_ATTACHMENT_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+  });
+});

--- a/tests/unit/api/campaigns/[id]/attachments/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/attachments/route.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from "next/server";
+import { POST } from "@/app/api/campaigns/[id]/attachments/route";
+import { assertCampaignAccess } from "@/lib/utils/campaign";
+import { getDatabase } from "@/lib/db";
+import * as gridfs from "@/lib/gridfs";
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  mockAuthState,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () =>
+  require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware()
+);
+
+jest.mock("@/lib/utils/campaign", () => ({
+  assertCampaignAccess: jest.fn(),
+}));
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock("@/lib/gridfs", () => ({
+  getAttachmentsBucket: jest.fn(),
+  uploadAttachment: jest.fn(),
+  deleteOrphanedAttachments: jest.fn(),
+}));
+
+const mockedAssertCampaignAccess = jest.mocked(assertCampaignAccess);
+const mockedGetDatabase = jest.mocked(getDatabase);
+const mockedGetAttachmentsBucket = jest.mocked(gridfs.getAttachmentsBucket);
+const mockedUploadAttachment = jest.mocked(gridfs.uploadAttachment);
+const mockedDeleteOrphanedAttachments = jest.mocked(gridfs.deleteOrphanedAttachments);
+
+const CAMPAIGN_ID = "campaign-1";
+const PARAMS = Promise.resolve({ id: CAMPAIGN_ID });
+const BASE_URL = `http://localhost/api/campaigns/${CAMPAIGN_ID}/attachments`;
+
+const DM_ACCESS = { campaign: { id: CAMPAIGN_ID } as any, role: "dm" as const };
+const PLAYER_ACCESS = { campaign: { id: CAMPAIGN_ID } as any, role: "player" as const };
+const MOCK_BUCKET = {} as any;
+
+function makeMultipartRequest(file?: File): Request {
+  if (!file) {
+    const form = new FormData();
+    form.append("other", "value");
+    return new Request(BASE_URL, { method: "POST", body: form });
+  }
+  const form = new FormData();
+  form.append("file", file, file.name);
+  return new Request(BASE_URL, { method: "POST", body: form });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthState.payload = MOCK_AUTH;
+  mockedGetDatabase.mockResolvedValue({} as any);
+  mockedGetAttachmentsBucket.mockReturnValue(MOCK_BUCKET);
+  mockedDeleteOrphanedAttachments.mockResolvedValue(undefined);
+  mockedUploadAttachment.mockResolvedValue("abc123def456abc123def456");
+});
+
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/campaigns/[id]/attachments — auth", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAuthState.payload = null;
+    const req = makeMultipartRequest();
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Campaign access ──────────────────────────────────────────────────────────
+
+describe("POST /api/campaigns/[id]/attachments — campaign access", () => {
+  it("returns 404 when assertCampaignAccess returns NextResponse (non-member)", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const req = makeMultipartRequest(new File(["x"], "f.jpg", { type: "image/jpeg" }));
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when role is player", async () => {
+    mockedAssertCampaignAccess.mockResolvedValue(PLAYER_ACCESS);
+    const req = makeMultipartRequest(new File(["x"], "f.jpg", { type: "image/jpeg" }));
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── File validation ──────────────────────────────────────────────────────────
+
+describe("POST /api/campaigns/[id]/attachments — validation", () => {
+  beforeEach(() => {
+    mockedAssertCampaignAccess.mockResolvedValue(DM_ACCESS);
+  });
+
+  it("returns 400 when no file field", async () => {
+    const req = makeMultipartRequest();
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "file is required" });
+  });
+
+  it("returns 415 for unsupported MIME type", async () => {
+    const req = makeMultipartRequest(new File(["x"], "f.pdf", { type: "application/pdf" }));
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(415);
+    expect(await res.json()).toEqual({ error: "Unsupported file type" });
+  });
+
+  it("returns 413 for file exceeding 5 MB", async () => {
+    const bigFile = new File([new ArrayBuffer(5 * 1024 * 1024 + 1)], "big.jpg", {
+      type: "image/jpeg",
+    });
+    const req = makeMultipartRequest(bigFile);
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: "File exceeds 5 MB limit" });
+  });
+});
+
+// ─── Successful upload ────────────────────────────────────────────────────────
+
+describe("POST /api/campaigns/[id]/attachments — success", () => {
+  beforeEach(() => {
+    mockedAssertCampaignAccess.mockResolvedValue(DM_ACCESS);
+  });
+
+  it("returns 201 with attachmentId for valid JPEG", async () => {
+    const req = makeMultipartRequest(new File(["imgdata"], "photo.jpg", { type: "image/jpeg" }));
+    const res = await POST(req as any, { params: PARAMS });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ attachmentId: "abc123def456abc123def456" });
+  });
+
+  it("calls deleteOrphanedAttachments before uploadAttachment", async () => {
+    const callOrder: string[] = [];
+    mockedDeleteOrphanedAttachments.mockImplementation(async () => { callOrder.push("delete"); });
+    mockedUploadAttachment.mockImplementation(async () => { callOrder.push("upload"); return "id"; });
+
+    const req = makeMultipartRequest(new File(["x"], "f.png", { type: "image/png" }));
+    await POST(req as any, { params: PARAMS });
+
+    expect(callOrder).toEqual(["delete", "upload"]);
+  });
+
+  it("accepts all allowed MIME types", async () => {
+    for (const mime of ["image/jpeg", "image/png", "image/webp", "image/gif"]) {
+      const req = makeMultipartRequest(new File(["x"], `f.${mime.split("/")[1]}`, { type: mime }));
+      const res = await POST(req as any, { params: PARAMS });
+      expect(res.status).toBe(201);
+    }
+  });
+});

--- a/tests/unit/api/campaigns/[id]/attachments/route.test.ts
+++ b/tests/unit/api/campaigns/[id]/attachments/route.test.ts
@@ -8,7 +8,6 @@ import { getDatabase } from "@/lib/db";
 import * as gridfs from "@/lib/gridfs";
 import {
   MOCK_AUTH,
-  makeRouteRequest,
   mockAuthState,
 } from "@/tests/unit/helpers/route.test.helpers";
 

--- a/tests/unit/lib/gridfs.test.ts
+++ b/tests/unit/lib/gridfs.test.ts
@@ -7,6 +7,7 @@ import {
   uploadAttachment,
   openDownloadStream,
   deleteOrphanedAttachments,
+  updateAttachmentStatus,
 } from '@/lib/gridfs';
 
 function makeBucket(overrides: Record<string, jest.Mock> = {}) {
@@ -208,7 +209,37 @@ describe('deleteOrphanedAttachments', () => {
 
     const callArg = bucket.find.mock.calls[0][0];
     const threshold: Date = callArg['metadata.uploadedAt'].$lt;
-    expect(threshold.getTime()).toBeGreaterThanOrEqual(before - 1000 - 10);
-    expect(threshold.getTime()).toBeLessThanOrEqual(after - 1000 + 10);
+    expect(threshold.getTime()).toBeGreaterThanOrEqual(before - 1000 - 500);
+    expect(threshold.getTime()).toBeLessThanOrEqual(after - 1000 + 500);
+  });
+});
+
+// ─── updateAttachmentStatus ───────────────────────────────────────────────────
+
+describe('updateAttachmentStatus', () => {
+  function makeDb(updateOne = jest.fn().mockResolvedValue({ modifiedCount: 1 })) {
+    return {
+      collection: jest.fn().mockReturnValue({ updateOne }),
+    } as any;
+  }
+
+  it('updates status in attachments.files collection', async () => {
+    const db = makeDb();
+    const id = new ObjectId().toHexString();
+
+    await updateAttachmentStatus(db, id, 'active');
+
+    expect(db.collection).toHaveBeenCalledWith('attachments.files');
+    expect(db.collection().updateOne).toHaveBeenCalledWith(
+      { _id: expect.any(ObjectId) },
+      { $set: { 'metadata.status': 'active' } },
+    );
+  });
+
+  it('throws INVALID_ID for a non-hex string', async () => {
+    const db = makeDb();
+    await expect(updateAttachmentStatus(db, 'not-an-id', 'active')).rejects.toMatchObject({
+      code: 'INVALID_ID',
+    });
   });
 });

--- a/tests/unit/lib/gridfs.test.ts
+++ b/tests/unit/lib/gridfs.test.ts
@@ -144,6 +144,13 @@ describe('openDownloadStream', () => {
       code: 'INVALID_ID',
     });
   });
+
+  it('throws INVALID_ID for a 12-char string (non-hex ObjectId)', async () => {
+    const bucket = makeBucket();
+    await expect(openDownloadStream(bucket, 'abcdef123456')).rejects.toMatchObject({
+      code: 'INVALID_ID',
+    });
+  });
 });
 
 // ─── deleteOrphanedAttachments ────────────────────────────────────────────────

--- a/tests/unit/lib/gridfs.test.ts
+++ b/tests/unit/lib/gridfs.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ */
+import { ObjectId } from 'mongodb';
+import {
+  getAttachmentsBucket,
+  uploadAttachment,
+  openDownloadStream,
+  deleteOrphanedAttachments,
+} from '@/lib/gridfs';
+
+function makeBucket(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    openUploadStreamWithId: jest.fn(),
+    openDownloadStream: jest.fn(),
+    find: jest.fn(),
+    delete: jest.fn(),
+    ...overrides,
+  } as any;
+}
+
+function makeFile(
+  name = 'test.jpg',
+  type = 'image/jpeg',
+  content = 'fake-image-bytes',
+): File {
+  return new File([content], name, { type });
+}
+
+// ─── getAttachmentsBucket ─────────────────────────────────────────────────────
+
+describe('getAttachmentsBucket', () => {
+  it('returns a GridFSBucket with bucketName attachments', () => {
+    const { GridFSBucket } = jest.requireActual('mongodb');
+    const mockDb = {
+      collection: jest.fn().mockReturnValue({}),
+    } as any;
+    const bucket = getAttachmentsBucket(mockDb);
+    expect(bucket).toBeInstanceOf(GridFSBucket);
+  });
+});
+
+// ─── uploadAttachment ─────────────────────────────────────────────────────────
+
+describe('uploadAttachment', () => {
+  it('streams file to GridFS and returns hex ObjectId', async () => {
+    const finishListeners: Array<() => void> = [];
+    const mockStream = {
+      on: jest.fn((event: string, cb: () => void) => {
+        if (event === 'finish') finishListeners.push(cb);
+        return mockStream;
+      }),
+      end: jest.fn(() => {
+        finishListeners.forEach((cb) => cb());
+      }),
+    };
+
+    const bucket = makeBucket({
+      openUploadStreamWithId: jest.fn().mockReturnValue(mockStream),
+    });
+
+    const file = makeFile();
+    const result = await uploadAttachment(bucket, file, 'campaign-abc');
+
+    expect(typeof result).toBe('string');
+    expect(result).toHaveLength(24);
+    expect(bucket.openUploadStreamWithId).toHaveBeenCalledWith(
+      expect.any(ObjectId),
+      'test.jpg',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          campaignId: 'campaign-abc',
+          status: 'pending',
+          contentType: 'image/jpeg',
+          uploadedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it('rejects if the upload stream emits an error', async () => {
+    const errorListeners: Array<(err: Error) => void> = [];
+    const mockStream = {
+      on: jest.fn((event: string, cb: (err: Error) => void) => {
+        if (event === 'error') errorListeners.push(cb);
+        return mockStream;
+      }),
+      end: jest.fn(() => {
+        errorListeners.forEach((cb) => cb(new Error('GridFS error')));
+      }),
+    };
+
+    const bucket = makeBucket({
+      openUploadStreamWithId: jest.fn().mockReturnValue(mockStream),
+    });
+
+    await expect(uploadAttachment(bucket, makeFile(), 'campaign-abc')).rejects.toThrow(
+      'GridFS error',
+    );
+  });
+});
+
+// ─── openDownloadStream ───────────────────────────────────────────────────────
+
+describe('openDownloadStream', () => {
+  const validId = new ObjectId().toHexString();
+
+  it('returns stream, contentType, and campaignId for a valid attachment', async () => {
+    const mockStream = { pipe: jest.fn() };
+    const bucket = makeBucket({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          {
+            _id: new ObjectId(validId),
+            metadata: { contentType: 'image/jpeg', campaignId: 'camp-1' },
+          },
+        ]),
+      }),
+      openDownloadStream: jest.fn().mockReturnValue(mockStream),
+    });
+
+    const result = await openDownloadStream(bucket, validId);
+    expect(result.stream).toBe(mockStream);
+    expect(result.contentType).toBe('image/jpeg');
+    expect(result.campaignId).toBe('camp-1');
+  });
+
+  it('throws NOT_FOUND for a non-existent attachment', async () => {
+    const bucket = makeBucket({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+
+    await expect(openDownloadStream(bucket, validId)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('throws INVALID_ID for a malformed attachmentId', async () => {
+    const bucket = makeBucket();
+    await expect(openDownloadStream(bucket, 'not-a-valid-id')).rejects.toMatchObject({
+      code: 'INVALID_ID',
+    });
+  });
+});
+
+// ─── deleteOrphanedAttachments ────────────────────────────────────────────────
+
+describe('deleteOrphanedAttachments', () => {
+  it('deletes orphaned pending files older than threshold', async () => {
+    const orphanId = new ObjectId();
+    const bucket = makeBucket({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ _id: orphanId }]),
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+    });
+
+    await deleteOrphanedAttachments(bucket, 'camp-1');
+
+    expect(bucket.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'metadata.campaignId': 'camp-1',
+        'metadata.status': 'pending',
+        'metadata.uploadedAt': expect.objectContaining({ $lt: expect.any(Date) }),
+      }),
+    );
+    expect(bucket.delete).toHaveBeenCalledWith(orphanId);
+  });
+
+  it('does not call delete when no orphans found', async () => {
+    const bucket = makeBucket({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+      delete: jest.fn(),
+    });
+
+    await deleteOrphanedAttachments(bucket, 'camp-1');
+    expect(bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors (best-effort sweep)', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const bucket = makeBucket({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockRejectedValue(new Error('MongoDB timeout')),
+      }),
+    });
+
+    await expect(deleteOrphanedAttachments(bucket, 'camp-1')).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('uses custom thresholdMs', async () => {
+    const bucket = makeBucket({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+      delete: jest.fn(),
+    });
+
+    const before = Date.now();
+    await deleteOrphanedAttachments(bucket, 'camp-1', 1000);
+    const after = Date.now();
+
+    const callArg = bucket.find.mock.calls[0][0];
+    const threshold: Date = callArg['metadata.uploadedAt'].$lt;
+    expect(threshold.getTime()).toBeGreaterThanOrEqual(before - 1000 - 10);
+    expect(threshold.getTime()).toBeLessThanOrEqual(after - 1000 + 10);
+  });
+});


### PR DESCRIPTION
## Summary

Implements GridFS-backed image upload and serve for campaign attachments (Phase 7b prep).

## Changes

- **`lib/types.ts`**: Add `MessageKind` type and optional `kind`/`attachmentId` fields to `CampaignMessage` (additive, no migration needed)
- **`lib/gridfs.ts`**: New helper module with `getAttachmentsBucket`, `uploadAttachment`, `openDownloadStream`, `deleteOrphanedAttachments`
- **`POST /api/campaigns/[id]/attachments`**: DM-only upload; validates MIME (JPEG/PNG/WebP/GIF) and size (≤5 MB); lazy orphan sweep before insert; returns `{ attachmentId }`
- **`GET /api/campaigns/[id]/attachments/[attachmentId]`**: Any active campaign member; streams image with stored `Content-Type`; enforces `campaignId` match to prevent cross-campaign leakage

## Tests

- 10 unit tests for `lib/gridfs.ts` (mocked GridFSBucket)
- 13 integration tests for upload route
- 8 integration tests for serve route

Closes #318