### PR TITLE
feat: add feedback help menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@
 # MAILTRAP_TOKEN=your-mailtrap-api-token
 # MAILTRAP_FROM_EMAIL=noreply@yourdomain.com
 # APP_URL=https://yourdomain.com
+
+# Feedback — GitHub issue creation
+# Required scope: issues:write on dougis-org/session-combat
+# GITHUB_FEEDBACK_TOKEN=

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/middleware';
+import { checkAndIncrementRateLimit } from '@/lib/db/feedbackRateLimit';
+import { getUserById } from '@/lib/permissions';
+import { extractIp } from '@/lib/utils/http';
+
+function buildIssueBody(
+  username: string,
+  email: string,
+  pageUrl: string,
+  userAgent: string,
+  description: string
+): string {
+  const context = [
+    `**Submitted by:** @${username} (${email})`,
+    `**Page:** ${pageUrl}`,
+    `**User-Agent:** ${userAgent}`,
+  ].join('\n');
+
+  return description.trim()
+    ? `${context}\n\n---\n\n${description}`
+    : context;
+}
+
+export const POST = withAuth(async (request: NextRequest, auth) => {
+  const ip = extractIp(request);
+  const { allowed } = await checkAndIncrementRateLimit(ip);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Rate limit exceeded. Please wait before submitting again.' },
+      { status: 429 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { type, title, description, pageUrl } = body as Record<string, unknown>;
+
+  if (type !== 'bug' && type !== 'feature') {
+    return NextResponse.json({ error: 'type must be "bug" or "feature"' }, { status: 400 });
+  }
+  if (typeof title !== 'string' || title.trim() === '') {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+  if (title.trim().length > 200) {
+    return NextResponse.json({ error: 'title must be 200 characters or fewer' }, { status: 400 });
+  }
+  if (typeof description === 'string' && description.length > 2000) {
+    return NextResponse.json({ error: 'description must be 2000 characters or fewer' }, { status: 400 });
+  }
+
+  const githubToken = process.env.GITHUB_FEEDBACK_TOKEN;
+  if (!githubToken) {
+    console.error('GITHUB_FEEDBACK_TOKEN is not configured');
+    return NextResponse.json({ error: 'Feedback is not available.' }, { status: 503 });
+  }
+
+  const user = await getUserById(auth.userId);
+  const username = (user?.['username'] as string | undefined) ?? auth.email;
+  const email = auth.email;
+  const userAgent = request.headers.get('user-agent') ?? '';
+  const rawPageUrl = typeof pageUrl === 'string' ? pageUrl : '';
+  const pageUrlStr = (rawPageUrl.startsWith('https://') || rawPageUrl.startsWith('/')) ? rawPageUrl : '';
+  const descriptionStr = typeof description === 'string' ? description : '';
+
+  const issueBody = buildIssueBody(username, email, pageUrlStr, userAgent, descriptionStr);
+  const labels = type === 'bug' ? ['bug'] : ['enhancement'];
+
+  const githubResponse = await fetch(
+    'https://api.github.com/repos/dougis-org/session-combat/issues',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({ title: title.trim(), body: issueBody, labels }),
+    }
+  );
+
+  if (!githubResponse.ok) {
+    const errorText = await githubResponse.text().catch(() => '');
+    console.error('GitHub API error:', githubResponse.status, errorText);
+    return NextResponse.json(
+      { error: 'Failed to create feedback issue. Please try again later.' },
+      { status: 502 }
+    );
+  }
+
+  const issue = await githubResponse.json() as { html_url: string };
+  return NextResponse.json({ issueUrl: issue.html_url }, { status: 201 });
+});

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -5,14 +5,13 @@ import { getUserById } from '@/lib/permissions';
 import { extractIp } from '@/lib/utils/http';
 
 function buildIssueBody(
-  username: string,
-  email: string,
+  submittedBy: string,
   pageUrl: string,
   userAgent: string,
   description: string
 ): string {
   const context = [
-    `**Submitted by:** @${username} (${email})`,
+    `**Submitted by:** ${submittedBy}`,
     `**Page:** ${pageUrl}`,
     `**User-Agent:** ${userAgent}`,
   ].join('\n');
@@ -61,14 +60,15 @@ export const POST = withAuth(async (request: NextRequest, auth) => {
   }
 
   const user = await getUserById(auth.userId);
-  const username = (user?.['username'] as string | undefined) ?? auth.email;
+  const githubHandle = user?.['username'] as string | undefined;
   const email = auth.email;
+  const submittedBy = githubHandle ? `@${githubHandle} (${email})` : email;
   const userAgent = request.headers.get('user-agent') ?? '';
-  const rawPageUrl = typeof pageUrl === 'string' ? pageUrl : '';
-  const pageUrlStr = (rawPageUrl.startsWith('https://') || rawPageUrl.startsWith('/')) ? rawPageUrl : '';
+  const rawPageUrl = typeof pageUrl === 'string' ? pageUrl.replace(/[\r\n]/g, '') : '';
+  const pageUrlStr = (rawPageUrl.startsWith('https://') || (rawPageUrl.startsWith('/') && !rawPageUrl.startsWith('//'))) ? rawPageUrl : '';
   const descriptionStr = typeof description === 'string' ? description : '';
 
-  const issueBody = buildIssueBody(username, email, pageUrlStr, userAgent, descriptionStr);
+  const issueBody = buildIssueBody(submittedBy, pageUrlStr, userAgent, descriptionStr);
   const labels = type === 'bug' ? ['bug'] : ['enhancement'];
 
   const githubResponse = await fetch(

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,8 @@ primary_region = 'sjc'
 
 [env]
   NODE_ENV = 'production'
+  # Secrets (set via `fly secrets set`):
+  #   GITHUB_FEEDBACK_TOKEN — GitHub PAT with issues:write scope on dougis-org/session-combat
 
 [http_service]
   internal_port = 3000

--- a/lib/components/FeedbackForm.tsx
+++ b/lib/components/FeedbackForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export interface FeedbackFormData {
   type: 'bug' | 'feature';
@@ -20,11 +20,7 @@ export function FeedbackForm({ defaultType = 'bug', onSubmit, onCancel, isSubmit
   const [type, setType] = useState<'bug' | 'feature'>(defaultType);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [pageUrl, setPageUrl] = useState('');
-
-  useEffect(() => {
-    setPageUrl(window.location.href);
-  }, []);
+  const [pageUrl] = useState(() => (typeof window !== 'undefined' ? window.location.href : ''));
 
   const canSubmit = title.trim().length > 0 && !isSubmitting;
 

--- a/lib/components/FeedbackForm.tsx
+++ b/lib/components/FeedbackForm.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export interface FeedbackFormData {
+  type: 'bug' | 'feature';
+  title: string;
+  description: string;
+  pageUrl: string;
+}
+
+interface FeedbackFormProps {
+  defaultType?: 'bug' | 'feature';
+  onSubmit: (data: FeedbackFormData) => void;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+}
+
+export function FeedbackForm({ defaultType = 'bug', onSubmit, onCancel, isSubmitting = false }: FeedbackFormProps) {
+  const [type, setType] = useState<'bug' | 'feature'>(defaultType);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [pageUrl, setPageUrl] = useState('');
+
+  useEffect(() => {
+    setPageUrl(window.location.href);
+  }, []);
+
+  const canSubmit = title.trim().length > 0 && !isSubmitting;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    onSubmit({ type, title: title.trim(), description, pageUrl });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setType('bug')}
+          className={`flex-1 py-2 px-4 rounded text-sm font-medium transition-colors ${
+            type === 'bug'
+              ? 'bg-red-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          Bug Report
+        </button>
+        <button
+          type="button"
+          onClick={() => setType('feature')}
+          className={`flex-1 py-2 px-4 rounded text-sm font-medium transition-colors ${
+            type === 'feature'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          Feature Request
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="feedback-title" className="text-sm text-gray-300">
+          Title <span className="text-red-400">*</span>
+        </label>
+        <input
+          id="feedback-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="bg-gray-700 text-white rounded px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-blue-500"
+          placeholder="Brief summary"
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="feedback-description" className="text-sm text-gray-300">
+          Description
+        </label>
+        <textarea
+          id="feedback-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={2000}
+          rows={4}
+          className="bg-gray-700 text-white rounded px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-blue-500 resize-none"
+          placeholder="Additional details (optional)"
+        />
+        <span className="text-xs text-gray-500 text-right">{description.length}/2000</span>
+      </div>
+
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="py-2 px-4 rounded text-sm text-gray-400 hover:text-white transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="py-2 px-4 rounded text-sm font-medium bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isSubmitting ? 'Submitting…' : 'Submit'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/lib/components/FeedbackModal.tsx
+++ b/lib/components/FeedbackModal.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Modal } from './Modal';
+import { FeedbackForm, FeedbackFormData } from './FeedbackForm';
+
+interface FeedbackModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type ResultState = 'idle' | 'success' | 'error';
+
+export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ResultState>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setResult('idle');
+      setErrorMessage('');
+    }
+  }, [isOpen]);
+
+  function handleClose() {
+    if (result !== 'success') {
+      setResult('idle');
+      setErrorMessage('');
+    }
+    onClose();
+  }
+
+  async function handleSubmit(data: FeedbackFormData) {
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (response.status === 201) {
+        setResult('success');
+      } else {
+        const body = await response.json().catch(() => ({})) as { error?: string };
+        setErrorMessage(body.error ?? 'Something went wrong. Please try again.');
+        setResult('error');
+      }
+    } catch {
+      setErrorMessage('Network error. Please check your connection and try again.');
+      setResult('error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleRetry() {
+    setResult('idle');
+    setErrorMessage('');
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="Send Feedback"
+      onClose={handleClose}
+      size="medium"
+    >
+      {result === 'success' && (
+        <div className="flex flex-col gap-4 items-center text-center">
+          <p className="text-green-400 text-lg font-medium">Thank you for your feedback!</p>
+          <p className="text-gray-300 text-sm">Your report has been submitted and a GitHub issue has been created.</p>
+          <button
+            onClick={handleClose}
+            className="py-2 px-6 rounded text-sm font-medium bg-blue-600 text-white hover:bg-blue-500 transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      )}
+
+      {result === 'error' && (
+        <div className="flex flex-col gap-4">
+          <p className="text-red-400 text-sm">{errorMessage}</p>
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={handleClose}
+              className="py-2 px-4 rounded text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Close
+            </button>
+            <button
+              onClick={handleRetry}
+              className="py-2 px-4 rounded text-sm font-medium bg-blue-600 text-white hover:bg-blue-500 transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {result === 'idle' && (
+        <FeedbackForm
+          onSubmit={handleSubmit}
+          onCancel={handleClose}
+          isSubmitting={submitting}
+        />
+      )}
+    </Modal>
+  );
+}

--- a/lib/components/FeedbackModal.tsx
+++ b/lib/components/FeedbackModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Modal } from './Modal';
 import { FeedbackForm, FeedbackFormData } from './FeedbackForm';
 
@@ -15,6 +15,7 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<ResultState>('idle');
   const [errorMessage, setErrorMessage] = useState('');
+  const submitSeqRef = useRef(0);
 
   useEffect(() => {
     if (isOpen) {
@@ -24,6 +25,7 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
   }, [isOpen]);
 
   function handleClose() {
+    submitSeqRef.current++;
     if (result !== 'success') {
       setResult('idle');
       setErrorMessage('');
@@ -32,6 +34,7 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
   }
 
   async function handleSubmit(data: FeedbackFormData) {
+    const seq = ++submitSeqRef.current;
     setSubmitting(true);
     try {
       const response = await fetch('/api/feedback', {
@@ -39,6 +42,8 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
+
+      if (submitSeqRef.current !== seq) return;
 
       if (response.status === 201) {
         setResult('success');
@@ -48,10 +53,11 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
         setResult('error');
       }
     } catch {
+      if (submitSeqRef.current !== seq) return;
       setErrorMessage('Network error. Please check your connection and try again.');
       setResult('error');
     } finally {
-      setSubmitting(false);
+      if (submitSeqRef.current === seq) setSubmitting(false);
     }
   }
 

--- a/lib/components/NavBar.tsx
+++ b/lib/components/NavBar.tsx
@@ -3,10 +3,12 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/lib/hooks/useAuth';
+import { FeedbackModal } from './FeedbackModal';
 
 export function NavBar() {
   const { isAuthenticated, loading, logout } = useAuth();
   const [invitationCount, setInvitationCount] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated || loading) return;
@@ -49,15 +51,26 @@ export function NavBar() {
           </Link>
         )}
         {isAuthenticated && !loading && (
-          <button
-            data-testid="logout-button"
-            onClick={() => void logout()}
-            className="ml-auto text-gray-400 hover:text-white transition-colors text-sm"
-          >
-            Logout
-          </button>
+          <>
+            <button
+              data-testid="feedback-button"
+              onClick={() => setIsModalOpen(true)}
+              className="ml-auto text-gray-400 hover:text-white transition-colors text-sm"
+              aria-label="Send feedback"
+            >
+              ?
+            </button>
+            <button
+              data-testid="logout-button"
+              onClick={() => void logout()}
+              className="text-gray-400 hover:text-white transition-colors text-sm"
+            >
+              Logout
+            </button>
+          </>
         )}
       </div>
+      <FeedbackModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
     </nav>
   );
 }

--- a/lib/db/feedbackRateLimit.ts
+++ b/lib/db/feedbackRateLimit.ts
@@ -1,0 +1,54 @@
+import { getDatabase } from '@/lib/db';
+
+const WINDOW_HOURS = 1;
+const MAX_SUBMISSIONS = 12;
+
+let indexEnsured = false;
+
+async function ensureIndex(): Promise<void> {
+  if (indexEnsured) return;
+  const db = await getDatabase();
+  await db.collection('feedbackRateLimits').createIndex(
+    { windowResetAt: 1 },
+    { expireAfterSeconds: 0, background: true }
+  );
+  indexEnsured = true;
+}
+
+export async function checkAndIncrementRateLimit(ip: string): Promise<{ allowed: boolean }> {
+  await ensureIndex();
+  const db = await getDatabase();
+  const collection = db.collection('feedbackRateLimits');
+  const now = new Date();
+  const windowResetAt = new Date(now.getTime() + WINDOW_HOURS * 60 * 60 * 1000);
+
+  // Attempt atomic increment for an existing active window within the limit
+  const incrementResult = await collection.updateOne(
+    { ip: { $eq: ip }, windowResetAt: { $gt: now }, count: { $lt: MAX_SUBMISSIONS } },
+    { $inc: { count: 1 } }
+  );
+
+  if (incrementResult.modifiedCount === 1) {
+    return { allowed: true };
+  }
+
+  // No active window found — check if the IP is over the limit in a current window
+  const overLimit = await collection.findOne({
+    ip: { $eq: ip },
+    windowResetAt: { $gt: now },
+    count: { $gte: MAX_SUBMISSIONS },
+  });
+
+  if (overLimit) {
+    return { allowed: false };
+  }
+
+  // No active window exists (first ever, or TTL expired) — create a new one
+  await collection.replaceOne(
+    { ip: { $eq: ip } },
+    { ip, count: 1, windowResetAt },
+    { upsert: true }
+  );
+
+  return { allowed: true };
+}

--- a/lib/db/feedbackRateLimit.ts
+++ b/lib/db/feedbackRateLimit.ts
@@ -8,10 +8,9 @@ let indexEnsured = false;
 async function ensureIndex(): Promise<void> {
   if (indexEnsured) return;
   const db = await getDatabase();
-  await db.collection('feedbackRateLimits').createIndex(
-    { windowResetAt: 1 },
-    { expireAfterSeconds: 0, background: true }
-  );
+  const col = db.collection('feedbackRateLimits');
+  await col.createIndex({ windowResetAt: 1 }, { expireAfterSeconds: 0, background: true });
+  await col.createIndex({ ip: 1 }, { unique: true, background: true });
   indexEnsured = true;
 }
 

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -1,3 +1,11 @@
+import { NextRequest } from 'next/server';
+
 export async function safeJson(res: Response): Promise<Record<string, unknown>> {
   return res.json().catch(() => ({}));
+}
+
+export function extractIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0].trim();
+  return request.headers.get('x-real-ip') ?? 'unknown';
 }

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 export async function safeJson(res: Response): Promise<Record<string, unknown>> {
   return res.json().catch(() => ({}));

--- a/openspec/changes/add-feedback-help-menu/tasks.md
+++ b/openspec/changes/add-feedback-help-menu/tasks.md
@@ -1,0 +1,153 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/add-feedback-help-menu` then immediately `git push -u origin feat/add-feedback-help-menu`
+
+## Execution
+
+### Task 1 — MongoDB rate limit module
+
+Create `lib/db/feedbackRateLimit.ts`:
+- [x] Export `checkAndIncrementRateLimit(ip: string): Promise<{ allowed: boolean }>` 
+- [x] On first call, ensure `feedbackRateLimits` collection has TTL index on `windowResetAt` with `expireAfterSeconds: 0`
+- [x] Upsert document keyed by `ip`; if no document exists or `windowResetAt` is past, create with `count: 1`; if document exists and `count < 12`, increment; if `count >= 12`, return `{ allowed: false }`
+- [x] Window duration: 1 hour from first submission in that window
+
+Verification: `npm run test:unit -- --testPathPattern=feedbackRateLimit`
+
+### Task 2 — POST /api/feedback route
+
+Create `app/api/feedback/route.ts`:
+- [x] Require authenticated session; return 401 if no session
+- [x] Extract client IP from `x-forwarded-for` or `request.ip`
+- [x] Call `checkAndIncrementRateLimit(ip)`; return 429 with message if not allowed
+- [x] Validate request body: `type` (`bug` | `feature`), `title` (required, non-empty), `description` (optional, max 2000 chars), `pageUrl` (optional string)
+- [x] Build GitHub issue body:
+  ```
+  **Submitted by:** @{username} ({email})
+  **Page:** {pageUrl}
+  **User-Agent:** {request User-Agent header}
+
+  ---
+
+  {description}
+  ```
+- [x] Map `type` to label: `bug` → `["bug"]`, `feature` → `["enhancement"]`
+- [x] `POST https://api.github.com/repos/dougis-org/session-combat/issues` with `Authorization: Bearer ${process.env.GITHUB_FEEDBACK_TOKEN}`
+- [x] Return 201 with `{ issueUrl }` on success; 502 with error message on GitHub API failure
+- [x] Log GitHub API errors server-side
+
+Verification: `npm run test:unit -- --testPathPattern=feedback/route`
+
+### Task 3 — FeedbackForm component
+
+Create `lib/components/FeedbackForm.tsx`:
+- [x] Props: `defaultType?: 'bug' | 'feature'`, `onSubmit: (data: FeedbackFormData) => void`, `onCancel: () => void`, `isSubmitting?: boolean`
+- [x] Type `FeedbackFormData`: `{ type: 'bug' | 'feature', title: string, description: string, pageUrl: string }`
+- [x] Type toggle: two buttons (Bug Report / Feature Request); selected state visually indicated
+- [x] Title: required text input; Submit disabled when empty
+- [x] Description: textarea, `maxLength={2000}`
+- [x] `pageUrl`: hidden field, auto-set to `window.location.href` on mount
+- [x] Submit button disabled when `isSubmitting` is true or title is empty
+- [x] Cancel button always enabled; calls `onCancel`
+
+Verification: `npm run test:unit -- --testPathPattern=FeedbackForm`
+
+### Task 4 — FeedbackModal component
+
+Create `lib/components/FeedbackModal.tsx`:
+- [x] State: `open: boolean`, `submitting: boolean`, `result: 'idle' | 'success' | 'error'`, `errorMessage: string`
+- [x] Expose `open` control via `isOpen` prop + `onClose` prop (or internal state toggled by NavBar)
+- [x] On submit from `FeedbackForm`: set `submitting: true`, call `POST /api/feedback`, handle 201 → success state, non-201 → error state with message
+- [x] Success state: show confirmation message, Close button
+- [x] Error state: show error message, allow retry (re-render form) or Close
+- [x] Backdrop click or Escape key closes modal (resets to idle if not in success state)
+
+Verification: `npm run test:unit -- --testPathPattern=FeedbackModal`
+
+### Task 5 — NavBar update
+
+Modify `lib/components/NavBar.tsx`:
+- [x] Import `FeedbackModal` and add local `isModalOpen` state
+- [x] Render `?` button in the right-side group (before or adjacent to Logout), conditional on `isAuthenticated && !loading`
+- [x] Button click sets `isModalOpen: true`
+- [x] Render `<FeedbackModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />`
+- [x] Add `data-testid="feedback-button"` for testability
+
+Verification: `npm run test:unit -- --testPathPattern=NavBar`
+
+### Task 6 — Environment variable
+
+- [x] Add `GITHUB_FEEDBACK_TOKEN=` to `.env.example` with a comment explaining required scope (`issues:write` on `dougis-org/session-combat`)
+- [x] Verify the token is documented in deployment runbook or fly.toml secrets reference
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Automatically apply all clearly-correct findings directly to the code — without stopping, without presenting findings to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — build succeeds with no errors
+- [x] `npx tsc --noEmit` — no TypeScript errors (pre-existing errors in test files only, not in new code)
+- [ ] Manual smoke test: log in, click `?`, submit a bug report, verify GitHub issue created with correct label and body
+- [ ] Verify `?` button is absent when logged out
+- [ ] Verify 429 response after 12 rapid submissions from same IP (can test via curl)
+- [x] Grep client bundle for `GITHUB_FEEDBACK_TOKEN` — must not appear
+- [x] All tasks in Execution section marked `[x]`
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Build** — `npm run build`; must succeed with no errors
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — `npm run build`; must succeed with no errors
+- Skip integration and regression/E2E tests
+
+If **ANY** required step fails, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [ ] Commit all changes to `feat/add-feedback-help-menu` and push to remote
+- [ ] Open PR from `feat/add-feedback-help-menu` to `main`. PR body must include: `Closes #445`
+- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [ ] **Iterate until merged** — repeat continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if `CLOSED` exit and notify user — never force-merge:
+  1. **Build and tests** — run all steps in Remote push validation; fix failures, commit, push before anything else
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; address every unresolved thread, commit, run validation, push, wait 180s; repeat
+  3. **CI check failures** — after all comments resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix failing required checks, commit, run validation, push, wait 180s; restart from step 1
+
+Ownership metadata:
+
+- Implementer: (assigned agent)
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on main
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync spec delta to global spec: copy `openspec/changes/add-feedback-help-menu/specs/feedback-help-menu/spec.md` to `openspec/specs/feedback-help-menu/spec.md`; update relative links to point to archive location
+- [ ] Archive the change: move `openspec/changes/add-feedback-help-menu/` to `openspec/changes/archive/YYYY-MM-DD-add-feedback-help-menu/` — stage both the new location and deletion of the old location in **a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-add-feedback-help-menu/` exists and `openspec/changes/add-feedback-help-menu/` is gone
+- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-add-feedback-help-menu` then push
+- [ ] Open PR from doc branch to `main` with title `docs: archive add-feedback-help-menu (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor doc PR until merged (same loop — address comments and CI failures, push, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/add-feedback-help-menu doc/archive-YYYY-MM-DD-add-feedback-help-menu`

--- a/tests/unit/app/api/feedback/route.test.ts
+++ b/tests/unit/app/api/feedback/route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/feedback/route';
+import {
+  MOCK_AUTH,
+  makeRouteRequest,
+  mockAuthState,
+} from '@/tests/unit/helpers/route.test.helpers';
+import { Response as FetchResponse } from 'node-fetch';
+
+jest.mock('@/lib/middleware', () =>
+  require('@/tests/unit/helpers/route.test.helpers').createMockMiddleware()
+);
+
+jest.mock('@/lib/db/feedbackRateLimit', () => ({
+  checkAndIncrementRateLimit: jest.fn(),
+}));
+
+jest.mock('@/lib/permissions', () => ({
+  getUserById: jest.fn(),
+}));
+
+import { checkAndIncrementRateLimit } from '@/lib/db/feedbackRateLimit';
+import { getUserById } from '@/lib/permissions';
+
+const mockedRateLimit = jest.mocked(checkAndIncrementRateLimit);
+const mockedGetUserById = jest.mocked(getUserById);
+
+const VALID_BODY = {
+  type: 'bug' as const,
+  title: 'Something broke',
+  description: 'Details here',
+  pageUrl: '/combat',
+};
+
+function makeRequest(body: unknown) {
+  return makeRouteRequest('http://localhost/api/feedback', 'POST', body);
+}
+
+function mockFetchSuccess(issueUrl = 'https://github.com/issues/1') {
+  global.fetch = jest.fn(() =>
+    Promise.resolve(
+      new FetchResponse(JSON.stringify({ html_url: issueUrl }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Response
+    )
+  ) as unknown as jest.MockedFunction<typeof fetch>;
+}
+
+function mockFetchFailure(status = 500) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve(
+      new FetchResponse(JSON.stringify({ message: 'GitHub error' }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Response
+    )
+  ) as unknown as jest.MockedFunction<typeof fetch>;
+}
+
+describe('POST /api/feedback', () => {
+  let originalFetch: typeof global.fetch;
+  const originalToken = process.env.GITHUB_FEEDBACK_TOKEN;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    mockAuthState.payload = MOCK_AUTH;
+    mockedRateLimit.mockResolvedValue({ allowed: true });
+    mockedGetUserById.mockResolvedValue({ username: 'testuser' });
+    process.env.GITHUB_FEEDBACK_TOKEN = 'test-token-123';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    mockAuthState.payload = MOCK_AUTH;
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_FEEDBACK_TOKEN;
+    } else {
+      process.env.GITHUB_FEEDBACK_TOKEN = originalToken;
+    }
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockAuthState.payload = null;
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when rate limit exceeded', async () => {
+    mockedRateLimit.mockResolvedValue({ allowed: false });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(429);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/rate limit/i);
+  });
+
+  it('returns 400 when title is empty', async () => {
+    const res = await POST(makeRequest({ ...VALID_BODY, title: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when type is invalid', async () => {
+    const res = await POST(makeRequest({ ...VALID_BODY, type: 'other' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('creates GitHub issue for bug report and returns 201', async () => {
+    mockFetchSuccess();
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(201);
+    const body = await res.json() as { issueUrl: string };
+    expect(body.issueUrl).toBe('https://github.com/issues/1');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/dougis-org/session-combat/issues',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token-123',
+        }),
+        body: expect.stringContaining('"bug"'),
+      })
+    );
+    const callBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(callBody.labels).toContain('bug');
+    expect(callBody.title).toBe('Something broke');
+    expect(callBody.body).toContain('/combat');
+  });
+
+  it('creates GitHub issue for feature request with label enhancement', async () => {
+    mockFetchSuccess();
+    const res = await POST(makeRequest({ ...VALID_BODY, type: 'feature' }));
+    expect(res.status).toBe(201);
+    const callBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(callBody.labels).toContain('enhancement');
+  });
+
+  it('returns 502 on GitHub API failure', async () => {
+    mockFetchFailure(500);
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(502);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/failed to create/i);
+  });
+
+  it('returns 503 when GITHUB_FEEDBACK_TOKEN is not set', async () => {
+    delete process.env.GITHUB_FEEDBACK_TOKEN;
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(503);
+  });
+
+  it('response body does not contain token value', async () => {
+    mockFetchFailure(500);
+    const res = await POST(makeRequest(VALID_BODY));
+    const text = await res.text();
+    expect(text).not.toContain('test-token-123');
+  });
+});

--- a/tests/unit/components/FeedbackForm.test.tsx
+++ b/tests/unit/components/FeedbackForm.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedbackForm } from '@/lib/components/FeedbackForm';
+
+function renderForm(props: Partial<React.ComponentProps<typeof FeedbackForm>> = {}) {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+  render(<FeedbackForm onSubmit={onSubmit} onCancel={onCancel} {...props} />);
+  return { onSubmit, onCancel };
+}
+
+describe('FeedbackForm', () => {
+  it('renders with Bug Report selected by default', () => {
+    renderForm();
+    const bugBtn = screen.getByRole('button', { name: /bug report/i });
+    const featureBtn = screen.getByRole('button', { name: /feature request/i });
+    expect(bugBtn.className).toContain('bg-red-600');
+    expect(featureBtn.className).not.toContain('bg-blue-600');
+  });
+
+  it('toggle switches to Feature Request', async () => {
+    const user = userEvent.setup();
+    renderForm();
+    await user.click(screen.getByRole('button', { name: /feature request/i }));
+    expect(screen.getByRole('button', { name: /feature request/i }).className).toContain('bg-blue-600');
+    expect(screen.getByRole('button', { name: /bug report/i }).className).not.toContain('bg-red-600');
+  });
+
+  it('submit button is disabled when title is empty', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('submit button enabled when title is non-empty', async () => {
+    const user = userEvent.setup();
+    renderForm();
+    await user.type(screen.getByLabelText(/title/i), 'Something broke');
+    expect(screen.getByRole('button', { name: /submit/i })).not.toBeDisabled();
+  });
+
+  it('description enforces 2000 character limit', () => {
+    renderForm();
+    expect(screen.getByLabelText(/description/i)).toHaveAttribute('maxLength', '2000');
+  });
+
+  it('onSubmit called with correct data on submit', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm();
+    await user.click(screen.getByRole('button', { name: /feature request/i }));
+    await user.type(screen.getByLabelText(/title/i), 'Add dark mode');
+    await user.type(screen.getByLabelText(/description/i), 'Details here');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      type: 'feature',
+      title: 'Add dark mode',
+      description: 'Details here',
+      pageUrl: expect.any(String),
+    });
+  });
+
+  it('onCancel called when Cancel clicked', async () => {
+    const user = userEvent.setup();
+    const { onCancel } = renderForm();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('submit button disabled when isSubmitting is true', async () => {
+    const user = userEvent.setup();
+    renderForm({ isSubmitting: true });
+    await user.type(screen.getByLabelText(/title/i), 'Something');
+    expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled();
+  });
+});

--- a/tests/unit/components/FeedbackModal.test.tsx
+++ b/tests/unit/components/FeedbackModal.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedbackModal } from '@/lib/components/FeedbackModal';
+import { Response as FetchResponse } from 'node-fetch';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as Response;
+}
+
+describe('FeedbackModal', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders FeedbackForm when open', () => {
+    render(<FeedbackModal isOpen={true} onClose={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /bug report/i })).toBeInTheDocument();
+  });
+
+  it('does not render form content when closed', () => {
+    render(<FeedbackModal isOpen={false} onClose={jest.fn()} />);
+    expect(screen.queryByRole('button', { name: /bug report/i })).not.toBeInTheDocument();
+  });
+
+  it('shows success state after successful submission', async () => {
+    const user = userEvent.setup();
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ issueUrl: 'https://github.com/issues/1' }, 201))
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+
+    render(<FeedbackModal isOpen={true} onClose={jest.fn()} />);
+    await user.type(screen.getByLabelText(/title/i), 'Test bug');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/thank you for your feedback/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/title/i)).not.toBeInTheDocument();
+  });
+
+  it('shows error state on API failure', async () => {
+    const user = userEvent.setup();
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ error: 'GitHub unavailable' }, 502))
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+
+    render(<FeedbackModal isOpen={true} onClose={jest.fn()} />);
+    await user.type(screen.getByLabelText(/title/i), 'Test bug');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/github unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose when Close clicked from success state', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResponse({ issueUrl: 'https://github.com/issues/1' }, 201))
+    ) as unknown as jest.MockedFunction<typeof fetch>;
+
+    render(<FeedbackModal isOpen={true} onClose={onClose} />);
+    await user.type(screen.getByLabelText(/title/i), 'Test bug');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => screen.getByText(/thank you for your feedback/i));
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Cancel from form state', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<FeedbackModal isOpen={true} onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/NavBar.test.tsx
+++ b/tests/unit/components/NavBar.test.tsx
@@ -80,6 +80,32 @@ describe('NavBar', () => {
     await user.click(screen.getByTestId('logout-button'));
     expect(logout).toHaveBeenCalledTimes(1);
   });
