### PR TITLE
feat: replace chapter select with display block and per-row activate controls

### DIFF
--- a/app/campaigns/CampaignEditor.tsx
+++ b/app/campaigns/CampaignEditor.tsx
@@ -147,26 +147,26 @@ export function CampaignEditor({
 
         {chaptersExpanded && (
           <div className="p-4 border-t border-gray-800/50 space-y-4">
-            {/* Active Chapter dropdown picker (if chapters exist) */}
+            {/* Active Chapter display (if chapters exist) */}
             {chapters.length > 0 ? (
-              <div className="mb-4 bg-gray-800/20 p-3 rounded-lg border border-gray-800/40">
+              <div
+                data-testid="current-chapter-display"
+                className="mb-4 bg-gray-800/20 p-3 rounded-lg border border-gray-800/40"
+              >
                 <label className="block text-xs font-bold uppercase tracking-wider text-gray-400 mb-1.5">
                   Current Chapter
                 </label>
-                <select
-                  data-testid="current-chapter-select"
-                  value={currentChapterId || ''}
-                  onChange={(e) => setCurrentChapterId(e.target.value)}
-                  disabled={saving}
-                  className="w-full text-sm bg-gray-950 border border-gray-700 hover:border-gray-600 rounded px-3 py-2 text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-all cursor-pointer"
-                >
-                  <option value="">-- No Active Chapter --</option>
-                  {chapters.map((ch) => (
-                    <option key={ch.id} value={ch.id}>
-                      Ch. {ch.order + 1}: {ch.title || 'Untitled Chapter'}
-                    </option>
-                  ))}
-                </select>
+                {(() => {
+                  const activeIndex = chapters.findIndex((ch) => ch.id === currentChapterId);
+                  const activeCh = activeIndex >= 0 ? chapters[activeIndex] : undefined;
+                  return activeCh ? (
+                    <p className="text-sm text-gray-200">
+                      Ch. {activeIndex + 1}: {activeCh.title || 'Untitled Chapter'}
+                    </p>
+                  ) : (
+                    <p className="text-sm text-gray-500 italic">-- No active chapter --</p>
+                  );
+                })()}
               </div>
             ) : (
               <p className="text-sm text-gray-400 italic py-2 text-center">
@@ -195,6 +195,26 @@ export function CampaignEditor({
                       placeholder="e.g. Arrival at the Village"
                       className="flex-1 bg-gray-950 border border-gray-700 hover:border-gray-600 focus:border-blue-500 rounded px-3 py-1.5 text-sm text-gray-200 focus:outline-none transition-all duration-200"
                     />
+
+                    {ch.id === currentChapterId ? (
+                      <span
+                        data-testid={`active-chapter-indicator-${ch.id}`}
+                        className="bg-green-900/40 text-green-400 border border-green-800/40 text-xs rounded px-2 py-0.5 font-semibold select-none"
+                      >
+                        ACTIVE
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        data-testid={`activate-chapter-${ch.id}`}
+                        title="Mark as current chapter"
+                        onClick={() => setCurrentChapterId(ch.id)}
+                        disabled={saving}
+                        className="px-2 py-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:pointer-events-none text-xs rounded text-gray-300 transition-all cursor-pointer"
+                      >
+                        🚩
+                      </button>
+                    )}
 
                     {/* Move buttons */}
                     <div className="flex gap-1">

--- a/app/campaigns/CampaignEditor.tsx
+++ b/app/campaigns/CampaignEditor.tsx
@@ -196,12 +196,17 @@ export function CampaignEditor({
                     />
 
                     {ch.id === currentChapterId ? (
-                      <span
+                      <button
+                        type="button"
                         data-testid={`active-chapter-indicator-${ch.id}`}
-                        className="bg-green-900/40 text-green-400 border border-green-800/40 text-xs rounded px-2 py-0.5 font-semibold select-none"
+                        title="Clear active chapter"
+                        aria-label="Clear active chapter"
+                        onClick={() => setCurrentChapterId(undefined)}
+                        disabled={saving}
+                        className="bg-green-900/40 text-green-400 border border-green-800/40 hover:bg-red-900/40 hover:text-red-400 hover:border-red-800/40 disabled:opacity-30 disabled:pointer-events-none text-xs rounded px-2 py-0.5 font-semibold transition-all cursor-pointer"
                       >
                         ACTIVE
-                      </span>
+                      </button>
                     ) : (
                       <button
                         type="button"

--- a/app/campaigns/CampaignEditor.tsx
+++ b/app/campaigns/CampaignEditor.tsx
@@ -153,9 +153,9 @@ export function CampaignEditor({
                 data-testid="current-chapter-display"
                 className="mb-4 bg-gray-800/20 p-3 rounded-lg border border-gray-800/40"
               >
-                <label className="block text-xs font-bold uppercase tracking-wider text-gray-400 mb-1.5">
+                <p className="block text-xs font-bold uppercase tracking-wider text-gray-400 mb-1.5">
                   Current Chapter
-                </label>
+                </p>
                 {(() => {
                   const activeIndex = chapters.findIndex((ch) => ch.id === currentChapterId);
                   const activeCh = activeIndex >= 0 ? chapters[activeIndex] : undefined;
@@ -208,11 +208,12 @@ export function CampaignEditor({
                         type="button"
                         data-testid={`activate-chapter-${ch.id}`}
                         title="Mark as current chapter"
+                        aria-label="Mark as current chapter"
                         onClick={() => setCurrentChapterId(ch.id)}
                         disabled={saving}
                         className="px-2 py-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:pointer-events-none text-xs rounded text-gray-300 transition-all cursor-pointer"
                       >
-                        🚩
+                        <span aria-hidden="true">🚩</span>
                       </button>
                     )}
 

--- a/app/campaigns/CampaignEditor.tsx
+++ b/app/campaigns/CampaignEditor.tsx
@@ -111,6 +111,9 @@ export function CampaignEditor({
     }
   };
 
+  const activeChapterIndex = chapters.findIndex((ch) => ch.id === currentChapterId);
+  const activeChapter = activeChapterIndex >= 0 ? chapters[activeChapterIndex] : undefined;
+
   return (
     <EditorShell
       title={isNew ? 'Create Campaign' : 'Edit Campaign'}
@@ -156,17 +159,13 @@ export function CampaignEditor({
                 <p className="block text-xs font-bold uppercase tracking-wider text-gray-400 mb-1.5">
                   Current Chapter
                 </p>
-                {(() => {
-                  const activeIndex = chapters.findIndex((ch) => ch.id === currentChapterId);
-                  const activeCh = activeIndex >= 0 ? chapters[activeIndex] : undefined;
-                  return activeCh ? (
-                    <p className="text-sm text-gray-200">
-                      Ch. {activeIndex + 1}: {activeCh.title || 'Untitled Chapter'}
-                    </p>
-                  ) : (
-                    <p className="text-sm text-gray-500 italic">-- No active chapter --</p>
-                  );
-                })()}
+                {activeChapter ? (
+                  <p className="text-sm text-gray-200">
+                    Ch. {activeChapterIndex + 1}: {activeChapter.title || 'Untitled Chapter'}
+                  </p>
+                ) : (
+                  <p className="text-sm text-gray-500 italic">-- No active chapter --</p>
+                )}
               </div>
             ) : (
               <p className="text-sm text-gray-400 italic py-2 text-center">

--- a/tests/unit/components/CampaignEditor.test.tsx
+++ b/tests/unit/components/CampaignEditor.test.tsx
@@ -309,8 +309,8 @@ describe('CampaignEditor', () => {
       const { user } = renderEditor();
       // Open accordion first to test the zero-chapters branch, not the collapsed state.
       await user.click(screen.getByRole('button', { name: /chapters/i }));
-      expect(screen.getByText('No chapters defined')).toBeInTheDocument();
       expect(screen.queryByTestId('current-chapter-display')).not.toBeInTheDocument();
+      expect(screen.getByText('No chapters defined')).toBeInTheDocument();
     });
 
     it('does not render the old select element', () => {

--- a/tests/unit/components/CampaignEditor.test.tsx
+++ b/tests/unit/components/CampaignEditor.test.tsx
@@ -17,7 +17,8 @@ const BASE_CAMPAIGN: Campaign = {
 };
 
 function renderEditor(props: Partial<Parameters<typeof CampaignEditor>[0]> = {}) {
-  return render(
+  const user = userEvent.setup();
+  render(
     <CampaignEditor
       campaign={BASE_CAMPAIGN}
       onSave={jest.fn()}
@@ -26,6 +27,7 @@ function renderEditor(props: Partial<Parameters<typeof CampaignEditor>[0]> = {})
       {...props}
     />
   );
+  return { user };
 }
 
 async function openChapters(user: UserEvent) {
@@ -104,17 +106,15 @@ describe('CampaignEditor', () => {
 
   describe('saving', () => {
     it('calls onSave with trimmed name', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({ onSave });
+      const { user } = renderEditor({ onSave });
       await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
       expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ name: 'Test Campaign' }));
     });
 
     it('calls onSave with trimmed moduleName', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, moduleName: '  DH  ' }, onSave });
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, moduleName: '  DH  ' }, onSave });
       await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
       expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ moduleName: 'DH' }));
     });
@@ -122,9 +122,8 @@ describe('CampaignEditor', () => {
     it.each(['completed', 'on-hold'] as const)(
       'calls onSave with status %s when dropdown changes',
       async (status) => {
-        const user = userEvent.setup();
         const onSave = jest.fn();
-        renderEditor({ onSave });
+        const { user } = renderEditor({ onSave });
         await user.selectOptions(screen.getByTestId('status-select'), status);
         await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
         expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ status }));
@@ -134,9 +133,8 @@ describe('CampaignEditor', () => {
 
   describe('cancel', () => {
     it('calls onCancel when Cancel button clicked', async () => {
-      const user = userEvent.setup();
       const onCancel = jest.fn();
-      renderEditor({ onCancel });
+      const { user } = renderEditor({ onCancel });
       await user.click(screen.getByRole('button', { name: 'Cancel' }));
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
@@ -163,9 +161,8 @@ describe('CampaignEditor', () => {
     });
 
     it('save with no chapters calls onSave with chapters: []', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({ onSave });
+      const { user } = renderEditor({ onSave });
       await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
       expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ chapters: [] }));
     });
@@ -173,8 +170,7 @@ describe('CampaignEditor', () => {
 
   describe('chapters editing', () => {
     it('toggles chapters editing section when accordion button is clicked', async () => {
-      const user = userEvent.setup();
-      renderEditor();
+      const { user } = renderEditor();
       expect(screen.queryByText('+ Add Chapter')).not.toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: /chapters/i }));
@@ -185,8 +181,7 @@ describe('CampaignEditor', () => {
     });
 
     it('adds a new chapter row when "+ Add Chapter" is clicked', async () => {
-      const user = userEvent.setup();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [] } });
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [] } });
 
       await openChapters(user);
 
@@ -202,9 +197,8 @@ describe('CampaignEditor', () => {
     });
 
     it('removes a chapter, shifts subsequent ones, and clears active chapter if deleted', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({
+      const { user } = renderEditor({
         campaign: { ...BASE_CAMPAIGN, currentChapterId: 'ch-2', chapters: CHAPTER_TRIO },
         onSave,
       });
@@ -231,9 +225,8 @@ describe('CampaignEditor', () => {
     });
 
     it('reorders chapters with move buttons and updates order index', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_TRIO }, onSave });
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_TRIO }, onSave });
 
       await openChapters(user);
 
@@ -264,8 +257,7 @@ describe('CampaignEditor', () => {
     });
 
     it('updates chapter title correctly when typing in the input field', async () => {
-      const user = userEvent.setup();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [{ id: 'ch-1', title: 'Arrival', order: 0 }] } });
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [{ id: 'ch-1', title: 'Arrival', order: 0 }] } });
 
       await openChapters(user);
 
@@ -278,9 +270,8 @@ describe('CampaignEditor', () => {
     });
 
     it('sets currentChapterId to undefined when active chapter is removed', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({
+      const { user } = renderEditor({
         campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-2' },
         onSave,
       });
@@ -314,8 +305,11 @@ describe('CampaignEditor', () => {
       expect(screen.getByTestId('current-chapter-display')).toHaveTextContent('-- No active chapter --');
     });
 
-    it('display block is absent when no chapters exist', () => {
-      renderEditor();
+    it('display block is absent when no chapters exist (accordion open)', async () => {
+      const { user } = renderEditor();
+      // Open accordion first to test the zero-chapters branch, not the collapsed state.
+      await user.click(screen.getByRole('button', { name: /chapters/i }));
+      expect(screen.getByText('No chapters defined')).toBeInTheDocument();
       expect(screen.queryByTestId('current-chapter-display')).not.toBeInTheDocument();
     });
 
@@ -362,8 +356,7 @@ describe('CampaignEditor', () => {
     });
 
     it('clicking activate button transfers active state to that chapter', async () => {
-      const user = userEvent.setup();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
 
       await user.click(screen.getByTestId('activate-chapter-ch-2'));
 
@@ -374,9 +367,8 @@ describe('CampaignEditor', () => {
     });
 
     it('clicking activate button and saving sends updated currentChapterId', async () => {
-      const user = userEvent.setup();
       const onSave = jest.fn();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' }, onSave });
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' }, onSave });
 
       await user.click(screen.getByTestId('activate-chapter-ch-2'));
       await user.click(screen.getByRole('button', { name: 'Save Campaign' }));

--- a/tests/unit/components/CampaignEditor.test.tsx
+++ b/tests/unit/components/CampaignEditor.test.tsx
@@ -380,5 +380,32 @@ describe('CampaignEditor', () => {
       renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
       expect(screen.getByTestId('activate-chapter-ch-2')).not.toBeDisabled();
     });
+
+    it('ACTIVE indicator is a button with clear-active-chapter aria-label', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      const btn = screen.getByTestId('active-chapter-indicator-ch-1');
+      expect(btn.tagName).toBe('BUTTON');
+      expect(btn).toHaveAttribute('aria-label', 'Clear active chapter');
+    });
+
+    it('clicking ACTIVE indicator clears the active chapter', async () => {
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+
+      await user.click(screen.getByTestId('active-chapter-indicator-ch-1'));
+
+      expect(screen.getByTestId('current-chapter-display')).toHaveTextContent('-- No active chapter --');
+      expect(screen.queryByTestId('active-chapter-indicator-ch-1')).not.toBeInTheDocument();
+      expect(screen.getByTestId('activate-chapter-ch-1')).toBeInTheDocument();
+    });
+
+    it('clicking ACTIVE indicator and saving sends currentChapterId: undefined', async () => {
+      const onSave = jest.fn();
+      const { user } = renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' }, onSave });
+
+      await user.click(screen.getByTestId('active-chapter-indicator-ch-1'));
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ currentChapterId: undefined }));
+    });
   });
 });

--- a/tests/unit/components/CampaignEditor.test.tsx
+++ b/tests/unit/components/CampaignEditor.test.tsx
@@ -1,138 +1,392 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { UserEvent } from '@testing-library/user-event';
 import { CampaignEditor } from '@/app/campaigns/CampaignEditor';
-import { Campaign } from '@/lib/types';
+import type { Campaign } from '@/lib/types';
 
-const CH_A = { id: 'ch-a', title: 'Into the Dungeon', order: 0 };
-const CH_B = { id: 'ch-b', title: 'The Catacombs', order: 1 };
+const BASE_CAMPAIGN: Campaign = {
+  id: 'camp-1',
+  userId: 'user-1',
+  name: 'Test Campaign',
+  moduleName: 'LMoP',
+  chapters: [],
+  status: 'planning',
+  notes: '',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
 
-function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
-  return {
-    id: 'camp-1',
-    userId: 'user-1',
-    name: 'Test Campaign',
-    moduleName: 'Test Module',
-    chapters: [],
-    status: 'active',
-    notes: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    ...overrides,
-  };
-}
-
-function renderEditor(campaign: Campaign) {
-  const user = userEvent.setup();
-  render(
+function renderEditor(props: Partial<Parameters<typeof CampaignEditor>[0]> = {}) {
+  return render(
     <CampaignEditor
-      campaign={campaign}
+      campaign={BASE_CAMPAIGN}
       onSave={jest.fn()}
       onCancel={jest.fn()}
       isNew={false}
+      {...props}
     />
   );
-  return { user };
 }
 
-describe('CampaignEditor — display block (task 1a)', () => {
-  it('shows active chapter name in display block', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    const display = screen.getByTestId('current-chapter-display');
-    expect(display).toBeInTheDocument();
-    expect(display).toHaveTextContent('Ch. 1:');
-    expect(display).toHaveTextContent(CH_A.title);
+async function openChapters(user: UserEvent) {
+  if (!screen.queryByText('+ Add Chapter')) {
+    await user.click(screen.getByRole('button', { name: /chapters/i }));
+  }
+}
+
+const CHAPTER_PAIR = [
+  { id: 'ch-1', title: 'Arrival', order: 0 },
+  { id: 'ch-2', title: 'The Inn', order: 1 },
+];
+
+const CHAPTER_TRIO = [
+  { id: 'ch-1', title: 'Arrival', order: 0 },
+  { id: 'ch-2', title: 'The Inn', order: 1 },
+  { id: 'ch-3', title: 'The Dungeon', order: 2 },
+];
+
+// ---------------------------------------------------------------------------
+
+describe('CampaignEditor', () => {
+  describe('rendering', () => {
+    it('shows "Create Campaign" title when isNew', () => {
+      renderEditor({ isNew: true });
+      expect(screen.getByRole('heading', { level: 2, name: 'Create Campaign' })).toBeInTheDocument();
+    });
+
+    it('shows "Edit Campaign" title when not isNew', () => {
+      renderEditor({ isNew: false });
+      expect(screen.getByRole('heading', { level: 2, name: 'Edit Campaign' })).toBeInTheDocument();
+    });
+
+    it('populates name input from campaign', () => {
+      renderEditor();
+      expect(screen.getByLabelText('Campaign Name *')).toHaveValue('Test Campaign');
+    });
+
+    it('populates moduleName input from campaign', () => {
+      renderEditor();
+      expect(screen.getByLabelText('Module / Adventure')).toHaveValue('LMoP');
+    });
+
+    it('renders status dropdown with current value selected', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, status: 'on-hold' } });
+      expect(screen.getByTestId('status-select')).toHaveValue('on-hold');
+    });
+
+    it('renders notes textarea with current value', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, notes: 'Party at level 5' } });
+      expect(screen.getByTestId('notes-textarea')).toHaveValue('Party at level 5');
+    });
+
+    it('notes textarea has maxLength of 10000', () => {
+      renderEditor();
+      expect((screen.getByTestId('notes-textarea') as HTMLTextAreaElement).maxLength).toBe(10000);
+    });
+
+    it('renders character counter showing length/10000', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, notes: 'Hello' } });
+      expect(screen.getByText('5/10000')).toBeInTheDocument();
+    });
   });
 
-  it('shows placeholder when no active chapter is set', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: undefined }));
-    const display = screen.getByTestId('current-chapter-display');
-    expect(display).toHaveTextContent('-- No active chapter --');
+  describe('validation', () => {
+    it('save button is disabled when name is empty', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, name: '' } });
+      expect(screen.getByRole('button', { name: 'Save Campaign' })).toBeDisabled();
+    });
+
+    it('save button is enabled when name has content', () => {
+      renderEditor();
+      expect(screen.getByRole('button', { name: 'Save Campaign' })).not.toBeDisabled();
+    });
   });
 
