### PR TITLE
fix: feedback route security hardening

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -17,3 +17,5 @@ exclude:
   - /openspec/**
   - /playwright.config.js
   - test-results.json
+  - .verity/**
+  - .vscode/**

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -31,14 +31,12 @@ function buildIssueBody(
 }
 
 export const POST = withAuth(async (request: NextRequest, auth) => {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
+  const parsed = await request.json().catch(() => null);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
 
-  const { type, title, description, pageUrl } = body as Record<string, unknown>;
+  const { type, title, description, pageUrl } = parsed as Record<string, unknown>;
 
   if (type !== 'bug' && type !== 'feature') {
     return NextResponse.json({ error: 'type must be "bug" or "feature"' }, { status: 400 });
@@ -79,7 +77,7 @@ export const POST = withAuth(async (request: NextRequest, auth) => {
     (rawPageUrl.startsWith('/') && !rawPageUrl.startsWith('//'))
       ? rawPageUrl
       : '';
-  const descriptionStr = typeof description === 'string' ? description : '';
+  const descriptionStr = typeof description === 'string' ? sanitizeIssueText(description, 2000) : '';
 
   const issueBody = buildIssueBody(submittedBy, pageUrlStr, userAgent, descriptionStr);
   const labels = type === 'bug' ? ['bug'] : ['enhancement'];

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -8,7 +8,7 @@ function sanitizeIssueText(value: string, maxLen = 200): string {
   return value
     .replace(/[\r\n]/g, ' ')
     .replace(/[\x00-\x1f\x7f]/g, '')
-    .replace(/[[\]*_`>]/g, '')
+    .replace(/[[\]*_`>@#]/g, '')
     .trim()
     .slice(0, maxLen);
 }

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -4,6 +4,15 @@ import { checkAndIncrementRateLimit } from '@/lib/db/feedbackRateLimit';
 import { getUserById } from '@/lib/permissions';
 import { extractIp } from '@/lib/utils/http';
 
+function sanitizeIssueText(value: string, maxLen = 200): string {
+  return value
+    .replace(/[\r\n]/g, ' ')
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/[[\]*_`>]/g, '')
+    .trim()
+    .slice(0, maxLen);
+}
+
 function buildIssueBody(
   submittedBy: string,
   pageUrl: string,
@@ -22,15 +31,6 @@ function buildIssueBody(
 }
 
 export const POST = withAuth(async (request: NextRequest, auth) => {
-  const ip = extractIp(request);
-  const { allowed } = await checkAndIncrementRateLimit(ip);
-  if (!allowed) {
-    return NextResponse.json(
-      { error: 'Rate limit exceeded. Please wait before submitting again.' },
-      { status: 429 }
-    );
-  }
-
   let body: unknown;
   try {
     body = await request.json();
@@ -53,6 +53,15 @@ export const POST = withAuth(async (request: NextRequest, auth) => {
     return NextResponse.json({ error: 'description must be 2000 characters or fewer' }, { status: 400 });
   }
 
+  const ip = extractIp(request);
+  const { allowed } = await checkAndIncrementRateLimit(ip);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Rate limit exceeded. Please wait before submitting again.' },
+      { status: 429 }
+    );
+  }
+
   const githubToken = process.env.GITHUB_FEEDBACK_TOKEN;
   if (!githubToken) {
     console.error('GITHUB_FEEDBACK_TOKEN is not configured');
@@ -63,9 +72,13 @@ export const POST = withAuth(async (request: NextRequest, auth) => {
   const githubHandle = user?.['username'] as string | undefined;
   const email = auth.email;
   const submittedBy = githubHandle ? `@${githubHandle} (${email})` : email;
-  const userAgent = request.headers.get('user-agent') ?? '';
+  const userAgent = sanitizeIssueText(request.headers.get('user-agent') ?? '');
   const rawPageUrl = typeof pageUrl === 'string' ? pageUrl.replace(/[\r\n]/g, '') : '';
-  const pageUrlStr = (rawPageUrl.startsWith('https://') || (rawPageUrl.startsWith('/') && !rawPageUrl.startsWith('//'))) ? rawPageUrl : '';
+  const pageUrlStr =
+    rawPageUrl.startsWith('https://') ||
+    (rawPageUrl.startsWith('/') && !rawPageUrl.startsWith('//'))
+      ? rawPageUrl
+      : '';
   const descriptionStr = typeof description === 'string' ? description : '';
 
   const issueBody = buildIssueBody(submittedBy, pageUrlStr, userAgent, descriptionStr);

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -9,7 +9,10 @@ function isValidIp(value: string): boolean {
   if (ipv4Parts.length === 4) {
     return ipv4Parts.every(p => /^\d{1,3}$/.test(p) && Number(p) <= 255);
   }
-  return /^[0-9a-f:]+$/i.test(value) && value.includes(':');
+  if (!value.includes(':') || value.includes(':::')) return false;
+  const segments = value.split(':');
+  if (segments.length < 3 || segments.length > 9) return false;
+  return segments.every(seg => /^[0-9a-f]{0,4}$/i.test(seg));
 }
 
 export function extractIp(request: NextRequest): string {

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -10,8 +10,9 @@ function isValidIp(value: string): boolean {
     return ipv4Parts.every(p => /^\d{1,3}$/.test(p) && Number(p) <= 255);
   }
   if (!value.includes(':') || value.includes(':::')) return false;
+  if ((value.match(/::/g) ?? []).length > 1) return false;
   const segments = value.split(':');
-  if (segments.length < 3 || segments.length > 9) return false;
+  if (segments.length < 3 || segments.length > 8) return false;
   return segments.every(seg => /^[0-9a-f]{0,4}$/i.test(seg));
 }
 

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -4,11 +4,12 @@ export async function safeJson(res: Response): Promise<Record<string, unknown>> 
   return res.json().catch(() => ({}));
 }
 
-const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/;
-const IPV6_RE = /^[0-9a-f:]+$/i;
-
 function isValidIp(value: string): boolean {
-  return IPV4_RE.test(value) || IPV6_RE.test(value);
+  const ipv4Parts = value.split('.');
+  if (ipv4Parts.length === 4) {
+    return ipv4Parts.every(p => /^\d{1,3}$/.test(p) && Number(p) <= 255);
+  }
+  return /^[0-9a-f:]+$/i.test(value) && value.includes(':');
 }
 
 export function extractIp(request: NextRequest): string {

--- a/lib/utils/http.ts
+++ b/lib/utils/http.ts
@@ -4,8 +4,20 @@ export async function safeJson(res: Response): Promise<Record<string, unknown>> 
   return res.json().catch(() => ({}));
 }
 
+const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/;
+const IPV6_RE = /^[0-9a-f:]+$/i;
+
+function isValidIp(value: string): boolean {
+  return IPV4_RE.test(value) || IPV6_RE.test(value);
+}
+
 export function extractIp(request: NextRequest): string {
   const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) return forwarded.split(',')[0].trim();
-  return request.headers.get('x-real-ip') ?? 'unknown';
+  if (forwarded) {
+    const candidate = forwarded.split(',')[0].trim();
+    if (isValidIp(candidate)) return candidate;
+  }
+  const realIp = request.headers.get('x-real-ip')?.trim() ?? '';
+  if (realIp && isValidIp(realIp)) return realIp;
+  return 'unknown';
 }

--- a/openspec/changes/archive/2026-06-28-add-feedback-help-menu/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-28-add-feedback-help-menu/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-06-28

--- a/openspec/changes/archive/2026-06-28-add-feedback-help-menu/design.md
+++ b/openspec/changes/archive/2026-06-28-add-feedback-help-menu/design.md
@@ -1,0 +1,176 @@
+## Context
+
+- Relevant architecture: Next.js App Router with API routes; `'use client'` NavBar component; MongoDB via existing `lib/db/` connection pattern; NextAuth (or equivalent) session for auth; Tailwind for styling
+- Dependencies: `GITHUB_FEEDBACK_TOKEN` env var (GitHub PAT, `issues:write` scope); MongoDB `feedbackRateLimits` collection; existing `useAuth` hook
+- Interfaces/contracts touched:
+  - `lib/components/NavBar.tsx` — adds `?` trigger button
+  - New: `lib/components/FeedbackForm.tsx`, `lib/components/FeedbackModal.tsx`
+  - New: `app/api/feedback/route.ts`
+  - New: `lib/db/feedbackRateLimit.ts`
+
+## Goals / Non-Goals
+
+### Goals
+
+- Add a `?` button to the NavBar (auth-gated, right-aligned) that opens a feedback modal
+- `FeedbackForm` is a self-contained, reusable component usable outside the modal
+- Server-side GitHub issue creation with no token exposure to the client
+- IP-based rate limiting (12/hr) via MongoDB TTL collection
+- Auto-attach context (username, email, page URL, user-agent) to every issue
+
+### Non-Goals
+
+- `/help` page (form component is ready for it; page itself is not built here)
+- Unauthenticated submission path
+- Admin tooling for submitted feedback
+
+## Decisions
+
+### Decision 1: FeedbackForm as standalone component, not modal-internal
+
+- Chosen: `FeedbackForm` is its own component in `lib/components/FeedbackForm.tsx`, accepting props (`onSubmit`, `onCancel`, `defaultType`). `FeedbackModal` imports and wraps it.
+- Alternatives considered: Inline the form JSX inside `FeedbackModal`
+- Rationale: The proposal explicitly requires future reuse on a `/help` page. Inlining would force extraction later.
+- Trade-offs: One extra file; negligible cost.
+
+### Decision 2: Server-side GitHub API call via Next.js API route
+
+- Chosen: `POST /api/feedback` reads `GITHUB_FEEDBACK_TOKEN` from `process.env` and calls the GitHub REST API server-side.
+- Alternatives considered: (a) client-side GitHub API call, (b) third-party service (Zapier/email relay)
+- Rationale: Token must never reach the client. Direct API call is simpler than a relay service and removes third-party dependency.
+- Trade-offs: API route must handle GitHub error responses and surface them to the UI.
+
+### Decision 3: MongoDB TTL collection for rate limiting
+
+- Chosen: `feedbackRateLimits` collection; documents keyed by IP with `count` and `windowResetAt`; TTL index on `windowResetAt` for auto-cleanup. Upsert increments count; reject if count > 12.
+- Alternatives considered: In-memory Map (fails multi-instance), Redis (extra dependency)
+- Rationale: MongoDB is the only DB in the stack. TTL index removes expired windows automatically, so no cron cleanup needed.
+- Trade-offs: MongoDB round-trip on every feedback submission (acceptable — low-frequency action).
+
+### Decision 4: Auto-context appended to GitHub issue body
+
+- Chosen: The API route appends a context block to the user's description:
+  ```
+  **Submitted by:** @username (email)
+  **Page:** <page URL from request body>
+  **User-Agent:** <from request headers>
+  ```
+  Page URL is sent by the client in the request body (not inferred server-side, to support SPAs).
+- Alternatives considered: Infer page from Referer header (unreliable)
+- Rationale: Client passes `window.location.href`; server has user session for email/username.
+- Trade-offs: Client must send page URL; minimal trust issue since it's decorative metadata.
+
+### Decision 5: `?` button placement and auth-gating
+
+- Chosen: Right side of NavBar, rendered only when `isAuthenticated && !loading`. Positioned before or adjacent to Logout using `ml-auto` layout.
+- Alternatives considered: Dropdown "Help" menu label
+- Rationale: `?` is universally understood; a dropdown adds complexity for only two items. Items can be added later.
+- Trade-offs: Less discoverable than labelled "Help" — acceptable for an MVP with two actions.
+
+### Decision 6: GitHub label mapping from form type toggle
+
+- Chosen: `bug` → GitHub label `bug`; `feature` → GitHub label `enhancement`. Labels applied at issue creation via GitHub API `labels` field.
+- Alternatives considered: No labels (harder to triage), custom labels
+- Rationale: `bug` and `enhancement` are GitHub's default labels; no setup required.
+- Trade-offs: None significant.
+
+## Proposal to Design Mapping
+
+- Proposal element: `?` button in NavBar, auth-gated
+  - Design decision: Decision 5
+  - Validation approach: E2E — button absent when logged out, present when logged in
+- Proposal element: In-app modal with FeedbackForm
+  - Design decision: Decision 1
+  - Validation approach: Unit test FeedbackForm props/state; E2E opens modal and submits
+- Proposal element: Server-side GitHub issue creation
+  - Design decision: Decision 2
+  - Validation approach: Unit test API route with mocked GitHub API; integration test issue creation
+- Proposal element: IP rate limiting 12/hr
+  - Design decision: Decision 3
+  - Validation approach: Unit test rate limit logic (mock MongoDB); integration test 429 after limit
+- Proposal element: Auto-attach context to issues
+  - Design decision: Decision 4
+  - Validation approach: Unit test issue body builder function; verify output format
+
+## Functional Requirements Mapping
+
+- Requirement: `?` button only visible to authenticated users
+  - Design element: NavBar conditional render on `isAuthenticated && !loading`
+  - Acceptance criteria reference: specs/feedback-help-menu/spec.md
+  - Testability notes: RTL unit test; E2E with logged-out/in states
+
+- Requirement: Form has type toggle (Bug / Feature), title, description fields
+  - Design element: `FeedbackForm` component props and controlled state
+  - Acceptance criteria reference: specs/feedback-help-menu/spec.md
+  - Testability notes: RTL unit test toggle state, field binding, submit handler call
+
+- Requirement: Submit creates GitHub issue with correct label
+  - Design element: `POST /api/feedback` → GitHub REST API `POST /repos/.../issues`
+  - Acceptance criteria reference: specs/feedback-help-menu/spec.md
+  - Testability notes: Mock `fetch`/GitHub API in unit test; assert label and body
+
+- Requirement: Rate limit 12/hr per IP
+  - Design element: `lib/db/feedbackRateLimit.ts` upsert + count check
+  - Acceptance criteria reference: specs/feedback-help-menu/spec.md
+  - Testability notes: Unit test with mock MongoDB; assert 429 on 13th request
+
+- Requirement: Auto-populate context in issue body
+  - Design element: API route builds issue body from session + request body + headers
+  - Acceptance criteria reference: specs/feedback-help-menu/spec.md
+  - Testability notes: Unit test issue body builder with known inputs; assert output
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: security
+  - Requirement: GitHub PAT never exposed to client
+  - Design element: Token read only in `app/api/feedback/route.ts` server-side
+  - Acceptance criteria reference: Code review — token must not appear in any `'use client'` module
+  - Testability notes: Static check; grep for `GITHUB_FEEDBACK_TOKEN` in client bundles
+
+- Requirement category: reliability
+  - Requirement: GitHub API failure surfaces to user, not silently swallowed
+  - Design element: API route returns 502 with error message on GitHub API failure; modal shows error state
+  - Acceptance criteria reference: specs/feedback-help-menu/spec.md
+  - Testability notes: Unit test with mocked GitHub API returning 500; assert modal shows error
+
+- Requirement category: operability
+  - Requirement: MongoDB rate limit collection self-cleans
+  - Design element: TTL index on `windowResetAt` field in `feedbackRateLimits`
+  - Acceptance criteria reference: Index created on first API route load; no cron needed
+  - Testability notes: Integration test — verify TTL index exists after route initialization
+
+## Risks / Trade-offs
+
+- Risk/trade-off: MongoDB TTL index not created before first request
+  - Impact: Rate limiting skipped on cold start
+  - Mitigation: Create index in `lib/db/feedbackRateLimit.ts` module init (runs on first import); use `createIndex` with `background: true`
+
+- Risk/trade-off: GitHub PAT expiry
+  - Impact: All feedback submissions fail silently (or with error) until token is rotated
+  - Mitigation: API route returns 502 with user-visible error; operator notified via logs
+
+- Risk/trade-off: `FeedbackForm` page URL from client is user-controllable
+  - Impact: Low — URL is decorative metadata in the issue body, not used for security decisions
+  - Mitigation: No mitigation needed; accept the trade-off
+
+## Rollback / Mitigation
+
+- Rollback trigger: GitHub API errors > 5% of submissions, or security issue found with token handling
+- Rollback steps:
+  1. Remove `?` button from NavBar (one-line change)
+  2. Delete or disable `app/api/feedback/route.ts`
+  3. `FeedbackForm` and `FeedbackModal` can remain (unused, no harm)
+  4. Drop `GITHUB_FEEDBACK_TOKEN` env var from deployment config
+- Data migration considerations: `feedbackRateLimits` collection can be dropped; no schema migration
+- Verification after rollback: NavBar no longer shows `?`; `POST /api/feedback` returns 404
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check. No bypasses via `--no-verify` or force-push.
+- If security checks fail: Treat as a blocker. Token exposure or injection issues must be resolved before merge.
+- If required reviews are blocked/stale: Ping reviewer after 24hr. Escalate to repo owner after 48hr.
+- Escalation path and timeout: If blocked > 72hr with no resolution, re-scope or defer to next sprint.
+
+## Open Questions
+
+No open questions. All design decisions were resolved during exploration prior to proposal.

--- a/openspec/changes/archive/2026-06-28-add-feedback-help-menu/proposal.md
+++ b/openspec/changes/archive/2026-06-28-add-feedback-help-menu/proposal.md
@@ -1,0 +1,96 @@
+## GitHub Issues
+
+- dougis-org/session-combat#445
+
+## Why
+
+- Problem statement: Users have no way to report bugs or request features from within the app. They must navigate to GitHub directly, which requires a GitHub account and knowledge of the repo — a barrier most end-users won't cross.
+- Why now: The app is growing in users and operational maturity. Capturing user feedback in-context (where the problem is visible) yields higher-quality reports and more actionable feature requests.
+- Business/user impact: Reduces friction for feedback submission; all feedback lands directly in the issue tracker where the team already works, with full context (page, user, user-agent) auto-attached.
+
+## Problem Space
+
+- Current behavior: No in-app mechanism to contact the team. Users who encounter bugs or have feature ideas have no path forward within the app.
+- Desired behavior: Authenticated users see a `?` button in the top-right NavBar. Clicking opens a modal with a type toggle (Bug Report / Feature Request), a title field, and a description field. On submit, a GitHub issue is created in the project repo via the GitHub API, labeled `bug` or `enhancement`, with auto-attached context (username, email, current page URL, user-agent). The modal shows success/error feedback.
+- Constraints:
+  - Only visible to authenticated users (auth guard on both UI and API route)
+  - Rate limit: 12 submissions per IP per hour, tracked in MongoDB
+  - GitHub PAT (`GITHUB_FEEDBACK_TOKEN`) stored as an env var; no client-side token exposure
+  - `FeedbackForm` must be a standalone reusable component, not tightly coupled to the modal
+- Assumptions:
+  - The submitting user's email and username are available from the session
+  - The app runs on a single-process container (Fly.io); MongoDB is the only DB
+  - The GitHub PAT is scoped to `issues:write` on this repo only
+- Edge cases considered:
+  - GitHub API failure → show user-facing error, do not swallow silently
+  - Rate limit hit → show friendly "too many submissions" message
+  - User submits while unauthenticated (race) → 401 from API route
+  - Very long descriptions → enforce a character limit on the form (e.g. 2000 chars)
+
+## Scope
+
+### In Scope
+
+- `?` button added to NavBar right side, visible only when authenticated
+- `FeedbackModal` component wrapping `FeedbackForm`
+- `FeedbackForm` component: type toggle (Bug / Feature), title, description, submit/cancel
+- Auto-population: user email, username, current page URL, user-agent (from request headers)
+- `POST /api/feedback` API route: auth check, IP rate limiting via MongoDB, GitHub issue creation
+- MongoDB `feedbackRateLimits` collection with TTL index for automatic window expiry
+- New env var: `GITHUB_FEEDBACK_TOKEN`
+- Success and error states in the modal UI
+
+### Out of Scope
+
+- `/help` page (future; `FeedbackForm` is designed to drop in there later)
+- Unauthenticated feedback submission
+- Email-based issue ingestion
+- Admin dashboard for submitted feedback
+- Attachment/screenshot uploads
+- User notification when their issue is triaged
+
+## What Changes
+
+- `lib/components/NavBar.tsx` — add `?` button (auth-gated, right side, opens modal)
+- `lib/components/FeedbackForm.tsx` — new standalone form component
+- `lib/components/FeedbackModal.tsx` — new modal wrapping `FeedbackForm`
+- `app/api/feedback/route.ts` — new POST route: auth, rate limit, GitHub API call
+- `lib/db/feedbackRateLimit.ts` — MongoDB upsert logic for IP rate limiting
+- `.env.example` / deployment config — document `GITHUB_FEEDBACK_TOKEN`
+
+## Risks
+
+- Risk: GitHub API token leaked via client-side code
+  - Impact: High — could allow anonymous issue creation or repo access
+  - Mitigation: Token only used server-side in the API route; never passed to client
+- Risk: Spam / abuse before rate limit kicks in
+  - Impact: Medium — noisy issue tracker
+  - Mitigation: 12/hr IP limit; auth required; issues visible in tracker so easy to close
+- Risk: MongoDB rate limit collection grows unbounded
+  - Impact: Low — TTL index auto-deletes expired documents
+  - Mitigation: Set TTL index on `windowResetAt` field at collection creation
+- Risk: GitHub API rate limit (5000 req/hr for authenticated PAT)
+  - Impact: Low — app rate limit of 12/hr/IP makes it very unlikely to hit
+  - Mitigation: Log GitHub API errors; surface to user as "try again later"
+
+## Open Questions
+
+No unresolved ambiguity remains. All decisions made during exploration:
+- Auth required: yes (login required to submit)
+- Rate limit: 12/hr per IP, MongoDB-backed
+- Storage: MongoDB only (no PostgreSQL)
+- Form placement: modal off `?` NavBar button; `FeedbackForm` extracted for reuse
+- Auto-context: email, username, page URL, user-agent all included in issue body
+- `?` button position: right side of NavBar, adjacent to Logout
+
+## Non-Goals
+
+- Building a general help system or FAQ page
+- Replacing GitHub as the issue tracker
+- Supporting unauthenticated users submitting feedback
+- Providing feedback status tracking to the submitter
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-06-28-add-feedback-help-menu/specs/feedback-help-menu/spec.md
+++ b/openspec/changes/archive/2026-06-28-add-feedback-help-menu/specs/feedback-help-menu/spec.md
@@ -1,0 +1,227 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED NavBar help button — auth-gated
+
+The system SHALL render a `?` button on the right side of the NavBar if and only if the user is authenticated.
+
+#### Scenario: Help button visible when authenticated
+
+- **Given** a user is logged in and the NavBar is rendered
+- **When** the NavBar mounts
+- **Then** a `?` button is visible on the right side of the nav, adjacent to the Logout button
+
+#### Scenario: Help button absent when unauthenticated
+
+- **Given** a user is not logged in and the NavBar is rendered
+- **When** the NavBar mounts
+- **Then** no `?` button is present in the DOM
+
+#### Scenario: Help button absent while auth is loading
+
+- **Given** the auth state is still loading
+- **When** the NavBar mounts
+- **Then** no `?` button is rendered (same guard as Logout)
+
+---
+
+### Requirement: ADDED FeedbackModal opens on help button click
+
+The system SHALL open a feedback modal when the authenticated user clicks the `?` button.
+
+#### Scenario: Modal opens on click
+
+- **Given** the user is authenticated and the `?` button is visible
+- **When** the user clicks `?`
+- **Then** the `FeedbackModal` opens, displaying the `FeedbackForm`
+
+#### Scenario: Modal closes on cancel
+
+- **Given** the `FeedbackModal` is open
+- **When** the user clicks Cancel
+- **Then** the modal closes and the NavBar is restored to its normal state
+
+---
+
+### Requirement: ADDED FeedbackForm — type toggle, title, description
+
+The system SHALL provide a form with a type toggle (Bug Report / Feature Request), a title field, and a description field.
+
+#### Scenario: Default type is Bug Report
+
+- **Given** the `FeedbackModal` is opened
+- **When** the form renders for the first time
+- **Then** the Bug Report option is selected by default
+
+#### Scenario: Toggle switches to Feature Request
+
+- **Given** the FeedbackForm is displayed with Bug Report selected
+- **When** the user clicks Feature Request
+- **Then** the Feature Request option becomes selected and Bug Report is deselected
+
+#### Scenario: Submit is disabled when title is empty
+
+- **Given** the FeedbackForm is displayed
+- **When** the title field is empty
+- **Then** the Submit button is disabled
+
+#### Scenario: Submit is enabled when title is non-empty
+
+- **Given** the FeedbackForm is displayed
+- **When** the user types a non-empty title
+- **Then** the Submit button becomes enabled
+
+#### Scenario: Description enforces character limit
+
+- **Given** the FeedbackForm is displayed
+- **When** the user types more than 2000 characters in the description field
+- **Then** input beyond 2000 characters is rejected (field enforces maxLength)
+
+---
+
+### Requirement: ADDED POST /api/feedback — creates GitHub issue
+
+The system SHALL create a GitHub issue via the GitHub REST API when a valid authenticated request is received.
+
+#### Scenario: Successful bug report submission
+
+- **Given** an authenticated user submits the form with type "bug", a title, and a description
+- **When** `POST /api/feedback` is called
+- **Then** a GitHub issue is created with label `bug`, title from the form, and a body containing the description and auto-attached context (username, email, page URL, user-agent)
+- **And** the API returns HTTP 201
+
+#### Scenario: Successful feature request submission
+
+- **Given** an authenticated user submits the form with type "feature" and a title
+- **When** `POST /api/feedback` is called
+- **Then** a GitHub issue is created with label `enhancement`
+- **And** the API returns HTTP 201
+
+#### Scenario: Modal shows success state after submission
+
+- **Given** `POST /api/feedback` returns 201
+- **When** the submit response is received
+- **Then** the modal displays a success message and the form is no longer editable
+
+#### Scenario: Modal shows error state on GitHub API failure
+
+- **Given** the GitHub API returns a non-2xx response
+- **When** the submit response is received
+- **Then** the API route returns HTTP 502 and the modal displays a user-visible error message
+
+---
+
+### Requirement: ADDED IP rate limiting — 12 submissions per hour
+
+The system SHALL reject feedback submissions from an IP address that has exceeded 12 submissions in the current one-hour window.
+
+#### Scenario: Submission accepted within rate limit
+
+- **Given** an IP address has submitted fewer than 12 times in the current hour
+- **When** `POST /api/feedback` is called
+- **Then** the submission is processed normally
+
+#### Scenario: Submission rejected at rate limit
+
+- **Given** an IP address has submitted 12 times in the current hour
+- **When** `POST /api/feedback` is called a 13th time
+- **Then** the API returns HTTP 429 with a rate limit error message
+- **And** no GitHub issue is created
+
+#### Scenario: Rate limit window resets after one hour
+
+- **Given** an IP address hit the rate limit in a previous one-hour window
+- **When** one hour has elapsed and the TTL document has expired
+- **Then** the next submission from that IP is accepted (count resets to 1)
+
+---
+
+### Requirement: ADDED Auto-context in GitHub issue body
+
+The system SHALL append submitter context to every created GitHub issue body.
+
+#### Scenario: Issue body includes username, email, page URL, user-agent
+
+- **Given** an authenticated user submits feedback from page `/combat/abc123`
+- **When** the GitHub issue is created
+- **Then** the issue body contains:
+  - `**Submitted by:** @username (email@example.com)`
+  - `**Page:** https://…/combat/abc123`
+  - `**User-Agent:** <request User-Agent header value>`
+  - The user's description text
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED NavBar — authenticated nav element set
+
+The NavBar SHALL include a `?` button (help/feedback trigger) as a new authenticated-only element, positioned on the right side before the Logout button.
+
+#### Scenario: NavBar right side includes help button when authenticated
+
+- **Given** the user is authenticated
+- **When** the NavBar renders
+- **Then** the right side contains `[?] [Logout]` in that order
+
+---
+
+## REMOVED Requirements
+
+None. This change only adds new capabilities and modifies the NavBar element set.
+
+---
+
+## Traceability
+
+- Proposal: auth-gated `?` button → Requirement: ADDED NavBar help button — auth-gated
+- Proposal: FeedbackModal + FeedbackForm with toggle → Requirement: ADDED FeedbackModal opens; ADDED FeedbackForm
+- Proposal: Server-side GitHub API call → Requirement: ADDED POST /api/feedback
+- Proposal: IP rate limit 12/hr → Requirement: ADDED IP rate limiting
+- Proposal: Auto-attach context → Requirement: ADDED Auto-context in GitHub issue body
+- Design Decision 1 (standalone FeedbackForm) → Requirement: ADDED FeedbackModal; ADDED FeedbackForm
+- Design Decision 2 (server-side API route) → Requirement: ADDED POST /api/feedback
+- Design Decision 3 (MongoDB TTL rate limit) → Requirement: ADDED IP rate limiting
+- Design Decision 4 (auto-context body) → Requirement: ADDED Auto-context in GitHub issue body
+- Design Decision 5 (NavBar placement) → Requirement: MODIFIED NavBar; ADDED NavBar help button
+- Design Decision 6 (label mapping) → Requirement: ADDED POST /api/feedback (bug/feature scenarios)
+- Requirements → Tasks: all requirements map to tasks in `tasks.md`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+> **Important:** NFAC scenarios MUST NOT duplicate scenarios already expressed in the functional requirements above.
+
+### Requirement: Security
+
+See functional scenarios: "Help button absent when unauthenticated", "Submission rejected at rate limit".
+
+#### Scenario: GitHub token not present in client bundle
+
+- **Given** the Next.js production build is generated
+- **When** the client-side JavaScript bundle is inspected
+- **Then** the string `GITHUB_FEEDBACK_TOKEN` and its value do not appear in any client bundle file
+
+#### Scenario: Unauthenticated POST rejected
+
+- **Given** a request is made to `POST /api/feedback` without a valid session
+- **When** the route handler executes
+- **Then** the route returns HTTP 401 before any rate limit check or GitHub API call
+
+### Requirement: Reliability
+
+#### Scenario: GitHub API error does not cause unhandled exception
+
+- **Given** the GitHub API returns a 500 error
+- **When** `POST /api/feedback` processes the response
+- **Then** the route catches the error, logs it server-side, and returns HTTP 502 with a user-readable message — no unhandled promise rejection occurs
+
+### Requirement: Operability
+
+#### Scenario: MongoDB rate limit collection has TTL index
+
+- **Given** the `feedbackRateLimits` collection is initialized
+- **When** the MongoDB index list for that collection is inspected
+- **Then** a TTL index on `windowResetAt` with `expireAfterSeconds: 0` is present

--- a/openspec/changes/archive/2026-06-28-add-feedback-help-menu/tasks.md
+++ b/openspec/changes/archive/2026-06-28-add-feedback-help-menu/tasks.md
@@ -92,9 +92,9 @@ Verification: `npm run test:unit -- --testPathPattern=NavBar`
 - [x] `npm run test:unit` — all tests pass
 - [x] `npm run build` — build succeeds with no errors
 - [x] `npx tsc --noEmit` — no TypeScript errors (pre-existing errors in test files only, not in new code)
-- [ ] Manual smoke test: log in, click `?`, submit a bug report, verify GitHub issue created with correct label and body
-- [ ] Verify `?` button is absent when logged out
-- [ ] Verify 429 response after 12 rapid submissions from same IP (can test via curl)
+- [x] Manual smoke test: log in, click `?`, submit a bug report, verify GitHub issue created with correct label and body
+- [x] Verify `?` button is absent when logged out
+- [x] Verify 429 response after 12 rapid submissions from same IP (can test via curl)
 - [x] Grep client bundle for `GITHUB_FEEDBACK_TOKEN` — must not appear
 - [x] All tasks in Execution section marked `[x]`
 
@@ -116,12 +116,12 @@ If **ANY** required step fails, iterate and address the failure before pushing.
 
 ## PR and Merge
 
-- [ ] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
-- [ ] Commit all changes to `feat/add-feedback-help-menu` and push to remote
-- [ ] Open PR from `feat/add-feedback-help-menu` to `main`. PR body must include: `Closes #445`
-- [ ] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post comments
-- [ ] **Iterate until merged** — repeat continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if `CLOSED` exit and notify user — never force-merge:
+- [x] Ensure `openspec-review-code` sub-agent was run and all findings addressed before final commit
+- [x] Commit all changes to `feat/add-feedback-help-menu` and push to remote
+- [x] Open PR from `feat/add-feedback-help-menu` to `main`. PR body must include: `Closes #445`
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin`)
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post comments
+- [x] **Iterate until merged** — repeat continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if `CLOSED` exit and notify user — never force-merge:
   1. **Build and tests** — run all steps in Remote push validation; fix failures, commit, push before anything else
   2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; address every unresolved thread, commit, run validation, push, wait 180s; repeat
   3. **CI check failures** — after all comments resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix failing required checks, commit, run validation, push, wait 180s; restart from step 1
@@ -140,14 +140,14 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify the merged changes appear on main
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync spec delta to global spec: copy `openspec/changes/add-feedback-help-menu/specs/feedback-help-menu/spec.md` to `openspec/specs/feedback-help-menu/spec.md`; update relative links to point to archive location
-- [ ] Archive the change: move `openspec/changes/add-feedback-help-menu/` to `openspec/changes/archive/YYYY-MM-DD-add-feedback-help-menu/` — stage both the new location and deletion of the old location in **a single commit**
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-add-feedback-help-menu/` exists and `openspec/changes/add-feedback-help-menu/` is gone
-- [ ] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-add-feedback-help-menu` then push
-- [ ] Open PR from doc branch to `main` with title `docs: archive add-feedback-help-menu (YYYY-MM-DD)`
-- [ ] **IMMEDIATELY** enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
-- [ ] Monitor doc PR until merged (same loop — address comments and CI failures, push, repeat)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/add-feedback-help-menu doc/archive-YYYY-MM-DD-add-feedback-help-menu`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify the merged changes appear on main
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Sync spec delta to global spec: copy `openspec/changes/add-feedback-help-menu/specs/feedback-help-menu/spec.md` to `openspec/specs/feedback-help-menu/spec.md`; update relative links to point to archive location
+- [x] Archive the change: move `openspec/changes/add-feedback-help-menu/` to `openspec/changes/archive/YYYY-MM-DD-add-feedback-help-menu/` — stage both the new location and deletion of the old location in **a single commit**
+- [x] Confirm `openspec/changes/archive/YYYY-MM-DD-add-feedback-help-menu/` exists and `openspec/changes/add-feedback-help-menu/` is gone
+- [x] **Create doc branch:** `git checkout -b doc/archive-YYYY-MM-DD-add-feedback-help-menu` then push
+- [x] Open PR from doc branch to `main` with title `docs: archive add-feedback-help-menu (YYYY-MM-DD)`
+- [x] **IMMEDIATELY** enable auto-merge on doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [x] Monitor doc PR until merged (same loop — address comments and CI failures, push, repeat)
+- [x] Prune merged local branches: `git fetch --prune` and `git branch -D feat/add-feedback-help-menu doc/archive-YYYY-MM-DD-add-feedback-help-menu`

--- a/openspec/changes/archive/2026-06-28-add-feedback-help-menu/tests.md
+++ b/openspec/changes/archive/2026-06-28-add-feedback-help-menu/tests.md
@@ -1,0 +1,195 @@
+---
+name: tests
+description: Tests for the add-feedback-help-menu change
+---
+
+# Tests
+
+## Overview
+
+Tests for the `add-feedback-help-menu` change. All work follows strict TDD: write a failing test → write code to pass → refactor.
+
+Test files:
+- `tests/unit/components/FeedbackForm.test.tsx`
+- `tests/unit/components/FeedbackModal.test.tsx`
+- `tests/unit/components/NavBar.test.tsx` (updated)
+- `tests/unit/app/api/feedback/route.test.ts`
+- `tests/unit/db/feedbackRateLimit.test.ts`
+
+## Testing Steps
+
+For each task in `tasks.md`:
+1. **Write a failing test** before writing any implementation code
+2. **Write the simplest code** to make the test pass
+3. **Refactor** while keeping tests green
+
+---
+
+## Test Cases
+
+### Task 1 — feedbackRateLimit.ts
+
+Maps to spec: "IP rate limiting — 12 submissions per hour"
+
+- [ ] **First submission from new IP is allowed**
+  - Mock MongoDB; no existing document for IP
+  - Call `checkAndIncrementRateLimit('1.2.3.4')`
+  - Assert returns `{ allowed: true }`; upsert called with `count: 1`
+
+- [ ] **Submission within limit (count < 12) is allowed**
+  - Mock MongoDB; existing document with `count: 5`
+  - Call `checkAndIncrementRateLimit('1.2.3.4')`
+  - Assert returns `{ allowed: true }`; count incremented
+
+- [ ] **12th submission is allowed**
+  - Mock MongoDB; existing document with `count: 11`
+  - Call `checkAndIncrementRateLimit('1.2.3.4')`
+  - Assert returns `{ allowed: true }`
+
+- [ ] **13th submission is rejected**
+  - Mock MongoDB; existing document with `count: 12`
+  - Call `checkAndIncrementRateLimit('1.2.3.4')`
+  - Assert returns `{ allowed: false }`; no increment attempted
+
+- [ ] **TTL index is ensured on collection init**
+  - Mock MongoDB `createIndex`
+  - Import `feedbackRateLimit` module
+  - Assert `createIndex` called with `{ windowResetAt: 1 }` and `{ expireAfterSeconds: 0 }`
+
+---
+
+### Task 2 — POST /api/feedback route
+
+Maps to spec: "POST /api/feedback — creates GitHub issue"; "Unauthenticated POST rejected"; "GitHub API error does not cause unhandled exception"
+
+- [ ] **Returns 401 when unauthenticated**
+  - Mock session as null
+  - POST to `/api/feedback`
+  - Assert response status 401; GitHub API not called
+
+- [ ] **Returns 429 when rate limit exceeded**
+  - Mock session as valid; mock `checkAndIncrementRateLimit` → `{ allowed: false }`
+  - POST to `/api/feedback` with valid body
+  - Assert response status 429 with message; GitHub API not called
+
+- [ ] **Returns 400 when title is missing**
+  - Mock session and rate limit as passing
+  - POST with body `{ type: 'bug', title: '', description: 'desc', pageUrl: '/' }`
+  - Assert response status 400
+
+- [ ] **Creates GitHub issue for bug report**
+  - Mock session, rate limit (allowed), and `fetch` to GitHub API (return 201)
+  - POST with `{ type: 'bug', title: 'Something broke', description: 'Details', pageUrl: '/combat' }`
+  - Assert `fetch` called with GitHub API URL, `Authorization: Bearer <token>`, body includes label `"bug"`, title `"Something broke"`, and body text contains username, email, `/combat`, user-agent
+  - Assert response status 201 with `{ issueUrl }`
+
+- [ ] **Creates GitHub issue for feature request with label "enhancement"**
+  - Mock session, rate limit (allowed), and `fetch` to GitHub API (return 201)
+  - POST with `{ type: 'feature', title: 'Add dark mode' }`
+  - Assert label `"enhancement"` in GitHub API call
+
+- [ ] **Returns 502 on GitHub API failure**
+  - Mock session, rate limit (allowed), and `fetch` → 500 from GitHub
+  - POST with valid body
+  - Assert response status 502 with user-readable error message; no unhandled rejection
+
+- [ ] **GITHUB_FEEDBACK_TOKEN not present in response body or error**
+  - Mock GitHub API failure
+  - POST and capture response body
+  - Assert response body does not contain the token value
+
+---
+
+### Task 3 — FeedbackForm component
+
+Maps to spec: "FeedbackForm — type toggle, title, description"
+
+- [ ] **Renders with Bug Report selected by default**
+  - Render `<FeedbackForm onSubmit={jest.fn()} onCancel={jest.fn()} />`
+  - Assert Bug Report toggle is in selected/active state
+
+- [ ] **Toggle switches to Feature Request**
+  - Render form; click Feature Request button
+  - Assert Feature Request is selected; Bug Report is not
+
+- [ ] **Submit button is disabled when title is empty**
+  - Render form; title field is empty
+  - Assert submit button has `disabled` attribute
+
+- [ ] **Submit button enabled when title is non-empty**
+  - Render form; type into title field
+  - Assert submit button is not disabled
+
+- [ ] **Description enforces 2000 character limit**
+  - Render form; inspect description textarea
+  - Assert `maxLength` attribute is 2000
+
+- [ ] **onSubmit called with correct data**
+  - Render form; select Feature Request; fill title and description; click Submit
+  - Assert `onSubmit` called with `{ type: 'feature', title: '...', description: '...', pageUrl: expect.any(String) }`
+
+- [ ] **onCancel called when Cancel clicked**
+  - Render form; click Cancel
+  - Assert `onCancel` called once
+
+- [ ] **Submit button disabled when isSubmitting is true**
+  - Render `<FeedbackForm onSubmit={jest.fn()} onCancel={jest.fn()} isSubmitting={true} />`
+  - Fill title; assert submit button is still disabled
+
+---
+
+### Task 4 — FeedbackModal component
+
+Maps to spec: "FeedbackModal opens on help button click"; "Modal shows success state"; "Modal shows error state"
+
+- [ ] **Renders FeedbackForm when open**
+  - Render `<FeedbackModal isOpen={true} onClose={jest.fn()} />`
+  - Assert FeedbackForm is present in the DOM
+
+- [ ] **Does not render form content when closed**
+  - Render `<FeedbackModal isOpen={false} onClose={jest.fn()} />`
+  - Assert FeedbackForm is not visible (or modal is not in DOM)
+
+- [ ] **Shows success state after successful submission**
+  - Mock `fetch` to return 201
+  - Render modal open; fill form; submit
+  - Assert success confirmation message is displayed; form inputs are gone
+
+- [ ] **Shows error state on API failure**
+  - Mock `fetch` to return 502 with error message
+  - Render modal open; fill form; submit
+  - Assert error message is displayed
+
+- [ ] **Calls onClose when Close clicked from success state**
+  - Reach success state; click Close button
+  - Assert `onClose` called
+
+- [ ] **onClose called on Cancel from form state**
+  - Render modal open; click Cancel in form
+  - Assert `onClose` called
+
+---
+
+### Task 5 — NavBar (updated)
+
+Maps to spec: "NavBar help button — auth-gated"; "MODIFIED NavBar — authenticated nav element set"
+
+- [ ] **`?` button present when authenticated**
+  - Render NavBar with `isAuthenticated: true, loading: false`
+  - Assert element with `data-testid="feedback-button"` is in the DOM
+
+- [ ] **`?` button absent when not authenticated**
+  - Render NavBar with `isAuthenticated: false, loading: false`
+  - Assert no `data-testid="feedback-button"` in the DOM
+
+- [ ] **`?` button absent while loading**
+  - Render NavBar with `isAuthenticated: true, loading: true`
+  - Assert no `data-testid="feedback-button"` in the DOM
+
+- [ ] **Clicking `?` opens FeedbackModal**
+  - Render NavBar authenticated; click `data-testid="feedback-button"`
+  - Assert FeedbackModal is now visible
+
+- [ ] **Modal closes when onClose triggered**
+  - Open modal via `?` click; trigger `onClose` (e.g. click Cancel)
+  - Assert FeedbackModal is no longer visible

--- a/openspec/specs/feedback-help-menu/spec.md
+++ b/openspec/specs/feedback-help-menu/spec.md
@@ -1,0 +1,227 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-06-28-add-feedback-help-menu/design.md) document, not a replacement.
+
+### Requirement: ADDED NavBar help button — auth-gated
+
+The system SHALL render a `?` button on the right side of the NavBar if and only if the user is authenticated.
+
+#### Scenario: Help button visible when authenticated
+
+- **Given** a user is logged in and the NavBar is rendered
+- **When** the NavBar mounts
+- **Then** a `?` button is visible on the right side of the nav, adjacent to the Logout button
+
+#### Scenario: Help button absent when unauthenticated
+
+- **Given** a user is not logged in and the NavBar is rendered
+- **When** the NavBar mounts
+- **Then** no `?` button is present in the DOM
+
+#### Scenario: Help button absent while auth is loading
+
+- **Given** the auth state is still loading
+- **When** the NavBar mounts
+- **Then** no `?` button is rendered (same guard as Logout)
+
+---
+
+### Requirement: ADDED FeedbackModal opens on help button click
+
+The system SHALL open a feedback modal when the authenticated user clicks the `?` button.
+
+#### Scenario: Modal opens on click
+
+- **Given** the user is authenticated and the `?` button is visible
+- **When** the user clicks `?`
+- **Then** the `FeedbackModal` opens, displaying the `FeedbackForm`
+
+#### Scenario: Modal closes on cancel
+
+- **Given** the `FeedbackModal` is open
+- **When** the user clicks Cancel
+- **Then** the modal closes and the NavBar is restored to its normal state
+
+---
+
+### Requirement: ADDED FeedbackForm — type toggle, title, description
+
+The system SHALL provide a form with a type toggle (Bug Report / Feature Request), a title field, and a description field.
+
+#### Scenario: Default type is Bug Report
+
+- **Given** the `FeedbackModal` is opened
+- **When** the form renders for the first time
+- **Then** the Bug Report option is selected by default
+
+#### Scenario: Toggle switches to Feature Request
+
+- **Given** the FeedbackForm is displayed with Bug Report selected
+- **When** the user clicks Feature Request
+- **Then** the Feature Request option becomes selected and Bug Report is deselected
+
+#### Scenario: Submit is disabled when title is empty
+
+- **Given** the FeedbackForm is displayed
+- **When** the title field is empty
+- **Then** the Submit button is disabled
+
+#### Scenario: Submit is enabled when title is non-empty
+
+- **Given** the FeedbackForm is displayed
+- **When** the user types a non-empty title
+- **Then** the Submit button becomes enabled
+
+#### Scenario: Description enforces character limit
+
+- **Given** the FeedbackForm is displayed
+- **When** the user types more than 2000 characters in the description field
+- **Then** input beyond 2000 characters is rejected (field enforces maxLength)
+
+---
+
+### Requirement: ADDED POST /api/feedback — creates GitHub issue
+
+The system SHALL create a GitHub issue via the GitHub REST API when a valid authenticated request is received.
+
+#### Scenario: Successful bug report submission
+
+- **Given** an authenticated user submits the form with type "bug", a title, and a description
+- **When** `POST /api/feedback` is called
+- **Then** a GitHub issue is created with label `bug`, title from the form, and a body containing the description and auto-attached context (username, email, page URL, user-agent)
+- **And** the API returns HTTP 201
+
+#### Scenario: Successful feature request submission
+
+- **Given** an authenticated user submits the form with type "feature" and a title
+- **When** `POST /api/feedback` is called
+- **Then** a GitHub issue is created with label `enhancement`
+- **And** the API returns HTTP 201
+
+#### Scenario: Modal shows success state after submission
+
+- **Given** `POST /api/feedback` returns 201
+- **When** the submit response is received
+- **Then** the modal displays a success message and the form is no longer editable
+
+#### Scenario: Modal shows error state on GitHub API failure
+
+- **Given** the GitHub API returns a non-2xx response
+- **When** the submit response is received
+- **Then** the API route returns HTTP 502 and the modal displays a user-visible error message
+
+---
+
+### Requirement: ADDED IP rate limiting — 12 submissions per hour
+
+The system SHALL reject feedback submissions from an IP address that has exceeded 12 submissions in the current one-hour window.
+
+#### Scenario: Submission accepted within rate limit
+
+- **Given** an IP address has submitted fewer than 12 times in the current hour
+- **When** `POST /api/feedback` is called
+- **Then** the submission is processed normally
+
+#### Scenario: Submission rejected at rate limit
+
+- **Given** an IP address has submitted 12 times in the current hour
+- **When** `POST /api/feedback` is called a 13th time
+- **Then** the API returns HTTP 429 with a rate limit error message
+- **And** no GitHub issue is created
+
+#### Scenario: Rate limit window resets after one hour
+
+- **Given** an IP address hit the rate limit in a previous one-hour window
+- **When** one hour has elapsed and the TTL document has expired
+- **Then** the next submission from that IP is accepted (count resets to 1)
+
+---
+
+### Requirement: ADDED Auto-context in GitHub issue body
+
+The system SHALL append submitter context to every created GitHub issue body.
+
+#### Scenario: Issue body includes username, email, page URL, user-agent
+
+- **Given** an authenticated user submits feedback from page `/combat/abc123`
+- **When** the GitHub issue is created
+- **Then** the issue body contains:
+  - `**Submitted by:** @username (email@example.com)`
+  - `**Page:** https://…/combat/abc123`
+  - `**User-Agent:** <request User-Agent header value>`
+  - The user's description text
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED NavBar — authenticated nav element set
+
+The NavBar SHALL include a `?` button (help/feedback trigger) as a new authenticated-only element, positioned on the right side before the Logout button.
+
+#### Scenario: NavBar right side includes help button when authenticated
+
+- **Given** the user is authenticated
+- **When** the NavBar renders
+- **Then** the right side contains `[?] [Logout]` in that order
+
+---
+
+## REMOVED Requirements
+
+None. This change only adds new capabilities and modifies the NavBar element set.
+
+---
+
+## Traceability
+
+- Proposal: auth-gated `?` button → Requirement: ADDED NavBar help button — auth-gated
+- Proposal: FeedbackModal + FeedbackForm with toggle → Requirement: ADDED FeedbackModal opens; ADDED FeedbackForm
+- Proposal: Server-side GitHub API call → Requirement: ADDED POST /api/feedback
+- Proposal: IP rate limit 12/hr → Requirement: ADDED IP rate limiting
+- Proposal: Auto-attach context → Requirement: ADDED Auto-context in GitHub issue body
+- Design Decision 1 (standalone FeedbackForm) → Requirement: ADDED FeedbackModal; ADDED FeedbackForm
+- Design Decision 2 (server-side API route) → Requirement: ADDED POST /api/feedback
+- Design Decision 3 (MongoDB TTL rate limit) → Requirement: ADDED IP rate limiting
+- Design Decision 4 (auto-context body) → Requirement: ADDED Auto-context in GitHub issue body
+- Design Decision 5 (NavBar placement) → Requirement: MODIFIED NavBar; ADDED NavBar help button
+- Design Decision 6 (label mapping) → Requirement: ADDED POST /api/feedback (bug/feature scenarios)
+- Requirements → Tasks: all requirements map to tasks in `tasks.md`
+
+---
+
+## Non-Functional Acceptance Criteria
+
+> **Important:** NFAC scenarios MUST NOT duplicate scenarios already expressed in the functional requirements above.
+
+### Requirement: Security
+
+See functional scenarios: "Help button absent when unauthenticated", "Submission rejected at rate limit".
+
+#### Scenario: GitHub token not present in client bundle
+
+- **Given** the Next.js production build is generated
+- **When** the client-side JavaScript bundle is inspected
+- **Then** the string `GITHUB_FEEDBACK_TOKEN` and its value do not appear in any client bundle file
+
+#### Scenario: Unauthenticated POST rejected
+
+- **Given** a request is made to `POST /api/feedback` without a valid session
+- **When** the route handler executes
+- **Then** the route returns HTTP 401 before any rate limit check or GitHub API call
+
+### Requirement: Reliability
+
+#### Scenario: GitHub API error does not cause unhandled exception
+
+- **Given** the GitHub API returns a 500 error
+- **When** `POST /api/feedback` processes the response
+- **Then** the route catches the error, logs it server-side, and returns HTTP 502 with a user-readable message — no unhandled promise rejection occurs
+
+### Requirement: Operability
+
+#### Scenario: MongoDB rate limit collection has TTL index
+
+- **Given** the `feedbackRateLimits` collection is initialized
+- **When** the MongoDB index list for that collection is inspected
+- **Then** a TTL index on `windowResetAt` with `expireAfterSeconds: 0` is present

--- a/tests/unit/app/api/feedback/route.test.ts
+++ b/tests/unit/app/api/feedback/route.test.ts
@@ -65,6 +65,7 @@ describe('POST /api/feedback', () => {
   const originalToken = process.env.GITHUB_FEEDBACK_TOKEN;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     originalFetch = global.fetch;
     mockAuthState.payload = MOCK_AUTH;
     mockedRateLimit.mockResolvedValue({ allowed: true });
@@ -102,11 +103,13 @@ describe('POST /api/feedback', () => {
   it('returns 400 when title is empty', async () => {
     const res = await POST(makeRequest({ ...VALID_BODY, title: '' }));
     expect(res.status).toBe(400);
+    expect(mockedRateLimit).not.toHaveBeenCalled();
   });
 
   it('returns 400 when type is invalid', async () => {
     const res = await POST(makeRequest({ ...VALID_BODY, type: 'other' }));
     expect(res.status).toBe(400);
+    expect(mockedRateLimit).not.toHaveBeenCalled();
   });
 
   it('creates GitHub issue for bug report and returns 201', async () => {

--- a/tests/unit/app/api/feedback/route.test.ts
+++ b/tests/unit/app/api/feedback/route.test.ts
@@ -100,6 +100,13 @@ describe('POST /api/feedback', () => {
     expect(body.error).toMatch(/rate limit/i);
   });
 
+  it('returns 400 when body is not an object', async () => {
+    const req = makeRouteRequest('http://localhost/api/feedback', 'POST', null);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockedRateLimit).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when title is empty', async () => {
     const res = await POST(makeRequest({ ...VALID_BODY, title: '' }));
     expect(res.status).toBe(400);

--- a/tests/unit/utils/http.test.ts
+++ b/tests/unit/utils/http.test.ts
@@ -59,4 +59,14 @@ describe('extractIp', () => {
     const req = makeRequest({ 'x-forwarded-for': ':' });
     expect(extractIp(req)).toBe('unknown');
   });
+
+  it('rejects multiple double-colon compressions', () => {
+    const req = makeRequest({ 'x-forwarded-for': '2001::db8::1' });
+    expect(extractIp(req)).toBe('unknown');
+  });
+
+  it('rejects IPv6 with more than 8 segments', () => {
+    const req = makeRequest({ 'x-forwarded-for': '1:2:3:4:5:6:7:8:9' });
+    expect(extractIp(req)).toBe('unknown');
+  });
 });

--- a/tests/unit/utils/http.test.ts
+++ b/tests/unit/utils/http.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { extractIp } from '@/lib/utils/http';
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/test', { headers });
+}
+
+describe('extractIp', () => {
+  it('returns the first IP from x-forwarded-for when valid IPv4', () => {
+    const req = makeRequest({ 'x-forwarded-for': '1.2.3.4, 10.0.0.1' });
+    expect(extractIp(req)).toBe('1.2.3.4');
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', () => {
+    const req = makeRequest({ 'x-real-ip': '5.6.7.8' });
+    expect(extractIp(req)).toBe('5.6.7.8');
+  });
+
+  it('returns unknown when no IP headers present', () => {
+    const req = makeRequest();
+    expect(extractIp(req)).toBe('unknown');
+  });
+
+  it('rejects malformed x-forwarded-for and falls back to x-real-ip', () => {
+    const req = makeRequest({
+      'x-forwarded-for': 'not-an-ip',
+      'x-real-ip': '9.9.9.9',
+    });
+    expect(extractIp(req)).toBe('9.9.9.9');
+  });
+
+  it('returns unknown when both headers are malformed', () => {
+    const req = makeRequest({
+      'x-forwarded-for': 'evil; DROP TABLE',
+      'x-real-ip': 'also-bad',
+    });
+    expect(extractIp(req)).toBe('unknown');
+  });
+
+  it('accepts a valid IPv6 address', () => {
+    const req = makeRequest({ 'x-forwarded-for': '2001:db8::1' });
+    expect(extractIp(req)).toBe('2001:db8::1');
+  });
+
+  it('rejects protocol-relative injection attempt in forwarded header', () => {
+    const req = makeRequest({ 'x-forwarded-for': '//evil.example' });
+    expect(extractIp(req)).toBe('unknown');
+  });
+});

--- a/tests/unit/utils/http.test.ts
+++ b/tests/unit/utils/http.test.ts
@@ -49,4 +49,14 @@ describe('extractIp', () => {
     const req = makeRequest({ 'x-forwarded-for': '//evil.example' });
     expect(extractIp(req)).toBe('unknown');
   });
+
+  it('rejects malformed IPv6 with triple colon', () => {
+    const req = makeRequest({ 'x-forwarded-for': '2001:::1' });
+    expect(extractIp(req)).toBe('unknown');
+  });
+
+  it('rejects single colon as IPv6', () => {
+    const req = makeRequest({ 'x-forwarded-for': ':' });
+    expect(extractIp(req)).toBe('unknown');
+  });
 });


### PR DESCRIPTION
Post-merge security fixes for the feedback help menu (PR #456):

- Validate body before rate-limit DB call (validation-before-db rule)
- Inline IP validation for x-forwarded-for header (rejects malformed values)
- Sanitize User-Agent before embedding in GitHub issue body (strips control chars and Markdown)
- Unit tests for extractIp validation

Relates to #456