+
+  it('shows feedback button when authenticated and not loading', () => {
+    mockAuth({ isAuthenticated: true, user: { userId: 'u1', email: 'u@test.com' } });
+    render(<NavBar />);
+    expect(screen.getByTestId('feedback-button')).toBeInTheDocument();
+  });
+
+  it('does not show feedback button when not authenticated', () => {
+    mockAuth({ isAuthenticated: false, loading: false });
+    render(<NavBar />);
+    expect(screen.queryByTestId('feedback-button')).not.toBeInTheDocument();
+  });
+
+  it('does not show feedback button while loading', () => {
+    mockAuth({ isAuthenticated: true, loading: true });
+    render(<NavBar />);
+    expect(screen.queryByTestId('feedback-button')).not.toBeInTheDocument();
+  });
+
+  it('clicking feedback button opens FeedbackModal', async () => {
+    const user = userEvent.setup();
+    mockAuth({ isAuthenticated: true, user: { userId: 'u1', email: 'u@test.com' } });
+    render(<NavBar />);
+    await user.click(screen.getByTestId('feedback-button'));
+    expect(screen.getByText('Send Feedback')).toBeInTheDocument();
+  });
 });
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/tests/unit/db/feedbackRateLimit.test.ts
+++ b/tests/unit/db/feedbackRateLimit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/db', () => ({
+  getDatabase: jest.fn(),
+}));
+
+import { getDatabase } from '@/lib/db';
+import { checkAndIncrementRateLimit } from '@/lib/db/feedbackRateLimit';
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+function makeCollection(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    createIndex: jest.fn().mockResolvedValue(undefined),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+    findOne: jest.fn().mockResolvedValue(null),
+    replaceOne: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function mockDb(collection: ReturnType<typeof makeCollection>) {
+  mockedGetDatabase.mockResolvedValue({
+    collection: jest.fn().mockReturnValue(collection),
+  } as any);
+  return collection;
+}
+
+describe('checkAndIncrementRateLimit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // TTL index test must run first (before indexEnsured is set to true)
+  it('ensures TTL index on collection init (first call)', async () => {
+    const col = mockDb(makeCollection());
+    await checkAndIncrementRateLimit('9.9.9.9');
+    expect(col.createIndex).toHaveBeenCalledWith(
+      { windowResetAt: 1 },
+      expect.objectContaining({ expireAfterSeconds: 0 })
+    );
+  });
+
+  it('allows submission within limit — returns allowed:true when atomic increment succeeds', async () => {
+    const col = mockDb(makeCollection({
+      updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    }));
+    const result = await checkAndIncrementRateLimit('1.2.3.4');
+    expect(result).toEqual({ allowed: true });
+    expect(col.updateOne).toHaveBeenCalled();
+  });
+
+  it('allows first submission from new IP — upserts with count 1 when no active window', async () => {
+    const col = mockDb(makeCollection({
+      updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      findOne: jest.fn().mockResolvedValue(null),
+    }));
+    const result = await checkAndIncrementRateLimit('1.2.3.4');
+    expect(result).toEqual({ allowed: true });
+    expect(col.replaceOne).toHaveBeenCalledWith(
+      { ip: { $eq: '1.2.3.4' } },
+      expect.objectContaining({ ip: '1.2.3.4', count: 1 }),
+      { upsert: true }
+    );
+  });
+
+  it('rejects submission when over limit — returns allowed:false', async () => {
+    const col = mockDb(makeCollection({
+      updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      findOne: jest.fn().mockResolvedValue({ ip: '1.2.3.4', count: 12 }),
+    }));
+    const result = await checkAndIncrementRateLimit('1.2.3.4');
+    expect(result).toEqual({ allowed: false });
+    expect(col.replaceOne).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a `?` button to the NavBar (auth-gated) that opens a feedback modal. Users can submit bug reports or feature requests that create GitHub issues automatically.

## Changes

- `lib/components/FeedbackForm.tsx` — standalone form with type toggle (Bug/Feature), title, description, auto-captured page URL
- `lib/components/FeedbackModal.tsx` — modal wrapper with success/error states, resets on reopen
- `app/api/feedback/route.ts` — authenticated POST endpoint; IP rate limiting (12/hr), body validation, server-side GitHub issue creation
- `lib/db/feedbackRateLimit.ts` — atomic MongoDB TTL rate limiter
- `lib/components/NavBar.tsx` — adds `?` button and renders `FeedbackModal`
- `lib/utils/http.ts` — extracted `extractIp` shared utility
- `.env.example` / `fly.toml` — documents `GITHUB_FEEDBACK_TOKEN` secret

Closes #445