-  it('display block is absent when no chapters exist', () => {
-    renderEditor(makeCampaign({ chapters: [] }));
-    expect(screen.queryByTestId('current-chapter-display')).not.toBeInTheDocument();
-  });
+  describe('saving', () => {
+    it('calls onSave with trimmed name', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({ onSave });
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ name: 'Test Campaign' }));
+    });
 
-  it('does not render the old select element', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A] }));
-    expect(screen.queryByTestId('current-chapter-select')).not.toBeInTheDocument();
-  });
-});
+    it('calls onSave with trimmed moduleName', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, moduleName: '  DH  ' }, onSave });
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ moduleName: 'DH' }));
+    });
 
-describe('CampaignEditor — ACTIVE pill (task 1b)', () => {
-  it('shows ACTIVE pill on the active chapter row', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    expect(screen.getByTestId(`active-chapter-indicator-${CH_A.id}`)).toBeInTheDocument();
-  });
-
-  it('does not show ACTIVE pill on inactive chapter rows', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    expect(screen.queryByTestId(`active-chapter-indicator-${CH_B.id}`)).not.toBeInTheDocument();
-  });
-
-  it('shows no ACTIVE pill when currentChapterId is unset', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: undefined }));
-    expect(screen.queryByTestId(`active-chapter-indicator-${CH_A.id}`)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(`active-chapter-indicator-${CH_B.id}`)).not.toBeInTheDocument();
-  });
-});
-
-describe('CampaignEditor — activate button (task 1c)', () => {
-  it('shows activate button on inactive rows', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    expect(screen.getByTestId(`activate-chapter-${CH_B.id}`)).toBeInTheDocument();
-  });
-
-  it('does not show activate button on the active row', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    expect(screen.queryByTestId(`activate-chapter-${CH_A.id}`)).not.toBeInTheDocument();
-  });
-
-  it('activate button has correct tooltip', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    expect(screen.getByTestId(`activate-chapter-${CH_B.id}`)).toHaveAttribute(
-      'title',
-      'Mark as current chapter'
+    it.each(['completed', 'on-hold'] as const)(
+      'calls onSave with status %s when dropdown changes',
+      async (status) => {
+        const user = userEvent.setup();
+        const onSave = jest.fn();
+        renderEditor({ onSave });
+        await user.selectOptions(screen.getByTestId('status-select'), status);
+        await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ status }));
+      },
     );
   });
 
