### PR TITLE
feat: add concentration tracking

### DIFF
--- a/lib/components/ActiveCombatView.tsx
+++ b/lib/components/ActiveCombatView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AuthUser } from '@/lib/hooks/useAuth';
 import { CombatInfoIcon } from '@/lib/components/CombatInfoIcon';
 import { CombatantCard } from '@/lib/components/CombatantCard';
@@ -139,11 +139,17 @@ export function ActiveCombatView({ combat, user }: ActiveCombatViewProps) {
 
   const activeCombatantId = combatState.combatants[combatState.currentTurnIndex]?.id;
 
+  const characterMap = useMemo(
+    () => new Map((characters ?? []).map(c => [c.id, c])),
+    [characters],
+  );
+
   const handleConSaveRequired = (combatant: CombatantState, dc: number) => {
     const campaignId = combatState.campaignId;
     if (!campaignId) return;
     if (!combatant.id.startsWith('character-')) return;
-    const character = characters.find(c => combatant.id.startsWith(`character-${c.id}-`));
+    const characterId = combatant.id.slice('character-'.length);
+    const character = characterMap.get(characterId);
     if (!character) return;
     fetch(`/api/campaigns/${campaignId}/messages`, {
       method: 'POST',

--- a/lib/components/ActiveCombatView.tsx
+++ b/lib/components/ActiveCombatView.tsx
@@ -158,7 +158,7 @@ export function ActiveCombatView({ combat, user }: ActiveCombatViewProps) {
         text: `${combatant.name} must make a CON saving throw (DC ${dc}) to maintain concentration on ${combatant.concentratingOn ?? 'their spell'}.`,
         visibility: { scope: 'direct', toUserId: character.userId },
       }),
-    });
+    }).catch(() => {});
   };
 
   const renderCard = (combatant: CombatantState) => (

--- a/lib/components/ActiveCombatView.tsx
+++ b/lib/components/ActiveCombatView.tsx
@@ -135,14 +135,14 @@ export function ActiveCombatView({ combat, user }: ActiveCombatViewProps) {
     }
   }, [initiativeEditId]);
 
-  if (!combatState) return null;
-
-  const activeCombatantId = combatState.combatants[combatState.currentTurnIndex]?.id;
-
   const characterMap = useMemo(
     () => new Map((characters ?? []).map(c => [c.id, c])),
     [characters],
   );
