### PR TITLE
feat(campaign-chat): add roll-share UI to chat dock

### DIFF
--- a/app/campaigns/[id]/layout.tsx
+++ b/app/campaigns/[id]/layout.tsx
@@ -1,14 +1,29 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import { CampaignChat } from '@/lib/components/CampaignChat'
 
 export default function CampaignLayout({ children }: { children: React.ReactNode }) {
   const { id } = useParams<{ id: string }>()
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    fetch(`/api/campaigns/${id}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!cancelled) setActiveSessionId(data?.activeSessionId ?? null)
+      })
+      .catch(() => { /* leave null */ })
+    return () => { cancelled = true }
+  }, [id])
+
   return (
     <>
       {children}
-      <CampaignChat key={id} campaignId={id} />
+      <CampaignChat key={id} campaignId={id} activeSessionId={activeSessionId} />
     </>
   )
 }

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -198,6 +198,7 @@ function ChatComposer({
         <MentionDropdown results={mentionResults} onSelect={onMentionSelect} />
         <textarea
           ref={textareaRef}
+          aria-label="Message"
           value={composerText}
           onChange={onTextChange}
           onKeyDown={onKeyDown}
@@ -230,12 +231,13 @@ interface RollEntryStripProps {
 }
 
 function RollEntryStrip({ campaignId, activeSessionId, streamStatus, onRollPosted }: RollEntryStripProps) {
-  const [modifier, setModifier] = useState(0)
+  const [modifierText, setModifierText] = useState('0')
+  const modifier = modifierText === '' || modifierText === '-' ? 0 : (parseInt(modifierText, 10) || 0)
   const [visibility, setVisibility] = useState<RollVisibility>({ scope: 'group' })
   const [isRolling, setIsRolling] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const isDisabled = activeSessionId === null || streamStatus !== 'open' || isRolling
+  const isDisabled = activeSessionId !== null ? streamStatus !== 'open' || isRolling : true
 
   async function handleDieClick(sides: number) {
     if (isDisabled) return
@@ -286,9 +288,13 @@ function RollEntryStrip({ campaignId, activeSessionId, streamStatus, onRollPoste
           </button>
         ))}
         <input
-          type="number"
-          value={modifier}
-          onChange={e => setModifier(parseInt(e.target.value, 10) || 0)}
+          type="text"
+          inputMode="numeric"
+          value={modifierText}
+          onChange={e => {
+            const v = e.target.value
+            if (v === '' || v === '-' || /^-?\d+$/.test(v)) setModifierText(v)
+          }}
           disabled={isDisabled}
           aria-label="Modifier"
           className="w-14 text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
@@ -412,10 +418,12 @@ export function CampaignChat({ campaignId, activeSessionId = null }: { campaignI
 
     const fetchMessages = fetch(`/api/campaigns/${campaignId}/messages?limit=30`)
       .then(r => (r.ok ? r.json() : null))
+      .catch(() => null)
 
-    const fetchRolls = activeSessionId
+    const fetchRolls = activeSessionId !== null
       ? fetch(`/api/campaigns/${campaignId}/rolls?sessionId=${activeSessionId}&limit=30`)
           .then(r => (r.ok ? r.json() : null))
+          .catch(() => null)
       : Promise.resolve(null)
 
     Promise.all([fetchMessages, fetchRolls])

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -4,9 +4,14 @@ import { useReducer, useEffect, useRef, useState } from 'react'
 import { LocalStore } from '@/lib/offline/LocalStore'
 import { useCampaignStream } from '@/lib/hooks/useCampaignStream'
 import { useAuth } from '@/lib/hooks/useAuth'
-import type { CampaignMessage, CampaignStreamEvent, MessageVisibility } from '@/lib/types'
+import { rollDie } from '@/lib/utils/dice'
+import type { CampaignMessage, CampaignRoll, CampaignStreamEvent, MessageVisibility, RollVisibility } from '@/lib/types'
 
 const PIN_KEY = 'campaign-chat-pin'
+
+type FeedItem =
+  | { kind: 'message'; data: CampaignMessage }
+  | { kind: 'roll'; data: CampaignRoll }
 
 interface EnrichedMember {
   id: string
@@ -56,14 +61,34 @@ function resolveUsername(members: EnrichedMember[], toUserId: string): string {
   return members.find(m => m.userId === toUserId)?.username ?? toUserId
 }
 
+function RollFeedItem({ roll }: { roll: CampaignRoll }) {
+  const ts = new Date(roll.createdAt).toLocaleTimeString()
+  const breakdown = `[${roll.rolls.join(', ')}]`
+  const dmMarker = roll.visibility.scope === 'dm-only' ? '[DM]' : null
+
+  return (
+    <div className="text-sm text-gray-200 bg-gray-700/50 rounded px-2 py-1.5">
+      <div className="flex items-center gap-1 flex-wrap">
+        <span aria-hidden="true">🎲</span>
+        <span className="font-semibold text-white">{roll.rollerName}</span>
+        <span className="text-gray-500 text-xs">{ts}</span>
+        {dmMarker && <span className="ml-1 text-xs text-yellow-400">{dmMarker}</span>}
+      </div>
+      <div className="mt-0.5 text-gray-300">
+        {roll.formula} → {breakdown} = <span className="font-bold text-white">{roll.total}</span>
+      </div>
+    </div>
+  )
+}
+
 interface ChatFeedProps {
-  messages: CampaignMessage[]
+  feed: FeedItem[]
   isLoadingHistory: boolean
   members: EnrichedMember[]
   feedRef: React.RefObject<HTMLDivElement | null>
 }
 
-function ChatFeed({ messages, isLoadingHistory, members, feedRef }: ChatFeedProps) {
+function ChatFeed({ feed, isLoadingHistory, members, feedRef }: ChatFeedProps) {
   function visibilityMarker(visibility: MessageVisibility): string | null {
     if (visibility.scope === 'dm-only') return '[DM]'
     if (visibility.scope === 'direct') return `[→ @${resolveUsername(members, visibility.toUserId)}]`
@@ -75,10 +100,14 @@ function ChatFeed({ messages, isLoadingHistory, members, feedRef }: ChatFeedProp
       {isLoadingHistory && (
         <div className="text-center text-xs text-gray-500 py-1">Loading…</div>
       )}
-      {messages.length === 0 && !isLoadingHistory && (
+      {feed.length === 0 && !isLoadingHistory && (
         <p className="text-gray-500 text-sm">No messages yet.</p>
       )}
-      {messages.map(msg => {
+      {feed.map(item => {
+        if (item.kind === 'roll') {
+          return <RollFeedItem key={item.data.id} roll={item.data} />
+        }
+        const msg = item.data
         const marker = visibilityMarker(msg.visibility)
         const ts = new Date(msg.createdAt).toLocaleTimeString()
         return (
@@ -149,6 +178,7 @@ function ChatComposer({
       )}
       <div className="flex gap-2 items-center">
         <select
+          aria-label="Message visibility"
           value={visibility.scope}
           onChange={e => onVisibilityChange(e.target.value)}
           disabled={isDisabled}
@@ -190,9 +220,98 @@ function ChatComposer({
   )
 }
 
+const DIE_SIDES = [4, 6, 8, 10, 12, 20] as const
+
+interface RollEntryStripProps {
+  campaignId: string
+  activeSessionId: string | null
+  streamStatus: 'connecting' | 'open' | 'error'
+  onRollPosted: (roll: CampaignRoll) => void
+}
+
+function RollEntryStrip({ campaignId, activeSessionId, streamStatus, onRollPosted }: RollEntryStripProps) {
+  const [modifier, setModifier] = useState(0)
+  const [visibility, setVisibility] = useState<RollVisibility>({ scope: 'group' })
+  const [isRolling, setIsRolling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isDisabled = activeSessionId === null || streamStatus !== 'open' || isRolling
+
+  async function handleDieClick(sides: number) {
+    if (isDisabled) return
+    const [result] = rollDie(sides, 1)
+    const total = result + modifier
+    const formula = modifier !== 0
+      ? `1d${sides}${modifier > 0 ? '+' : ''}${modifier}`
+      : `1d${sides}`
+    setIsRolling(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/campaigns/${campaignId}/rolls`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ formula, rolls: [result], total, visibility }),
+      })
+      if (res.status === 201) {
+        const roll: CampaignRoll = await res.json()
+        onRollPosted(roll)
+      } else if (res.status === 409) {
+        setError('No active session')
+      } else {
+        setError('Roll failed, try again')
+      }
+    } catch {
+      setError('Roll failed, try again')
+    } finally {
+      setIsRolling(false)
+    }
+  }
+
+  return (
+    <div className="border-t border-gray-700 p-2 flex-shrink-0">
+      {activeSessionId === null && (
+        <p className="text-xs text-gray-500 mb-1">No active session</p>
+      )}
+      <div className="flex flex-wrap gap-1 items-center">
+        {DIE_SIDES.map(sides => (
+          <button
+            key={sides}
+            type="button"
+            onClick={() => handleDieClick(sides)}
+            disabled={isDisabled}
+            aria-label={`d${sides}`}
+            className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white px-2 py-1 rounded"
+          >
+            d{sides}
+          </button>
+        ))}
+        <input
+          type="number"
+          value={modifier}
+          onChange={e => setModifier(parseInt(e.target.value, 10) || 0)}
+          disabled={isDisabled}
+          aria-label="Modifier"
+          className="w-14 text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
+        />
+        <select
+          value={visibility.scope}
+          onChange={e => setVisibility({ scope: e.target.value as RollVisibility['scope'] })}
+          disabled={isDisabled}
+          aria-label="Roll visibility"
+          className="text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
+        >
+          <option value="group">Group</option>
+          <option value="dm-only">DM-only</option>
+        </select>
+      </div>
+      {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+    </div>
+  )
+}
+
 // ── Main component ────────────────────────────────────────────────
 