-  it('clicking activate button transfers active state to that chapter', async () => {
-    const { user } = renderEditor(
-      makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id })
-    );
-
-    await user.click(screen.getByTestId(`activate-chapter-${CH_B.id}`));
-
-    const display = screen.getByTestId('current-chapter-display');
-    expect(display).toHaveTextContent(CH_B.title);
-    expect(screen.getByTestId(`active-chapter-indicator-${CH_B.id}`)).toBeInTheDocument();
-    expect(screen.queryByTestId(`active-chapter-indicator-${CH_A.id}`)).not.toBeInTheDocument();
-    expect(screen.getByTestId(`activate-chapter-${CH_A.id}`)).toBeInTheDocument();
+  describe('cancel', () => {
+    it('calls onCancel when Cancel button clicked', async () => {
+      const user = userEvent.setup();
+      const onCancel = jest.fn();
+      renderEditor({ onCancel });
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('activate button is not disabled in default (non-saving) state', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
-    expect(screen.getByTestId(`activate-chapter-${CH_B.id}`)).not.toBeDisabled();
+  describe('legacy fields removed', () => {
+    it('does not render currentChapter input', () => {
+      renderEditor();
+      expect(screen.queryByText(/Current Chapter/)).not.toBeInTheDocument();
+    });
+
+    it('does not render currentChapterOrder input', () => {
+      renderEditor();
+      expect(screen.queryByText(/Chapter Order/)).not.toBeInTheDocument();
+    });
   });
-});
 
-describe('CampaignEditor — existing functionality (regression)', () => {
-  it('move up/down buttons are still present', () => {
-    renderEditor(makeCampaign({ chapters: [CH_A, CH_B] }));
-    expect(screen.getByTestId('move-up-1')).toBeInTheDocument();
-    expect(screen.getByTestId('move-down-0')).toBeInTheDocument();
+  describe('chapters display', () => {
+    it('renders chapter list when chapters present', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_TRIO } });
+      expect(screen.getByDisplayValue('Arrival')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('The Inn')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('The Dungeon')).toBeInTheDocument();
+    });
+
+    it('save with no chapters calls onSave with chapters: []', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({ onSave });
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ chapters: [] }));
+    });
   });
 
