### PR TITLE
docs: archive gridfs-attachment-upload-serve (2026-06-20)

### DIFF
--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-15

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/design.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/design.md
@@ -1,0 +1,180 @@
+## Context
+
+- Relevant architecture:
+  - Next.js App Router API routes under `app/api/`
+  - Native `mongodb` driver; no Mongoose. `connectToDatabase()` / `getDatabase()` in `lib/db.ts`
+  - `withAuthAndParams` middleware for auth + typed route params
+  - `assertCampaignAccess(campaignId, userId)` → `{ campaign, role } | NextResponse` in `lib/utils/campaign.ts`
+  - `CampaignMessage` interface in `lib/types.ts`
+  - Fly.io deployment — ephemeral local disk, MongoDB Atlas for persistence
+- Dependencies: MongoDB GridFS (`GridFSBucket` from native `mongodb` driver — already a dependency)
+- Interfaces/contracts touched:
+  - `CampaignMessage` type (extended with `kind` and `attachmentId`)
+  - New REST endpoints: `POST /api/campaigns/[id]/attachments`, `GET /api/campaigns/[id]/attachments/[attachmentId]`
+
+## Goals / Non-Goals
+
+### Goals
+
+- DM can upload an image (≤5 MB, JPEG/PNG/WebP/GIF) and receive an `attachmentId`
+- Any active campaign member can stream the image by `attachmentId`
+- Non-members are rejected with 403
+- Files with mismatched `campaignId` are rejected with 404
+- Orphaned pending uploads >24h are lazily swept on the next DM upload to the same campaign
+- `CampaignMessage` type extended to express `kind` and `attachmentId` for Phase 7b
+
+### Non-Goals
+
+- DM "push scene" UI (Phase 7b)
+- Scheduled orphan sweep
+- Image resizing, thumbnails, virus scanning
+- Non-image file types
+
+## Decisions
+
+### Decision 1: Two-step upload (separate upload and message creation)
+
+- Chosen: `POST /api/campaigns/[id]/attachments` returns `attachmentId`; caller separately POSTs to `/messages` with `kind: 'scene'` and `attachmentId`
+- Alternatives considered: Single atomic endpoint that creates the GridFS file and `CampaignMessage` in one request
+- Rationale: Keeps the upload endpoint focused and reusable; decouples file storage from message creation; simpler to test each step independently
+- Trade-offs: Risk of orphaned files if Step 2 is never called — mitigated by lazy orphan sweep
+
+### Decision 2: Lazy orphan sweep per campaign on upload
+
+- Chosen: Before inserting a new GridFS file, delete all files in the same campaign's GridFS bucket where `metadata.status === 'pending'` and `metadata.uploadedAt < now - 24h`
+- Alternatives considered: (a) Scheduled cron job; (b) No sweep at all; (c) Marking files as `referenced` when a message uses them and sweeping unreferenced
+- Rationale: Zero infrastructure overhead; runs naturally with DM upload activity; 24h window gives enough time for interrupted sessions
+- Trade-offs: Orphans accumulate until the next DM upload; campaigns with no subsequent uploads never sweep. Acceptable at current scale.
+
+### Decision 3: `lib/gridfs.ts` helper module
+
+- Chosen: New `lib/gridfs.ts` exposing `getAttachmentsBucket(db)`, `uploadAttachment(...)`, `openDownloadStream(...)`, `deleteOrphanedAttachments(...)`
+- Alternatives considered: Inline GridFS logic directly in route handlers
+- Rationale: Keeps route handlers thin; GridFS logic is testable in isolation; consistent with `lib/storage.ts` pattern
+- Trade-offs: One more file to maintain
+
+### Decision 4: MIME type validated from parsed `FormData`, not Content-Type header
+
+- Chosen: Read `file.type` from the `File` object returned by `request.formData()` and validate against allowlist
+- Alternatives considered: Parse `Content-Type` of the multipart part headers directly
+- Rationale: `request.formData()` already parses parts; `file.type` is the MIME type reported by the browser; consistent with how Next.js App Router exposes uploaded files
+- Trade-offs: Browser-reported MIME type can be spoofed; acceptable risk for an internal DM tool
+
+### Decision 5: `campaignId` enforced on serve by matching GridFS file metadata
+
+- Chosen: On GET, after fetching the GridFS file info, verify `metadata.campaignId === campaignId` from the URL
+- Alternatives considered: Trust that `attachmentId` is globally unique (ObjectId) and skip campaign check
+- Rationale: Prevents cross-campaign data leakage if an `attachmentId` is guessed or shared
+- Trade-offs: One extra GridFS metadata lookup before streaming
+
+### Decision 6: `attachmentId` trusted in POST /messages (no re-validation)
+
+- Chosen: The messages route accepts `attachmentId` as a string and stores it without verifying it exists in GridFS
+- Alternatives considered: Look up GridFS file by id before accepting the message
+- Rationale: DM-only upload flow; the `attachmentId` comes from the upload response in the same session; extra lookup adds latency for marginal safety gain
+- Trade-offs: A stale or fabricated `attachmentId` could be stored in a message; the GET endpoint will 404 when it tries to stream
+
+## Proposal to Design Mapping
+
+- Proposal element: DM-only upload
+  - Design decision: D1 (two-step POST /attachments), D3 (role check via assertCampaignAccess → role === 'dm')
+  - Validation approach: Integration test with player role → expect 403
+
+- Proposal element: Any active member can fetch
+  - Design decision: D5 (campaignId enforced), assertCampaignAccess on GET
+  - Validation approach: Integration test with active member → expect 200 stream; non-member → 403
+
+- Proposal element: Lazy orphan sweep
+  - Design decision: D2
+  - Validation approach: Unit test `deleteOrphanedAttachments()` with mocked GridFS; integration test verifying old pending file deleted after new upload
+
+- Proposal element: 5 MB limit, MIME allowlist
+  - Design decision: D4
+  - Validation approach: Integration tests with oversized file → 413; wrong MIME → 415
+
+- Proposal element: Bytes survive Fly restart
+  - Design decision: GridFSBucket writes to MongoDB Atlas (not local disk); verified by acceptance test
+
+## Functional Requirements Mapping
+
+- Requirement: DM uploads image → receives `attachmentId`
+  - Design element: POST /api/campaigns/[id]/attachments, `uploadAttachment()` in lib/gridfs.ts
+  - Acceptance criteria reference: specs/gridfs-upload/spec.md
+  - Testability notes: Integration test; mock GridFS for unit tests
+
+- Requirement: Active member fetches image by id
+  - Design element: GET /api/campaigns/[id]/attachments/[attachmentId], `openDownloadStream()`
+  - Acceptance criteria reference: specs/gridfs-serve/spec.md
+  - Testability notes: Integration test streaming response
+
+- Requirement: Non-member rejected
+  - Design element: `assertCampaignAccess` in both handlers
+  - Acceptance criteria reference: specs/gridfs-upload/spec.md, specs/gridfs-serve/spec.md
+  - Testability notes: Integration test with unauthenticated or non-member user
+
+- Requirement: Oversized/invalid files rejected
+  - Design element: Size and MIME checks before GridFS write in POST handler
+  - Acceptance criteria reference: specs/gridfs-upload/spec.md
+  - Testability notes: Unit test validation logic; integration test with bad file
+
+- Requirement: Orphan never permanent
+  - Design element: `deleteOrphanedAttachments()` called in POST handler before upload
+  - Acceptance criteria reference: specs/gridfs-orphan/spec.md
+  - Testability notes: Unit test with time-shifted mock; integration test verifying deletion
+
+- Requirement: `CampaignMessage` can reference attachment
+  - Design element: `kind?` and `attachmentId?` fields on `CampaignMessage` interface
+  - Acceptance criteria reference: specs/campaign-message-type/spec.md
+  - Testability notes: TypeScript compilation; existing message tests must remain passing
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Files survive Fly machine restart
+  - Design element: GridFSBucket backed by MongoDB Atlas
+  - Acceptance criteria reference: specs/gridfs-serve/spec.md (acceptance test)
+  - Testability notes: Confirmed by architecture (no local disk); not unit-testable
+
+- Requirement category: security
+  - Requirement: Cross-campaign isolation
+  - Design element: D5 — `metadata.campaignId` checked on serve
+  - Acceptance criteria reference: specs/gridfs-serve/spec.md
+  - Testability notes: Integration test with mismatched campaignId → 404
+
+- Requirement category: performance
+  - Requirement: 5 MB max keeps memory spike bounded
+  - Design element: D4 — size check before upload; formData() buffers in memory
+  - Acceptance criteria reference: specs/gridfs-upload/spec.md
+  - Testability notes: Integration test with 5 MB + 1 byte file
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Browser-spoofed MIME type bypasses file type validation
+  - Impact: Low — DM-only upload; internal tool
+  - Mitigation: Accept risk; add magic-byte validation in a future hardening pass if needed
+
+- Risk/trade-off: Campaigns with no subsequent DM uploads never trigger orphan sweep
+  - Impact: Low storage growth
+  - Mitigation: Acceptable at current scale; scheduled sweep can be added later
+
+- Risk/trade-off: `formData()` buffers entire file in memory
+  - Impact: Memory spike on concurrent uploads
+  - Mitigation: 5 MB limit; DM-only reduces concurrency risk
+
+## Rollback / Mitigation
+
+- Rollback trigger: Serve endpoint streams corrupt data, upload silently loses bytes, or orphan sweep incorrectly deletes referenced files
+- Rollback steps: Revert `lib/gridfs.ts` and both route files; revert `lib/types.ts` changes (additive only — safe to remove `kind?` and `attachmentId?`)
+- Data migration considerations: GridFS `attachments` bucket can be dropped if needed; no relational FK constraints
+- Verification after rollback: Run `npm run test:unit` and `npm run test:integration`; confirm no GridFS bucket in `db.listCollections()`
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the root cause; do not use `--no-verify` or force push.
+- If security checks fail: Treat as a blocker; investigate before proceeding.
+- If required reviews are blocked/stale: Ping the reviewer after 24h; escalate to another reviewer after 48h.
+- Escalation path and timeout: If no review after 48h, escalate to project maintainer.
+
+## Open Questions
+
+No open questions. All design decisions were resolved during exploration prior to proposal creation.

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/proposal.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/proposal.md
@@ -1,0 +1,93 @@
+## GitHub Issues
+
+- #318
+
+## Why
+
+- Problem statement: Scene images (maps, handouts) uploaded during a campaign session are not persisted — there is no storage layer for binary attachments. DMs cannot push visual scene content to players.
+- Why now: Issue 7a is the prerequisite for 7b (DM "push scene" UI) and has no upstream dependency beyond Phase 1. It can be built in parallel with Phase 5 messaging work.
+- Business/user impact: Without this, the Phase 7 scene-content feature is blocked. With it, DMs can upload images that survive Fly machine restarts and players can retrieve them during a session.
+
+## Problem Space
+
+- Current behavior: `CampaignMessage` supports text only. There is no endpoint for uploading or serving binary files. No GridFS bucket exists.
+- Desired behavior: A DM can POST an image file to `/api/campaigns/[id]/attachments`, receive an `attachmentId`, and later reference it in a `CampaignMessage` with `kind: 'scene'`. Any active campaign member can GET that attachment by id; non-members are rejected.
+- Constraints:
+  - Fly.io ephemeral disk — files must live in MongoDB GridFS, not the local filesystem.
+  - Native `mongodb` driver already in use; no Mongoose.
+  - Next.js App Router buffers `request.formData()` in memory — acceptable at 5 MB max.
+  - Upload is DM-only; serve is any active member.
+- Assumptions:
+  - The `mongodb` driver's `GridFSBucket` API is sufficient; no additional packages needed.
+  - `assertCampaignAccess` from `lib/utils/campaign.ts` is the correct access-check primitive.
+  - Orphan files are acceptable to exist for up to 24 h before cleanup.
+  - `attachmentId` passed into POST `/messages` is trusted (not re-validated against GridFS).
+- Edge cases considered:
+  - File exceeds 5 MB — rejected with 413.
+  - Unsupported MIME type — rejected with 415.
+  - Non-DM member attempts upload — rejected with 403.
+  - Non-member attempts serve — rejected with 403.
+  - `campaignId` in URL does not match file's stored `metadata.campaignId` — rejected with 404.
+  - Abandoned upload (Step 1 done, Step 2 never called) — swept by lazy orphan cleanup on next upload.
+  - `attachmentId` is not a valid ObjectId hex string — rejected with 400.
+
+## Scope
+
+### In Scope
+
+- `POST /api/campaigns/[id]/attachments` — upload image to GridFS (DM only), lazy orphan sweep before insert
+- `GET /api/campaigns/[id]/attachments/[attachmentId]` — stream image from GridFS (any active member), enforcing campaignId match
+- `lib/gridfs.ts` — `getAttachmentsBucket()`, `uploadAttachment()`, `openDownloadStream()`, `deleteOrphanedAttachments()`
+- Extend `CampaignMessage` in `lib/types.ts` with optional `kind?: 'chat' | 'scene'` and `attachmentId?: string`
+- Validation: MIME type allowlist (image/jpeg, image/png, image/webp, image/gif), 5 MB max size
+- Lazy orphan sweep: delete GridFS files for same `campaignId` where `status: 'pending'` and `uploadedAt < now - 24h`
+
+### Out of Scope
+
+- DM "push scene" UI (issue #319 / Phase 7b)
+- Marking attachments as `referenced` when a message uses them (kept simple — orphan sweep covers cleanup)
+- Scheduled/cron-based orphan sweep
+- Per-scene visibility or access beyond campaign membership
+- Video, audio, or non-image file types
+- Image resizing or thumbnail generation
+
+## What Changes
+
+- `lib/types.ts` — add `MessageKind` type; extend `CampaignMessage` with `kind?` and `attachmentId?`
+- `lib/gridfs.ts` — new file with GridFS helper functions
+- `app/api/campaigns/[id]/attachments/route.ts` — new POST handler
+- `app/api/campaigns/[id]/attachments/[attachmentId]/route.ts` — new GET handler
+
+## Risks
+
+- Risk: GridFS bucket creation on first use races in concurrent cold starts
+  - Impact: Low — `GridFSBucket` constructor is synchronous and idempotent; no migration needed
+  - Mitigation: Instantiate bucket inside request handler via `getAttachmentsBucket()`; reuse `getDatabase()` which already handles connection pooling
+- Risk: 5 MB files buffered in memory by Next.js formData()
+  - Impact: Low at expected load; could spike memory under concurrent DM uploads
+  - Mitigation: 5 MB limit enforced before GridFS write; acceptable for current scale
+- Risk: Orphaned files accumulate if DMs repeatedly abandon step 2
+  - Impact: MongoDB storage growth
+  - Mitigation: Lazy sweep on each upload cleans per-campaign orphans >24h old
+
+## Open Questions
+
+No unresolved ambiguity remains. All design decisions were resolved during exploration:
+- Two-step upload confirmed (not single atomic)
+- Lazy sweep per campaign confirmed (not scheduled cron)
+- 5 MB max, JPEG/PNG/WebP/GIF confirmed
+- DM-only upload, any active member serve confirmed
+- `attachmentId` trusted in POST /messages (no re-validation against GridFS)
+- `campaignId` enforced on serve endpoint
+
+## Non-Goals
+
+- Real-time image delivery (images are fetched on demand via GET, not pushed via SSE)
+- Access revocation after upload
+- Audit logging of file access
+- Virus/malware scanning
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED `MessageKind` type exported from `lib/types.ts`
+
+The system SHALL export a `MessageKind` union type `'chat' | 'scene'` for use in `CampaignMessage` and future message kinds.
+
+#### Scenario: TypeScript consumers can import MessageKind
+
+- **Given** `lib/types.ts` exports `MessageKind`
+- **When** a TypeScript file imports `MessageKind` from `@/lib/types`
+- **Then** it compiles without error and the type constrains values to `'chat'` or `'scene'`
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `CampaignMessage` interface — add optional `kind` and `attachmentId` fields
+
+The system SHALL extend the `CampaignMessage` interface with `kind?: MessageKind` and `attachmentId?: string` as optional fields, preserving backward compatibility with all existing messages (where `kind` is undefined, implying `'chat'`).
+
+#### Scenario: Existing messages without kind remain valid
+
+- **Given** a `CampaignMessage` document in the database with no `kind` or `attachmentId` field
+- **When** it is deserialized into a `CampaignMessage` TypeScript interface
+- **Then** TypeScript compilation succeeds and `kind` is `undefined`
+
+#### Scenario: Scene message with attachmentId is valid
+
+- **Given** a `CampaignMessage` with `kind: 'scene'` and `attachmentId: '<hex-string>'`
+- **When** it is assigned to a `CampaignMessage` variable
+- **Then** TypeScript compilation succeeds without error
+
+#### Scenario: All existing unit tests continue to pass
+
+- **Given** the type extension is applied to `lib/types.ts`
+- **When** `npm run test:unit` is run
+- **Then** all tests pass (no regressions from the additive type change)
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "returns an `attachmentId` usable as `CampaignMessage.attachmentId`" → Requirement: MODIFIED CampaignMessage
+- Proposal element "Extend CampaignMessage with kind and attachmentId" → both requirements above
+- Design decision (additive type change, no migration needed) → backward-compat scenarios
+- Requirement → Task: T0 (lib/types.ts changes)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No database migration required
+
+- **Given** the `kind` and `attachmentId` fields are optional on `CampaignMessage`
+- **When** the change is deployed to production
+- **Then** existing `campaignMessages` documents without these fields remain readable and functional without any migration script

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-orphan/spec.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-orphan/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Lazy orphan sweep — delete abandoned pending uploads before each new upload
+
+The system SHALL, before inserting a new GridFS file for a given campaign, delete all GridFS files in that campaign where `metadata.status === 'pending'` and `metadata.uploadedAt` is older than 24 hours, so that abandoned uploads never accumulate permanently.
+
+#### Scenario: Orphaned file is swept on next DM upload
+
+- **Given** a GridFS file exists for campaign `campaignId` with `metadata.status: "pending"` and `metadata.uploadedAt` more than 24 hours ago
+- **And** no `CampaignMessage` with `attachmentId` referencing this file exists
+- **When** a DM uploads a new image to `/api/campaigns/[id]/attachments`
+- **Then** the orphaned GridFS file is deleted before the new file is inserted
+- **And** the new upload succeeds with `201 Created`
+
+#### Scenario: Recent pending file is not swept
+
+- **Given** a GridFS file exists for campaign `campaignId` with `metadata.status: "pending"` and `metadata.uploadedAt` less than 24 hours ago
+- **When** a DM uploads a new image to the same campaign
+- **Then** the recent pending file is NOT deleted
+- **And** the new upload succeeds with `201 Created`
+
+#### Scenario: Pending files from other campaigns are not swept
+
+- **Given** a GridFS file exists for campaign `campaignId-B` with `metadata.status: "pending"` and `metadata.uploadedAt` more than 24 hours ago
+- **When** a DM uploads a new image to campaign `campaignId-A`
+- **Then** the file for `campaignId-B` is NOT deleted
+
+#### Scenario: No orphaned files exist — upload proceeds normally
+
+- **Given** no pending GridFS files older than 24 hours exist for campaign `campaignId`
+- **When** a DM uploads a new image to `/api/campaigns/[id]/attachments`
+- **Then** the upload succeeds with `201 Created` and no GridFS files are deleted
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "abandoned upload never leaves a permanently orphaned file" → Requirement: ADDED Lazy orphan sweep
+- Design decision D2 (lazy sweep per campaign on upload) → all scenarios above
+- Requirement → Task: T1 (`deleteOrphanedAttachments()` in lib/gridfs.ts), T2 (called in POST /attachments before insert)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Sweep failure does not block the upload
+
+- **Given** `deleteOrphanedAttachments()` encounters an error (e.g., transient MongoDB timeout)
+- **When** a DM uploads a new image
+- **Then** the sweep error is logged but the upload proceeds and returns `201 Created`
+
+> Note: orphan sweep is best-effort. A sweep failure should not fail the user's upload request.

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED GET /api/campaigns/[id]/attachments/[attachmentId] — stream image from GridFS
+
+The system SHALL stream the raw image bytes from GridFS to any authenticated active campaign member, setting `Content-Type` to the file's stored MIME type, and reject all others.
+
+#### Scenario: Active member fetches a valid attachment
+
+- **Given** an authenticated user who is an active member of campaign `campaignId`
+- **And** a GridFS file exists with id `attachmentId` and `metadata.campaignId === campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `200 OK` with the image bytes streamed and `Content-Type` matching the stored MIME type (e.g., `image/jpeg`)
+
+#### Scenario: DM fetches a valid attachment
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **And** a GridFS file exists with id `attachmentId` and `metadata.campaignId === campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `200 OK` with the image bytes streamed
+
+#### Scenario: Non-member attempts fetch
+
+- **Given** an authenticated user who is not a member of campaign `campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Unauthenticated fetch
+
+- **Given** a request with no auth credentials
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `401 Unauthorized`
+
+#### Scenario: Attachment belongs to a different campaign
+
+- **Given** an authenticated active member of campaign `campaignId-A`
+- **And** a GridFS file exists with id `attachmentId` and `metadata.campaignId === campaignId-B`
+- **When** they GET `/api/campaigns/campaignId-A/attachments/[attachmentId]`
+- **Then** the response is `404 Not Found`
+
+#### Scenario: Attachment does not exist
+
+- **Given** an authenticated active member of campaign `campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/nonexistent-id`
+- **Then** the response is `404 Not Found`
+
+#### Scenario: Invalid attachmentId format
+
+- **Given** an authenticated active member of campaign `campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/not-a-valid-objectid`
+- **Then** the response is `400 Bad Request` with `{ "error": "Invalid attachmentId" }`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "any active member can fetch" → Scenario: Active member fetches a valid attachment
+- Proposal element "non-members cannot" → Scenario: Non-member attempts fetch
+- Proposal element "bytes survive Fly restart" → NFAC Reliability scenario (gridfs-upload/spec.md)
+- Design decision D5 (campaignId enforced on serve) → Scenario: Attachment belongs to a different campaign
+- Requirement → Task: T3 (GET /attachments/[attachmentId] route), T1 (lib/gridfs.ts openDownloadStream)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios: "Non-member attempts fetch", "Unauthenticated fetch", "Attachment belongs to a different campaign". These cover all access-control properties.
+
+#### Scenario: `attachmentId` from another campaign does not leak file existence
+
+- **Given** an authenticated active member of campaign `campaignId-A`
+- **And** a valid GridFS file exists belonging to `campaignId-B`
+- **When** they request the file via campaign A's URL
+- **Then** the response is `404 Not Found` (not `403`) — the file's existence is not revealed

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED POST /api/campaigns/[id]/attachments — upload image to GridFS
+
+The system SHALL accept a multipart/form-data POST from an authenticated DM, validate the file, store it in MongoDB GridFS, and return an `attachmentId`.
+
+#### Scenario: DM uploads a valid JPEG
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST `multipart/form-data` with a valid JPEG file (≤5 MB) to `/api/campaigns/[id]/attachments`
+- **Then** the response is `201 Created` with body `{ "attachmentId": "<hex-string>" }` and the file is stored in GridFS with `metadata.campaignId`, `metadata.status: "pending"`, and `metadata.uploadedAt`
+
+#### Scenario: DM uploads a valid PNG
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a valid PNG file (≤5 MB)
+- **Then** the response is `201 Created` with a valid `attachmentId`
+
+#### Scenario: DM uploads a valid WebP
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a valid WebP file (≤5 MB)
+- **Then** the response is `201 Created` with a valid `attachmentId`
+
+#### Scenario: DM uploads a valid GIF
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a valid GIF file (≤5 MB)
+- **Then** the response is `201 Created` with a valid `attachmentId`
+
+#### Scenario: File exceeds 5 MB limit
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a file larger than 5 MB (5,242,881 bytes)
+- **Then** the response is `413 Content Too Large` with `{ "error": "File exceeds 5 MB limit" }` and no GridFS file is created
+
+#### Scenario: Unsupported MIME type
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a file with MIME type `application/pdf`
+- **Then** the response is `415 Unsupported Media Type` with `{ "error": "Unsupported file type" }` and no GridFS file is created
+
+#### Scenario: No file in request
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST multipart/form-data with no `file` field
+- **Then** the response is `400 Bad Request` with `{ "error": "file is required" }`
+
+#### Scenario: Player attempts upload
+
+- **Given** an authenticated user with role `player` (not `dm`) in campaign `campaignId`
+- **When** they POST a valid image file to `/api/campaigns/[id]/attachments`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Non-member attempts upload
+
+- **Given** an authenticated user who is not a member of campaign `campaignId`
+- **When** they POST a valid image file to `/api/campaigns/[id]/attachments`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Unauthenticated request
+
+- **Given** a request with no auth credentials
+- **When** they POST to `/api/campaigns/[id]/attachments`
+- **Then** the response is `401 Unauthorized`
+
+#### Scenario: Campaign does not exist
+
+- **Given** an authenticated user
+- **When** they POST to `/api/campaigns/nonexistent-id/attachments`
+- **Then** the response is `404 Not Found`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "DM-only upload" → Requirement: ADDED POST /api/campaigns/[id]/attachments
+- Proposal element "5 MB max, JPEG/PNG/WebP/GIF" → Scenarios: file exceeds limit, unsupported MIME type
+- Design decision D1 (two-step upload) → this endpoint returns `attachmentId` only
+- Design decision D2 (lazy orphan sweep) → sweep fires before GridFS insert (see specs/gridfs-orphan/spec.md)
+- Design decision D4 (MIME from formData file.type) → unsupported MIME scenario
+- Requirement → Task: T1 (lib/gridfs.ts), T2 (POST /attachments route)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios: "Player attempts upload", "Non-member attempts upload", "Unauthenticated request". No additional NFAC security scenarios.
+
+### Requirement: Reliability
+
+#### Scenario: File bytes are persisted in MongoDB (not local disk)
+
+- **Given** a successful upload
+- **When** the Fly machine is restarted (ephemeral disk cleared)
+- **Then** the file remains retrievable via `GET /api/campaigns/[id]/attachments/[attachmentId]`
+
+> Note: verified by architecture (GridFS → MongoDB Atlas); not unit-testable. Confirmed by integration test if run against a real database.

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tasks.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tasks.md
@@ -80,11 +80,11 @@ If **ANY** required step fails, iterate and fix before pushing.
 ## PR and Merge
 
 - [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
-- [ ] Commit all changes to `feat/gridfs-attachment-upload-serve` and push to remote
-- [ ] Open PR from `feat/gridfs-attachment-upload-serve` to `main`. PR body MUST include `Closes #318`.
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
-- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
+- [x] Commit all changes to `feat/gridfs-attachment-upload-serve` and push to remote
+- [x] Open PR from `feat/gridfs-attachment-upload-serve` to `main`. PR body MUST include `Closes #318`.
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
   1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
   2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
   3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
@@ -105,18 +105,18 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on main
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync approved spec deltas into `openspec/specs/`:
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on main
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Sync approved spec deltas into `openspec/specs/`:
   - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md` → `openspec/specs/gridfs-upload/spec.md`
   - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md` → `openspec/specs/gridfs-serve/spec.md`
   - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-orphan/spec.md` → `openspec/specs/gridfs-orphan/spec.md`
   - Copy `openspec/changes/gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md` → `openspec/specs/campaign-message-type/spec.md`
   - Update relative links in each copied spec: replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/design.md` and `../../tasks.md` with `../../changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/tasks.md`
-- [ ] Archive the change: move `openspec/changes/gridfs-attachment-upload-serve/` to `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` **in a single atomic commit** (stage both the new location and the deletion of the old location together)
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` exists and `openspec/changes/gridfs-attachment-upload-serve/` is gone
-- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-gridfs-attachment-upload-serve` then `git push -u origin doc/archive-gridfs-attachment-upload-serve`
+- [x] Archive the change: move `openspec/changes/gridfs-attachment-upload-serve/` to `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` **in a single atomic commit** (stage both the new location and the deletion of the old location together)
+- [x] Confirm `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` exists and `openspec/changes/gridfs-attachment-upload-serve/` is gone
+- [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-gridfs-attachment-upload-serve` then `git push -u origin doc/archive-gridfs-attachment-upload-serve`
 - [ ] Open a PR from `doc/archive-gridfs-attachment-upload-serve` to `main` with title `docs: archive gridfs-attachment-upload-serve (YYYY-MM-DD)`
 - [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
 - [ ] Monitor the doc PR until it merges; address any comments or CI failures

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tasks.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tasks.md
@@ -117,7 +117,7 @@ Blocking resolution flow:
 - [x] Archive the change: move `openspec/changes/gridfs-attachment-upload-serve/` to `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` **in a single atomic commit** (stage both the new location and the deletion of the old location together)
 - [x] Confirm `openspec/changes/archive/YYYY-MM-DD-gridfs-attachment-upload-serve/` exists and `openspec/changes/gridfs-attachment-upload-serve/` is gone
 - [x] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-gridfs-attachment-upload-serve` then `git push -u origin doc/archive-gridfs-attachment-upload-serve`
-- [ ] Open a PR from `doc/archive-gridfs-attachment-upload-serve` to `main` with title `docs: archive gridfs-attachment-upload-serve (YYYY-MM-DD)`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [x] Open a PR from `doc/archive-gridfs-attachment-upload-serve` to `main` with title `docs: archive gridfs-attachment-upload-serve (YYYY-MM-DD)`
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
 - [ ] Monitor the doc PR until it merges; address any comments or CI failures
 - [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/gridfs-attachment-upload-serve doc/archive-gridfs-attachment-upload-serve`

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tests.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tests.md
@@ -18,7 +18,7 @@ Test files:
 
 ## T0 — `CampaignMessage` type extension (`lib/types.ts`)
 
-Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md`
+Spec: `openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md`
 
 - [x] **T0-1** TypeScript compiles with `kind` and `attachmentId` absent — existing `CampaignMessage` objects remain valid (`npx tsc --noEmit`)
 - [x] **T0-2** TypeScript accepts `{ kind: 'scene', attachmentId: 'abc123' }` on a `CampaignMessage` without error
@@ -28,7 +28,7 @@ Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/campaign-message-ty
 
 ## T1 — `lib/gridfs.ts` helper module
 
-Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md`, `specs/gridfs-orphan/spec.md`
+Spec: `openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md`, `specs/gridfs-orphan/spec.md`
 
 File: `tests/unit/lib/gridfs.test.ts`
 
@@ -58,7 +58,7 @@ File: `tests/unit/lib/gridfs.test.ts`
 
 ## T2 — `POST /api/campaigns/[id]/attachments`
 
-Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md`
+Spec: `openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md`
 
 File: `tests/integration/api/campaigns/[id]/attachments/route.test.ts`
 
@@ -82,7 +82,7 @@ File: `tests/integration/api/campaigns/[id]/attachments/route.test.ts`
 
 ## T3 — `GET /api/campaigns/[id]/attachments/[attachmentId]`
 
-Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md`
+Spec: `openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md`
 
 File: `tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts`
 

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tests.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tests.md
@@ -20,9 +20,9 @@ Test files:
 
 Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md`
 
-- [ ] **T0-1** TypeScript compiles with `kind` and `attachmentId` absent — existing `CampaignMessage` objects remain valid (`npx tsc --noEmit`)
-- [ ] **T0-2** TypeScript accepts `{ kind: 'scene', attachmentId: 'abc123' }` on a `CampaignMessage` without error
-- [ ] **T0-3** `npm run test:unit` — all pre-existing unit tests pass after the additive type change
+- [x] **T0-1** TypeScript compiles with `kind` and `attachmentId` absent — existing `CampaignMessage` objects remain valid (`npx tsc --noEmit`)
+- [x] **T0-2** TypeScript accepts `{ kind: 'scene', attachmentId: 'abc123' }` on a `CampaignMessage` without error
+- [x] **T0-3** `npm run test:unit` — all pre-existing unit tests pass after the additive type change
 
 ---
 
@@ -34,25 +34,25 @@ File: `tests/unit/lib/gridfs.test.ts`
 
 ### `getAttachmentsBucket`
 
-- [ ] **T1-1** Returns a `GridFSBucket` instance with `bucketName: 'attachments'`
+- [x] **T1-1** Returns a `GridFSBucket` instance with `bucketName: 'attachments'`
 
 ### `uploadAttachment`
 
-- [ ] **T1-2** Calls `bucket.openUploadStream` with filename, metadata `{ campaignId, status: 'pending', uploadedAt, contentType }` and pipes file bytes
-- [ ] **T1-3** Returns a hex string ObjectId on success
+- [x] **T1-2** Calls `bucket.openUploadStream` with filename, metadata `{ campaignId, status: 'pending', uploadedAt, contentType }` and pipes file bytes
+- [x] **T1-3** Returns a hex string ObjectId on success
 
 ### `openDownloadStream`
 
-- [ ] **T1-4** Calls `bucket.find` with the parsed ObjectId and returns `{ stream, contentType, campaignId }` from file metadata
-- [ ] **T1-5** Throws (or rejects) when `attachmentId` is not a valid hex ObjectId
-- [ ] **T1-6** Throws (or rejects) when no file is found for the given id
+- [x] **T1-4** Calls `bucket.find` with the parsed ObjectId and returns `{ stream, contentType, campaignId }` from file metadata
+- [x] **T1-5** Throws (or rejects) when `attachmentId` is not a valid hex ObjectId
+- [x] **T1-6** Throws (or rejects) when no file is found for the given id
 
 ### `deleteOrphanedAttachments`
 
-- [ ] **T1-7** Calls `bucket.find` filtering by `metadata.campaignId`, `metadata.status: 'pending'`, and `metadata.uploadedAt < threshold` and deletes each matching file
-- [ ] **T1-8** Does NOT delete a pending file whose `uploadedAt` is within the 24h threshold
-- [ ] **T1-9** Does NOT delete files belonging to a different `campaignId`
-- [ ] **T1-10** Swallows and logs errors (does not throw) when GridFS operations fail
+- [x] **T1-7** Calls `bucket.find` filtering by `metadata.campaignId`, `metadata.status: 'pending'`, and `metadata.uploadedAt < threshold` and deletes each matching file
+- [x] **T1-8** Does NOT delete a pending file whose `uploadedAt` is within the 24h threshold
+- [x] **T1-9** Does NOT delete files belonging to a different `campaignId`
+- [x] **T1-10** Swallows and logs errors (does not throw) when GridFS operations fail
 
 ---
 
@@ -62,21 +62,21 @@ Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.
 
 File: `tests/integration/api/campaigns/[id]/attachments/route.test.ts`
 
-- [ ] **T2-1** DM uploads valid JPEG (≤5 MB) → `201 { attachmentId: <string> }`
-- [ ] **T2-2** DM uploads valid PNG → `201 { attachmentId: <string> }`
-- [ ] **T2-3** DM uploads valid WebP → `201 { attachmentId: <string> }`
-- [ ] **T2-4** DM uploads valid GIF → `201 { attachmentId: <string> }`
-- [ ] **T2-5** File size exactly 5,242,880 bytes (5 MB) → `201` (boundary: accepted)
-- [ ] **T2-6** File size 5,242,881 bytes (5 MB + 1) → `413 { error: 'File exceeds 5 MB limit' }`
-- [ ] **T2-7** MIME type `application/pdf` → `415 { error: 'Unsupported file type' }`
-- [ ] **T2-8** MIME type `text/plain` → `415 { error: 'Unsupported file type' }`
-- [ ] **T2-9** No `file` field in formData → `400 { error: 'file is required' }`
-- [ ] **T2-10** Player role (not DM) → `403 Forbidden`
-- [ ] **T2-11** Non-member → `403 Forbidden`
-- [ ] **T2-12** Unauthenticated → `401 Unauthorized`
-- [ ] **T2-13** Campaign does not exist → `404 Not Found`
-- [ ] **T2-14** Orphaned pending file (>24h) for same campaign is deleted before insert (verify via GridFS find after upload)
-- [ ] **T2-15** Recent pending file (<24h) for same campaign is NOT deleted
+- [x] **T2-1** DM uploads valid JPEG (≤5 MB) → `201 { attachmentId: <string> }`
+- [x] **T2-2** DM uploads valid PNG → `201 { attachmentId: <string> }`
+- [x] **T2-3** DM uploads valid WebP → `201 { attachmentId: <string> }`
+- [x] **T2-4** DM uploads valid GIF → `201 { attachmentId: <string> }`
+- [x] **T2-5** File size exactly 5,242,880 bytes (5 MB) → `201` (boundary: accepted)
+- [x] **T2-6** File size 5,242,881 bytes (5 MB + 1) → `413 { error: 'File exceeds 5 MB limit' }`
+- [x] **T2-7** MIME type `application/pdf` → `415 { error: 'Unsupported file type' }`
+- [x] **T2-8** MIME type `text/plain` → `415 { error: 'Unsupported file type' }`
+- [x] **T2-9** No `file` field in formData → `400 { error: 'file is required' }`
+- [x] **T2-10** Player role (not DM) → `403 Forbidden`
+- [x] **T2-11** Non-member → `403 Forbidden`
+- [x] **T2-12** Unauthenticated → `401 Unauthorized`
+- [x] **T2-13** Campaign does not exist → `404 Not Found`
+- [x] **T2-14** Orphaned pending file (>24h) for same campaign is deleted before insert (verify via GridFS find after upload)
+- [x] **T2-15** Recent pending file (<24h) for same campaign is NOT deleted
 
 ---
 
@@ -86,11 +86,11 @@ Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-serve/spec.m
 
 File: `tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts`
 
-- [ ] **T3-1** Active member fetches existing attachment → `200` with binary body and correct `Content-Type: image/jpeg`
-- [ ] **T3-2** DM fetches existing attachment → `200` with binary body
-- [ ] **T3-3** Active member fetches PNG → `200` with `Content-Type: image/png`
-- [ ] **T3-4** Non-member → `403 Forbidden`
-- [ ] **T3-5** Unauthenticated → `401 Unauthorized`
-- [ ] **T3-6** Valid `attachmentId` but `metadata.campaignId` belongs to a different campaign → `404 Not Found` (not 403 — existence not revealed)
-- [ ] **T3-7** `attachmentId` does not exist in GridFS → `404 Not Found`
-- [ ] **T3-8** `attachmentId` is not a valid ObjectId hex string (e.g. `"not-an-id"`) → `400 { error: 'Invalid attachmentId' }`
+- [x] **T3-1** Active member fetches existing attachment → `200` with binary body and correct `Content-Type: image/jpeg`
+- [x] **T3-2** DM fetches existing attachment → `200` with binary body
+- [x] **T3-3** Active member fetches PNG → `200` with `Content-Type: image/png`
+- [x] **T3-4** Non-member → `403 Forbidden`
+- [x] **T3-5** Unauthenticated → `401 Unauthorized`
+- [x] **T3-6** Valid `attachmentId` but `metadata.campaignId` belongs to a different campaign → `404 Not Found` (not 403 — existence not revealed)
+- [x] **T3-7** `attachmentId` does not exist in GridFS → `404 Not Found`
+- [x] **T3-8** `attachmentId` is not a valid ObjectId hex string (e.g. `"not-an-id"`) → `400 { error: 'Invalid attachmentId' }`

--- a/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tests.md
+++ b/openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/tests.md
@@ -1,0 +1,96 @@
+---
+name: tests
+description: Tests for the gridfs-attachment-upload-serve change
+---
+
+# Tests
+
+## Overview
+
+All work follows strict TDD: write a failing test first, implement the minimum code to pass it, then refactor.
+
+Test files:
+- Unit: `tests/unit/lib/gridfs.test.ts`
+- Integration (upload): `tests/integration/api/campaigns/[id]/attachments/route.test.ts`
+- Integration (serve): `tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts`
+
+---
+
+## T0 — `CampaignMessage` type extension (`lib/types.ts`)
+
+Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/campaign-message-type/spec.md`
+
+- [ ] **T0-1** TypeScript compiles with `kind` and `attachmentId` absent — existing `CampaignMessage` objects remain valid (`npx tsc --noEmit`)
+- [ ] **T0-2** TypeScript accepts `{ kind: 'scene', attachmentId: 'abc123' }` on a `CampaignMessage` without error
+- [ ] **T0-3** `npm run test:unit` — all pre-existing unit tests pass after the additive type change
+
+---
+
+## T1 — `lib/gridfs.ts` helper module
+
+Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md`, `specs/gridfs-orphan/spec.md`
+
+File: `tests/unit/lib/gridfs.test.ts`
+
+### `getAttachmentsBucket`
+
+- [ ] **T1-1** Returns a `GridFSBucket` instance with `bucketName: 'attachments'`
+
+### `uploadAttachment`
+
+- [ ] **T1-2** Calls `bucket.openUploadStream` with filename, metadata `{ campaignId, status: 'pending', uploadedAt, contentType }` and pipes file bytes
+- [ ] **T1-3** Returns a hex string ObjectId on success
+
+### `openDownloadStream`
+
+- [ ] **T1-4** Calls `bucket.find` with the parsed ObjectId and returns `{ stream, contentType, campaignId }` from file metadata
+- [ ] **T1-5** Throws (or rejects) when `attachmentId` is not a valid hex ObjectId
+- [ ] **T1-6** Throws (or rejects) when no file is found for the given id
+
+### `deleteOrphanedAttachments`
+
+- [ ] **T1-7** Calls `bucket.find` filtering by `metadata.campaignId`, `metadata.status: 'pending'`, and `metadata.uploadedAt < threshold` and deletes each matching file
+- [ ] **T1-8** Does NOT delete a pending file whose `uploadedAt` is within the 24h threshold
+- [ ] **T1-9** Does NOT delete files belonging to a different `campaignId`
+- [ ] **T1-10** Swallows and logs errors (does not throw) when GridFS operations fail
+
+---
+
+## T2 — `POST /api/campaigns/[id]/attachments`
+
+Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-upload/spec.md`
+
+File: `tests/integration/api/campaigns/[id]/attachments/route.test.ts`
+
+- [ ] **T2-1** DM uploads valid JPEG (≤5 MB) → `201 { attachmentId: <string> }`
+- [ ] **T2-2** DM uploads valid PNG → `201 { attachmentId: <string> }`
+- [ ] **T2-3** DM uploads valid WebP → `201 { attachmentId: <string> }`
+- [ ] **T2-4** DM uploads valid GIF → `201 { attachmentId: <string> }`
+- [ ] **T2-5** File size exactly 5,242,880 bytes (5 MB) → `201` (boundary: accepted)
+- [ ] **T2-6** File size 5,242,881 bytes (5 MB + 1) → `413 { error: 'File exceeds 5 MB limit' }`
+- [ ] **T2-7** MIME type `application/pdf` → `415 { error: 'Unsupported file type' }`
+- [ ] **T2-8** MIME type `text/plain` → `415 { error: 'Unsupported file type' }`
+- [ ] **T2-9** No `file` field in formData → `400 { error: 'file is required' }`
+- [ ] **T2-10** Player role (not DM) → `403 Forbidden`
+- [ ] **T2-11** Non-member → `403 Forbidden`
+- [ ] **T2-12** Unauthenticated → `401 Unauthorized`
+- [ ] **T2-13** Campaign does not exist → `404 Not Found`
+- [ ] **T2-14** Orphaned pending file (>24h) for same campaign is deleted before insert (verify via GridFS find after upload)
+- [ ] **T2-15** Recent pending file (<24h) for same campaign is NOT deleted
+
+---
+
+## T3 — `GET /api/campaigns/[id]/attachments/[attachmentId]`
+
+Spec: `openspec/changes/gridfs-attachment-upload-serve/specs/gridfs-serve/spec.md`
+
+File: `tests/integration/api/campaigns/[id]/attachments/[attachmentId]/route.test.ts`
+
+- [ ] **T3-1** Active member fetches existing attachment → `200` with binary body and correct `Content-Type: image/jpeg`
+- [ ] **T3-2** DM fetches existing attachment → `200` with binary body
+- [ ] **T3-3** Active member fetches PNG → `200` with `Content-Type: image/png`
+- [ ] **T3-4** Non-member → `403 Forbidden`
+- [ ] **T3-5** Unauthenticated → `401 Unauthorized`
+- [ ] **T3-6** Valid `attachmentId` but `metadata.campaignId` belongs to a different campaign → `404 Not Found` (not 403 — existence not revealed)
+- [ ] **T3-7** `attachmentId` does not exist in GridFS → `404 Not Found`
+- [ ] **T3-8** `attachmentId` is not a valid ObjectId hex string (e.g. `"not-an-id"`) → `400 { error: 'Invalid attachmentId' }`

--- a/openspec/specs/campaign-message-type/spec.md
+++ b/openspec/specs/campaign-message-type/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-06-20-gridfs-attachment-upload-serve/design.md) document, not a replacement.
+
+### Requirement: ADDED `MessageKind` type exported from `lib/types.ts`
+
+The system SHALL export a `MessageKind` union type `'chat' | 'scene'` for use in `CampaignMessage` and future message kinds.
+
+#### Scenario: TypeScript consumers can import MessageKind
+
+- **Given** `lib/types.ts` exports `MessageKind`
+- **When** a TypeScript file imports `MessageKind` from `@/lib/types`
+- **Then** it compiles without error and the type constrains values to `'chat'` or `'scene'`
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `CampaignMessage` interface — add optional `kind` and `attachmentId` fields
+
+The system SHALL extend the `CampaignMessage` interface with `kind?: MessageKind` and `attachmentId?: string` as optional fields, preserving backward compatibility with all existing messages (where `kind` is undefined, implying `'chat'`).
+
+#### Scenario: Existing messages without kind remain valid
+
+- **Given** a `CampaignMessage` document in the database with no `kind` or `attachmentId` field
+- **When** it is deserialized into a `CampaignMessage` TypeScript interface
+- **Then** TypeScript compilation succeeds and `kind` is `undefined`
+
+#### Scenario: Scene message with attachmentId is valid
+
+- **Given** a `CampaignMessage` with `kind: 'scene'` and `attachmentId: '<hex-string>'`
+- **When** it is assigned to a `CampaignMessage` variable
+- **Then** TypeScript compilation succeeds without error
+
+#### Scenario: All existing unit tests continue to pass
+
+- **Given** the type extension is applied to `lib/types.ts`
+- **When** `npm run test:unit` is run
+- **Then** all tests pass (no regressions from the additive type change)
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "returns an `attachmentId` usable as `CampaignMessage.attachmentId`" → Requirement: MODIFIED CampaignMessage
+- Proposal element "Extend CampaignMessage with kind and attachmentId" → both requirements above
+- Design decision (additive type change, no migration needed) → backward-compat scenarios
+- Requirement → Task: T0 (lib/types.ts changes)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No database migration required
+
+- **Given** the `kind` and `attachmentId` fields are optional on `CampaignMessage`
+- **When** the change is deployed to production
+- **Then** existing `campaignMessages` documents without these fields remain readable and functional without any migration script

--- a/openspec/specs/gridfs-orphan/spec.md
+++ b/openspec/specs/gridfs-orphan/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-06-20-gridfs-attachment-upload-serve/design.md) document, not a replacement.
+
+### Requirement: ADDED Lazy orphan sweep — delete abandoned pending uploads before each new upload
+
+The system SHALL, before inserting a new GridFS file for a given campaign, delete all GridFS files in that campaign where `metadata.status === 'pending'` and `metadata.uploadedAt` is older than 24 hours, so that abandoned uploads never accumulate permanently.
+
+#### Scenario: Orphaned file is swept on next DM upload
+
+- **Given** a GridFS file exists for campaign `campaignId` with `metadata.status: "pending"` and `metadata.uploadedAt` more than 24 hours ago
+- **And** no `CampaignMessage` with `attachmentId` referencing this file exists
+- **When** a DM uploads a new image to `/api/campaigns/[id]/attachments`
+- **Then** the orphaned GridFS file is deleted before the new file is inserted
+- **And** the new upload succeeds with `201 Created`
+
+#### Scenario: Recent pending file is not swept
+
+- **Given** a GridFS file exists for campaign `campaignId` with `metadata.status: "pending"` and `metadata.uploadedAt` less than 24 hours ago
+- **When** a DM uploads a new image to the same campaign
+- **Then** the recent pending file is NOT deleted
+- **And** the new upload succeeds with `201 Created`
+
+#### Scenario: Pending files from other campaigns are not swept
+
+- **Given** a GridFS file exists for campaign `campaignId-B` with `metadata.status: "pending"` and `metadata.uploadedAt` more than 24 hours ago
+- **When** a DM uploads a new image to campaign `campaignId-A`
+- **Then** the file for `campaignId-B` is NOT deleted
+
+#### Scenario: No orphaned files exist — upload proceeds normally
+
+- **Given** no pending GridFS files older than 24 hours exist for campaign `campaignId`
+- **When** a DM uploads a new image to `/api/campaigns/[id]/attachments`
+- **Then** the upload succeeds with `201 Created` and no GridFS files are deleted
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "abandoned upload never leaves a permanently orphaned file" → Requirement: ADDED Lazy orphan sweep
+- Design decision D2 (lazy sweep per campaign on upload) → all scenarios above
+- Requirement → Task: T1 (`deleteOrphanedAttachments()` in lib/gridfs.ts), T2 (called in POST /attachments before insert)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Sweep failure does not block the upload
+
+- **Given** `deleteOrphanedAttachments()` encounters an error (e.g., transient MongoDB timeout)
+- **When** a DM uploads a new image
+- **Then** the sweep error is logged but the upload proceeds and returns `201 Created`
+
+> Note: orphan sweep is best-effort. A sweep failure should not fail the user's upload request.

--- a/openspec/specs/gridfs-serve/spec.md
+++ b/openspec/specs/gridfs-serve/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-06-20-gridfs-attachment-upload-serve/design.md) document, not a replacement.
+
+### Requirement: ADDED GET /api/campaigns/[id]/attachments/[attachmentId] — stream image from GridFS
+
+The system SHALL stream the raw image bytes from GridFS to any authenticated active campaign member, setting `Content-Type` to the file's stored MIME type, and reject all others.
+
+#### Scenario: Active member fetches a valid attachment
+
+- **Given** an authenticated user who is an active member of campaign `campaignId`
+- **And** a GridFS file exists with id `attachmentId` and `metadata.campaignId === campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `200 OK` with the image bytes streamed and `Content-Type` matching the stored MIME type (e.g., `image/jpeg`)
+
+#### Scenario: DM fetches a valid attachment
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **And** a GridFS file exists with id `attachmentId` and `metadata.campaignId === campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `200 OK` with the image bytes streamed
+
+#### Scenario: Non-member attempts fetch
+
+- **Given** an authenticated user who is not a member of campaign `campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Unauthenticated fetch
+
+- **Given** a request with no auth credentials
+- **When** they GET `/api/campaigns/[id]/attachments/[attachmentId]`
+- **Then** the response is `401 Unauthorized`
+
+#### Scenario: Attachment belongs to a different campaign
+
+- **Given** an authenticated active member of campaign `campaignId-A`
+- **And** a GridFS file exists with id `attachmentId` and `metadata.campaignId === campaignId-B`
+- **When** they GET `/api/campaigns/campaignId-A/attachments/[attachmentId]`
+- **Then** the response is `404 Not Found`
+
+#### Scenario: Attachment does not exist
+
+- **Given** an authenticated active member of campaign `campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/nonexistent-id`
+- **Then** the response is `404 Not Found`
+
+#### Scenario: Invalid attachmentId format
+
+- **Given** an authenticated active member of campaign `campaignId`
+- **When** they GET `/api/campaigns/[id]/attachments/not-a-valid-objectid`
+- **Then** the response is `400 Bad Request` with `{ "error": "Invalid attachmentId" }`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "any active member can fetch" → Scenario: Active member fetches a valid attachment
+- Proposal element "non-members cannot" → Scenario: Non-member attempts fetch
+- Proposal element "bytes survive Fly restart" → NFAC Reliability scenario (gridfs-upload/spec.md)
+- Design decision D5 (campaignId enforced on serve) → Scenario: Attachment belongs to a different campaign
+- Requirement → Task: T3 (GET /attachments/[attachmentId] route), T1 (lib/gridfs.ts openDownloadStream)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios: "Non-member attempts fetch", "Unauthenticated fetch", "Attachment belongs to a different campaign". These cover all access-control properties.
+
+#### Scenario: `attachmentId` from another campaign does not leak file existence
+
+- **Given** an authenticated active member of campaign `campaignId-A`
+- **And** a valid GridFS file exists belonging to `campaignId-B`
+- **When** they request the file via campaign A's URL
+- **Then** the response is `404 Not Found` (not `403`) — the file's existence is not revealed

--- a/openspec/specs/gridfs-upload/spec.md
+++ b/openspec/specs/gridfs-upload/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-06-20-gridfs-attachment-upload-serve/design.md) document, not a replacement.
+
+### Requirement: ADDED POST /api/campaigns/[id]/attachments — upload image to GridFS
+
+The system SHALL accept a multipart/form-data POST from an authenticated DM, validate the file, store it in MongoDB GridFS, and return an `attachmentId`.
+
+#### Scenario: DM uploads a valid JPEG
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST `multipart/form-data` with a valid JPEG file (≤5 MB) to `/api/campaigns/[id]/attachments`
+- **Then** the response is `201 Created` with body `{ "attachmentId": "<hex-string>" }` and the file is stored in GridFS with `metadata.campaignId`, `metadata.status: "pending"`, and `metadata.uploadedAt`
+
+#### Scenario: DM uploads a valid PNG
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a valid PNG file (≤5 MB)
+- **Then** the response is `201 Created` with a valid `attachmentId`
+
+#### Scenario: DM uploads a valid WebP
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a valid WebP file (≤5 MB)
+- **Then** the response is `201 Created` with a valid `attachmentId`
+
+#### Scenario: DM uploads a valid GIF
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a valid GIF file (≤5 MB)
+- **Then** the response is `201 Created` with a valid `attachmentId`
+
+#### Scenario: File exceeds 5 MB limit
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a file larger than 5 MB (5,242,881 bytes)
+- **Then** the response is `413 Content Too Large` with `{ "error": "File exceeds 5 MB limit" }` and no GridFS file is created
+
+#### Scenario: Unsupported MIME type
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST a file with MIME type `application/pdf`
+- **Then** the response is `415 Unsupported Media Type` with `{ "error": "Unsupported file type" }` and no GridFS file is created
+
+#### Scenario: No file in request
+
+- **Given** an authenticated user with role `dm` in campaign `campaignId`
+- **When** they POST multipart/form-data with no `file` field
+- **Then** the response is `400 Bad Request` with `{ "error": "file is required" }`
+
+#### Scenario: Player attempts upload
+
+- **Given** an authenticated user with role `player` (not `dm`) in campaign `campaignId`
+- **When** they POST a valid image file to `/api/campaigns/[id]/attachments`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Non-member attempts upload
+
+- **Given** an authenticated user who is not a member of campaign `campaignId`
+- **When** they POST a valid image file to `/api/campaigns/[id]/attachments`
+- **Then** the response is `403 Forbidden`
+
+#### Scenario: Unauthenticated request
+
+- **Given** a request with no auth credentials
+- **When** they POST to `/api/campaigns/[id]/attachments`
+- **Then** the response is `401 Unauthorized`
+
+#### Scenario: Campaign does not exist
+
+- **Given** an authenticated user
+- **When** they POST to `/api/campaigns/nonexistent-id/attachments`
+- **Then** the response is `404 Not Found`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "DM-only upload" → Requirement: ADDED POST /api/campaigns/[id]/attachments
+- Proposal element "5 MB max, JPEG/PNG/WebP/GIF" → Scenarios: file exceeds limit, unsupported MIME type
+- Design decision D1 (two-step upload) → this endpoint returns `attachmentId` only
+- Design decision D2 (lazy orphan sweep) → sweep fires before GridFS insert (see specs/gridfs-orphan/spec.md)
+- Design decision D4 (MIME from formData file.type) → unsupported MIME scenario
+- Requirement → Task: T1 (lib/gridfs.ts), T2 (POST /attachments route)
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Security
+
+See functional scenarios: "Player attempts upload", "Non-member attempts upload", "Unauthenticated request". No additional NFAC security scenarios.
+
+### Requirement: Reliability
+
+#### Scenario: File bytes are persisted in MongoDB (not local disk)
+
+- **Given** a successful upload
+- **When** the Fly machine is restarted (ephemeral disk cleared)
+- **Then** the file remains retrievable via `GET /api/campaigns/[id]/attachments/[attachmentId]`
+
+> Note: verified by architecture (GridFS → MongoDB Atlas); not unit-testable. Confirmed by integration test if run against a real database.


### PR DESCRIPTION
Archives the completed gridfs-attachment-upload-serve change and syncs approved specs to openspec/specs/.

- Moves change directory to `openspec/changes/archive/2026-06-20-gridfs-attachment-upload-serve/`
- Copies 4 approved specs to `openspec/specs/`: gridfs-upload, gridfs-serve, gridfs-orphan, campaign-message-type
- Updates spec relative links to point to archive location