-export function CampaignChat({ campaignId }: { campaignId: string }) {
+export function CampaignChat({ campaignId, activeSessionId = null }: { campaignId: string; activeSessionId?: string | null }) {
   const { user } = useAuth()
   const [{ isExpanded, isPinned }, dispatch] = useReducer(dockReducer, {
     isExpanded: false,
@@ -201,7 +320,7 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const isMounted = useRef(false)
 
-  const [messages, setMessages] = useState<CampaignMessage[]>([])
+  const [feed, setFeed] = useState<FeedItem[]>([])
   const seenIds = useRef<Set<string>>(new Set())
 
   const [members, setMembers] = useState<EnrichedMember[]>([])
@@ -230,13 +349,19 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
 
   // ── SSE stream ──
   function onStreamEvent(e: CampaignStreamEvent) {
-    if (e.type !== 'message') return
-    const msg = e.data
-    if (seenIds.current.has(msg.id)) return
-    seenIds.current.add(msg.id)
-    setMessages(prev => [...prev, msg])
-    if (!isExpanded && new Date(msg.createdAt) > lastOpenRef.current) {
-      setUnreadCount(c => c + 1)
+    if (e.type === 'message') {
+      const msg = e.data
+      if (seenIds.current.has(msg.id)) return
+      seenIds.current.add(msg.id)
+      setFeed(prev => [...prev, { kind: 'message', data: msg }])
+      if (!isExpanded && new Date(msg.createdAt) > lastOpenRef.current) {
+        setUnreadCount(c => c + 1)
+      }
+    } else if (e.type === 'roll') {
+      const roll = e.data
+      if (seenIds.current.has(roll.id)) return
+      seenIds.current.add(roll.id)
+      setFeed(prev => [...prev, { kind: 'roll', data: roll }])
     }
   }
 
@@ -284,18 +409,37 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
     historyLoadedRef.current = true
     setIsLoadingHistory(true)
     isLoadingHistoryRef.current = true
-    fetch(`/api/campaigns/${campaignId}/messages?limit=30`)
+
+    const fetchMessages = fetch(`/api/campaigns/${campaignId}/messages?limit=30`)
       .then(r => (r.ok ? r.json() : null))
-      .then(data => {
-        if (!data?.messages) return
-        // API returns newest-first; reverse so feed shows oldest at top, newest at bottom
-        const results: CampaignMessage[] = [...data.messages].reverse()
-        // Deduplicate against stream messages that may have arrived while loading
-        const newMsgs = results.filter(m => !seenIds.current.has(m.id))
-        newMsgs.forEach(m => seenIds.current.add(m.id))
-        setMessages(prev => [...newMsgs, ...prev])
-        cursorRef.current = data.nextCursor ?? null
-        hasMoreRef.current = !!data.nextCursor
+
+    const fetchRolls = activeSessionId
+      ? fetch(`/api/campaigns/${campaignId}/rolls?sessionId=${activeSessionId}&limit=30`)
+          .then(r => (r.ok ? r.json() : null))
+      : Promise.resolve(null)
+
+    Promise.all([fetchMessages, fetchRolls])
+      .then(([msgData, rollData]) => {
+        if (!msgData?.messages) return
+
+        const rawMsgs: CampaignMessage[] = [...msgData.messages].reverse()
+        const rawRolls: CampaignRoll[] = rollData?.rolls ? [...rollData.rolls].reverse() : []
+
+        const msgItems: FeedItem[] = rawMsgs
+          .filter(m => !seenIds.current.has(m.id))
+          .map(m => { seenIds.current.add(m.id); return { kind: 'message' as const, data: m } })
+
+        const rollItems: FeedItem[] = rawRolls
+          .filter(r => !seenIds.current.has(r.id))
+          .map(r => { seenIds.current.add(r.id); return { kind: 'roll' as const, data: r } })
+
+        const merged = [...msgItems, ...rollItems].sort(
+          (a, b) => new Date(a.data.createdAt).getTime() - new Date(b.data.createdAt).getTime()
+        )
+
+        setFeed(prev => [...merged, ...prev])
+        cursorRef.current = msgData.nextCursor ?? null
+        hasMoreRef.current = !!msgData.nextCursor
       })
       .catch(() => { /* leave feed empty */ })
       .finally(() => { setIsLoadingHistory(false); isLoadingHistoryRef.current = false })
@@ -325,7 +469,8 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
           const results: CampaignMessage[] = [...data.messages].reverse()
           const newMsgs = results.filter(m => !seenIds.current.has(m.id))
           newMsgs.forEach(m => seenIds.current.add(m.id))
-          setMessages(prev => [...newMsgs, ...prev])
+          const newItems: FeedItem[] = newMsgs.map(m => ({ kind: 'message' as const, data: m }))
+          setFeed(prev => [...newItems, ...prev])
           cursorRef.current = data.nextCursor ?? null
           hasMoreRef.current = !!data.nextCursor
           requestAnimationFrame(() => {
@@ -415,7 +560,7 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
       visibility,
       createdAt: new Date(),
     }
-    setMessages(prev => [...prev, optimisticMsg])
+    setFeed(prev => [...prev, { kind: 'message', data: optimisticMsg }])
     seenIds.current.add(optimisticMsg.id)
 
     try {
@@ -434,6 +579,12 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
     } finally {
       setIsSending(false)
     }
+  }
+
+  function handleRollPosted(roll: CampaignRoll) {
+    if (seenIds.current.has(roll.id)) return
+    seenIds.current.add(roll.id)
+    setFeed(prev => [...prev, { kind: 'roll', data: roll }])
   }
 
   // ── Collapsed pill ──
@@ -488,7 +639,7 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
         </div>
       </div>
       <ChatFeed
-        messages={messages}
+        feed={feed}
         isLoadingHistory={isLoadingHistory}
         members={members}
         feedRef={feedRef}
@@ -507,6 +658,12 @@ export function CampaignChat({ campaignId }: { campaignId: string }) {
         mentionResults={mentionResults}
         onMentionSelect={handleMentionSelect}
         textareaRef={textareaRef}
+      />
+      <RollEntryStrip
+        campaignId={campaignId}
+        activeSessionId={activeSessionId}
+        streamStatus={streamStatus}
+        onRollPosted={handleRollPosted}
       />
     </div>
   )

--- a/lib/hooks/useCampaignStream.ts
+++ b/lib/hooks/useCampaignStream.ts
@@ -57,6 +57,7 @@ export function useCampaignStream(
       es.addEventListener('heartbeat', handler);
       es.addEventListener('change', handler);
       es.addEventListener('message', handler);
+      es.addEventListener('roll', handler);
 
       es.onerror = () => {
         if (torn) { es.close(); return; }

--- a/openspec/changes/issue-317-roll-share-ui/.openspec.yaml
+++ b/openspec/changes/issue-317-roll-share-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-20

--- a/openspec/changes/issue-317-roll-share-ui/design.md
+++ b/openspec/changes/issue-317-roll-share-ui/design.md
@@ -1,0 +1,167 @@
+## Context
+
+- Relevant architecture: `CampaignChat` is a self-contained client component at `lib/components/CampaignChat.tsx`. It owns dock state (expanded/pinned), message state, SSE subscription via `useCampaignStream`, history pagination, and the `ChatComposer`. The SSE stream (`CampaignStreamEvent`) already carries `type: "roll"` events. Roll persistence and visibility enforcement live in the API (`app/api/campaigns/[id]/rolls/route.ts`) and `lib/utils/campaignRolls.ts`. Dice rolling uses `lib/utils/dice.ts` (`rollDie(sides)`).
+- Dependencies: `CampaignRoll` and `RollVisibility` types in `lib/types.ts`; `rollDie()` in `lib/utils/dice.ts`; rolls API at `/api/campaigns/[id]/rolls`.
+- Interfaces/contracts touched:
+  - `CampaignChat` props: add `activeSessionId: string | null`.
+  - Internal feed state: replace `messages: CampaignMessage[]` with `feed: FeedItem[]`.
+  - SSE handler: extend to handle `type: "roll"`.
+  - Campaign page component: pass `activeSessionId` prop to `CampaignChat`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Interleaved feed of messages and rolls sorted by `createdAt`.
+- Roll-entry strip with d4/d6/d8/d10/d12/d20 quick buttons, flat modifier field, and group/dm-only visibility selector.
+- Strip disabled (greyed, labelled "No active session") when `activeSessionId` is null.
+- Rolls broadcast and received live via SSE; history loaded on dock expand.
+- Roll feed items visually distinct: formula, per-die breakdown, total, roller handle, timestamp, visibility marker.
+
+### Non-Goals
+
+- Free-text formula input, multi-die formulas, advantage/disadvantage.
+- Roll history across sessions other than the active one.
+- Optimistic roll entries.
+- Unread count for roll events.
+
+## Decisions
+
+### Decision 1: FeedItem discriminated union defined locally in CampaignChat.tsx
+
+- Chosen: Define `type FeedItem = { kind: 'message'; data: CampaignMessage } | { kind: 'roll'; data: CampaignRoll }` in `CampaignChat.tsx`, not exported from `lib/types.ts`.
+- Alternatives considered: Export from `lib/types.ts` for potential reuse.
+- Rationale: No other component currently consumes a mixed feed. Keeping it local avoids premature abstraction in the shared type file. Can be promoted later if needed.
+- Trade-offs: If a second component needs a mixed feed, the type must be moved. Acceptable given current scope.
+
+### Decision 2: activeSessionId passed as a prop
+
+- Chosen: `CampaignChat` accepts `activeSessionId: string | null` as a prop from its parent (the campaign page).
+- Alternatives considered: (a) Fetch the campaign inside `CampaignChat`; (b) Derive from SSE `change` events inside the component.
+- Rationale: The campaign page already holds campaign state. Passing it as a prop is the simplest, most testable approach and avoids a redundant fetch. Staleness of `activeSessionId` (DM starts/ends session mid-visit) is flagged as a follow-up; the SSE `change` event handler in the parent should update the prop when the campaign changes.
+- Trade-offs: Parent must be updated to pass the prop. If the parent does not subscribe to `change` events for the campaign, the strip may lag behind. Acceptable for MVP.
+
+### Decision 3: Sorted insert for feed updates
+
+- Chosen: On initial history load, merge messages and rolls, sort by `createdAt` ascending, set as `feed`. On stream events, append to end of `feed` (stream events arrive in order). On history prepend (infinite scroll), sort the prepended batch then prepend the block.
+- Alternatives considered: Re-sort the entire array on every update.
+- Rationale: Avoids O(n log n) re-sort on every SSE event. Stream events are always newer than existing feed items, so append is correct. History pagination prepend requires a sort of the fetched page only (≤100 items), not the full feed.
+- Trade-offs: Assumes stream events arrive in chronological order (valid per SSE semantics). Slightly more complex insertion logic.
+
+### Decision 4: Roll history fetched in parallel with message history
+
+- Chosen: On dock expand, fire both `GET /api/campaigns/[id]/messages` and `GET /api/campaigns/[id]/rolls?sessionId=<activeSessionId>` concurrently via `Promise.all`. If `activeSessionId` is null, skip the rolls fetch and load messages only.
+- Alternatives considered: Sequential fetch (simpler, slower); single merged API endpoint (out of scope).
+- Rationale: Both fetches are independent. Parallel reduces perceived latency on first expand.
+- Trade-offs: Two loading states must both resolve before the merged feed renders. Implement a single `isLoadingHistory` flag gated on both promises resolving.
+
+### Decision 5: Client-side rolling with rollDie()
+
+- Chosen: On die-button click, call `rollDie(sides, 1)` client-side, compute `total = result + modifier`, build `formula` string (`"1dX"` or `"1dX+M"` / `"1dX-M"` for non-zero modifier), POST to API.
+- Alternatives considered: Send only formula to server and have server roll (would require API change).
+- Rationale: API contract expects pre-computed `rolls[]` and `total`. `rollDie()` uses crypto-secure randomness. No API changes needed.
+- Trade-offs: Roll result is computed client-side before the API persists it; a network failure means the roll is lost (no optimistic entry). Acceptable for MVP.
+
+### Decision 6: Roll-entry strip as a sibling section below ChatComposer
+
+- Chosen: Render `RollEntryStrip` below `ChatComposer` in the dock, separated by a border. The strip holds: a row of die buttons (d4 d6 d8 d10 d12 d20), a modifier `<input type="number">`, a visibility `<select>` (Group / DM-only), and a spinner/error state. When `activeSessionId` is null, the entire strip is `disabled` with a tooltip label "No active session".
+- Alternatives considered: Integrate roll controls into `ChatComposer` (clutters composer); separate tab (adds navigation complexity).
+- Rationale: Minimal surface area, visually distinct from text composition, easy to disable atomically.
+- Trade-offs: Dock height increases slightly. At `33vh` this is acceptable; if cramped, the strip can collapse.
+
+## Proposal to Design Mapping
+
+- Proposal element: Unified feed type replacing `messages` state
+  - Design decision: Decision 1 (FeedItem local type), Decision 3 (sorted insert)
+  - Validation approach: Unit test feed merge/sort logic; E2E confirms ordering in rendered feed
+
+- Proposal element: Roll-entry strip with die buttons, modifier, visibility, disabled state
+  - Design decision: Decision 5 (client-side rolling), Decision 6 (strip placement)
+  - Validation approach: Unit tests for strip render/disable; integration test for POST flow
+
+- Proposal element: SSE stream extended to consume roll events
+  - Design decision: Decision 3 (append on stream event)
+  - Validation approach: Unit test onStreamEvent with roll event type
+
+- Proposal element: Roll history fetch on expand
+  - Design decision: Decision 4 (parallel fetch)
+  - Validation approach: Unit test with mocked fetch; verify merged sort order
+
+- Proposal element: activeSessionId as prop
+  - Design decision: Decision 2
+  - Validation approach: Prop passed correctly from campaign page; strip disabled when null
+
+## Functional Requirements Mapping
+
+- Requirement: Active member can roll a die and share to group or DM-only
+  - Design element: RollEntryStrip (Decision 6), rollDie() (Decision 5), POST /rolls
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — roll submission scenarios
+  - Testability notes: Unit test button click → fetch called with correct body; integration test end-to-end post
+
+- Requirement: Roll appears in feed interleaved with messages by time
+  - Design element: FeedItem union (Decision 1), sorted insert (Decision 3)
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — feed rendering scenarios
+  - Testability notes: Unit test feed merge with known timestamps; render test for RollFeedItem
+
+- Requirement: Roll feed item shows formula, breakdown, total, roller, visibility marker
+  - Design element: RollFeedItem sub-component
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — roll feed item rendering
+  - Testability notes: Snapshot/render test with known CampaignRoll fixture
+
+- Requirement: Strip disabled when no active session
+  - Design element: Decision 2 (activeSessionId prop), Decision 6 (strip disabled)
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — no active session scenario
+  - Testability notes: Render test with activeSessionId=null; assert buttons and inputs disabled
+
+- Requirement: Live roll delivery via SSE
+  - Design element: Extended onStreamEvent handler, Decision 3
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — live roll delivery
+  - Testability notes: Unit test onStreamEvent dispatches roll into feed; dedup by id
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: performance
+  - Requirement: Feed updates must not re-sort the entire array on each SSE event
+  - Design element: Decision 3 — append-only for stream events
+  - Acceptance criteria reference: Implicit; no perceptible jank on rapid roll events
+  - Testability notes: Manual verification; no automated perf test required for MVP
+
+- Requirement category: reliability
+  - Requirement: Duplicate roll events (stream + history overlap) must not appear twice
+  - Design element: `seenIds` ref extended to cover roll ids alongside message ids
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — dedup scenario
+  - Testability notes: Unit test: add roll via history, then deliver same id via stream; assert feed length unchanged
+
+- Requirement category: security
+  - Requirement: Rolls not visible to ineligible users must not be rendered
+  - Design element: Server enforces visibility on SSE emit; client uses `canSeeRoll` as a secondary guard if a roll event arrives unexpectedly
+  - Acceptance criteria reference: specs/roll-share-ui/spec.md — visibility enforcement
+  - Testability notes: Unit test canSeeRoll (already tested in utils); integration test DM-only roll invisible to player
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `activeSessionId` staleness when DM starts/ends session mid-visit
+  - Impact: Strip stays greyed (or enabled) incorrectly until page refresh
+  - Mitigation: Parent should update prop from SSE `change` events. If not already done, flag as a follow-up issue; MVP ships with the known limitation documented.
+
+- Risk/trade-off: Dock height with roll strip added
+  - Impact: Less vertical space for the feed at 33vh
+  - Mitigation: Roll strip is compact (single row ~40px). If cramped, strip can be made collapsible in a follow-up.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Roll-entry POST causes unexpected 409s in production; or feed merge introduces a regression in message rendering.
+- Rollback steps: Revert `CampaignChat.tsx` to prior version (messages-only feed); the rolls API is unaffected and can stay.
+- Data migration considerations: None — this change is purely additive UI.
+- Verification after rollback: Confirm chat messages render and send correctly; confirm no JS errors on the campaign page.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check. All unit and integration tests must pass, and `npm run build` must succeed.
+- If security checks fail: Do not merge. Investigate before proceeding.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to repo owner after 48 hours.
+- Escalation path and timeout: Repo owner (dougis) is the escalation path; no external stakeholders for this change.
+
+## Open Questions
+
+- No open questions. All design decisions are resolved. The `activeSessionId` staleness issue is acknowledged and deferred to a follow-up.

--- a/openspec/changes/issue-317-roll-share-ui/proposal.md
+++ b/openspec/changes/issue-317-roll-share-ui/proposal.md
@@ -1,0 +1,90 @@
+## GitHub Issues
+
+- dougis-org/session-combat#317
+- dougis-org/session-combat#298 (Phase 6 epic)
+
+## Why
+
+- Problem statement: Players and the DM have no way to share dice rolls in the campaign chat dock. The rolls API (6a, #316) is complete and the chat dock is live (5b, #315), but they are not connected — rolls cannot be entered, posted, or seen by other session participants.
+- Why now: Both blocking dependencies (#315, #316) closed on 2026-06-19. This is the final deliverable of Phase 6.
+- Business/user impact: Without this, the chat dock is text-only and players must share roll results verbally or in free-text messages, which is error-prone and loses the structured breakdown needed for transparent play (e.g., "did that hit?" verification).
+
+## Problem Space
+
+- Current behavior: `CampaignChat` handles `CampaignStreamEvent` of type `message` only; `type: "roll"` events from the SSE stream are silently ignored. There is no roll-entry UI in the dock. Roll history is never fetched.
+- Desired behavior: A roll-entry strip below the chat composer lets any active member select a die size (d4–d20), optionally add a flat modifier, choose group or DM-only visibility, and fire the roll. Rolls appear in the feed interleaved with messages by timestamp, rendered as a distinct item showing formula, per-die breakdown, total, roller handle, and visibility marker. The strip is disabled (greyed, labelled "No active session") when `campaign.activeSessionId` is null.
+- Constraints:
+  - `RollVisibility` is `group | dm-only` only — no direct/whisper scope for rolls.
+  - The API requires `formula`, `rolls[]`, `total`, and `visibility`; rolling is done client-side using the existing `rollDie()` utility.
+  - The API returns 409 when there is no `activeSessionId` — the UI must guard against this pre-flight.
+  - Roll history GET requires an explicit `sessionId` param; only `campaign.activeSessionId` is available client-side.
+- Assumptions:
+  - `CampaignChat` receives `activeSessionId` as a prop from its parent (the campaign page already holds campaign state).
+  - One die per roll click (e.g., clicking d20 rolls 1d20 + modifier). Multi-die shortcuts (2d6) are out of scope.
+  - Roll history is loaded for the active session only; prior-session rolls are out of scope.
+  - Optimistic feed entries for rolls (like messages have) are not required for MVP — the SSE echo back is fast enough.
+- Edge cases considered:
+  - No active session: strip is greyed out; if a 409 arrives anyway (race), show inline error and do not clear the roll state.
+  - Stream delivers a roll event before history loads (dedup by id, same pattern as messages).
+  - Modifier field: allow negative values (e.g., −2 to simulate disadvantage penalty); clamp display but do not clamp value.
+  - Roll event received for a roll the current user cannot see (server should not emit it, but if it arrives, `canSeeRoll` acts as a client-side guard).
+
+## Scope
+
+### In Scope
+
+- Unified feed type (`FeedItem`) replacing the `messages` state in `CampaignChat`.
+- Roll feed item component: formula, per-die breakdown, total, roller handle, timestamp, visibility marker.
+- Roll-entry strip in the dock: d4/d6/d8/d10/d12/d20 buttons, modifier input (integer, positive or negative), visibility selector (group/dm-only), disabled state when no active session.
+- SSE stream handler extended to consume `type: "roll"` events.
+- Roll history fetch on dock expand (parallel with message history fetch), merged and sorted by `createdAt`.
+- `activeSessionId` prop added to `CampaignChat`.
+
+### Out of Scope
+
+- Multi-die formula input (e.g., "2d6+3" free text entry).
+- Roll history across multiple sessions.
+- Advantage/disadvantage rolling (2d20 keep highest/lowest).
+- Whisper-scoped rolls (`direct` visibility).
+- Optimistic roll feed items.
+- Unread-count tracking for roll events.
+
+## What Changes
+
+- `lib/components/CampaignChat.tsx`: add `activeSessionId` prop; replace `messages: CampaignMessage[]` state with `feed: FeedItem[]`; extend stream handler; add roll history fetch; add `RollFeedItem` sub-component; add `RollEntryStrip` sub-component.
+- `lib/types.ts`: export `FeedItem` discriminated union (or define it locally in `CampaignChat.tsx` — TBD in design).
+- Caller of `CampaignChat` (campaign page): pass `activeSessionId` prop.
+
+## Risks
+
+- Risk: Feed merge complexity — sorting mixed message/roll arrays on each state update could cause render thrash.
+  - Impact: Jank on rapid incoming events.
+  - Mitigation: Insert into sorted position rather than re-sorting the entire array; or sort once on initial load and append/insert incrementally via stream.
+
+- Risk: Roll history and message history fetched in parallel but merged — a slow roll history fetch could cause a layout jump.
+  - Impact: Visual shift after initial render.
+  - Mitigation: Show loading indicator until both fetches resolve; merge before first render of history items.
+
+- Risk: `activeSessionId` going stale — the campaign page may not re-fetch the campaign when a DM starts/ends a session mid-visit.
+  - Impact: Roll strip remains enabled/disabled incorrectly.
+  - Mitigation: The campaign SSE `change` event should carry updated campaign fields; `CampaignChat` (or parent) should update `activeSessionId` on `type: "change"` events. Flag as a follow-up if not already handled.
+
+## Open Questions
+
+- No unresolved questions remain that would block implementation. All design decisions were made during the explore session:
+  - Mixed feed: confirmed.
+  - Quick buttons + modifier field: confirmed.
+  - No active session → greyed strip: confirmed.
+  - `activeSessionId` via prop: confirmed.
+
+## Non-Goals
+
+- Server-side formula parsing or re-rolling.
+- Roll statistics, history search, or export.
+- Push notifications for rolls.
+- Sound effects or animation on roll.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/issue-317-roll-share-ui/specs/roll-share-ui/spec.md
+++ b/openspec/changes/issue-317-roll-share-ui/specs/roll-share-ui/spec.md
@@ -1,0 +1,201 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Roll-entry strip in the chat dock
+
+The system SHALL display a roll-entry strip below the chat composer when the chat dock is expanded, containing die buttons (d4, d6, d8, d10, d12, d20), a modifier number input, and a visibility selector (Group / DM-only).
+
+#### Scenario: Roll strip renders when dock is expanded and session is active
+
+- **Given** a campaign page where `activeSessionId` is a non-null string and the chat dock is expanded
+- **When** the dock content renders
+- **Then** six die buttons labelled d4, d6, d8, d10, d12, and d20 are visible and enabled, the modifier input is enabled, and the visibility selector is enabled
+
+#### Scenario: Roll strip is disabled when no active session
+
+- **Given** a campaign page where `activeSessionId` is null and the chat dock is expanded
+- **When** the dock content renders
+- **Then** all six die buttons are disabled, the modifier input is disabled, the visibility selector is disabled, and a "No active session" label is visible in the strip
+
+#### Scenario: Clicking a die button posts a roll with correct formula and total
+
+- **Given** the roll strip is enabled, modifier is 3, visibility is "group"
+- **When** the user clicks the d20 button
+- **Then** a POST to `/api/campaigns/[id]/rolls` is made with `formula: "1d20+3"`, `rolls: [<result>]`, `total: <result + 3>`, and `visibility: { scope: "group" }`
+
+#### Scenario: Clicking a die button with zero modifier omits the modifier from formula
+
+- **Given** the roll strip is enabled and modifier input is empty or 0
+- **When** the user clicks the d6 button
+- **Then** a POST is made with `formula: "1d6"` (no `+0` suffix)
+
+#### Scenario: Clicking a die button with a negative modifier includes sign in formula
+
+- **Given** the roll strip is enabled and modifier input is −2
+- **When** the user clicks the d8 button
+- **Then** a POST is made with `formula: "1d8-2"` and `total: <roll - 2>`
+
+#### Scenario: Visibility selector defaults to group
+
+- **Given** the roll strip is first rendered
+- **When** no user interaction has occurred
+- **Then** the visibility selector shows "Group" as the selected value
+
+#### Scenario: DM-only visibility sends correct scope
+
+- **Given** the user has selected "DM-only" in the visibility selector
+- **When** the user clicks any die button
+- **Then** the POST body includes `visibility: { scope: "dm-only" }`
+
+#### Scenario: Roll button is disabled while a roll is in flight
+
+- **Given** a roll POST is pending (awaiting server response)
+- **When** the roll strip re-renders
+- **Then** all die buttons are disabled until the POST resolves or rejects
+
+#### Scenario: 409 response (no active session race) shows inline error
+
+- **Given** the strip appears enabled (activeSessionId was non-null) but the server returns 409
+- **When** the POST resolves with status 409
+- **Then** an inline error message "No active session" is shown in the strip and no roll is added to the feed
+
+---
+
+### Requirement: ADDED Roll feed item rendering
+
+The system SHALL render roll events in the chat feed as a distinct visual item showing the roller's name, timestamp, visibility marker, formula, per-die breakdown, and total.
+
+#### Scenario: Roll feed item shows formula breakdown and total
+
+- **Given** a `CampaignRoll` with `formula: "1d20+3"`, `rolls: [17]`, `total: 20`, `rollerName: "thegm"`, `visibility: { scope: "dm-only" }`, `createdAt: <timestamp>`
+- **When** the roll is rendered in the feed
+- **Then** the item displays "thegm", a formatted timestamp, "[DM]" visibility marker, "1d20+3", the breakdown "[17]", and "20"
+
+#### Scenario: Group-scoped roll shows no visibility marker
+
+- **Given** a `CampaignRoll` with `visibility: { scope: "group" }`
+- **When** the roll is rendered in the feed
+- **Then** no visibility marker (such as "[DM]") appears on the item
+
+#### Scenario: Roll feed item is visually distinct from a message item
+
+- **Given** both a `CampaignMessage` and a `CampaignRoll` are in the feed
+- **When** the feed renders
+- **Then** the roll item has a visual treatment (e.g., dice icon, background tint, or border) that distinguishes it from adjacent message items
+
+---
+
+### Requirement: ADDED Interleaved feed of messages and rolls
+
+The system SHALL display messages and rolls in a single unified feed sorted by `createdAt` ascending.
+
+#### Scenario: Messages and rolls interleave by timestamp
+
+- **Given** a message at time T1, a roll at time T2 > T1, and a message at time T3 > T2 loaded from history
+- **When** the feed renders
+- **Then** items appear in order: message(T1), roll(T2), message(T3)
+
+#### Scenario: Stream roll event appended after existing feed
+
+- **Given** an existing feed with items up to time T
+- **When** an SSE event of type "roll" with `createdAt` > T arrives
+- **Then** the roll item is appended to the end of the feed without re-ordering existing items
+
+#### Scenario: Duplicate roll id from stream is ignored
+
+- **Given** a roll with id "roll-abc" was loaded from history into the feed
+- **When** an SSE event of type "roll" arrives with the same id "roll-abc"
+- **Then** the feed length does not increase and "roll-abc" appears only once
+
+---
+
+### Requirement: ADDED Roll history loaded on dock expand
+
+The system SHALL fetch roll history for the active session when the chat dock is expanded, in parallel with message history.
+
+#### Scenario: Roll history fetched with active sessionId on expand
+
+- **Given** the dock is collapsed, `activeSessionId` is "session-xyz"
+- **When** the user expands the dock
+- **Then** a GET to `/api/campaigns/[id]/rolls?sessionId=session-xyz&limit=30` is made
+
+#### Scenario: Roll history skipped when no active session
+
+- **Given** the dock is collapsed, `activeSessionId` is null
+- **When** the user expands the dock
+- **Then** no GET to `/api/campaigns/[id]/rolls` is made; message history is still fetched normally
+
+#### Scenario: History messages and rolls merged and sorted by createdAt
+
+- **Given** message history returns items at T1 and T3, roll history returns an item at T2
+- **When** both fetches resolve
+- **Then** the feed displays items sorted T1, T2, T3
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED CampaignChat accepts activeSessionId prop
+
+The system SHALL accept an `activeSessionId: string | null` prop on `CampaignChat` and use it to gate roll history fetching and the roll-entry strip.
+
+#### Scenario: activeSessionId null disables roll functionality
+
+- **Given** `CampaignChat` is rendered with `activeSessionId={null}`
+- **When** the dock is expanded
+- **Then** the roll strip is fully disabled, no roll history fetch is attempted, and the message feed loads normally
+
+#### Scenario: activeSessionId non-null enables roll functionality
+
+- **Given** `CampaignChat` is rendered with `activeSessionId="session-abc"`
+- **When** the dock is expanded
+- **Then** the roll strip is enabled and roll history is fetched for "session-abc"
+
+---
+
+## REMOVED Requirements
+
+None.
+
+---
+
+## Traceability
+
+- Proposal element "Roll-entry strip with die buttons, modifier, visibility, disabled state" → Requirements: Roll-entry strip in the chat dock
+- Proposal element "Unified feed type replacing messages state" → Requirements: Interleaved feed of messages and rolls
+- Proposal element "Roll feed item visually distinct" → Requirements: Roll feed item rendering
+- Proposal element "SSE stream extended to consume roll events" → Requirements: Interleaved feed (stream scenario), Duplicate dedup scenario
+- Proposal element "Roll history fetch on expand" → Requirements: Roll history loaded on dock expand
+- Proposal element "activeSessionId as prop" → Requirements: MODIFIED CampaignChat accepts activeSessionId prop
+
+- Design decision 1 (FeedItem local type) → Requirements: Interleaved feed of messages and rolls
+- Design decision 2 (activeSessionId prop) → Requirements: MODIFIED CampaignChat accepts activeSessionId prop
+- Design decision 3 (sorted insert) → Requirements: Interleaved feed — ordering scenarios
+- Design decision 4 (parallel fetch) → Requirements: Roll history loaded on dock expand
+- Design decision 5 (client-side rolling) → Requirements: Roll-entry strip — POST body scenarios
+- Design decision 6 (strip placement) → Requirements: Roll-entry strip — render and disabled scenarios
+
+- Requirements → Tasks: all requirements map to Task 2 (FeedItem/stream), Task 3 (RollFeedItem), Task 4 (RollEntryStrip), Task 5 (history fetch), Task 6 (campaign page prop) — see `tasks.md`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Feed append does not re-sort on SSE roll event
+
+- **Given** a feed with 50+ existing items
+- **When** a single SSE roll event arrives
+- **Then** the feed item is appended without a full array sort; no perceptible layout thrash occurs
+
+### Requirement: Security
+
+See functional scenarios: "DM-only visibility sends correct scope", "409 response (no active session race) shows inline error". Visibility enforcement is owned by the server (SSE fan-out in `emitFiltered`) and is not re-implemented in the UI beyond using `canSeeRoll` as a secondary guard for unexpected events.
+
+### Requirement: Reliability
+
+#### Scenario: Duplicate roll dedup across history and stream
+
+See functional scenario: "Duplicate roll id from stream is ignored". The `seenIds` ref must be extended to cover roll ids in addition to message ids.

--- a/openspec/changes/issue-317-roll-share-ui/tasks.md
+++ b/openspec/changes/issue-317-roll-share-ui/tasks.md
@@ -1,0 +1,161 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feature/issue-317-roll-share-ui` then immediately `git push -u origin feature/issue-317-roll-share-ui`
+
+## Execution
+
+### Task 1 — Add `activeSessionId` prop to `CampaignChat` and pass it from the campaign page
+
+Files: `lib/components/CampaignChat.tsx`, caller component (campaign page).
+
+- [x] Add `activeSessionId: string | null` to the `CampaignChat` props signature.
+- [x] Update the campaign page to pass `campaign.activeSessionId ?? null` to `<CampaignChat>`.
+- [x] Confirm: `CampaignChat` compiles; existing message functionality unaffected.
+
+Acceptance criteria: spec scenario "activeSessionId null disables roll functionality", "activeSessionId non-null enables roll functionality".
+
+---
+
+### Task 2 — Unify feed state as `FeedItem` discriminated union
+
+Files: `lib/components/CampaignChat.tsx`.
+
+- [x] Define `type FeedItem = { kind: 'message'; data: CampaignMessage } | { kind: 'roll'; data: CampaignRoll }` locally in `CampaignChat.tsx`.
+- [x] Replace `messages: CampaignMessage[]` state with `feed: FeedItem[]`.
+- [x] Update `seenIds` ref to track both message ids and roll ids (no change needed to the ref itself — ids are already strings; ensure roll id is added on stream receipt and on history load).
+- [x] Update `onStreamEvent` to handle `e.type === 'roll'`: wrap in `{ kind: 'roll', data: e.data }` and append to feed (same dedup guard as messages).
+- [x] Update `ChatFeed` props from `messages: CampaignMessage[]` to `feed: FeedItem[]`.
+- [x] Update `ChatFeed` render loop to branch on `item.kind` — message items render existing markup; roll items delegate to `RollFeedItem` (stub returning `null` at this stage is fine).
+- [x] Unit tests: `onStreamEvent` with `type: "roll"` appends to feed; duplicate roll id is ignored.
+
+Acceptance criteria: spec scenarios "Stream roll event appended after existing feed", "Duplicate roll id from stream is ignored".
+
+---
+
+### Task 3 — Implement `RollFeedItem` sub-component
+
+Files: `lib/components/CampaignChat.tsx`.
+
+- [x] Add `function RollFeedItem({ roll }: { roll: CampaignRoll })` inside `CampaignChat.tsx`.
+- [x] Display: roller name (`roll.rollerName`), formatted timestamp, visibility marker (`[DM]` if `dm-only`, nothing if `group`), formula (`roll.formula`), breakdown (`roll.rolls.join(', ')` wrapped in `[…]`), total.
+- [x] Apply visual distinction: a dice icon (`🎲` or SVG) and a subtle background tint (e.g., `bg-gray-700/50 rounded`) to differentiate from message items.
+- [x] Wire `RollFeedItem` into the `ChatFeed` render loop (replace the `null` stub from Task 2).
+- [x] Unit/render tests: given a `CampaignRoll` fixture, assert formula, breakdown, total, roller name, and visibility marker are rendered; assert group-scoped roll shows no marker.
+
+Acceptance criteria: spec scenarios "Roll feed item shows formula breakdown and total", "Group-scoped roll shows no visibility marker", "Roll feed item is visually distinct from a message item".
+
+---
+
+### Task 4 — Implement `RollEntryStrip` sub-component
+
+Files: `lib/components/CampaignChat.tsx`, `lib/utils/dice.ts` (import only).
+
+- [x] Add `interface RollEntryStripProps` with: `campaignId: string`, `activeSessionId: string | null`, `streamStatus: 'connecting' | 'open' | 'error'`, `members` (for visibility selector — not needed, RollVisibility has no `direct`), `onRollPosted: (roll: CampaignRoll) => void`.
+- [x] Add `function RollEntryStrip(props: RollEntryStripProps)` with state: `modifier: number` (default 0), `visibility: RollVisibility` (default `{ scope: 'group' }`), `isRolling: boolean`, `error: string | null`.
+- [x] Render: a row of six buttons labelled "d4", "d6", "d8", "d10", "d12", "d20"; a `<input type="number">` for modifier; a `<select>` for visibility (Group / DM-only); and conditional error text.
+- [x] Disabled condition: `activeSessionId === null || streamStatus !== 'open' || isRolling`. Show "No active session" label when `activeSessionId === null`.
+- [x] On die button click: implemented per spec.
+- [x] Wire `RollEntryStrip` into `CampaignChat`'s expanded drawer below `ChatComposer`, passing `onRollPosted` which wraps the roll in a `FeedItem` and appends to feed (with dedup guard).
+- [x] Unit tests: button click with modifier=3 produces correct formula/total; modifier=0 omits sign; negative modifier uses minus sign; disabled when `activeSessionId` is null; 409 shows inline error; successful roll calls `onRollPosted`.
+
+Acceptance criteria: all Roll-entry strip spec scenarios.
+
+---
+
+### Task 5 — Fetch roll history in parallel with message history on dock expand
+
+Files: `lib/components/CampaignChat.tsx`.
+
+- [x] In the `useEffect` that fires on `isExpanded`, replace the single `fetch` call with `Promise.all([fetchMessages(), fetchRolls()])` when `activeSessionId` is non-null; otherwise keep the single message fetch.
+- [x] `fetchRolls`: `GET /api/campaigns/${campaignId}/rolls?sessionId=${activeSessionId}&limit=30` — returns `{ rolls: CampaignRoll[], nextCursor?: string }` (consult existing API route for exact shape).
+- [x] Merge results: map messages to `FeedItem` (kind: 'message') and rolls to `FeedItem` (kind: 'roll'), combine arrays, sort by `createdAt` ascending, dedup via `seenIds`, set as initial `feed`.
+- [x] Keep `isLoadingHistory` flag gated on both fetches completing.
+- [x] Unit tests: verify `GET /rolls` is called with correct `sessionId`; verify merged feed sorted by timestamp; verify no rolls fetch when `activeSessionId` is null.
+
+Acceptance criteria: spec scenarios "Roll history fetched with active sessionId on expand", "Roll history skipped when no active session", "History messages and rolls merged and sorted by createdAt".
+
+---
+
+### Task 6 — Run tests, type check, and build
+
+- [x] `npm run test:unit` — all tests pass.
+- [x] `npm run test:integration` — requires `npm run build` first; all tests pass.
+- [x] `npx tsc --noEmit` — no type errors (only pre-existing test file errors unchanged from main).
+- [x] `npm run build` — build succeeds.
+
+---
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill on the staged/modified files. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [ ] `npm run test:unit` — all suites pass
+- [ ] `npm run build` — succeeds
+- [ ] `npm run test:integration` — all suites pass (run after build)
+- [ ] `npx tsc --noEmit` — no errors
+- [ ] Roll strip renders enabled when `activeSessionId` is non-null
+- [ ] Roll strip renders disabled with "No active session" label when `activeSessionId` is null
+- [ ] Clicking a die button posts correct formula/rolls/total to the API
+- [ ] Roll appears in the feed interleaved with messages by timestamp
+- [ ] DM-only roll shows `[DM]` marker; group roll shows no marker
+- [ ] Duplicate roll id from stream/history does not appear twice
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- `npm run test:unit` — all tests must pass
+- `npm run build` — build must succeed
+- `npm run test:integration` — all tests must pass (requires build)
+
+**Docs-only path** (every changed file is `.md`):
+
+- `npm run build` — build must succeed
+- Skip integration tests
+
+If **ANY** required step fails, iterate and fix before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to `feature/issue-317-roll-share-ui` and push
+- [ ] Open PR from `feature/issue-317-roll-share-ui` to `main`. PR body must include: `Closes #317`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Iterate until merged** — repeat continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if `CLOSED`, exit and notify the user:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix failures, commit, push before anything else
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; address each unresolved thread, commit, run [Remote push validation], push, wait 180 seconds; repeat until all resolved
+  3. **CI check failures** — only after all comments resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix failing required checks, commit, run [Remote push validation], push, wait 180 seconds; restart loop from step 1
+
+Ownership metadata:
+
+- Implementer: (assigned at apply time)
+- Reviewer(s): repo owner (dougis)
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec deltas: copy `openspec/changes/issue-317-roll-share-ui/specs/roll-share-ui/spec.md` to `openspec/specs/roll-share-ui/spec.md`; update relative links in the copied file: replace `../../design.md` → `../../changes/archive/YYYY-MM-DD-issue-317-roll-share-ui/design.md` and `../../tasks.md` → `../../changes/archive/YYYY-MM-DD-issue-317-roll-share-ui/tasks.md`
+- [ ] Archive the change: move `openspec/changes/issue-317-roll-share-ui/` to `openspec/changes/archive/YYYY-MM-DD-issue-317-roll-share-ui/` — **stage both the copy and the deletion in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-issue-317-roll-share-ui/` exists and `openspec/changes/issue-317-roll-share-ui/` is gone
+- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-issue-317-roll-share-ui` then `git push -u origin doc/archive-YYYY-MM-DD-issue-317-roll-share-ui`
+- [ ] Open PR from `doc/archive-YYYY-MM-DD-issue-317-roll-share-ui` to `main` with title `docs: archive issue-317-roll-share-ui (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge`
+- [ ] Monitor the doc PR until merged (same loop — address comments/CI, push to doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feature/issue-317-roll-share-ui doc/archive-YYYY-MM-DD-issue-317-roll-share-ui`

--- a/openspec/changes/issue-317-roll-share-ui/tasks.md
+++ b/openspec/changes/issue-317-roll-share-ui/tasks.md
@@ -90,7 +90,7 @@ Acceptance criteria: spec scenarios "Roll history fetched with active sessionId 
 
 ## Pre-Commit Code Review
 
-- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill on the staged/modified files. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill on the staged/modified files. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
 
 ## Validation
 

--- a/openspec/changes/issue-317-roll-share-ui/tests.md
+++ b/openspec/changes/issue-317-roll-share-ui/tests.md
@@ -1,0 +1,160 @@
+---
+name: tests
+description: Tests for issue-317-roll-share-ui (Roll-share UI in the chat dock)
+---
+
+# Tests
+
+## Overview
+
+All work follows strict TDD: write a failing test, write code to pass it, refactor.
+Unit tests live under `tests/unit/` (required by project convention — never co-located with source).
+Integration tests live under `tests/integration/`.
+
+Test files:
+- `tests/unit/components/CampaignChat.roll.test.tsx` — new file for all roll-related unit tests
+- `tests/unit/components/CampaignChat.test.tsx` — extend existing file for prop/feed regression tests (if it exists; otherwise cover in the new file)
+
+---
+
+## Testing Steps
+
+For each task in `tasks.md`, follow the TDD cycle:
+
+1. **Write a failing test** capturing the requirement.
+2. **Write the simplest code** to make it pass.
+3. **Refactor** while keeping tests green.
+
+---
+
+## Test Cases
+
+### Task 1 — `activeSessionId` prop
+
+- [ ] **T1.1** `CampaignChat` renders without error when `activeSessionId` is null (smoke test; existing message feed renders normally)
+  - Spec: "activeSessionId null disables roll functionality"
+  - Type: Unit (render)
+
+- [ ] **T1.2** `CampaignChat` renders without error when `activeSessionId` is a non-null string
+  - Spec: "activeSessionId non-null enables roll functionality"
+  - Type: Unit (render)
+
+---
+
+### Task 2 — FeedItem union and stream handler
+
+- [ ] **T2.1** `onStreamEvent` with `{ type: 'roll', data: <CampaignRoll> }` appends a `{ kind: 'roll' }` FeedItem to the feed
+  - Spec: "Stream roll event appended after existing feed"
+  - Type: Unit (hook/handler)
+
+- [ ] **T2.2** `onStreamEvent` with a roll whose id is already in `seenIds` does not add a duplicate to the feed
+  - Spec: "Duplicate roll id from stream is ignored"
+  - Type: Unit (handler)
+
+- [ ] **T2.3** `onStreamEvent` with `{ type: 'message' }` still appends a `{ kind: 'message' }` FeedItem (regression)
+  - Type: Unit (handler)
+
+- [ ] **T2.4** `ChatFeed` renders a `RollFeedItem` for `{ kind: 'roll' }` items and a message item for `{ kind: 'message' }` items
+  - Type: Unit (render)
+
+---
+
+### Task 3 — `RollFeedItem` rendering
+
+- [ ] **T3.1** Given `CampaignRoll { formula: "1d20+3", rolls: [17], total: 20, rollerName: "thegm", visibility: { scope: "dm-only" } }`, the rendered item contains "thegm", "1d20+3", "[17]" (or equivalent breakdown), "20", and "[DM]"
+  - Spec: "Roll feed item shows formula breakdown and total"
+  - Type: Unit (render)
+
+- [ ] **T3.2** Given `visibility: { scope: "group" }`, no "[DM]" marker appears in the rendered item
+  - Spec: "Group-scoped roll shows no visibility marker"
+  - Type: Unit (render)
+
+- [ ] **T3.3** A roll item and a message item rendered side by side have visually different container classes (e.g., roll item has a background class that message item does not)
+  - Spec: "Roll feed item is visually distinct from a message item"
+  - Type: Unit (render)
+
+- [ ] **T3.4** Roll item displays a dice indicator (icon element or text) not present on message items
+  - Spec: "Roll feed item is visually distinct"
+  - Type: Unit (render)
+
+---
+
+### Task 4 — `RollEntryStrip`
+
+- [ ] **T4.1** When `activeSessionId` is null, all six die buttons, the modifier input, and the visibility select are disabled, and a "No active session" text is visible
+  - Spec: "Roll strip is disabled when no active session"
+  - Type: Unit (render)
+
+- [ ] **T4.2** When `activeSessionId` is non-null and `streamStatus` is "open", die buttons, modifier input, and visibility select are enabled
+  - Spec: "Roll strip renders when dock is expanded and session is active"
+  - Type: Unit (render)
+
+- [ ] **T4.3** Clicking the d20 button with modifier=3 and visibility=group triggers a `fetch` POST to `/api/campaigns/[id]/rolls` with body `{ formula: "1d20+3", rolls: [<number>], total: <number>, visibility: { scope: "group" } }`
+  - Spec: "Clicking a die button posts a roll with correct formula and total"
+  - Type: Unit (fetch mock)
+
+- [ ] **T4.4** Clicking the d6 button with modifier=0 (or empty) sends `formula: "1d6"` with no `+0` suffix
+  - Spec: "Clicking a die button with zero modifier omits the modifier from formula"
+  - Type: Unit (fetch mock)
+
+- [ ] **T4.5** Clicking the d8 button with modifier=−2 sends `formula: "1d8-2"` and `total: <roll - 2>`
+  - Spec: "Clicking a die button with a negative modifier includes sign in formula"
+  - Type: Unit (fetch mock)
+
+- [ ] **T4.6** Visibility select defaults to "group" on first render
+  - Spec: "Visibility selector defaults to group"
+  - Type: Unit (render)
+
+- [ ] **T4.7** Selecting "DM-only" then clicking a die button sends `visibility: { scope: "dm-only" }`
+  - Spec: "DM-only visibility sends correct scope"
+  - Type: Unit (fetch mock)
+
+- [ ] **T4.8** While a roll POST is in flight (`isRolling=true`), all die buttons are disabled
+  - Spec: "Roll button is disabled while a roll is in flight"
+  - Type: Unit (render/state)
+
+- [ ] **T4.9** When the POST responds with 409, an inline "No active session" error message is visible and `isRolling` returns to false
+  - Spec: "409 response shows inline error"
+  - Type: Unit (fetch mock)
+
+- [ ] **T4.10** On a successful 201 response, `onRollPosted` is called with the returned `CampaignRoll` and `isRolling` returns to false
+  - Spec: roll submission happy path
+  - Type: Unit (fetch mock)
+
+---
+
+### Task 5 — Roll history fetch on expand
+
+- [ ] **T5.1** When the dock expands and `activeSessionId` is "session-xyz", `fetch` is called with `/api/campaigns/[id]/rolls?sessionId=session-xyz&limit=30`
+  - Spec: "Roll history fetched with active sessionId on expand"
+  - Type: Unit (fetch mock)
+
+- [ ] **T5.2** When `activeSessionId` is null and the dock expands, no `fetch` call to `/rolls` is made; the message history fetch still fires
+  - Spec: "Roll history skipped when no active session"
+  - Type: Unit (fetch mock)
+
+- [ ] **T5.3** Message history at T1/T3 and roll history at T2 produce a feed in order T1, T2, T3 after the parallel fetch resolves
+  - Spec: "History messages and rolls merged and sorted by createdAt"
+  - Type: Unit (state)
+
+- [ ] **T5.4** A roll id present in both history response and a prior stream event appears only once in the feed
+  - Spec: dedup across history and stream
+  - Type: Unit (state)
+
+---
+
+## Integration Test Cases
+
+These require `npm run build` first (integration tests run against `next start`).
+
+- [ ] **I1** POST `/api/campaigns/[id]/rolls` with a valid body while `activeSessionId` is set returns 201 and the roll appears in the SSE stream for group-visibility subscribers
+  - Spec: "Clicking a die button posts a roll" (end-to-end)
+  - Type: Integration
+
+- [ ] **I2** POST `/api/campaigns/[id]/rolls` when `activeSessionId` is null returns 409
+  - Spec: "409 response (no active session race)"
+  - Type: Integration (existing API test — verify it still passes)
+
+- [ ] **I3** GET `/api/campaigns/[id]/rolls?sessionId=<id>` returns only rolls for the specified session and respects dm-only visibility for non-DM callers
+  - Spec: visibility enforcement (server-side)
+  - Type: Integration (existing API test — verify it still passes)

--- a/tests/unit/components/CampaignChat.roll.test.tsx
+++ b/tests/unit/components/CampaignChat.roll.test.tsx
@@ -350,6 +350,30 @@ it('selecting DM-only sends correct scope', async () => {
   })
 })
 
+// T4.8 — buttons disabled while roll is in flight
+it('all die buttons are disabled while a roll POST is in flight', async () => {
+  let resolvePost: (value: unknown) => void
+  fetchSpy.mockImplementation((url: string, init?: RequestInit) => {
+    if (url.includes('/rolls') && init?.method === 'POST') {
+      return new Promise(resolve => { resolvePost = resolve })
+    }
+    if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+    if (url.includes('/messages')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    if (url.includes('/rolls')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ rolls: [] }) })
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+  await openDock('session-1')
+  // Click a die button — POST hangs
+  userEvent.click(screen.getByRole('button', { name: 'd6' }))
+  // While in flight, all die buttons should be disabled
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'd6' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'd20' })).toBeDisabled()
+  })
+  // Resolve the POST to clean up
+  resolvePost!({ ok: true, status: 201, json: () => Promise.resolve(makeRoll()) })
+})
+
 // T4.9
 it('409 response shows inline "No active session" error', async () => {
   setupFetchMock({ rollPostStatus: 409 })

--- a/tests/unit/components/CampaignChat.roll.test.tsx
+++ b/tests/unit/components/CampaignChat.roll.test.tsx
@@ -1,0 +1,457 @@
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CampaignChat } from '@/lib/components/CampaignChat'
+import type { CampaignRoll, CampaignStreamEvent } from '@/lib/types'
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+jest.mock('@/lib/offline/LocalStore', () => ({
+  LocalStore: { get: jest.fn().mockReturnValue(null), set: jest.fn(), remove: jest.fn() },
+}))
+
+jest.mock('@/lib/utils/dice', () => ({
+  rollDie: jest.fn().mockReturnValue([15]),
+}))
+
+let capturedOnEvent: ((e: CampaignStreamEvent) => void) | null = null
+jest.mock('@/lib/hooks/useCampaignStream', () => ({
+  useCampaignStream: jest.fn((_, onEvent) => {
+    capturedOnEvent = onEvent
+    return { status: 'open' }
+  }),
+}))
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: jest.fn(() => ({
+    user: { userId: 'user-1', email: 'test@example.com', username: 'tester' },
+    loading: false,
+  })),
+}))
+
+// ── Test fixtures ─────────────────────────────────────────────────
+
+function makeRoll(overrides: Partial<CampaignRoll> = {}): CampaignRoll {
+  return {
+    id: 'roll-1',
+    campaignId: 'test-campaign',
+    sessionId: 'session-1',
+    rollerId: 'user-1',
+    rollerName: 'thegm',
+    formula: '1d20+3',
+    rolls: [17],
+    total: 20,
+    visibility: { scope: 'group' },
+    createdAt: new Date('2026-01-01T12:00:00Z'),
+    ...overrides,
+  }
+}
+
+// ── Setup ─────────────────────────────────────────────────────────
+
+let fetchSpy: jest.Mock
+const originalFetch = global.fetch
+
+function setupFetchMock(overrides: Record<string, unknown> = {}) {
+  fetchSpy = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
+    if (url.includes('/members')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+    }
+    if (url.includes('/messages') && (!init || init.method !== 'POST')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(overrides.messages ?? { messages: [] }),
+      })
+    }
+    if (url.includes('/rolls') && (!init || init.method !== 'POST')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(overrides.rolls ?? { rolls: [] }),
+      })
+    }
+    if (url.includes('/rolls') && init?.method === 'POST') {
+      const status = (overrides.rollPostStatus as number) ?? 201
+      const body = overrides.rollPostBody ?? makeRoll()
+      return Promise.resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+      })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+  global.fetch = fetchSpy as unknown as typeof global.fetch
+}
+
+async function openDock(activeSessionId?: string | null) {
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" activeSessionId={activeSessionId ?? null} />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  return user
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  capturedOnEvent = null
+  setupFetchMock()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+// ── T1 — activeSessionId prop ────────────────────────────────────
+
+// T1.1
+it('renders without error when activeSessionId is null', async () => {
+  await openDock(null)
+  expect(screen.getByRole('complementary', { name: /campaign chat/i })).toBeInTheDocument()
+})
+
+// T1.2
+it('renders without error when activeSessionId is a non-null string', async () => {
+  await openDock('session-abc')
+  expect(screen.getByRole('complementary', { name: /campaign chat/i })).toBeInTheDocument()
+})
+
+// ── T2 — FeedItem union and stream handler ────────────────────────
+
+// T2.1
+it('stream roll event appends a roll item to the feed', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ formula: '1d20+3', rolls: [17], total: 20 }),
+    })
+  })
+  expect(screen.getByText('1d20+3 → [17] =')).toBeInTheDocument()
+})
+
+// T2.2
+it('duplicate roll id from stream is ignored', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ id: 'roll-dup', formula: '1d6', rolls: [4], total: 4 }),
+    })
+  })
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ id: 'roll-dup', formula: '1d6', rolls: [4], total: 4 }),
+    })
+  })
+  expect(screen.getAllByText(/1d6/)).toHaveLength(1)
+})
+
+// T2.3
+it('stream message event still appends a message item to the feed (regression)', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: {
+        id: 'msg-1', campaignId: 'test-campaign', senderId: 'user-1',
+        senderName: 'Alice', text: 'Hello world',
+        visibility: { scope: 'group' }, createdAt: new Date(),
+      },
+    })
+  })
+  expect(screen.getByText('Hello world')).toBeInTheDocument()
+})
+
+// T2.4
+it('feed renders both message and roll items from stream events', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: { id: 'msg-1', campaignId: 'test-campaign', senderId: 'u1', senderName: 'Alice', text: 'Hi', visibility: { scope: 'group' }, createdAt: new Date() },
+    })
+  })
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ id: 'roll-2', formula: '1d8', rolls: [5], total: 5 }),
+    })
+  })
+  expect(screen.getByText('Hi')).toBeInTheDocument()
+  expect(screen.getByText(/1d8/)).toBeInTheDocument()
+})
+
+// ── T3 — RollFeedItem rendering ───────────────────────────────────
+
+// T3.1
+it('roll feed item shows formula, breakdown, total, roller name, and [DM] for dm-only', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ rollerName: 'thegm', formula: '1d20+3', rolls: [17], total: 20, visibility: { scope: 'dm-only' } }),
+    })
+  })
+  expect(screen.getByText('thegm')).toBeInTheDocument()
+  expect(screen.getByText(/1d20\+3/)).toBeInTheDocument()
+  expect(screen.getByText(/\[17\]/)).toBeInTheDocument()
+  expect(screen.getByText('20')).toBeInTheDocument()
+  expect(screen.getByText('[DM]')).toBeInTheDocument()
+})
+
+// T3.2
+it('group-scoped roll shows no [DM] marker', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ visibility: { scope: 'group' } }),
+    })
+  })
+  expect(screen.queryByText('[DM]')).not.toBeInTheDocument()
+})
+
+// T3.3
+it('roll item has background class that message item does not', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'message',
+      campaignId: 'test-campaign',
+      data: { id: 'msg-1', campaignId: 'test-campaign', senderId: 'u1', senderName: 'Alice', text: 'Plain message', visibility: { scope: 'group' }, createdAt: new Date() },
+    })
+  })
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ id: 'roll-2' }),
+    })
+  })
+  // Roll items have bg-gray-700/50 class, message items don't
+  const rollItem = screen.getByText('thegm').closest('div[class*="bg-gray-700"]')
+  expect(rollItem).toBeInTheDocument()
+})
+
+// T3.4
+it('roll item displays dice indicator emoji', async () => {
+  await openDock('session-1')
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll(),
+    })
+  })
+  expect(screen.getByText('🎲')).toBeInTheDocument()
+})
+
+// ── T4 — RollEntryStrip ───────────────────────────────────────────
+
+// T4.1
+it('roll strip disabled with "No active session" when activeSessionId is null', async () => {
+  await openDock(null)
+  expect(screen.getByText('No active session')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'd20' })).toBeDisabled()
+  expect(screen.getByLabelText('Modifier')).toBeDisabled()
+  expect(screen.getByLabelText('Roll visibility')).toBeDisabled()
+})
+
+// T4.2
+it('roll strip enabled when activeSessionId is non-null and stream is open', async () => {
+  await openDock('session-1')
+  expect(screen.queryByText('No active session')).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'd20' })).not.toBeDisabled()
+  expect(screen.getByLabelText('Modifier')).not.toBeDisabled()
+  expect(screen.getByLabelText('Roll visibility')).not.toBeDisabled()
+})
+
+// T4.3
+it('clicking d20 with modifier=3 posts correct formula and total', async () => {
+  const { rollDie } = await import('@/lib/utils/dice')
+  ;(rollDie as jest.Mock).mockReturnValue([15])
+  const user = await openDock('session-1')
+  const modifierInput = screen.getByLabelText('Modifier')
+  await user.clear(modifierInput)
+  await user.type(modifierInput, '3')
+  await user.click(screen.getByRole('button', { name: 'd20' }))
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/campaigns/test-campaign/rolls',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ formula: '1d20+3', rolls: [15], total: 18, visibility: { scope: 'group' } }),
+      }),
+    )
+  })
+})
+
+// T4.4
+it('clicking d6 with modifier=0 sends formula without +0', async () => {
+  const { rollDie } = await import('@/lib/utils/dice')
+  ;(rollDie as jest.Mock).mockReturnValue([4])
+  await openDock('session-1')
+  await userEvent.click(screen.getByRole('button', { name: 'd6' }))
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/campaigns/test-campaign/rolls',
+      expect.objectContaining({
+        body: JSON.stringify({ formula: '1d6', rolls: [4], total: 4, visibility: { scope: 'group' } }),
+      }),
+    )
+  })
+})
+
+// T4.5
+it('clicking d8 with modifier=-2 sends formula with minus sign', async () => {
+  const { rollDie } = await import('@/lib/utils/dice')
+  ;(rollDie as jest.Mock).mockReturnValue([5])
+  const user = await openDock('session-1')
+  const modifierInput = screen.getByLabelText('Modifier')
+  fireEvent.change(modifierInput, { target: { value: '-2' } })
+  await user.click(screen.getByRole('button', { name: 'd8' }))
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/campaigns/test-campaign/rolls',
+      expect.objectContaining({
+        body: JSON.stringify({ formula: '1d8-2', rolls: [5], total: 3, visibility: { scope: 'group' } }),
+      }),
+    )
+  })
+})
+
+// T4.6
+it('visibility selector defaults to group on first render', async () => {
+  await openDock('session-1')
+  expect(screen.getByLabelText('Roll visibility')).toHaveValue('group')
+})
+
+// T4.7
+it('selecting DM-only sends correct scope', async () => {
+  const { rollDie } = await import('@/lib/utils/dice')
+  ;(rollDie as jest.Mock).mockReturnValue([10])
+  const user = await openDock('session-1')
+  await user.selectOptions(screen.getByLabelText('Roll visibility'), 'dm-only')
+  await user.click(screen.getByRole('button', { name: 'd6' }))
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/campaigns/test-campaign/rolls',
+      expect.objectContaining({
+        body: expect.stringContaining('"scope":"dm-only"'),
+      }),
+    )
+  })
+})
+
+// T4.9
+it('409 response shows inline "No active session" error', async () => {
+  setupFetchMock({ rollPostStatus: 409 })
+  await openDock('session-1')
+  await userEvent.click(screen.getByRole('button', { name: 'd20' }))
+  await waitFor(() => {
+    expect(screen.getByText('No active session')).toBeInTheDocument()
+  })
+})
+
+// T4.10
+it('successful 201 response calls onRollPosted (roll appears in feed)', async () => {
+  const returnedRoll = makeRoll({ id: 'roll-from-server', formula: '1d20', rolls: [15], total: 15 })
+  setupFetchMock({ rollPostBody: returnedRoll, rollPostStatus: 201 })
+  await openDock('session-1')
+  await userEvent.click(screen.getByRole('button', { name: 'd20' }))
+  await waitFor(() => {
+    expect(screen.getByText(/1d20/)).toBeInTheDocument()
+  })
+})
+
+// ── T5 — Roll history fetch on expand ────────────────────────────
+
+// T5.1
+it('fetches roll history with correct sessionId on dock expand', async () => {
+  await openDock('session-xyz')
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/campaigns/test-campaign/rolls?sessionId=session-xyz&limit=30',
+    )
+  })
+})
+
+// T5.2
+it('does not fetch rolls when activeSessionId is null; still fetches messages', async () => {
+  await openDock(null)
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/messages?limit=30'))
+  })
+  expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('/rolls?sessionId'))
+})
+
+// T5.3
+it('merged feed is sorted by createdAt', async () => {
+  const t1 = new Date('2026-01-01T10:00:00Z').toISOString()
+  const t2 = new Date('2026-01-01T11:00:00Z').toISOString()
+  const t3 = new Date('2026-01-01T12:00:00Z').toISOString()
+
+  setupFetchMock({
+    messages: {
+      messages: [
+        // API returns newest-first
+        { id: 'msg-3', campaignId: 'test-campaign', senderId: 'u1', senderName: 'Alice', text: 'Msg T3', visibility: { scope: 'group' }, createdAt: t3 },
+        { id: 'msg-1', campaignId: 'test-campaign', senderId: 'u1', senderName: 'Alice', text: 'Msg T1', visibility: { scope: 'group' }, createdAt: t1 },
+      ],
+    },
+    rolls: {
+      rolls: [
+        { id: 'roll-2', campaignId: 'test-campaign', sessionId: 'session-1', rollerId: 'u1', rollerName: 'Alice', formula: '1d6', rolls: [3], total: 3, visibility: { scope: 'group' }, createdAt: t2 },
+      ],
+    },
+  })
+
+  await openDock('session-1')
+
+  await waitFor(() => {
+    const items = screen.getAllByText(/Msg T|1d6/)
+    expect(items[0].textContent).toContain('Msg T1')
+    expect(items[1].textContent).toContain('1d6')
+    expect(items[2].textContent).toContain('Msg T3')
+  })
+})
+
+// T5.4
+it('roll id in both history and prior stream event appears only once', async () => {
+  setupFetchMock({
+    messages: { messages: [] },
+    rolls: {
+      rolls: [makeRoll({ id: 'roll-dup', formula: '1d4', rolls: [2], total: 2 })],
+    },
+  })
+
+  const user = userEvent.setup()
+  render(<CampaignChat campaignId="test-campaign" activeSessionId="session-1" />)
+
+  // Stream event arrives before history loads
+  act(() => {
+    capturedOnEvent?.({
+      type: 'roll',
+      campaignId: 'test-campaign',
+      data: makeRoll({ id: 'roll-dup', formula: '1d4', rolls: [2], total: 2 }),
+    })
+  })
+
+  // Now expand dock (triggers history fetch)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/rolls?sessionId'))
+  })
+
+  // Should appear only once
+  await waitFor(() => {
+    expect(screen.getAllByText(/1d4/)).toHaveLength(1)
+  })
+})

--- a/tests/unit/components/CampaignChat.test.tsx
+++ b/tests/unit/components/CampaignChat.test.tsx
@@ -341,11 +341,10 @@ it('composer shows three visibility options when dock is expanded', async () => 
   await openDock()
   const msgSelect = screen.getByRole('combobox', { name: 'Message visibility' })
   expect(msgSelect).toBeInTheDocument()
-  expect(screen.getByRole('option', { name: 'Whisper' })).toBeInTheDocument()
-  // Verify message visibility has all three options
-  expect(msgSelect).toContainHTML('Group')
-  expect(msgSelect).toContainHTML('DM-only')
-  expect(msgSelect).toContainHTML('Whisper')
+  const options = Array.from(msgSelect.querySelectorAll('option')).map(o => o.textContent)
+  expect(options).toContain('Group')
+  expect(options).toContain('DM-only')
+  expect(options).toContain('Whisper')
 })
 
 // T6e-2: selecting DM-only changes visibility
@@ -364,7 +363,7 @@ it('composer is disabled when stream status is not open', async () => {
     return { status: 'error' }
   })
   await openDock()
-  expect(screen.getByRole('textbox')).toBeDisabled()
+  expect(screen.getByRole('textbox', { name: 'Message' })).toBeDisabled()
   expect(screen.getByRole('button', { name: /send/i })).toBeDisabled()
   ;(useCampaignStream as jest.Mock).mockImplementation((_, onEvent) => {
     capturedOnEvent = onEvent
@@ -379,7 +378,7 @@ it('typing @prefix shows matching member in dropdown', async () => {
   withMembers([{ id: 'm2', userId: 'u2', username: 'bob' }])
   const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-  await user.type(screen.getByRole('textbox'), '@al')
+  await user.type(screen.getByRole('textbox', { name: 'Message' }), '@al')
   await waitFor(() => expect(screen.getByText('@alice')).toBeInTheDocument())
   expect(screen.queryByText('@bob')).not.toBeInTheDocument()
 })
@@ -389,7 +388,7 @@ it('no matching members hides the mention dropdown', async () => {
   withMembers()
   const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-  await user.type(screen.getByRole('textbox'), '@xyz')
+  await user.type(screen.getByRole('textbox', { name: 'Message' }), '@xyz')
   await waitFor(() => expect(screen.queryByText('@alice')).not.toBeInTheDocument())
 })
 
@@ -398,11 +397,11 @@ it('selecting mention sets visibility to direct and updates textarea', async () 
   withMembers()
   const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-  await user.type(screen.getByRole('textbox'), '@al')
+  await user.type(screen.getByRole('textbox', { name: 'Message' }), '@al')
   await waitFor(() => screen.getByText('@alice'))
   fireEvent.mouseDown(screen.getByText('@alice'))
   await waitFor(() => {
-    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toContain('@alice')
+    expect((screen.getByRole('textbox', { name: 'Message' }) as HTMLTextAreaElement).value).toContain('@alice')
     expect(screen.getByRole('combobox', { name: 'Message visibility' })).toHaveValue('direct')
   })
 })
@@ -412,11 +411,11 @@ it('deleting @mention text resets visibility to group', async () => {
   withMembers()
   const user = await openDock()
   await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/members')))
-  await user.type(screen.getByRole('textbox'), '@al')
+  await user.type(screen.getByRole('textbox', { name: 'Message' }), '@al')
   await waitFor(() => screen.getByText('@alice'))
   fireEvent.mouseDown(screen.getByText('@alice'))
   await waitFor(() => expect(screen.getByRole('combobox', { name: 'Message visibility' })).toHaveValue('direct'))
-  fireEvent.change(screen.getByRole('textbox'), { target: { value: '', selectionStart: 0 } })
+  fireEvent.change(screen.getByRole('textbox', { name: 'Message' }), { target: { value: '', selectionStart: 0 } })
   expect(screen.getByRole('combobox', { name: 'Message visibility' })).toHaveValue('group')
 })
 
@@ -425,7 +424,7 @@ it('deleting @mention text resets visibility to group', async () => {
 // T8e-1: POST called with correct body on send
 it('send button calls POST with text and visibility', async () => {
   const user = await openDock()
-  await user.type(screen.getByRole('textbox'), 'Hello everyone')
+  await user.type(screen.getByRole('textbox', { name: 'Message' }), 'Hello everyone')
   await user.click(screen.getByRole('button', { name: /send/i }))
   await waitFor(() => {
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -441,7 +440,7 @@ it('send button calls POST with text and visibility', async () => {
 // T8e-2: composer cleared on successful send
 it('composer text is cleared after successful send', async () => {
   const user = await openDock()
-  const textarea = screen.getByRole('textbox')
+  const textarea = screen.getByRole('textbox', { name: 'Message' })
   await user.type(textarea, 'Clear me')
   await user.click(screen.getByRole('button', { name: /send/i }))
   await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe(''))
@@ -461,7 +460,7 @@ it('send does nothing when composer text is empty', async () => {
 it('send does nothing when direct visibility has no mention target', async () => {
   const user = await openDock()
   await user.selectOptions(screen.getByRole('combobox', { name: 'Message visibility' }), 'direct')
-  await user.type(screen.getByRole('textbox'), 'whisper without target')
+  await user.type(screen.getByRole('textbox', { name: 'Message' }), 'whisper without target')
   await user.click(screen.getByRole('button', { name: /send/i }))
   expect(fetchSpy).not.toHaveBeenCalledWith(
     expect.stringContaining('/messages'),

--- a/tests/unit/components/CampaignChat.test.tsx
+++ b/tests/unit/components/CampaignChat.test.tsx
@@ -339,15 +339,19 @@ it('LocalStore.get throwing does not crash the component', () => {
 // T6e-1: three visibility options present when dock is open
 it('composer shows three visibility options when dock is expanded', async () => {
   await openDock()
-  expect(screen.getByRole('option', { name: 'Group' })).toBeInTheDocument()
-  expect(screen.getByRole('option', { name: 'DM-only' })).toBeInTheDocument()
+  const msgSelect = screen.getByRole('combobox', { name: 'Message visibility' })
+  expect(msgSelect).toBeInTheDocument()
   expect(screen.getByRole('option', { name: 'Whisper' })).toBeInTheDocument()
+  // Verify message visibility has all three options
+  expect(msgSelect).toContainHTML('Group')
+  expect(msgSelect).toContainHTML('DM-only')
+  expect(msgSelect).toContainHTML('Whisper')
 })
 
 // T6e-2: selecting DM-only changes visibility
 it('selecting DM-only visibility updates the select value', async () => {
   const user = await openDock()
-  const select = screen.getByRole('combobox')
+  const select = screen.getByRole('combobox', { name: 'Message visibility' })
   await user.selectOptions(select, 'dm-only')
   expect((select as HTMLSelectElement).value).toBe('dm-only')
 })
@@ -399,7 +403,7 @@ it('selecting mention sets visibility to direct and updates textarea', async () 
   fireEvent.mouseDown(screen.getByText('@alice'))
   await waitFor(() => {
     expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toContain('@alice')
-    expect(screen.getByRole('combobox')).toHaveValue('direct')
+    expect(screen.getByRole('combobox', { name: 'Message visibility' })).toHaveValue('direct')
   })
 })
 
@@ -411,9 +415,9 @@ it('deleting @mention text resets visibility to group', async () => {
   await user.type(screen.getByRole('textbox'), '@al')
   await waitFor(() => screen.getByText('@alice'))
   fireEvent.mouseDown(screen.getByText('@alice'))
-  await waitFor(() => expect(screen.getByRole('combobox')).toHaveValue('direct'))
+  await waitFor(() => expect(screen.getByRole('combobox', { name: 'Message visibility' })).toHaveValue('direct'))
   fireEvent.change(screen.getByRole('textbox'), { target: { value: '', selectionStart: 0 } })
-  expect(screen.getByRole('combobox')).toHaveValue('group')
+  expect(screen.getByRole('combobox', { name: 'Message visibility' })).toHaveValue('group')
 })
 
 // ── T8 — Send tests ──────────────────────────────────────────────────
@@ -456,7 +460,7 @@ it('send does nothing when composer text is empty', async () => {
 // T8e-4: direct visibility with no toUserId does not POST
 it('send does nothing when direct visibility has no mention target', async () => {
   const user = await openDock()
-  await user.selectOptions(screen.getByRole('combobox'), 'direct')
+  await user.selectOptions(screen.getByRole('combobox', { name: 'Message visibility' }), 'direct')
   await user.type(screen.getByRole('textbox'), 'whisper without target')
   await user.click(screen.getByRole('button', { name: /send/i }))
   expect(fetchSpy).not.toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Implements the roll-share UI feature in the campaign chat dock (issue #317).

## Changes

- **FeedItem discriminated union** — replaces  state with  supporting both messages and rolls
- **RollFeedItem component** — displays roller name, timestamp, formula, per-die breakdown, total, and [DM] visibility marker with dice icon and background tint for visual distinction
- **RollEntryStrip component** — d4/d6/d8/d10/d12/d20 buttons, modifier number input, group/DM-only visibility select; disabled with "No active session" label when no active session
- **Parallel history fetch** — on dock expand, fetches roll history and message history concurrently, merges and sorts by createdAt ascending
- **Roll SSE events** — extends onStreamEvent to handle type: 'roll' events; adds 'roll' event listener to useCampaignStream
- **Layout update** — CampaignLayout fetches campaign to get activeSessionId and passes it to CampaignChat
- **Test coverage** — new test file with 26 test cases covering all scenarios

## Test Results

- Unit tests: 2444/2444 passing
- Integration tests: 302/302 passing
- Build: successful

Closes #317