-  it('removing the active chapter clears the display to placeholder', async () => {
-    const { user } = renderEditor(
-      makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id })
-    );
+  describe('chapters editing', () => {
+    it('toggles chapters editing section when accordion button is clicked', async () => {
+      const user = userEvent.setup();
+      renderEditor();
+      expect(screen.queryByText('+ Add Chapter')).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId('remove-chapter-0'));
+      await user.click(screen.getByRole('button', { name: /chapters/i }));
+      expect(screen.getByText('+ Add Chapter')).toBeInTheDocument();
 
-    const display = screen.getByTestId('current-chapter-display');
-    expect(display).toHaveTextContent('-- No active chapter --');
+      await user.click(screen.getByRole('button', { name: /chapters/i }));
+      expect(screen.queryByText('+ Add Chapter')).not.toBeInTheDocument();
+    });
+
+    it('adds a new chapter row when "+ Add Chapter" is clicked', async () => {
+      const user = userEvent.setup();
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [] } });
+
+      await openChapters(user);
+
+      expect(screen.getByText('No chapters defined')).toBeInTheDocument();
+
+      await user.click(screen.getByText('+ Add Chapter'));
+
+      const inputs = screen.getAllByTestId('chapter-title-input');
+      expect(inputs.length).toBe(1);
+      expect(inputs[0]).toHaveValue('');
+      expect(screen.queryByText('No chapters defined')).not.toBeInTheDocument();
+      expect(screen.getByTestId('current-chapter-display')).toBeInTheDocument();
+    });
+
+    it('removes a chapter, shifts subsequent ones, and clears active chapter if deleted', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({
+        campaign: { ...BASE_CAMPAIGN, currentChapterId: 'ch-2', chapters: CHAPTER_TRIO },
+        onSave,
+      });
+
+      await openChapters(user);
+
+      await user.click(screen.getByTestId('remove-chapter-1'));
+
+      const inputs = screen.getAllByTestId('chapter-title-input');
+      expect(inputs.length).toBe(2);
+      expect(inputs[0]).toHaveValue('Arrival');
+      expect(inputs[1]).toHaveValue('The Dungeon');
+
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chapters: [
+            { id: 'ch-1', title: 'Arrival', order: 0 },
+            { id: 'ch-3', title: 'The Dungeon', order: 1 },
+          ],
+          currentChapterId: undefined,
+        })
+      );
+    });
+
+    it('reorders chapters with move buttons and updates order index', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_TRIO }, onSave });
+
+      await openChapters(user);
+
+      await user.click(screen.getByTestId('move-up-1'));
+
+      let inputs = screen.getAllByTestId('chapter-title-input');
+      expect(inputs[0]).toHaveValue('The Inn');
+      expect(inputs[1]).toHaveValue('Arrival');
+      expect(inputs[2]).toHaveValue('The Dungeon');
+
+      await user.click(screen.getByTestId('move-down-0'));
+
+      inputs = screen.getAllByTestId('chapter-title-input');
+      expect(inputs[0]).toHaveValue('Arrival');
+      expect(inputs[1]).toHaveValue('The Inn');
+      expect(inputs[2]).toHaveValue('The Dungeon');
+
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chapters: [
+            { id: 'ch-1', title: 'Arrival', order: 0 },
+            { id: 'ch-2', title: 'The Inn', order: 1 },
+            { id: 'ch-3', title: 'The Dungeon', order: 2 },
+          ],
+        })
+      );
+    });
+
+    it('updates chapter title correctly when typing in the input field', async () => {
+      const user = userEvent.setup();
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [{ id: 'ch-1', title: 'Arrival', order: 0 }] } });
+
+      await openChapters(user);
+
+      const input = screen.getByTestId('chapter-title-input');
+      expect(input).toHaveValue('Arrival');
+
+      await user.clear(input);
+      await user.type(input, 'New Arrival');
+      expect(input).toHaveValue('New Arrival');
+    });
+
+    it('sets currentChapterId to undefined when active chapter is removed', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({
+        campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-2' },
+        onSave,
+      });
+
+      await openChapters(user);
+
+      const removeBtn = screen.getByTestId('remove-chapter-1');
+      expect(removeBtn).toBeInTheDocument();
+
+      await user.click(removeBtn);
+
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ currentChapterId: undefined }));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Chapter active indicator tests (campaign-chapter-active-indicator)
+  // ---------------------------------------------------------------------------
+
+  describe('current chapter display block', () => {
+    it('shows active chapter name in display block', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      const display = screen.getByTestId('current-chapter-display');
+      expect(display).toHaveTextContent('Ch. 1:');
+      expect(display).toHaveTextContent('Arrival');
+    });
+
+    it('shows placeholder when no active chapter is set', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: undefined } });
+      expect(screen.getByTestId('current-chapter-display')).toHaveTextContent('-- No active chapter --');
+    });
+
+    it('display block is absent when no chapters exist', () => {
+      renderEditor();
+      expect(screen.queryByTestId('current-chapter-display')).not.toBeInTheDocument();
+    });
+
+    it('does not render the old select element', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR } });
+      expect(screen.queryByTestId('current-chapter-select')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ACTIVE pill', () => {
+    it('shows ACTIVE pill on the active chapter row', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      expect(screen.getByTestId('active-chapter-indicator-ch-1')).toBeInTheDocument();
+    });
+
+    it('does not show ACTIVE pill on inactive chapter rows', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      expect(screen.queryByTestId('active-chapter-indicator-ch-2')).not.toBeInTheDocument();
+    });
+
+    it('shows no ACTIVE pill when currentChapterId is unset', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: undefined } });
+      expect(screen.queryByTestId('active-chapter-indicator-ch-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('active-chapter-indicator-ch-2')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('activate button', () => {
+    it('shows activate button on inactive rows', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      expect(screen.getByTestId('activate-chapter-ch-2')).toBeInTheDocument();
+    });
+
+    it('does not show activate button on the active row', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      expect(screen.queryByTestId('activate-chapter-ch-1')).not.toBeInTheDocument();
+    });
+
+    it('activate button has correct tooltip and aria-label', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      const btn = screen.getByTestId('activate-chapter-ch-2');
+      expect(btn).toHaveAttribute('title', 'Mark as current chapter');
+      expect(btn).toHaveAttribute('aria-label', 'Mark as current chapter');
+    });
+
+    it('clicking activate button transfers active state to that chapter', async () => {
+      const user = userEvent.setup();
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+
+      await user.click(screen.getByTestId('activate-chapter-ch-2'));
+
+      expect(screen.getByTestId('current-chapter-display')).toHaveTextContent('The Inn');
+      expect(screen.getByTestId('active-chapter-indicator-ch-2')).toBeInTheDocument();
+      expect(screen.queryByTestId('active-chapter-indicator-ch-1')).not.toBeInTheDocument();
+      expect(screen.getByTestId('activate-chapter-ch-1')).toBeInTheDocument();
+    });
+
+    it('clicking activate button and saving sends updated currentChapterId', async () => {
+      const user = userEvent.setup();
+      const onSave = jest.fn();
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' }, onSave });
+
+      await user.click(screen.getByTestId('activate-chapter-ch-2'));
+      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
+
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ currentChapterId: 'ch-2' }));
+    });
+
+    it('activate button is not disabled in default (non-saving) state', () => {
+      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-1' } });
+      expect(screen.getByTestId('activate-chapter-ch-2')).not.toBeDisabled();
+    });
   });
 });