+
+  if (!combatState) return null;
+
+  const activeCombatantId = combatState.combatants[combatState.currentTurnIndex]?.id;
 
   const handleConSaveRequired = (combatant: CombatantState, dc: number) => {
     const campaignId = combatState.campaignId;

--- a/lib/components/ActiveCombatView.tsx
+++ b/lib/components/ActiveCombatView.tsx
@@ -139,6 +139,22 @@ export function ActiveCombatView({ combat, user }: ActiveCombatViewProps) {
 
   const activeCombatantId = combatState.combatants[combatState.currentTurnIndex]?.id;
 
+  const handleConSaveRequired = (combatant: CombatantState, dc: number) => {
+    const campaignId = combatState.campaignId;
+    if (!campaignId) return;
+    if (!combatant.id.startsWith('character-')) return;
+    const character = characters.find(c => combatant.id.startsWith(`character-${c.id}-`));
+    if (!character) return;
+    fetch(`/api/campaigns/${campaignId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: `${combatant.name} must make a CON saving throw (DC ${dc}) to maintain concentration on ${combatant.concentratingOn ?? 'their spell'}.`,
+        visibility: { scope: 'direct', toUserId: character.userId },
+      }),
+    });
+  };
+
   const renderCard = (combatant: CombatantState) => (
     <CombatantCard
       key={combatant.id}
@@ -159,6 +175,7 @@ export function ActiveCombatView({ combat, user }: ActiveCombatViewProps) {
       }}
       allCombatants={combatState.combatants}
       onUpdateCombatant={(id, updates) => updateCombatant(id, updates)}
+      onConSaveRequired={(dc) => handleConSaveRequired(combatant, dc)}
     />
   );
 

--- a/lib/components/CombatantCard.tsx
+++ b/lib/components/CombatantCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { CombatantState, ActiveDamageEffect, StatusCondition } from '@/lib/types';
+import type { CombatantState, ActiveDamageEffect, StatusCondition } from '@/lib/types';
 import { applyDamage as calcApplyDamage, applyHealing as calcApplyHealing, setTempHp as calcSetTempHp, applyDamageWithType as calcApplyDamageWithType, mergeActiveDamageEffects, removeActiveDamageEffects, calcConSaveDC } from '@/lib/utils/combat';
 import { pushHpHistory, popHpHistory, getHpHistoryStack } from '@/lib/utils/hpHistory';
 import { DAMAGE_TYPE_GROUPS, DAMAGE_EFFECT_PRESETS, DamageType } from '@/lib/constants';

--- a/lib/components/CombatantCard.tsx
+++ b/lib/components/CombatantCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { CombatantState, ActiveDamageEffect, StatusCondition } from '@/lib/types';
-import { applyDamage as calcApplyDamage, applyHealing as calcApplyHealing, setTempHp as calcSetTempHp, applyDamageWithType as calcApplyDamageWithType, mergeActiveDamageEffects, removeActiveDamageEffects } from '@/lib/utils/combat';
+import { applyDamage as calcApplyDamage, applyHealing as calcApplyHealing, setTempHp as calcSetTempHp, applyDamageWithType as calcApplyDamageWithType, mergeActiveDamageEffects, removeActiveDamageEffects, calcConSaveDC } from '@/lib/utils/combat';
 import { pushHpHistory, popHpHistory, getHpHistoryStack } from '@/lib/utils/hpHistory';
 import { DAMAGE_TYPE_GROUPS, DAMAGE_EFFECT_PRESETS, DamageType } from '@/lib/constants';
 import { LegendaryActionsPanel } from '@/lib/components/LegendaryActionsPanel';
@@ -21,6 +21,7 @@ export interface CombatantCardProps {
   onShowRemoveConfirm?: (combatantId: string, position: { top: number; left: number }) => void;
   allCombatants?: CombatantState[];
   onUpdateCombatant?: (combatantId: string, updates: Partial<CombatantState>) => void;
+  onConSaveRequired?: (dc: number) => void;
 }
 
 function applyTypedDamage(
@@ -29,7 +30,7 @@ function applyTypedDamage(
   damage: number,
   damageType: DamageType | '',
   combatant: Pick<CombatantState, 'damageResistances' | 'damageImmunities' | 'damageVulnerabilities' | 'activeDamageEffects'>
-): { hp: number; tempHp: number } {
+): { hp: number; tempHp: number; effectiveDamage: number } {
   if (damageType) {
     return calcApplyDamageWithType(hp, tempHp, damage, damageType, {
       damageResistances: combatant.damageResistances,
@@ -38,7 +39,9 @@ function applyTypedDamage(
       activeDamageEffects: combatant.activeDamageEffects,
     });
   }
-  return calcApplyDamage(hp, tempHp, damage);
+  const result = calcApplyDamage(hp, tempHp, damage);
+  const effectiveDamage = (hp + tempHp) - (result.hp + result.tempHp);
+  return { ...result, effectiveDamage };
 }
 
 function DamageEffectsPanel({
@@ -232,6 +235,7 @@ export function CombatantCard(props: CombatantCardProps) {
     onShowRemoveConfirm,
     allCombatants,
     onUpdateCombatant,
+    onConSaveRequired,
   } = props;
   const combatantMap = useMemo(() => new Map(allCombatants?.map(c => [c.id, c])), [allCombatants]);
 
@@ -250,12 +254,21 @@ export function CombatantCard(props: CombatantCardProps) {
     const prevTempHp = combatant.tempHp ?? 0;
     if (amount < 0) {
       const rawDamage = -amount;
-      const { hp: resultHp, tempHp: resultTempHp } = applyTypedDamage(prevHp, prevTempHp, rawDamage, selectedDamageType, combatant);
+      const { hp: resultHp, tempHp: resultTempHp, effectiveDamage } = applyTypedDamage(prevHp, prevTempHp, rawDamage, selectedDamageType, combatant);
       if (resultHp !== prevHp || resultTempHp !== prevTempHp) {
         pushHpHistory(combatId, combatant.id, { hp: prevHp, tempHp: prevTempHp, type: 'damage', amount: rawDamage, timestamp: Date.now() });
         setHistoryLength(getHpHistoryStack(combatId, combatant.id).length);
       }
-      onUpdate({ hp: resultHp, tempHp: resultTempHp });
+      const concentrationUpdates: Partial<CombatantState> = {};
+      if (resultHp === 0) {
+        concentrationUpdates.concentratingOn = undefined;
+        concentrationUpdates.pendingConSaveDC = undefined;
+      } else if (combatant.concentratingOn && effectiveDamage > 0) {
+        const dc = calcConSaveDC(effectiveDamage);
+        concentrationUpdates.pendingConSaveDC = dc;
+        onConSaveRequired?.(dc);
+      }
+      onUpdate({ hp: resultHp, tempHp: resultTempHp, ...concentrationUpdates });
     } else {
       const result = calcApplyHealing(prevHp, combatant.maxHp, amount);
       if (result.hp !== prevHp) {
@@ -580,6 +593,29 @@ export function CombatantCard(props: CombatantCardProps) {
             selectedDamageType={selectedDamageType}
             onUpdate={onUpdate}
           />
+
+          {combatant.concentratingOn && (
+            <span
+              className="inline-block text-xs bg-indigo-800 text-indigo-200 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1"
+              data-testid="concentration-badge"
+            >
+              🎯 {combatant.concentratingOn}
+            </span>
+          )}
+
+          {combatant.pendingConSaveDC !== undefined && (
+            <div className="flex items-center gap-2 mt-1 bg-amber-900 border border-amber-600 rounded px-2 py-1 text-xs text-amber-200">
+              <span>CON Save DC {combatant.pendingConSaveDC}</span>
+              <button
+                onClick={() => onUpdate({ pendingConSaveDC: undefined })}
+                className="text-amber-400 hover:text-amber-200 leading-none"
+                aria-label="Dismiss CON save"
+                title="Dismiss CON save prompt"
+              >
+                ×
+              </button>
+            </div>
+          )}
 
           {combatant.conditions.length > 0 && (
             <div className="mb-2">

--- a/lib/components/CombatantDetailPanel.tsx
+++ b/lib/components/CombatantDetailPanel.tsx
@@ -115,7 +115,7 @@ export function CombatantDetailPanel({
                 onBlur={(e) => {
                   const v = e.target.value.trim();
                   if (v === (combatant.concentratingOn ?? '')) return;
-                  onUpdate(combatant.id, { concentratingOn: v || undefined });
+                  onUpdate(combatant.id, { concentratingOn: v || undefined, pendingConSaveDC: undefined });
                 }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {

--- a/lib/components/CombatantDetailPanel.tsx
+++ b/lib/components/CombatantDetailPanel.tsx
@@ -114,12 +114,12 @@ export function CombatantDetailPanel({
                 defaultValue={combatant.concentratingOn ?? ''}
                 onBlur={(e) => {
                   const v = e.target.value.trim();
+                  if (v === (combatant.concentratingOn ?? '')) return;
                   onUpdate(combatant.id, { concentratingOn: v || undefined });
                 }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
-                    const v = e.currentTarget.value.trim();
-                    onUpdate(combatant.id, { concentratingOn: v || undefined });
+                    e.currentTarget.blur();
                   }
                 }}
                 className="flex-1 bg-gray-700 rounded px-2 py-1 text-xs text-white border border-gray-600"

--- a/lib/components/CombatantDetailPanel.tsx
+++ b/lib/components/CombatantDetailPanel.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { CombatantState } from '@/lib/types';
 import { LegendaryActionsPanel } from '@/lib/components/LegendaryActionsPanel';
 
@@ -33,17 +32,6 @@ export function CombatantDetailPanel({
   onClose,
   onUpdate
 }: CombatantDetailPanelProps) {
-  const [spellInput, setSpellInput] = useState(combatant.concentratingOn ?? '');
-
-  useEffect(() => {
-    setSpellInput(combatant.concentratingOn ?? '');
-  }, [combatant.concentratingOn]);
-
-  const saveConcentration = () => {
-    const value = spellInput.trim();
-    onUpdate(combatant.id, { concentratingOn: value || undefined });
-  };
-
   return (
     <>
       <div
@@ -120,12 +108,20 @@ export function CombatantDetailPanel({
                 Concentrating on spell
               </label>
               <input
+                key={combatant.concentratingOn ?? ''}
                 id="concentration-spell-input"
                 type="text"
-                value={spellInput}
-                onChange={(e) => setSpellInput(e.target.value)}
-                onBlur={saveConcentration}
-                onKeyDown={(e) => { if (e.key === 'Enter') saveConcentration(); }}
+                defaultValue={combatant.concentratingOn ?? ''}
+                onBlur={(e) => {
+                  const v = e.target.value.trim();
+                  onUpdate(combatant.id, { concentratingOn: v || undefined });
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    const v = e.currentTarget.value.trim();
+                    onUpdate(combatant.id, { concentratingOn: v || undefined });
+                  }
+                }}
                 className="flex-1 bg-gray-700 rounded px-2 py-1 text-xs text-white border border-gray-600"
                 placeholder="Spell name"
               />

--- a/lib/components/CombatantDetailPanel.tsx
+++ b/lib/components/CombatantDetailPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { CombatantState } from '@/lib/types';
 import { LegendaryActionsPanel } from '@/lib/components/LegendaryActionsPanel';
 
@@ -32,6 +33,17 @@ export function CombatantDetailPanel({
   onClose,
   onUpdate
 }: CombatantDetailPanelProps) {
+  const [spellInput, setSpellInput] = useState(combatant.concentratingOn ?? '');
+
+  useEffect(() => {
+    setSpellInput(combatant.concentratingOn ?? '');
+  }, [combatant.concentratingOn]);
+
+  const saveConcentration = () => {
+    const value = spellInput.trim();
+    onUpdate(combatant.id, { concentratingOn: value || undefined });
+  };
+
   return (
     <>
       <div
@@ -100,6 +112,33 @@ export function CombatantDetailPanel({
           {combatant.lairActions && combatant.lairActions.length > 0 && (
             <ActionList label="Lair Actions" actions={combatant.lairActions} />
           )}
+
+          <div>
+            <p className="text-gray-400 text-sm mb-1 font-semibold">Concentration</p>
+            <div className="flex items-center gap-2">
+              <label htmlFor="concentration-spell-input" className="text-xs text-gray-300 whitespace-nowrap">
+                Concentrating on spell
+              </label>
+              <input
+                id="concentration-spell-input"
+                type="text"
+                value={spellInput}
+                onChange={(e) => setSpellInput(e.target.value)}
+                onBlur={saveConcentration}
+                onKeyDown={(e) => { if (e.key === 'Enter') saveConcentration(); }}
+                className="flex-1 bg-gray-700 rounded px-2 py-1 text-xs text-white border border-gray-600"
+                placeholder="Spell name"
+              />
+            </div>
+            {combatant.concentratingOn && (
+              <button
+                onClick={() => onUpdate(combatant.id, { concentratingOn: undefined, pendingConSaveDC: undefined })}
+                className="mt-1 text-xs bg-red-700 hover:bg-red-600 text-red-100 px-2 py-1 rounded"
+              >
+                End Concentration
+              </button>
+            )}
+          </div>
 
           {combatant.abilityScores && (
             <div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -544,6 +544,8 @@ export interface CombatantState extends CreatureStats {
   legendaryActionCount?: number; // DM-adjustable pool size (copied from template)
   legendaryActionsRemaining?: number; // Runtime counter; resets on turn start
   activeDamageEffects?: ActiveDamageEffect[];
+  concentratingOn?: string;
+  pendingConSaveDC?: number;
   initiativeAdvantage?: boolean;
   initiativeFlatBonus?: number;
 }

--- a/lib/utils/combat.ts
+++ b/lib/utils/combat.ts
@@ -126,6 +126,14 @@ export function incrementLegendaryPool(
   };
 }
 
+/**
+ * Compute the CON save DC for a concentration check per D&D 5e rules.
+ * DC = max(10, floor(effectiveDamage / 2)).
+ */
+export function calcConSaveDC(effectiveDamage: number): number {
+  return Math.max(10, Math.floor(effectiveDamage / 2));
+}
+
 /** Clamp a potentially non-finite number to a non-negative finite value. */
 function safeNonNeg(n: number): number {
   return Number.isFinite(n) ? Math.max(0, n) : 0;

--- a/openspec/changes/concentration-tracking/.openspec.yaml
+++ b/openspec/changes/concentration-tracking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-21

--- a/openspec/changes/concentration-tracking/design.md
+++ b/openspec/changes/concentration-tracking/design.md
@@ -1,0 +1,166 @@
+## Context
+
+- Relevant architecture: `CombatantState` (lib/types.ts:527) is the in-memory runtime record for each combatant during a session. It extends `CreatureStats` and already carries optional runtime fields (`tempHp`, `activeDamageEffects`, `legendaryActionsRemaining`). Damage is applied in `CombatantCard.tsx` via `applyDamage()` / `applyDamageWithType()` from `lib/utils/combat.ts`; both return the post-damage state as a plain object. The `CombatantDetailPanel` component provides the DM with a per-combatant configuration surface.
+- Dependencies: `lib/utils/combat.ts` — damage helpers; `lib/types.ts` — type model; `lib/components/CombatantCard.tsx` — damage application and card rendering; `lib/components/CombatantDetailPanel.tsx` — combatant configuration UI; existing notification/chat channel (to be investigated per risk in proposal).
+- Interfaces/contracts touched: `CombatantState` (add two optional fields), `applyDamageWithType` return value is already `{ hp, tempHp, effectiveDamage }` — no signature change needed.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add `concentratingOn` and `pendingConSaveDC` to `CombatantState` as optional fields
+- Pure helper `calcConSaveDC` computes `max(10, floor(effectiveDamage / 2))`
+- Damage path in `CombatantCard` sets `pendingConSaveDC` when `concentratingOn` is set and `effectiveDamage > 0`; clears `concentratingOn` (and `pendingConSaveDC`) when `hp` reaches 0
+- Card renders a concentration badge (spell name pill) and a DC prompt when `pendingConSaveDC` is set
+- DC prompt is DM-visible only; a CON-save notification fires to DM and the affected player
+- `CombatantDetailPanel` gains a spell-name text input and an "End Concentration" button
+
+### Non-Goals
+
+- DB persistence (see proposal Non-Goals)
+- Automatic save resolution
+- Player-facing combat UI
+
+## Decisions
+
+### D1: State fields on `CombatantState`, not a separate object
+
+- Chosen: Add `concentratingOn?: string` and `pendingConSaveDC?: number` directly to `CombatantState`.
+- Alternatives considered: Separate `concentrationState` sub-object; store only in component local state.
+- Rationale: Consistent with how `tempHp`, `activeDamageEffects`, and `legendaryActionsRemaining` are handled — all are optional runtime-only fields on `CombatantState`. Keeps the state shape flat and co-located with the combatant.
+- Trade-offs: Slightly widens `CombatantState` — acceptable given both fields are optional and zero-cost when undefined.
+
+### D2: DC computed at damage time and stored on state, not recomputed on render
+
+- Chosen: `calcConSaveDC(effectiveDamage)` is called in the damage handler; result is written to `pendingConSaveDC` on the combatant state update.
+- Alternatives considered: Derive DC in the render function from stored damage history.
+- Rationale: The effective damage that drove the save is not otherwise stored; computing and storing the DC at damage time is simpler and avoids dependency on a separate damage history field. Consistent with how `effectiveDamage` is already returned by `applyDamageWithType` but not persisted.
+- Trade-offs: `pendingConSaveDC` must be explicitly cleared (dismiss button, next damage hit, or HP-0 clear).
+
+### D3: Auto-clear `concentratingOn` at HP = 0 in the damage handler
+
+- Chosen: When the post-damage `hp === 0`, the state update also sets `concentratingOn: undefined` and `pendingConSaveDC: undefined`.
+- Alternatives considered: Watch for HP 0 in a `useEffect`; handle in `useCombat` hook.
+- Rationale: The damage handler already has the new HP value at the point of the state update — no additional pass needed. Mirrors how temp HP drain is handled in the same path.
+- Trade-offs: None significant; the change is local to the damage handler callback.
+
+### D4: DC prompt displays on the card; CON-save notice fires via a new callback prop
+
+- Chosen: `pendingConSaveDC` renders an inline alert on `CombatantCard` visible to the DM. `CombatantCard` fires a new `onConSaveRequired?: (dc: number) => void` callback prop. `ActiveCombatView` implements the callback: it extracts the character ID from the combatant ID (pattern `character-${character.id}`), looks up the `Character` in the `characters[]` array to get `userId`, then posts a `CampaignMessage` with `visibility: { scope: "direct"; toUserId: character.userId }` to the campaign chat/stream API. A separate DM-visible alert/toast fires simultaneously.
+- Alternatives considered: Toast only; chat message only; passing `characters[]` into `CombatantCard`; no player notification.
+- Rationale: `CombatantState` carries no `userId` field — confirmed by code inspection. Player userId must be resolved via the `character-${id}` combatant ID pattern against the `characters[]` array available in `ActiveCombatView`. Keeping this logic in `ActiveCombatView` (not `CombatantCard`) respects separation of concerns: the card handles HP/damage rendering, the view handles multi-user orchestration. The campaign message API already supports `{ scope: "direct"; toUserId }` visibility, so no new infrastructure is needed.
+- Trade-offs: Adds one prop to `CombatantCardProps`. Non-player combatants (monsters, lair) have no character ID match — the callback fires for player-type combatants only; for monster-type, only the DM alert fires.
+
+### D5: `CombatantDetailPanel` is the surface for setting / ending concentration
+
+- Chosen: Add a labeled text input ("Concentrating on spell") and an "End Concentration" button to `CombatantDetailPanel`.
+- Alternatives considered: Inline input on the card itself; a dedicated modal.
+- Rationale: The detail panel is already the DM's configuration surface for a combatant. Adding to it avoids cluttering the card row and is consistent with the existing UX pattern.
+- Trade-offs: The DM must open the panel to set concentration; they cannot do it directly from the card row. Acceptable given the DM typically sets concentration at the start of a spell, not mid-action.
+
+## Proposal to Design Mapping
+
+- Proposal element: `concentratingOn?: string` and `pendingConSaveDC?: number` on `CombatantState`
+  - Design decision: D1
+  - Validation approach: TypeScript compile check; unit tests assert fields are present/absent as expected
+
+- Proposal element: `calcConSaveDC(effectiveDamage)` helper
+  - Design decision: D2
+  - Validation approach: Unit tests covering boundary values (0, 1, 19, 20, 21)
+
+- Proposal element: Auto-clear at 0 HP
+  - Design decision: D3
+  - Validation approach: Unit test: apply lethal damage to concentrating combatant, assert `concentratingOn` and `pendingConSaveDC` are cleared
+
+- Proposal element: DC prompt on card (DM-only), notification to player
+  - Design decision: D4
+  - Validation approach: RTL test asserts DC prompt renders when `pendingConSaveDC` is set; `onConSaveRequired` callback verified via mock; `ActiveCombatView` test asserts campaign message POST with `{ scope: "direct"; toUserId }` for player-type combatants
+
+- Proposal element: Set/end concentration via detail panel
+  - Design decision: D5
+  - Validation approach: RTL test for input and button in `CombatantDetailPanel`
+
+## Functional Requirements Mapping
+
+- Requirement: Mark a combatant as concentrating on a named spell
+  - Design element: `concentratingOn` field; text input in `CombatantDetailPanel`
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — Set Concentration
+  - Testability notes: RTL test sets spell name via input, asserts `onUpdate` called with `concentratingOn` set
+
+- Requirement: Auto-calculate and display CON save DC when concentrating combatant takes damage
+  - Design element: `calcConSaveDC`; damage handler writes `pendingConSaveDC`; card renders DC prompt
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — CON Save DC Display
+  - Testability notes: Unit test for `calcConSaveDC`; RTL test asserts DC badge appears after damage
+
+- Requirement: Visual indicator (spell name shown) when concentrating
+  - Design element: Spell name badge rendered when `concentratingOn` is set
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — Concentration Badge
+  - Testability notes: RTL test asserts pill/badge with spell name is visible
+
+- Requirement: "End Concentration" button to manually clear
+  - Design element: Button in `CombatantDetailPanel` clears `concentratingOn` and `pendingConSaveDC`
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — End Concentration
+  - Testability notes: RTL test clicks button, asserts `onUpdate` called with both fields undefined
+
+- Requirement: Concentration clears automatically at 0 HP
+  - Design element: D3 — damage handler conditional
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — Auto-Clear at 0 HP
+  - Testability notes: Unit/RTL test applies lethal damage, asserts fields cleared
+
+- Requirement: Only one spell at a time (new replaces old)
+  - Design element: Single `string` field (not array); input in panel overwrites on save
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — Single Spell Enforcement
+  - Testability notes: Set two spell names in sequence, assert only the second remains
+
+- Requirement: CON save notice to DM and affected player
+  - Design element: `CombatantCard` fires `onConSaveRequired(dc)` callback; `ActiveCombatView` resolves player userId via `characters[]` and posts `CampaignMessage` with `{ scope: "direct"; toUserId }` to `/api/campaigns/${campaignId}/messages` (or equivalent)
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — Player Notification
+  - Testability notes: Mock `onConSaveRequired` callback in `CombatantCard` RTL tests; mock `fetch` in `ActiveCombatView` tests and assert direct-message POST for player-type combatants; assert no player message for monster-type combatants
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: Immunity (effectiveDamage = 0) must not trigger a save
+  - Design element: `calcConSaveDC` is only called when `effectiveDamage > 0`; DC = max(10, floor(0/2)) = 10 would be wrong (0 damage = no save required by RAW)
+  - Acceptance criteria reference: specs/concentration-tracking/spec.md — Immunity No-Op
+  - Testability notes: Unit test: concentrating combatant immune to damage type → no `pendingConSaveDC` set
+
+- Requirement category: performance
+  - Requirement: Concentration check adds no perceptible latency to damage application
+  - Design element: `calcConSaveDC` is O(1) integer math; no I/O; no additional renders beyond existing state update
+  - Acceptance criteria reference: n/a (not measurable at unit level)
+  - Testability notes: No dedicated perf test; complexity is trivially low
+
+- Requirement category: operability
+  - Requirement: No DB migration or schema change required
+  - Design element: In-memory only; no storage layer touched
+  - Acceptance criteria reference: proposal Non-Goals
+  - Testability notes: Confirm no changes to `lib/storage.ts` or any MongoDB collection shape
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Player notification requires combatant-to-player ownership linkage
+  - Impact: **Resolved.** `CombatantState` carries no `userId`. Player combatant IDs follow `character-${character.id}` (set in `useCombat.ts`). `ActiveCombatView` has `characters[]` from `useCombat`, each with a `userId`. Lookup: strip `character-` prefix → find `Character` by `id` → use `character.userId`. Campaign chat already supports `{ scope: "direct"; toUserId }` messages. Full player-targeted notification is achievable.
+  - Mitigation: N/A — resolved by investigation. Monster-type combatants have no character match; their notifications go to DM only (no change to monster gameplay behavior).
+
+- Risk/trade-off: `pendingConSaveDC` persists until explicitly dismissed
+  - Impact: Cosmetic confusion if the DM forgets to dismiss after the save is resolved
+  - Mitigation: Auto-clear on next damage event to the same combatant; prominent dismiss (×) button
+
+## Rollback / Mitigation
+
+- Rollback trigger: Regressions in existing `CombatantCard` HP or damage tests; unexpected TypeScript errors from new optional fields.
+- Rollback steps: Revert the PR. No DB migration means no data to undo.
+- Data migration considerations: None — in-memory only.
+- Verification after rollback: `npm run test:unit` passes; `npm run test:integration` passes.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failure in the feature branch.
+- If security checks fail: Do not merge. Triage within 24 hours.
+- If required reviews are blocked/stale: Re-request after 48 hours; escalate to maintainer after 72 hours.
+- Escalation path and timeout: Tag maintainer on the PR after 72-hour review stale window.
+
+## Open Questions
+
+- No open questions remain. All design decisions were finalised during the exploration session and confirmed by code investigation of `lib/hooks/useCombat.ts`, `lib/types.ts`, `lib/components/CombatantCard.tsx`, `lib/components/ActiveCombatView.tsx`, and `lib/hooks/useCampaignStream.ts`.

--- a/openspec/changes/concentration-tracking/proposal.md
+++ b/openspec/changes/concentration-tracking/proposal.md
@@ -1,0 +1,85 @@
+## GitHub Issues
+
+- #93
+
+## Why
+
+- Problem statement: D&D 5e has a concentration mechanic where spells require sustained focus. When a concentrating creature takes damage it must succeed on a Constitution saving throw (DC = max(10, half the damage taken)) or lose the spell. The app currently has no way to track which combatant is concentrating, no way to surface the required save, and no visual indicator during combat.
+- Why now: Issue #93 is open and unblocked. The damage pipeline (`applyDamageWithType`) already returns `effectiveDamage`, and `CombatantState` already carries `abilityScores.constitution` — the mechanic slots in cleanly without touching unrelated systems.
+- Business/user impact: Without this, the DM must mentally track all concentrating spells during a fast-moving combat, regularly forgetting to call for saves. This is one of the most frequently missed rules at the table.
+
+## Problem Space
+
+- Current behavior: No field on `CombatantState` records concentration. Damage application in `CombatantCard` does not check for concentration. There is no UI element showing a spell is active.
+- Desired behavior: The DM can mark a combatant as concentrating on a named spell. When that combatant takes damage, the CON save DC is surfaced on the card (DM-visible only) and a "make a CON save" notification fires to both the DM and the affected player. The DM can end concentration manually or it clears automatically at 0 HP.
+- Constraints: No DB persistence required — concentration state is in-memory only and resets between sessions. The DC display is non-blocking; the DM still asks the player to roll.
+- Assumptions: The app is DM-operated in the current session. Player-facing views (if they come later) are out of scope for this change. The `effectiveDamage` value returned by `applyDamageWithType` is the correct basis for the DC (post-resistance).
+- Edge cases considered:
+  - Damage reduced to 0 by immunity → no save required (effectiveDamage = 0)
+  - Multiple hits in the same turn → each hit is a separate save trigger
+  - Setting a new concentration spell replaces the old one immediately
+  - Healing does not trigger or clear concentration
+  - Lair-type combatants cannot concentrate (not a spellcasting type in this app)
+
+## Scope
+
+### In Scope
+
+- New optional fields on `CombatantState`: `concentratingOn?: string` and `pendingConSaveDC?: number`
+- Helper `calcConSaveDC(effectiveDamage: number): number` in `lib/utils/combat.ts`
+- Logic in `CombatantCard.tsx` to set `pendingConSaveDC` on damage if `concentratingOn` is set, and to clear `concentratingOn` when HP reaches 0
+- Visual badge on `CombatantCard` showing the spell name when concentrating
+- Inline DC prompt on the card when `pendingConSaveDC` is set (DM-only display), with a dismiss button
+- "End Concentration" button in `CombatantDetailPanel.tsx`
+- Text input in `CombatantDetailPanel.tsx` to set the concentrating spell name
+- Notification to both DM and affected player via the existing notification/chat channel when a CON save is required
+- Unit tests for `calcConSaveDC` and the auto-clear-on-0-HP logic
+- Unit tests for the concentration badge and DC prompt rendering in `CombatantCard`
+
+### Out of Scope
+
+- Persisting concentration state to the database
+- Player-facing combat views
+- Automatic pass/fail determination (the DM still asks the player to roll)
+- Tracking which round concentration started or how many rounds it has been active
+- Linking concentration to a spell object from the spell collection
+
+## What Changes
+
+- `lib/types.ts`: Add `concentratingOn?: string` and `pendingConSaveDC?: number` to `CombatantState`
+- `lib/utils/combat.ts`: Add `calcConSaveDC(effectiveDamage: number): number`
+- `lib/components/CombatantCard.tsx`: Check concentration on damage, set DC field, auto-clear on 0 HP, render badge and DC prompt
+- `lib/components/CombatantDetailPanel.tsx`: Add spell-name input and "End Concentration" button
+- `tests/unit/components/CombatantCard.*.test.tsx`: New/updated tests covering concentration badge, DC prompt, and auto-clear
+- `tests/unit/utils/combat.test.ts` (or equivalent): Tests for `calcConSaveDC`
+
+## Risks
+
+- Risk: `CombatantState` carries no `userId` — player ownership must be resolved indirectly.
+  - Impact: Resolved. Player combatant IDs follow the pattern `character-${character.id}`. The `characters[]` array in `useCombat` / `ActiveCombatView` carries full `Character` objects with `userId`. The lookup is deterministic. The campaign chat system supports `{ scope: "direct"; toUserId: string }` messages. Notification is fully achievable via a new `onConSaveRequired` callback prop on `CombatantCard`, implemented by `ActiveCombatView`.
+  - Mitigation: N/A — resolved.
+
+- Risk: `pendingConSaveDC` persists on the card until dismissed. If the DM forgets to dismiss it, it could be confusing after the relevant save is resolved.
+  - Impact: Low — cosmetic confusion only, no game-state impact.
+  - Mitigation: Make the dismiss action obvious (× button); auto-clear on the next damage event to that combatant.
+
+## Open Questions
+
+- No unresolved ambiguity remains. All design decisions were settled during the exploration session and subsequent investigation:
+  - Card-based DC display confirmed (not toast)
+  - No persistence required
+  - DC is DM-only; "make a CON save" prompt fires to DM + affected player
+  - Player notification is achievable: combatant ID → character ID → userId lookup via `characters[]`; campaign direct-message channel already supports `{ scope: "direct"; toUserId }` visibility
+
+## Non-Goals
+
+- Automatic dice rolling for the CON save
+- CON save advantage/disadvantage tracking
+- Concentration duration tracking (rounds)
+- Linking to a structured spell object
+- Persisting concentration across sessions
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/concentration-tracking/specs/concentration-tracking/spec.md
+++ b/openspec/changes/concentration-tracking/specs/concentration-tracking/spec.md
@@ -1,0 +1,220 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Concentration badge renders when combatant is concentrating
+
+The system SHALL display a visual badge showing the spell name on a combatant's card when `concentratingOn` is set.
+
+#### Scenario: Concentration badge visible
+
+- **Given** a combatant with `concentratingOn: "Hold Person"` is rendered in `CombatantCard`
+- **When** the card renders
+- **Then** a badge/pill displaying "Hold Person" is visible in the combatant row
+
+#### Scenario: No badge when not concentrating
+
+- **Given** a combatant with `concentratingOn` undefined
+- **When** the card renders
+- **Then** no concentration badge is present in the DOM
+
+---
+
+### Requirement: ADDED CON save DC is displayed on the card after the combatant takes damage while concentrating
+
+The system SHALL set `pendingConSaveDC` on the combatant and render a DC prompt on the card when a concentrating combatant takes effective damage greater than zero.
+
+#### Scenario: DC prompt appears after damage
+
+- **Given** a combatant with `concentratingOn: "Fly"` and current HP > 0
+- **When** damage is applied and `effectiveDamage > 0`
+- **Then** `pendingConSaveDC` is set to `max(10, floor(effectiveDamage / 2))` and the card renders a DC prompt showing that value
+
+#### Scenario: DC prompt absent when no concentration
+
+- **Given** a combatant with `concentratingOn` undefined
+- **When** damage is applied
+- **Then** `pendingConSaveDC` is not set and no DC prompt is rendered
+
+#### Scenario: DC prompt absent when damage is fully absorbed by immunity (effectiveDamage = 0)
+
+- **Given** a combatant with `concentratingOn: "Web"` and immunity to the damage type
+- **When** damage is applied and `effectiveDamage = 0`
+- **Then** `pendingConSaveDC` is not set and no DC prompt is rendered
+
+#### Scenario: DC prompt dismissed
+
+- **Given** a combatant card showing `pendingConSaveDC: 14`
+- **When** the DM clicks the dismiss (×) button on the DC prompt
+- **Then** `pendingConSaveDC` is cleared and the DC prompt is removed from the card
+
+#### Scenario: DC prompt auto-clears on next damage
+
+- **Given** a combatant card showing `pendingConSaveDC: 12`
+- **When** a second damage event is applied to the same combatant while concentrating
+- **Then** the DC prompt updates to the new DC value for the latest hit
+
+---
+
+### Requirement: ADDED `calcConSaveDC` computes the correct DC
+
+The system SHALL compute CON save DC as `max(10, floor(effectiveDamage / 2))`.
+
+#### Scenario: Damage below threshold
+
+- **Given** `effectiveDamage = 14`
+- **When** `calcConSaveDC(14)` is called
+- **Then** the result is `10` (floor(14/2) = 7, max(10,7) = 10)
+
+#### Scenario: Damage at threshold
+
+- **Given** `effectiveDamage = 20`
+- **When** `calcConSaveDC(20)` is called
+- **Then** the result is `10` (floor(20/2) = 10, max(10,10) = 10)
+
+#### Scenario: Damage above threshold
+
+- **Given** `effectiveDamage = 21`
+- **When** `calcConSaveDC(21)` is called
+- **Then** the result is `10` (floor(21/2) = 10, max(10,10) = 10)
+
+#### Scenario: High damage
+
+- **Given** `effectiveDamage = 50`
+- **When** `calcConSaveDC(50)` is called
+- **Then** the result is `25` (floor(50/2) = 25, max(10,25) = 25)
+
+#### Scenario: Odd damage
+
+- **Given** `effectiveDamage = 19`
+- **When** `calcConSaveDC(19)` is called
+- **Then** the result is `9`... wait — floor(19/2) = 9, max(10,9) = 10. Result is `10`.
+
+---
+
+### Requirement: ADDED CON save notification fires to DM and affected player
+
+The system SHALL invoke the `onConSaveRequired(dc)` callback on `CombatantCard` when `effectiveDamage > 0` and `concentratingOn` is set. `ActiveCombatView` SHALL implement this callback: for player-type combatants, resolve the player `userId` by extracting the character ID from the combatant ID (pattern `character-${character.id}`) and looking up the `Character` in `characters[]`, then POST a `CampaignMessage` with `visibility: { scope: "direct"; toUserId: character.userId }` to the campaign message API. For monster-type combatants, no player message is sent.
+
+#### Scenario: Notification fires for player combatant
+
+- **Given** a concentrating combatant with `type: "player"` and `id: "character-abc123"`, with a matching `Character` in `characters[]` with `userId: "user-xyz"`, and `effectiveDamage > 0`
+- **When** damage is applied and `onConSaveRequired(dc)` is invoked
+- **Then** `ActiveCombatView` POSTs a `CampaignMessage` with `visibility: { scope: "direct"; toUserId: "user-xyz" }` containing the CON save DC
+
+#### Scenario: No player message for monster combatant
+
+- **Given** a concentrating combatant with `type: "monster"` and `effectiveDamage > 0`
+- **When** damage is applied and `onConSaveRequired(dc)` is invoked
+- **Then** no direct-message campaign POST is made (DM-only alert only)
+
+#### Scenario: No notification when damage is zero
+
+- **Given** a concentrating combatant immune to the incoming damage type
+- **When** damage is applied and `effectiveDamage = 0`
+- **Then** `onConSaveRequired` is not called and no campaign message is posted
+
+---
+
+### Requirement: ADDED End Concentration clears state
+
+The system SHALL clear `concentratingOn` and `pendingConSaveDC` from the combatant when the DM clicks "End Concentration" in `CombatantDetailPanel`.
+
+#### Scenario: End Concentration button clears fields
+
+- **Given** `CombatantDetailPanel` rendered with a combatant where `concentratingOn: "Silence"` and `pendingConSaveDC: 11`
+- **When** the DM clicks "End Concentration"
+- **Then** `onUpdate` is called with `concentratingOn: undefined` and `pendingConSaveDC: undefined`
+
+---
+
+### Requirement: ADDED Setting a new spell replaces the previous concentration
+
+The system SHALL overwrite `concentratingOn` when the DM submits a new spell name, regardless of the current value.
+
+#### Scenario: New spell overwrites old
+
+- **Given** a combatant with `concentratingOn: "Hold Monster"`
+- **When** the DM enters "Bless" in the spell name input and saves
+- **Then** `onUpdate` is called with `concentratingOn: "Bless"` and the previous value is gone
+
+---
+
+### Requirement: ADDED Concentration auto-clears when combatant reaches 0 HP
+
+The system SHALL clear `concentratingOn` and `pendingConSaveDC` when damage reduces the combatant's HP to 0.
+
+#### Scenario: Auto-clear at 0 HP
+
+- **Given** a combatant with `concentratingOn: "Entangle"`, `hp: 5`, and incoming `damage: 10`
+- **When** damage is applied
+- **Then** `hp = 0`, `concentratingOn` is undefined, and `pendingConSaveDC` is undefined
+
+#### Scenario: Concentration preserved when HP > 0 after damage
+
+- **Given** a combatant with `concentratingOn: "Entangle"`, `hp: 10`, and incoming `damage: 5`
+- **When** damage is applied
+- **Then** `hp = 5` and `concentratingOn` remains `"Entangle"`
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED `CombatantState` type carries optional concentration fields
+
+The `CombatantState` interface SHALL include two new optional fields: `concentratingOn?: string` and `pendingConSaveDC?: number`. All existing code that constructs or spreads `CombatantState` is unaffected because both fields are optional.
+
+#### Scenario: Existing combatant construction is unchanged
+
+- **Given** `buildCombatantFromSource` is called with a monster or character source
+- **When** the returned `CombatantState` is inspected
+- **Then** `concentratingOn` and `pendingConSaveDC` are both `undefined` (absent), and no existing tests break
+
+---
+
+## REMOVED Requirements
+
+None.
+
+---
+
+## Traceability
+
+- Proposal: "Mark a combatant as concentrating on a named spell" → Requirement: Set Concentration / End Concentration (detail panel, D5)
+- Proposal: "Auto-calculate and display CON save DC" → Requirement: `calcConSaveDC` + DC prompt (D2, D4)
+- Proposal: "Visual indicator in the combatant row" → Requirement: Concentration badge
+- Proposal: "End concentration button" → Requirement: End Concentration
+- Proposal: "Auto-clear at 0 HP" → Requirement: Auto-clear at 0 HP (D3)
+- Proposal: "Only one spell at a time" → Requirement: Single spell enforcement
+- Proposal: "CON save notice to DM and player" → Requirement: Player Notification (D4)
+- Design D1 → `CombatantState` MODIFIED Requirement
+- Design D2 → `calcConSaveDC` Requirement + DC prompt Requirement
+- Design D3 → Auto-clear at 0 HP Requirement
+- Design D4 → CON save notification Requirement + DC prompt Requirement
+- Design D5 → End Concentration Requirement + Set Concentration Requirement
+
+---
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Immunity produces no CON save
+
+- See functional scenario: "DC prompt absent when damage is fully absorbed by immunity (effectiveDamage = 0)"
+
+#### Scenario: No DB write occurs during concentration state changes
+
+- **Given** any concentration state update (set, clear, DC display)
+- **When** the state change is applied
+- **Then** no writes to `lib/storage.ts` or any MongoDB collection are made; all changes are in-memory only
+
+### Requirement: Performance
+
+#### Scenario: Concentration check adds no latency
+
+- `calcConSaveDC` is O(1) integer math with no I/O. No dedicated latency scenario is required; complexity is trivially negligible.
+
+### Requirement: Security
+
+- DC value is rendered only in the DM-facing combatant card view. See functional scenario: "DC prompt appears after damage". No separate access-control scenario is required because the DC prompt renders within the existing DM-only card UI.

--- a/openspec/changes/concentration-tracking/specs/concentration-tracking/spec.md
+++ b/openspec/changes/concentration-tracking/specs/concentration-tracking/spec.md
@@ -88,7 +88,7 @@ The system SHALL compute CON save DC as `max(10, floor(effectiveDamage / 2))`.
 
 - **Given** `effectiveDamage = 19`
 - **When** `calcConSaveDC(19)` is called
-- **Then** the result is `9`... wait — floor(19/2) = 9, max(10,9) = 10. Result is `10`.
+- **Then** the result is `10` (floor(19/2) = 9 → max(10, 9) = 10)
 
 ---
 

--- a/openspec/changes/concentration-tracking/tasks.md
+++ b/openspec/changes/concentration-tracking/tasks.md
@@ -1,0 +1,170 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/concentration-tracking` then immediately `git push -u origin feat/concentration-tracking`
+
+## Execution
+
+### 1. Type model — add concentration fields to `CombatantState`
+
+- [x] In `lib/types.ts`, add to `CombatantState` (after `activeDamageEffects?`):
+  ```ts
+  concentratingOn?: string;
+  pendingConSaveDC?: number;
+  ```
+- [x] Verify: `npx tsc --noEmit` — no new type errors
+
+### 2. Utility — `calcConSaveDC` in `lib/utils/combat.ts`
+
+- [x] Add pure helper:
+  ```ts
+  export function calcConSaveDC(effectiveDamage: number): number {
+    return Math.max(10, Math.floor(effectiveDamage / 2));
+  }
+  ```
+- [x] Write unit tests in `tests/unit/utils/` (new or existing combat utils test file):
+  - `calcConSaveDC(0)` → 10 (edge: zero damage; though this path should not be reached at call sites)
+  - `calcConSaveDC(14)` → 10
+  - `calcConSaveDC(19)` → 10 (floor(19/2) = 9 → max(10,9) = 10)
+  - `calcConSaveDC(20)` → 10
+  - `calcConSaveDC(21)` → 10 (floor(21/2) = 10)
+  - `calcConSaveDC(50)` → 25
+- [x] Verify: `npm run test:unit -- --testPathPattern=combat` — all pass
+
+### 3. Damage handler — concentration check in `CombatantCard.tsx`
+
+- [x] In the existing damage-apply callback in `lib/components/CombatantCard.tsx`:
+  - After computing `effectiveDamage` (from `applyDamage` / `applyDamageWithType`):
+    - If `combatant.concentratingOn` is set **and** `effectiveDamage > 0`: set `pendingConSaveDC: calcConSaveDC(effectiveDamage)` in the state update
+    - If new `hp === 0`: also set `concentratingOn: undefined, pendingConSaveDC: undefined`
+  - Import `calcConSaveDC` from `lib/utils/combat`
+- [x] Write RTL tests in `tests/unit/components/CombatantCard.concentration.test.tsx` (new file, following the split-file pattern already in place):
+  - Damage to concentrating combatant sets `pendingConSaveDC` via `onUpdate`
+  - Damage with `effectiveDamage = 0` (immunity) does not set `pendingConSaveDC`
+  - Lethal damage clears `concentratingOn` and `pendingConSaveDC`
+  - Non-lethal damage preserves `concentratingOn`
+  - Damage to non-concentrating combatant does not set `pendingConSaveDC`
+- [x] Verify: `npm run test:unit -- --testPathPattern=CombatantCard` — all pass
+
+### 4. CON save notification — `onConSaveRequired` callback and `ActiveCombatView` handler
+
+**Context (pre-investigated):** `CombatantState` has no `userId`. Player combatant IDs follow `character-${character.id}`. `ActiveCombatView` has `characters[]` from `useCombat`. Campaign chat supports `{ scope: "direct"; toUserId }` messages.
+
+- [x] Add `onConSaveRequired?: (dc: number) => void` to `CombatantCardProps` in `lib/components/CombatantCard.tsx`
+- [x] In the damage handler in `CombatantCard`, call `onConSaveRequired?.(calcConSaveDC(effectiveDamage))` when `concentratingOn` is set and `effectiveDamage > 0`
+- [x] In `lib/components/ActiveCombatView.tsx`, implement the `onConSaveRequired` prop passed to each `CombatantCard`:
+  - Extract character ID: if `combatant.id.startsWith('character-')`, strip prefix to get `characterId`
+  - Look up `Character` in `characters` array by `character.id === characterId`
+  - If found (player-type): POST a `CampaignMessage` to the campaign messages API with `visibility: { scope: "direct"; toUserId: character.userId }` and text describing the required save and DC
+  - If not found (monster-type): no player message — DM-only awareness via the card DC prompt
+- [x] Write RTL tests in `tests/unit/components/CombatantCard.concentration.test.tsx`:
+  - `onConSaveRequired` is called with correct DC when concentrating combatant takes effective damage
+  - `onConSaveRequired` is NOT called when `effectiveDamage = 0`
+  - `onConSaveRequired` is NOT called when `concentratingOn` is undefined
+- [x] Write unit tests for `ActiveCombatView` notification handler:
+  - Player-type combatant: assert `fetch` called with direct-message body containing `toUserId`
+  - Monster-type combatant: assert `fetch` NOT called with a direct message
+- [x] Verify: `npm run test:unit` — all pass
+
+### 5. Card UI — concentration badge and DC prompt
+
+- [x] In `lib/components/CombatantCard.tsx`, render:
+  - **Concentration badge:** when `concentratingOn` is set, a pill/badge displaying the spell name (consistent with existing pill style in the design system)
+  - **DC prompt:** when `pendingConSaveDC` is set, an inline alert showing "CON Save DC {pendingConSaveDC}" with a dismiss (×) button; clicking dismiss calls `onUpdate` with `pendingConSaveDC: undefined`
+- [x] Extend `tests/unit/components/CombatantCard.concentration.test.tsx`:
+  - Badge renders with spell name
+  - Badge absent when `concentratingOn` is undefined
+  - DC prompt renders with correct DC value
+  - DC prompt absent when `pendingConSaveDC` is undefined
+  - Dismiss button clears `pendingConSaveDC` via `onUpdate`
+- [x] Verify: `npm run test:unit -- --testPathPattern=CombatantCard` — all pass
+
+### 6. Detail panel — set/end concentration UI
+
+- [x] In `lib/components/CombatantDetailPanel.tsx`, add:
+  - A labeled text input ("Concentrating on spell") pre-filled with `combatant.concentratingOn ?? ""`; on save (blur or Enter) calls `onUpdate` with `concentratingOn: value || undefined`
+  - An "End Concentration" button (visible only when `concentratingOn` is set) that calls `onUpdate` with `concentratingOn: undefined, pendingConSaveDC: undefined`
+- [x] Write RTL tests in `tests/unit/components/CombatantDetailPanel.test.tsx` (new or extend if file exists):
+  - Input pre-filled with current spell name
+  - Submitting a new spell name calls `onUpdate` with `concentratingOn: "NewSpell"`
+  - "End Concentration" button visible when concentrating
+  - "End Concentration" button absent when not concentrating
+  - Clicking "End Concentration" calls `onUpdate` with both fields cleared
+  - Setting a second spell name overwrites the first (single-spell enforcement)
+- [x] Verify: `npm run test:unit -- --testPathPattern=CombatantDetailPanel` — all pass
+
+### 7. Full unit suite
+
+- [x] `npm run test:unit` — all tests pass
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npx tsc --noEmit` — zero type errors
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run test:integration` — all tests pass
+- [x] `npm run build` — build succeeds with no errors
+- [x] All execution tasks marked complete
+- [x] All steps in [Remote push validation] pass
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — `npm run test:unit` — all pass
+- **Integration tests** — `npm run test:integration` — all pass
+- **Build** — `npm run build` — succeeds
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — `npm run build` — succeeds
+- Skip integration and unit tests
+
+If **ANY** required step fails, iterate and fix before pushing.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/concentration-tracking` and push to remote
+- [x] Open PR from `feat/concentration-tracking` to `main`. PR body MUST include `Closes #93`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`; NEVER use `--merge` — repo ruleset requires squash)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, push before doing anything else
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL>`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: AI agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec delta: copy `openspec/changes/concentration-tracking/specs/concentration-tracking/spec.md` → `openspec/specs/concentration-tracking/spec.md`; update relative links from `../../design.md` → `../../changes/archive/YYYY-MM-DD-concentration-tracking/design.md` and `../../tasks.md` → `../../changes/archive/YYYY-MM-DD-concentration-tracking/tasks.md`
+- [ ] Archive the change: move `openspec/changes/concentration-tracking/` to `openspec/changes/archive/YYYY-MM-DD-concentration-tracking/` — **stage both the new location and the deletion of the old location in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-concentration-tracking/` exists and `openspec/changes/concentration-tracking/` is gone
+- [ ] **Create a doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-concentration-tracking` then `git push -u origin doc/archive-YYYY-MM-DD-concentration-tracking`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-concentration-tracking` to `main` with title `docs: archive concentration-tracking (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until merged (same loop as implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/concentration-tracking doc/archive-YYYY-MM-DD-concentration-tracking`

--- a/openspec/changes/concentration-tracking/tests.md
+++ b/openspec/changes/concentration-tracking/tests.md
@@ -1,0 +1,140 @@
+---
+name: tests
+description: Tests for the concentration-tracking change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `concentration-tracking` change. All work must follow strict TDD: write a failing test first, make it pass with the minimum code, then refactor.
+
+All unit tests use `npm run test:unit`. Integration tests use `npm run test:integration`.
+
+---
+
+## Test Cases
+
+### Task 2 — `calcConSaveDC` (lib/utils/combat.ts)
+
+Test file: new or existing combat utils test in `tests/unit/utils/`
+
+- [ ] **T2.1** `calcConSaveDC(0)` returns `10`
+  - Spec: `calcConSaveDC` Requirement (edge — zero damage)
+  - TDD: Write test → fails → implement helper → passes
+
+- [ ] **T2.2** `calcConSaveDC(14)` returns `10` (floor(14/2)=7, max(10,7)=10)
+  - Spec: "Damage below threshold" scenario
+
+- [ ] **T2.3** `calcConSaveDC(19)` returns `10` (floor(19/2)=9, max(10,9)=10)
+  - Spec: "Odd damage" scenario
+
+- [ ] **T2.4** `calcConSaveDC(20)` returns `10` (floor(20/2)=10, max(10,10)=10)
+  - Spec: "Damage at threshold" scenario
+
+- [ ] **T2.5** `calcConSaveDC(21)` returns `10` (floor(21/2)=10)
+  - Spec: "Damage above threshold" scenario
+
+- [ ] **T2.6** `calcConSaveDC(50)` returns `25`
+  - Spec: "High damage" scenario
+
+---
+
+### Task 3 — Damage handler concentration check (CombatantCard.tsx)
+
+Test file: `tests/unit/components/CombatantCard.concentration.test.tsx` (new)
+
+- [ ] **T3.1** Damage to a concentrating combatant with `effectiveDamage > 0` calls `onUpdate` with `pendingConSaveDC` set to the correct DC value
+  - Spec: "DC prompt appears after damage" scenario
+
+- [ ] **T3.2** Damage with `effectiveDamage = 0` (immunity) on a concentrating combatant does NOT call `onUpdate` with `pendingConSaveDC` set
+  - Spec: "DC prompt absent when damage is fully absorbed by immunity" scenario
+
+- [ ] **T3.3** Damage that reduces HP to 0 on a concentrating combatant calls `onUpdate` with `concentratingOn: undefined` and `pendingConSaveDC: undefined`
+  - Spec: "Auto-clear at 0 HP" scenario
+
+- [ ] **T3.4** Non-lethal damage on a concentrating combatant preserves `concentratingOn` in the `onUpdate` call
+  - Spec: "Concentration preserved when HP > 0 after damage" scenario
+
+- [ ] **T3.5** Damage on a non-concentrating combatant (`concentratingOn` undefined) does not set `pendingConSaveDC`
+  - Spec: "DC prompt absent when no concentration" scenario
+
+---
+
+### Task 4 — CON save notification (`onConSaveRequired` callback + `ActiveCombatView` handler)
+
+Test files:
+- `tests/unit/components/CombatantCard.concentration.test.tsx` (extend) — callback firing
+- `tests/unit/components/ActiveCombatView.test.tsx` (extend or new) — message dispatch
+
+- [ ] **T4.1** `onConSaveRequired` mock is called with the correct DC when a concentrating player-type combatant takes `effectiveDamage > 0`
+  - Spec: "Notification fires for player combatant" scenario
+
+- [ ] **T4.2** `onConSaveRequired` is NOT called when `effectiveDamage = 0` (immunity)
+  - Spec: "No notification when damage is zero" scenario
+
+- [ ] **T4.3** `onConSaveRequired` is NOT called when `concentratingOn` is undefined
+  - Spec: "DC prompt absent when no concentration" scenario (notification corollary)
+
+- [ ] **T4.4** In `ActiveCombatView`, when `onConSaveRequired` fires for a player-type combatant (`id: "character-abc123"`), `fetch` is called with a POST body containing `visibility: { scope: "direct"; toUserId: "<expected-userId>" }`
+  - Spec: "Notification fires for player combatant" scenario
+
+- [ ] **T4.5** In `ActiveCombatView`, when `onConSaveRequired` fires for a monster-type combatant, no `fetch` with `scope: "direct"` is made
+  - Spec: "No player message for monster combatant" scenario
+
+---
+
+### Task 5 — Card UI badge and DC prompt (CombatantCard.tsx)
+
+Test file: `tests/unit/components/CombatantCard.concentration.test.tsx` (extend)
+
+- [ ] **T5.1** Card renders a badge/pill with the spell name when `concentratingOn` is set
+  - Spec: "Concentration badge visible" scenario
+
+- [ ] **T5.2** No concentration badge in the DOM when `concentratingOn` is undefined
+  - Spec: "No badge when not concentrating" scenario
+
+- [ ] **T5.3** DC prompt renders with the correct DC value when `pendingConSaveDC` is set
+  - Spec: "DC prompt appears after damage" scenario (render assertion)
+
+- [ ] **T5.4** No DC prompt when `pendingConSaveDC` is undefined
+  - Spec: "DC prompt absent when no concentration" scenario
+
+- [ ] **T5.5** Clicking the dismiss (×) button calls `onUpdate` with `pendingConSaveDC: undefined`
+  - Spec: "DC prompt dismissed" scenario
+
+---
+
+### Task 6 — Detail panel set/end concentration (CombatantDetailPanel.tsx)
+
+Test file: `tests/unit/components/CombatantDetailPanel.test.tsx` (new or extend)
+
+- [ ] **T6.1** Text input is pre-filled with `concentratingOn` when the combatant is concentrating
+  - Spec: Set Concentration requirement (input pre-fill)
+
+- [ ] **T6.2** Entering a spell name and saving calls `onUpdate` with `concentratingOn: "Bless"`
+  - Spec: "New spell overwrites old" scenario
+
+- [ ] **T6.3** "End Concentration" button is visible when `concentratingOn` is set
+  - Spec: "End Concentration button clears fields" scenario
+
+- [ ] **T6.4** "End Concentration" button is absent when `concentratingOn` is undefined
+  - Spec: "No badge when not concentrating" (parallel for panel)
+
+- [ ] **T6.5** Clicking "End Concentration" calls `onUpdate` with `concentratingOn: undefined` and `pendingConSaveDC: undefined`
+  - Spec: "End Concentration button clears fields" scenario
+
+- [ ] **T6.6** Entering a second spell name after the first calls `onUpdate` with the new name only (single-spell enforcement)
+  - Spec: "New spell overwrites old" scenario
+
+---
+
+### Task 1 — Type model (lib/types.ts)
+
+Validated by TypeScript compiler and all existing tests continuing to pass — no dedicated test file needed.
+
+- [ ] **T1.1** `npx tsc --noEmit` produces zero errors after adding the two new optional fields
+  - Spec: "Existing combatant construction is unchanged" scenario
+
+- [ ] **T1.2** All existing `CombatantCard` and `CombatantDetailPanel` tests still pass (no regressions from new optional fields)
+  - Spec: "Existing combatant construction is unchanged" scenario

--- a/tests/unit/components/ActiveCombatView.test.tsx
+++ b/tests/unit/components/ActiveCombatView.test.tsx
@@ -14,9 +14,13 @@ import type { UseCombatReturn } from '@/lib/hooks/useCombat';
 import type { CombatantState, Character } from '@/lib/types';
 
 const mockFetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+const originalFetch = global.fetch;
 beforeEach(() => {
   global.fetch = mockFetch;
   mockFetch.mockClear();
+});
+afterAll(() => {
+  global.fetch = originalFetch;
 });
 
 function makeCombat(

--- a/tests/unit/components/ActiveCombatView.test.tsx
+++ b/tests/unit/components/ActiveCombatView.test.tsx
@@ -11,7 +11,13 @@ import { ActiveCombatView } from '@/lib/components/ActiveCombatView';
 import { makeUseCombat } from '@/tests/unit/fixtures/useCombat';
 import { makeCombatant, makeCombatState } from '@/tests/unit/fixtures/combatHelpers';
 import type { UseCombatReturn } from '@/lib/hooks/useCombat';
-import type { CombatantState } from '@/lib/types';
+import type { CombatantState, Character } from '@/lib/types';
+
+const mockFetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+beforeEach(() => {
+  global.fetch = mockFetch;
+  mockFetch.mockClear();
+});
 
 function makeCombat(
   overrides: Partial<UseCombatReturn> = {},
@@ -191,5 +197,87 @@ describe('ActiveCombatView', () => {
     await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(removeCombatant).not.toHaveBeenCalled();
     expect(setRemoveConfirmId).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('ActiveCombatView — CON save notification', () => {
+  const CHARACTER_ID = 'char-abc';
+  const CHARACTER_USER_ID = 'user-xyz';
+  const CAMPAIGN_ID = 'campaign-1';
+
+  const playerCharacter: Character = {
+    id: CHARACTER_ID,
+    userId: CHARACTER_USER_ID,
+    name: 'Aria',
+    hp: 30,
+    maxHp: 30,
+    ac: 15,
+    conditions: [],
+    classes: [],
+    abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
+  } as unknown as Character;
+
+  function makeConcentratingPlayer(overrides: Partial<CombatantState> = {}): CombatantState {
+    return makeCombatant({
+      id: `character-${CHARACTER_ID}-some-uuid`,
+      name: 'Aria',
+      type: 'player',
+      hp: 30,
+      maxHp: 30,
+      concentratingOn: 'Bless',
+      ...overrides,
+    });
+  }
+
+  it('player-type concentrating combatant: posts direct message with toUserId on damage', async () => {
+    const user = userEvent.setup();
+    const combatant = makeConcentratingPlayer();
+    const combat = makeCombat(
+      {
+        combatState: makeCombatState({ combatants: [combatant], campaignId: CAMPAIGN_ID }),
+        characters: [playerCharacter],
+        getDisplayCombatants: jest.fn().mockReturnValue([combatant]),
+      },
+    );
+    render(<ActiveCombatView combat={combat} user={null} />);
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '10');
+    await user.click(screen.getByRole('button', { name: 'Damage' }));
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/campaigns/${CAMPAIGN_ID}/messages`,
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining(`"toUserId":"${CHARACTER_USER_ID}"`),
+      }),
+    );
+  });
+
+  it('monster-type concentrating combatant: does NOT post direct message on damage', async () => {
+    const user = userEvent.setup();
+    const combatant = makeCombatant({
+      id: 'monster-goblin-uuid',
+      name: 'Goblin',
+      type: 'monster',
+      hp: 30,
+      maxHp: 30,
+      concentratingOn: 'Hold Person',
+    });
+    const combat = makeCombat(
+      {
+        combatState: makeCombatState({ combatants: [combatant], campaignId: CAMPAIGN_ID }),
+        characters: [playerCharacter],
+        getDisplayCombatants: jest.fn().mockReturnValue([combatant]),
+      },
+    );
+    render(<ActiveCombatView combat={combat} user={null} />);
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '10');
+    await user.click(screen.getByRole('button', { name: 'Damage' }));
+    const directMessageCall = mockFetch.mock.calls.find(
+      ([, opts]) => typeof opts?.body === 'string' && opts.body.includes('toUserId'),
+    );
+    expect(directMessageCall).toBeUndefined();
   });
 });

--- a/tests/unit/components/ActiveCombatView.test.tsx
+++ b/tests/unit/components/ActiveCombatView.test.tsx
@@ -212,14 +212,13 @@ describe('ActiveCombatView — CON save notification', () => {
     hp: 30,
     maxHp: 30,
     ac: 15,
-    conditions: [],
     classes: [],
     abilityScores: { strength: 10, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 },
   } as unknown as Character;
 
   function makeConcentratingPlayer(overrides: Partial<CombatantState> = {}): CombatantState {
     return makeCombatant({
-      id: `character-${CHARACTER_ID}-some-uuid`,
+      id: `character-${CHARACTER_ID}`,
       name: 'Aria',
       type: 'player',
       hp: 30,

--- a/tests/unit/components/CombatantCard.concentration.test.tsx
+++ b/tests/unit/components/CombatantCard.concentration.test.tsx
@@ -1,0 +1,137 @@
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string; [k: string]: unknown }) =>
+    React.createElement('a', { href, ...rest }, children),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { CombatantState } from '@/lib/types';
+import { BASE, renderCard } from './CombatantCard.test-helpers';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+async function applyDamage(
+  amount: string,
+  overrides: Partial<CombatantState> = {},
+  extra: Record<string, unknown> = {},
+): Promise<jest.Mock> {
+  const user = userEvent.setup();
+  const onUpdate = renderCard({ hp: 30, maxHp: 30, ...overrides }, jest.fn(), extra);
+  const input = screen.getByRole('spinbutton');
+  await user.clear(input);
+  await user.type(input, amount);
+  await user.click(screen.getByRole('button', { name: 'Damage' }));
+  return onUpdate as jest.Mock;
+}
+
+// ---------------------------------------------------------------------------
+// Damage handler — concentration checks
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.concentration — damage handler', () => {
+  test('damage to concentrating combatant sets pendingConSaveDC via onUpdate', async () => {
+    const onUpdate = await applyDamage('20', { concentratingOn: 'Bless' });
+    // effectiveDamage=20 → DC=max(10, floor(20/2))=10
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pendingConSaveDC: 10 }),
+    );
+  });
+
+  test('damage > 20 sets DC above 10', async () => {
+    const onUpdate = await applyDamage('50', { hp: 100, maxHp: 100, concentratingOn: 'Hold Person' });
+    // effectiveDamage=50 → DC=max(10, floor(50/2))=25
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ pendingConSaveDC: 25 }),
+    );
+  });
+
+  test('lethal damage clears concentratingOn and pendingConSaveDC', async () => {
+    const onUpdate = await applyDamage('30', {
+      hp: 30,
+      maxHp: 30,
+      concentratingOn: 'Bless',
+      pendingConSaveDC: 15,
+    });
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        concentratingOn: undefined,
+        pendingConSaveDC: undefined,
+      }),
+    );
+  });
+
+  test('non-lethal damage preserves concentratingOn', async () => {
+    const onUpdate = await applyDamage('10', { concentratingOn: 'Bless' });
+    const call = onUpdate.mock.calls[0][0];
+    expect(call.concentratingOn).toBeUndefined(); // not cleared (only set when 0 hp)
+    expect(call.pendingConSaveDC).toBe(10);
+  });
+
+  test('damage to non-concentrating combatant does not set pendingConSaveDC', async () => {
+    const onUpdate = await applyDamage('20', { concentratingOn: undefined });
+    const call = onUpdate.mock.calls[0][0];
+    expect(call.pendingConSaveDC).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onConSaveRequired callback
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.concentration — onConSaveRequired callback', () => {
+  test('onConSaveRequired is called with correct DC when concentrating combatant takes effective damage', async () => {
+    const onConSaveRequired = jest.fn();
+    await applyDamage('20', { concentratingOn: 'Bless' }, { onConSaveRequired });
+    expect(onConSaveRequired).toHaveBeenCalledWith(10);
+  });
+
+  test('onConSaveRequired is NOT called when concentratingOn is undefined', async () => {
+    const onConSaveRequired = jest.fn();
+    await applyDamage('20', { concentratingOn: undefined }, { onConSaveRequired });
+    expect(onConSaveRequired).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card UI — concentration badge and DC prompt
+// ---------------------------------------------------------------------------
+
+describe('CombatantCard.concentration — badge', () => {
+  test('badge renders with spell name when concentratingOn is set', () => {
+    renderCard({ concentratingOn: 'Bless' });
+    expect(screen.getByTestId('concentration-badge')).toHaveTextContent('Bless');
+  });
+
+  test('badge absent when concentratingOn is undefined', () => {
+    renderCard({ concentratingOn: undefined });
+    expect(screen.queryByTestId('concentration-badge')).not.toBeInTheDocument();
+  });
+});
+
+describe('CombatantCard.concentration — DC prompt', () => {
+  test('DC prompt renders with correct DC value when pendingConSaveDC is set', () => {
+    renderCard({ pendingConSaveDC: 15 });
+    expect(screen.getByText(/CON Save DC 15/)).toBeInTheDocument();
+  });
+
+  test('DC prompt absent when pendingConSaveDC is undefined', () => {
+    renderCard({ pendingConSaveDC: undefined });
+    expect(screen.queryByText(/CON Save DC/)).not.toBeInTheDocument();
+  });
+
+  test('dismiss button clears pendingConSaveDC via onUpdate', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderCard({ pendingConSaveDC: 15 });
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onUpdate).toHaveBeenCalledWith({ pendingConSaveDC: undefined });
+  });
+});

--- a/tests/unit/components/CombatantDetailPanel.test.tsx
+++ b/tests/unit/components/CombatantDetailPanel.test.tsx
@@ -1,0 +1,112 @@
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string; [k: string]: unknown }) =>
+    React.createElement('a', { href, ...rest }, children),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CombatantDetailPanel } from '@/lib/components/CombatantDetailPanel';
+import type { CombatantState } from '@/lib/types';
+
+const BASE: CombatantState = {
+  id: 'c1',
+  name: 'Test Fighter',
+  type: 'player',
+  initiative: 10,
+  conditions: [],
+  hp: 30,
+  maxHp: 30,
+  ac: 15,
+  abilityScores: {
+    strength: 10,
+    dexterity: 10,
+    constitution: 10,
+    intelligence: 10,
+    wisdom: 10,
+    charisma: 10,
+  },
+};
+
+function renderPanel(
+  overrides: Partial<CombatantState> = {},
+  onUpdate = jest.fn(),
+) {
+  const combatant = { ...BASE, ...overrides };
+  render(
+    <CombatantDetailPanel
+      combatant={combatant}
+      detailPosition={{ top: 0, left: 0 }}
+      onClose={jest.fn()}
+      onUpdate={onUpdate}
+    />,
+  );
+  return onUpdate as jest.Mock;
+}
+
+describe('CombatantDetailPanel — concentration', () => {
+  test('input is pre-filled with current spell name', () => {
+    renderPanel({ concentratingOn: 'Bless' });
+    const input = screen.getByLabelText(/concentrating on spell/i) as HTMLInputElement;
+    expect(input.value).toBe('Bless');
+  });
+
+  test('input is empty when concentratingOn is undefined', () => {
+    renderPanel({ concentratingOn: undefined });
+    const input = screen.getByLabelText(/concentrating on spell/i) as HTMLInputElement;
+    expect(input.value).toBe('');
+  });
+
+  test('submitting a new spell name calls onUpdate with concentratingOn', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderPanel({ concentratingOn: undefined });
+    const input = screen.getByLabelText(/concentrating on spell/i);
+    await user.clear(input);
+    await user.type(input, 'Hold Person');
+    await user.keyboard('{Enter}');
+    expect(onUpdate).toHaveBeenCalledWith('c1', { concentratingOn: 'Hold Person' });
+  });
+
+  test('blurring input with value calls onUpdate with concentratingOn', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderPanel({ concentratingOn: undefined });
+    const input = screen.getByLabelText(/concentrating on spell/i);
+    await user.clear(input);
+    await user.type(input, 'Web');
+    await user.tab();
+    expect(onUpdate).toHaveBeenCalledWith('c1', { concentratingOn: 'Web' });
+  });
+
+  test('"End Concentration" button is visible when concentrating', () => {
+    renderPanel({ concentratingOn: 'Bless' });
+    expect(screen.getByRole('button', { name: /end concentration/i })).toBeInTheDocument();
+  });
+
+  test('"End Concentration" button is absent when not concentrating', () => {
+    renderPanel({ concentratingOn: undefined });
+    expect(screen.queryByRole('button', { name: /end concentration/i })).not.toBeInTheDocument();
+  });
+
+  test('clicking "End Concentration" calls onUpdate with both fields cleared', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderPanel({ concentratingOn: 'Bless', pendingConSaveDC: 12 });
+    await user.click(screen.getByRole('button', { name: /end concentration/i }));
+    expect(onUpdate).toHaveBeenCalledWith('c1', { concentratingOn: undefined, pendingConSaveDC: undefined });
+  });
+
+  test('setting a second spell name overwrites the first', async () => {
+    const user = userEvent.setup();
+    const onUpdate = renderPanel({ concentratingOn: 'Bless' });
+    const input = screen.getByLabelText(/concentrating on spell/i);
+    await user.clear(input);
+    await user.type(input, 'Hold Person');
+    await user.keyboard('{Enter}');
+    expect(onUpdate).toHaveBeenCalledWith('c1', { concentratingOn: 'Hold Person' });
+  });
+});

--- a/tests/unit/utils/combat.test.ts
+++ b/tests/unit/utils/combat.test.ts
@@ -1,0 +1,27 @@
+import { calcConSaveDC } from '@/lib/utils/combat';
+
+describe('calcConSaveDC', () => {
+  it('returns 10 for 0 damage (edge: zero damage)', () => {
+    expect(calcConSaveDC(0)).toBe(10);
+  });
+
+  it('returns 10 for 14 damage (floor(14/2)=7 → max(10,7)=10)', () => {
+    expect(calcConSaveDC(14)).toBe(10);
+  });
+
+  it('returns 10 for 19 damage (floor(19/2)=9 → max(10,9)=10)', () => {
+    expect(calcConSaveDC(19)).toBe(10);
+  });
+
+  it('returns 10 for 20 damage (floor(20/2)=10 → max(10,10)=10)', () => {
+    expect(calcConSaveDC(20)).toBe(10);
+  });
+
+  it('returns 10 for 21 damage (floor(21/2)=10 → max(10,10)=10)', () => {
+    expect(calcConSaveDC(21)).toBe(10);
+  });
+
+  it('returns 25 for 50 damage (floor(50/2)=25 → max(10,25)=25)', () => {
+    expect(calcConSaveDC(50)).toBe(25);
+  });
+});


### PR DESCRIPTION
## Summary

Implements D&D 5e concentration tracking for the combat tracker.

### Changes
- **Type model**: Added `concentratingOn?: string` and `pendingConSaveDC?: number` to `CombatantState`
- **Utility**: Added `calcConSaveDC(effectiveDamage)` helper — `max(10, floor(damage/2))`
- **Damage handler**: Sets `pendingConSaveDC` when concentrating combatant takes effective damage; auto-clears concentration at HP 0
- **Card UI**: Concentration badge (spell name pill) and CON Save DC prompt with dismiss button
- **Player notification**: `ActiveCombatView` posts direct campaign message to player on damage
- **Detail panel**: Spell name input and End Concentration button in `CombatantDetailPanel`
- **Tests**: 22 new unit tests covering all new behavior

Closes #93