--- a/tests/unit/components/CampaignEditor.test.tsx
+++ b/tests/unit/components/CampaignEditor.test.tsx
@@ -1,314 +1,138 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent, { UserEvent } from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import { CampaignEditor } from '@/app/campaigns/CampaignEditor';
-import type { Campaign } from '@/lib/types';
+import { Campaign } from '@/lib/types';
 
-const BASE_CAMPAIGN: Campaign = {
-  id: 'camp-1',
-  userId: 'user-1',
-  name: 'Test Campaign',
-  moduleName: 'LMoP',
-  chapters: [],
-  status: 'planning',
-  notes: '',
-  createdAt: new Date('2026-01-01'),
-  updatedAt: new Date('2026-01-01'),
-};
+const CH_A = { id: 'ch-a', title: 'Into the Dungeon', order: 0 };
+const CH_B = { id: 'ch-b', title: 'The Catacombs', order: 1 };
 
-function renderEditor(props: Partial<Parameters<typeof CampaignEditor>[0]> = {}) {
-  return render(
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: 'camp-1',
+    userId: 'user-1',
+    name: 'Test Campaign',
+    moduleName: 'Test Module',
+    chapters: [],
+    status: 'active',
+    notes: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function renderEditor(campaign: Campaign) {
+  const user = userEvent.setup();
+  render(
     <CampaignEditor
-      campaign={BASE_CAMPAIGN}
+      campaign={campaign}
       onSave={jest.fn()}
       onCancel={jest.fn()}
       isNew={false}
-      {...props}
     />
   );
+  return { user };
 }
 
-async function openChapters(user: UserEvent) {
-  if (!screen.queryByText('+ Add Chapter')) {
-    await user.click(screen.getByRole('button', { name: /chapters/i }));
-  }
-}
-
-const CHAPTER_PAIR = [
-  { id: 'ch-1', title: 'Arrival', order: 0 },
-  { id: 'ch-2', title: 'The Inn', order: 1 },
-];
-
-const CHAPTER_TRIO = [
-  { id: 'ch-1', title: 'Arrival', order: 0 },
-  { id: 'ch-2', title: 'The Inn', order: 1 },
-  { id: 'ch-3', title: 'The Dungeon', order: 2 },
-];
-
-// ---------------------------------------------------------------------------
-
-describe('CampaignEditor', () => {
-  describe('rendering', () => {
-    it('shows "Create Campaign" title when isNew', () => {
-      renderEditor({ isNew: true });
-      expect(screen.getByRole('heading', { level: 2, name: 'Create Campaign' })).toBeInTheDocument();
-    });
-
-    it('shows "Edit Campaign" title when not isNew', () => {
-      renderEditor({ isNew: false });
-      expect(screen.getByRole('heading', { level: 2, name: 'Edit Campaign' })).toBeInTheDocument();
-    });
-
-    it('populates name input from campaign', () => {
-      renderEditor();
-      expect(screen.getByLabelText('Campaign Name *')).toHaveValue('Test Campaign');
-    });
-
-    it('populates moduleName input from campaign', () => {
-      renderEditor();
-      expect(screen.getByLabelText('Module / Adventure')).toHaveValue('LMoP');
-    });
-
-    it('renders status dropdown with current value selected', () => {
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, status: 'on-hold' } });
-      expect(screen.getByTestId('status-select')).toHaveValue('on-hold');
-    });
-
-    it('renders notes textarea with current value', () => {
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, notes: 'Party at level 5' } });
-      expect(screen.getByTestId('notes-textarea')).toHaveValue('Party at level 5');
-    });
-
-    it('notes textarea has maxLength of 10000', () => {
-      renderEditor();
-      expect((screen.getByTestId('notes-textarea') as HTMLTextAreaElement).maxLength).toBe(10000);
-    });
-
-    it('renders character counter showing length/10000', () => {
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, notes: 'Hello' } });
-      expect(screen.getByText('5/10000')).toBeInTheDocument();
-    });
+describe('CampaignEditor — display block (task 1a)', () => {
+  it('shows active chapter name in display block', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    const display = screen.getByTestId('current-chapter-display');
+    expect(display).toBeInTheDocument();
+    expect(display).toHaveTextContent('Ch. 1:');
+    expect(display).toHaveTextContent(CH_A.title);
   });
 
-  describe('validation', () => {
-    it('save button is disabled when name is empty', () => {
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, name: '' } });
-      expect(screen.getByRole('button', { name: 'Save Campaign' })).toBeDisabled();
-    });
-
-    it('save button is enabled when name has content', () => {
-      renderEditor();
-      expect(screen.getByRole('button', { name: 'Save Campaign' })).not.toBeDisabled();
-    });
+  it('shows placeholder when no active chapter is set', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: undefined }));
+    const display = screen.getByTestId('current-chapter-display');
+    expect(display).toHaveTextContent('-- No active chapter --');
   });
 
-  describe('saving', () => {
-    it('calls onSave with trimmed name', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({ onSave });
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ name: 'Test Campaign' }));
-    });
+  it('display block is absent when no chapters exist', () => {
+    renderEditor(makeCampaign({ chapters: [] }));
+    expect(screen.queryByTestId('current-chapter-display')).not.toBeInTheDocument();
+  });
 
-    it('calls onSave with trimmed moduleName', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, moduleName: '  DH  ' }, onSave });
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ moduleName: 'DH' }));
-    });
+  it('does not render the old select element', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A] }));
+    expect(screen.queryByTestId('current-chapter-select')).not.toBeInTheDocument();
+  });
+});
 
-    it.each(['completed', 'on-hold'] as const)(
-      'calls onSave with status %s when dropdown changes',
-      async (status) => {
-        const user = userEvent.setup();
-        const onSave = jest.fn();
-        renderEditor({ onSave });
-        await user.selectOptions(screen.getByTestId('status-select'), status);
-        await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ status }));
-      },
+describe('CampaignEditor — ACTIVE pill (task 1b)', () => {
+  it('shows ACTIVE pill on the active chapter row', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    expect(screen.getByTestId(`active-chapter-indicator-${CH_A.id}`)).toBeInTheDocument();
+  });
+
+  it('does not show ACTIVE pill on inactive chapter rows', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    expect(screen.queryByTestId(`active-chapter-indicator-${CH_B.id}`)).not.toBeInTheDocument();
+  });
+
+  it('shows no ACTIVE pill when currentChapterId is unset', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: undefined }));
+    expect(screen.queryByTestId(`active-chapter-indicator-${CH_A.id}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`active-chapter-indicator-${CH_B.id}`)).not.toBeInTheDocument();
+  });
+});
+
+describe('CampaignEditor — activate button (task 1c)', () => {
+  it('shows activate button on inactive rows', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    expect(screen.getByTestId(`activate-chapter-${CH_B.id}`)).toBeInTheDocument();
+  });
+
+  it('does not show activate button on the active row', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    expect(screen.queryByTestId(`activate-chapter-${CH_A.id}`)).not.toBeInTheDocument();
+  });
+
+  it('activate button has correct tooltip', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    expect(screen.getByTestId(`activate-chapter-${CH_B.id}`)).toHaveAttribute(
+      'title',
+      'Mark as current chapter'
     );
   });
 
-  describe('cancel', () => {
-    it('calls onCancel when Cancel button clicked', async () => {
-      const user = userEvent.setup();
-      const onCancel = jest.fn();
-      renderEditor({ onCancel });
-      await user.click(screen.getByRole('button', { name: 'Cancel' }));
-      expect(onCancel).toHaveBeenCalledTimes(1);
-    });
+  it('clicking activate button transfers active state to that chapter', async () => {
+    const { user } = renderEditor(
+      makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id })
+    );
+
+    await user.click(screen.getByTestId(`activate-chapter-${CH_B.id}`));
+
+    const display = screen.getByTestId('current-chapter-display');
+    expect(display).toHaveTextContent(CH_B.title);
+    expect(screen.getByTestId(`active-chapter-indicator-${CH_B.id}`)).toBeInTheDocument();
+    expect(screen.queryByTestId(`active-chapter-indicator-${CH_A.id}`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`activate-chapter-${CH_A.id}`)).toBeInTheDocument();
   });
 
-  describe('legacy fields removed', () => {
-    it('does not render currentChapter input', () => {
-      renderEditor();
-      expect(screen.queryByText(/Current Chapter/)).not.toBeInTheDocument();
-    });
+  it('activate button is not disabled in default (non-saving) state', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id }));
+    expect(screen.getByTestId(`activate-chapter-${CH_B.id}`)).not.toBeDisabled();
+  });
+});
 
-    it('does not render currentChapterOrder input', () => {
-      renderEditor();
-      expect(screen.queryByText(/Chapter Order/)).not.toBeInTheDocument();
-    });
+describe('CampaignEditor — existing functionality (regression)', () => {
+  it('move up/down buttons are still present', () => {
+    renderEditor(makeCampaign({ chapters: [CH_A, CH_B] }));
+    expect(screen.getByTestId('move-up-1')).toBeInTheDocument();
+    expect(screen.getByTestId('move-down-0')).toBeInTheDocument();
   });
 
-  describe('chapters display', () => {
-    it('renders chapter list when chapters present', () => {
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_TRIO } });
-      expect(screen.getByDisplayValue('Arrival')).toBeInTheDocument();
-      expect(screen.getByDisplayValue('The Inn')).toBeInTheDocument();
-      expect(screen.getByDisplayValue('The Dungeon')).toBeInTheDocument();
-    });
+  it('removing the active chapter clears the display to placeholder', async () => {
+    const { user } = renderEditor(
+      makeCampaign({ chapters: [CH_A, CH_B], currentChapterId: CH_A.id })
+    );
 
-    it('save with no chapters calls onSave with chapters: []', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({ onSave });
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ chapters: [] }));
-    });
-  });
+    await user.click(screen.getByTestId('remove-chapter-0'));
 
-  describe('chapters editing', () => {
-    it('toggles chapters editing section when accordion button is clicked', async () => {
-      const user = userEvent.setup();
-      renderEditor();
-      expect(screen.queryByText('+ Add Chapter')).not.toBeInTheDocument();
-
-      await user.click(screen.getByRole('button', { name: /chapters/i }));
-      expect(screen.getByText('+ Add Chapter')).toBeInTheDocument();
-
-      await user.click(screen.getByRole('button', { name: /chapters/i }));
-      expect(screen.queryByText('+ Add Chapter')).not.toBeInTheDocument();
-    });
-
-    it('adds a new chapter row when "+ Add Chapter" is clicked', async () => {
-      const user = userEvent.setup();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [] } });
-
-      await openChapters(user);
-
-      expect(screen.getByText('No chapters defined')).toBeInTheDocument();
-
-      await user.click(screen.getByText('+ Add Chapter'));
-
-      const inputs = screen.getAllByTestId('chapter-title-input');
-      expect(inputs.length).toBe(1);
-      expect(inputs[0]).toHaveValue('');
-      expect(screen.queryByText('No chapters defined')).not.toBeInTheDocument();
-      expect(screen.getByTestId('current-chapter-select')).toBeInTheDocument();
-    });
-
-    it('removes a chapter, shifts subsequent ones, and clears active chapter if deleted', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({
-        campaign: { ...BASE_CAMPAIGN, currentChapterId: 'ch-2', chapters: CHAPTER_TRIO },
-        onSave,
-      });
-
-      await openChapters(user);
-
-      await user.click(screen.getByTestId('remove-chapter-1'));
-
-      const inputs = screen.getAllByTestId('chapter-title-input');
-      expect(inputs.length).toBe(2);
-      expect(inputs[0]).toHaveValue('Arrival');
-      expect(inputs[1]).toHaveValue('The Dungeon');
-
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(
-        expect.objectContaining({
-          chapters: [
-            { id: 'ch-1', title: 'Arrival', order: 0 },
-            { id: 'ch-3', title: 'The Dungeon', order: 1 },
-          ],
-          currentChapterId: undefined,
-        })
-      );
-    });
-
-    it('reorders chapters with move buttons and updates order index', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_TRIO }, onSave });
-
-      await openChapters(user);
-
-      await user.click(screen.getByTestId('move-up-1'));
-
-      let inputs = screen.getAllByTestId('chapter-title-input');
-      expect(inputs[0]).toHaveValue('The Inn');
-      expect(inputs[1]).toHaveValue('Arrival');
-      expect(inputs[2]).toHaveValue('The Dungeon');
-
-      await user.click(screen.getByTestId('move-down-0'));
-
-      inputs = screen.getAllByTestId('chapter-title-input');
-      expect(inputs[0]).toHaveValue('Arrival');
-      expect(inputs[1]).toHaveValue('The Inn');
-      expect(inputs[2]).toHaveValue('The Dungeon');
-
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(
-        expect.objectContaining({
-          chapters: [
-            { id: 'ch-1', title: 'Arrival', order: 0 },
-            { id: 'ch-2', title: 'The Inn', order: 1 },
-            { id: 'ch-3', title: 'The Dungeon', order: 2 },
-          ],
-        })
-      );
-    });
-
-    it('updates currentChapterId when a chapter is selected in active chapter select', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR }, onSave });
-
-      await openChapters(user);
-
-      expect(screen.getByTestId('current-chapter-select')).toBeInTheDocument();
-
-      await user.selectOptions(screen.getByTestId('current-chapter-select'), 'ch-2');
-
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ currentChapterId: 'ch-2' }));
-    });
-
-    it('updates chapter title correctly when typing in the input field', async () => {
-      const user = userEvent.setup();
-      renderEditor({ campaign: { ...BASE_CAMPAIGN, chapters: [{ id: 'ch-1', title: 'Arrival', order: 0 }] } });
-
-      await openChapters(user);
-
-      const input = screen.getByTestId('chapter-title-input');
-      expect(input).toHaveValue('Arrival');
-
-      await user.clear(input);
-      await user.type(input, 'New Arrival');
-      expect(input).toHaveValue('New Arrival');
-    });
-
-    it('sets currentChapterId to undefined when active chapter is removed', async () => {
-      const user = userEvent.setup();
-      const onSave = jest.fn();
-      renderEditor({
-        campaign: { ...BASE_CAMPAIGN, chapters: CHAPTER_PAIR, currentChapterId: 'ch-2' },
-        onSave,
-      });
-
-      await openChapters(user);
-
-      const removeBtn = screen.getByTestId('remove-chapter-1');
-      expect(removeBtn).toBeInTheDocument();
-
-      await user.click(removeBtn);
-
-      await user.click(screen.getByRole('button', { name: 'Save Campaign' }));
-      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ currentChapterId: undefined }));
-    });
+    const display = screen.getByTestId('current-chapter-display');
+    expect(display).toHaveTextContent('-- No active chapter --');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the `<select>` dropdown for current chapter selection with a display-only block and per-row inline controls, so DMs can see and set the active chapter without scrolling to the top.

## Changes

- **CampaignEditor.tsx**: Remove `<select data-testid="current-chapter-select">`. Add display-only `<div data-testid="current-chapter-display">` showing `Ch. N: Title` or `-- No active chapter --` (dimmed, italic). Add conditional ACTIVE pill (`active-chapter-indicator-{id}`) on the active row. Add 🚩 activate button (`activate-chapter-{id}`, tooltip "Mark as current chapter") on each inactive row; disabled while saving.
- **CampaignEditor.test.tsx**: Remove `current-chapter-select` tests; add display block, ACTIVE pill, and activate button tests.

## Testing

- `npm run test:unit` — all 2576 tests pass
- `npm run build` — build succeeds

Closes #446