### PR TITLE
docs: archive campaign-chapter-active-indicator (2026-07-01)

### DIFF
--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-07-01

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/design.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/design.md
@@ -1,0 +1,131 @@
+## Context
+
+- Relevant architecture: `app/campaigns/CampaignEditor.tsx` is a pure React client component (`'use client'`). All chapter state is local — `chapters`, `currentChapterId`, `setCurrentChapterId`. No server calls are involved in this change.
+- Dependencies: No external icon library. Project uses inline emoji and Unicode (▲, ▼, 📖). Tailwind CSS for styling.
+- Interfaces/contracts touched: `data-testid="current-chapter-select"` is removed. New test IDs introduced: `current-chapter-display`, `activate-chapter-{id}`, `active-chapter-indicator-{id}`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Replace the `<select>` with a display-only block showing the resolved active chapter name
+- Add a per-row active indicator (green "ACTIVE" pill) when a chapter is active
+- Add a per-row activate button (🚩, tooltip "Mark as current chapter") when a chapter is inactive
+- Keep ▲/▼ move buttons unchanged
+
+### Non-Goals
+
+- Drag-and-drop reordering (tracked in #462)
+- API or data model changes
+- Any changes outside `app/campaigns/CampaignEditor.tsx` and its test file
+
+## Decisions
+
+### Decision 1: Display-only current chapter block
+
+- Chosen: Replace `<select>` with a `<div>` containing a `<p>` (or `<span>`) that resolves the active chapter title. When `currentChapterId` is set, show `Ch. N: <title>` (same format as the former select option). When unset, show "-- No active chapter --" in dimmed, italic style (`text-gray-500 italic`).
+- Alternatives considered: Hide the block entirely when nothing is active (cleaner but removes discoverability of the concept for new users).
+- Rationale: Dimmed text matches the existing UI's convention for empty/placeholder states and keeps the layout stable.
+- Trade-offs: Slightly more JSX than hiding entirely, but better first-time-user experience.
+
+### Decision 2: Per-row active indicator — green pill
+
+- Chosen: A `<span>` with `data-testid="active-chapter-indicator-{ch.id}"` styled as a small green pill: `bg-green-900/40 text-green-400 border border-green-800/40 text-xs rounded px-2 py-0.5 font-semibold`. Text: "ACTIVE".
+- Alternatives considered: A colored left border on the row, a filled star emoji (★).
+- Rationale: Pill matches the "Remove" button's visual pattern (same sizing/border idiom). Green communicates "currently active" clearly. Text label is unambiguous vs. an icon alone.
+- Trade-offs: Adds a fixed-width element to the row; slightly more crowded, but the activate button is hidden for this row, so net width change is minimal.
+
+### Decision 3: Per-row activate button — flag emoji
+
+- Chosen: A `<button>` with `data-testid="activate-chapter-{ch.id}"`, emoji `🚩`, `title="Mark as current chapter"`, calling `setCurrentChapterId(ch.id)`. Styled similarly to move buttons: `px-2 py-1.5 bg-gray-800 hover:bg-gray-700 text-xs rounded text-gray-300 transition-all cursor-pointer`. Disabled when `saving`.
+- Alternatives considered: Text label "Set Active" (more explicit but wide), ▶ or ⚡ emoji.
+- Rationale: 🚩 is universally understood as "flag/mark this" and is compact. The `title` tooltip provides full context for screen readers and hover users.
+- Trade-offs: Emoji rendering can vary across OS/browser, but this is already the project's pattern (📖 in accordion header).
+
+### Decision 4: Row layout order
+
+- Chosen: `[Ch.N] [title input] [ACTIVE pill OR 🚩 button] [▲][▼] [Remove]`
+- Rationale: Grouping the chapter-identity controls (title, active state) together before the reorder controls (▲▼) and destructive control (Remove) follows a left-to-right logical flow: identify → status → reorder → delete.
+- Trade-offs: None significant.
+
+## Proposal to Design Mapping
+
+- Proposal element: Replace `<select>` with display-only block
+  - Design decision: Decision 1
+  - Validation approach: Unit test asserts `current-chapter-display` renders the resolved name; asserts no `current-chapter-select` in DOM.
+
+- Proposal element: Green "ACTIVE" pill per active row
+  - Design decision: Decision 2
+  - Validation approach: Unit test asserts `active-chapter-indicator-{id}` present only for the active chapter.
+
+- Proposal element: 🚩 activate button per inactive row
+  - Design decision: Decision 3
+  - Validation approach: Unit test clicks `activate-chapter-{id}` and asserts `current-chapter-display` updates; asserts button absent for already-active chapter.
+
+- Proposal element: ▲/▼ unchanged
+  - Design decision: Decision 4 (layout order)
+  - Validation approach: Existing move-button tests continue to pass.
+
+## Functional Requirements Mapping
+
+- Requirement: Display-only current chapter block shows active chapter name
+  - Design element: Decision 1 — `<div>` with resolved title
+  - Acceptance criteria reference: specs/chapter-active-indicator/spec.md
+  - Testability notes: Render with `currentChapterId` set; assert display text matches chapter title.
+
+- Requirement: Display-only block shows dimmed placeholder when no active chapter
+  - Design element: Decision 1 — conditional italic/dimmed text
+  - Acceptance criteria reference: specs/chapter-active-indicator/spec.md
+  - Testability notes: Render with `currentChapterId` undefined; assert placeholder text present.
+
+- Requirement: Active chapter row shows ACTIVE pill
+  - Design element: Decision 2
+  - Acceptance criteria reference: specs/chapter-active-indicator/spec.md
+  - Testability notes: Assert `active-chapter-indicator-{id}` present for active chapter, absent for others.
+
+- Requirement: Inactive chapter row shows activate button
+  - Design element: Decision 3
+  - Acceptance criteria reference: specs/chapter-active-indicator/spec.md
+  - Testability notes: Assert `activate-chapter-{id}` present for inactive chapters, absent for active chapter.
+
+- Requirement: Clicking activate button sets that chapter as active
+  - Design element: Decision 3 — `setCurrentChapterId(ch.id)` onClick
+  - Acceptance criteria reference: specs/chapter-active-indicator/spec.md
+  - Testability notes: Click `activate-chapter-{id}`; assert display block updates and ACTIVE pill moves to that row.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: accessibility
+  - Requirement: Activate button must have a visible tooltip and be keyboard-focusable
+  - Design element: `title="Mark as current chapter"` attribute; standard `<button>` element is natively focusable
+  - Acceptance criteria reference: specs/chapter-active-indicator/spec.md
+  - Testability notes: Assert `title` attribute on activate button. Full keyboard nav is out of scope for automated tests but should be manually verified.
+
+- Requirement category: consistency
+  - Requirement: New UI elements must match existing visual patterns
+  - Design element: Pill and button use same Tailwind sizing/border patterns as existing "Remove" button and move buttons
+  - Testability notes: Visual review; no automated test needed.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Removing `data-testid="current-chapter-select"` breaks existing tests
+  - Impact: CI failure if tests are not updated simultaneously
+  - Mitigation: Tasks artifact explicitly pairs JSX change with test update in the same step.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Post-merge regression in campaign save flow or active chapter persistence.
+- Rollback steps: Revert the PR. The change is purely UI-layer; no migrations or data changes exist.
+- Data migration considerations: None.
+- Verification after rollback: Run `npm run test:unit` and manually verify campaign edit screen renders the select again.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing test or lint error before requesting re-review.
+- If security checks fail: Do not merge. This change has no server-side impact, so security failures likely indicate an unrelated issue — investigate before merging.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours. Escalate to team lead after 48 hours.
+- Escalation path and timeout: If blocked >48 hours, raise in team standup.
+
+## Open Questions
+
+No open questions. All design decisions confirmed during explore session.

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/proposal.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/proposal.md
@@ -1,0 +1,66 @@
+## GitHub Issues
+
+- #446
+
+## Why
+
+- Problem statement: The "Current Chapter" field in the Campaign edit screen is a dropdown `<select>`, which requires users to scroll to the top of the chapter list to change the active chapter. There is no visual indicator on the chapter rows themselves showing which is active.
+- Why now: Issue #446 raised by product owner; the pattern is confusing — users must mentally map the dropdown selection back to the chapter row they are looking at.
+- Business/user impact: DMs managing multi-chapter campaigns must context-switch between the top control and the chapter list. Making activation inline reduces friction and makes the active state immediately visible.
+
+## Problem Space
+
+- Current behavior: A `<select>` dropdown above the chapter list lets the user pick the active chapter. Chapter rows have no active-state indicator.
+- Desired behavior: The top section becomes display-only (shows the active chapter name, or dimmed "-- No active chapter --" when unset). Each chapter row has a green "ACTIVE" pill when it is the active chapter, or a 🚩 activate button (tooltip: "Mark as current chapter") when it is not.
+- Constraints: No new state is needed — `currentChapterId` / `setCurrentChapterId` already exist. No icon library available; inline emoji/Unicode only (consistent with existing ▲▼ and 📖 usage).
+- Assumptions: The `<select>` test (`data-testid="current-chapter-select"`) will be removed and replaced with a display element and per-row activate buttons. Existing unit tests that target the select must be updated.
+- Edge cases considered:
+  - No chapters defined: display-only section is hidden (same as today — the select is only shown when `chapters.length > 0`).
+  - Active chapter is deleted: existing `handleRemoveChapter` already clears `currentChapterId` when the removed chapter was active — no change needed.
+  - All chapters are unnamed: display shows "Ch. N: Untitled Chapter" (mirrors current select option text).
+
+## Scope
+
+### In Scope
+
+- Replace `<select>` with a display-only block in `app/campaigns/CampaignEditor.tsx`
+- Add green "ACTIVE" pill to the active chapter row
+- Add 🚩 activate button (tooltip: "Mark as current chapter") to each inactive chapter row
+- Update/add unit tests in `tests/unit/components/CampaignEditor.test.tsx`
+
+### Out of Scope
+
+- Drag-and-drop reordering (deferred to #462)
+- Any changes to the data model, API, or persistence layer
+- Changes to how `currentChapterId` is displayed elsewhere (campaign cards, combat view)
+
+## What Changes
+
+- `app/campaigns/CampaignEditor.tsx`: Remove `<select>` control; add display-only chapter name block; add conditional pill/button per chapter row
+- `tests/unit/components/CampaignEditor.test.tsx`: Remove tests targeting `current-chapter-select`; add tests for display block, ACTIVE pill, and activate button
+
+## Risks
+
+- Risk: Removing `data-testid="current-chapter-select"` breaks existing tests that query it.
+  - Impact: Test suite failures if tests are not updated alongside the JSX change.
+  - Mitigation: Update tests in the same PR; the tasks artifact calls this out explicitly.
+
+## Open Questions
+
+No unresolved ambiguity. All design decisions were confirmed during exploration:
+1. Display-only block: dimmed text when no active chapter. ✓
+2. Active indicator: green "ACTIVE" pill. ✓
+3. Activate button: 🚩 emoji, tooltip "Mark as current chapter". ✓
+4. Button position: after move buttons, before Remove. ✓
+5. ▲/▼ buttons: unchanged (drag/drop deferred to #462). ✓
+
+## Non-Goals
+
+- Keyboard-accessible drag-and-drop (out of scope for this change; tracked in #462)
+- Changing any server-side or API behavior
+- Modifying how active chapter is displayed on the campaign card or in the combat view
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/specs/chapter-active-indicator/spec.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/specs/chapter-active-indicator/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Display-only current chapter block
+
+The system SHALL display the active chapter's name as non-interactive text above the chapter list when chapters exist.
+
+#### Scenario: Active chapter name is shown in display block
+
+- **Given** a campaign with chapters and `currentChapterId` set to an existing chapter
+- **When** the Campaign edit screen renders the Chapters section
+- **Then** a display element with `data-testid="current-chapter-display"` shows "Ch. N: <title>" matching the active chapter, with no `<select>` in the DOM
+
+#### Scenario: Placeholder shown when no active chapter is set
+
+- **Given** a campaign with chapters and `currentChapterId` undefined or not set
+- **When** the Campaign edit screen renders the Chapters section
+- **Then** `data-testid="current-chapter-display"` shows "-- No active chapter --" in dimmed, italic styling
+
+#### Scenario: Display block absent when no chapters exist
+
+- **Given** a campaign with no chapters defined
+- **When** the Campaign edit screen renders the Chapters section
+- **Then** `data-testid="current-chapter-display"` is not present in the DOM
+
+### Requirement: ADDED Active chapter row indicator
+
+The system SHALL render a visible "ACTIVE" pill on the chapter row that is currently the active chapter.
+
+#### Scenario: ACTIVE pill appears on the active chapter row
+
+- **Given** a campaign with multiple chapters and `currentChapterId` set to chapter X
+- **When** the chapter list renders
+- **Then** `data-testid="active-chapter-indicator-{X.id}"` is present on chapter X's row
+- **And** no other chapter row has an `active-chapter-indicator` test ID
+
+#### Scenario: No ACTIVE pill when no chapter is active
+
+- **Given** a campaign with chapters and `currentChapterId` undefined
+- **When** the chapter list renders
+- **Then** no element with a `data-testid` matching `active-chapter-indicator-*` is present
+
+### Requirement: ADDED Per-row activate button for inactive chapters
+
+The system SHALL render a 🚩 activate button on every chapter row that is not currently active.
+
+#### Scenario: Activate button appears on inactive chapter rows
+
+- **Given** a campaign with multiple chapters and `currentChapterId` set to chapter X
+- **When** the chapter list renders
+- **Then** every chapter row except X has a button with `data-testid="activate-chapter-{ch.id}"` and `title="Mark as current chapter"`
+- **And** chapter X's row does not have an `activate-chapter-*` button
+
+#### Scenario: Clicking activate button sets that chapter as active
+
+- **Given** a campaign with chapters where chapter A is active and chapter B is not
+- **When** the user clicks `activate-chapter-{B.id}`
+- **Then** `current-chapter-display` updates to show chapter B's name
+- **And** `active-chapter-indicator-{B.id}` appears on chapter B's row
+- **And** `active-chapter-indicator-{A.id}` is no longer present
+- **And** `activate-chapter-{A.id}` now appears on chapter A's row
+
+#### Scenario: Activate button is disabled while saving
+
+- **Given** the Campaign editor is in a saving state
+- **When** the chapter list renders
+- **Then** all activate buttons are disabled
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Chapter row layout includes status control
+
+The chapter row layout is updated from `[Ch.N] [title] [▲][▼] [Remove]` to `[Ch.N] [title] [ACTIVE pill OR 🚩 button] [▲][▼] [Remove]`.
+
+#### Scenario: Active chapter row layout
+
+- **Given** chapter X is the active chapter
+- **When** its row renders
+- **Then** the row contains: chapter number label, title input, ACTIVE pill (`active-chapter-indicator-{X.id}`), ▲ button, ▼ button, Remove button — in that order
+- **And** no activate button is present on this row
+
+#### Scenario: Inactive chapter row layout
+
+- **Given** chapter Y is not the active chapter
+- **When** its row renders
+- **Then** the row contains: chapter number label, title input, 🚩 activate button (`activate-chapter-{Y.id}`), ▲ button, ▼ button, Remove button — in that order
+- **And** no ACTIVE pill is present on this row
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Interactive current-chapter select dropdown
+
+The `<select data-testid="current-chapter-select">` control is removed from the Campaign editor UI.
+
+Reason for removal: Replaced by the display-only block (Decision 1) and per-row activate buttons (Decision 3) as specified in `design.md`. The select required users to scroll away from the chapter list to change the active chapter; the new design makes activation inline.
+
+## Traceability
+
+- Proposal: "Replace `<select>` with display-only block" → Requirement: ADDED Display-only current chapter block; REMOVED Interactive current-chapter select dropdown
+- Proposal: "Green ACTIVE pill per active row" → Requirement: ADDED Active chapter row indicator
+- Proposal: "🚩 activate button per inactive row" → Requirement: ADDED Per-row activate button for inactive chapters
+- Design Decision 1 → Requirement: ADDED Display-only current chapter block
+- Design Decision 2 → Requirement: ADDED Active chapter row indicator
+- Design Decision 3 → Requirement: ADDED Per-row activate button for inactive chapters
+- Design Decision 4 → Requirement: MODIFIED Chapter row layout
+- Requirements → Tasks: all requirements map to Task 1 (JSX changes) and Task 2 (test updates) in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+No latency budget applies — this change is purely client-side React state rendering with no new network requests.
+
+### Requirement: Security
+
+See functional scenarios above. No new access-control surface is introduced. The activate button calls `setCurrentChapterId` (local state only); no privileged API calls are involved.
+
+### Requirement: Reliability
+
+#### Scenario: Active chapter deleted while set as current
+
+- **Given** chapter X is the active chapter
+- **When** the user clicks Remove on chapter X's row
+- **Then** `currentChapterId` is cleared (existing behavior via `handleRemoveChapter`)
+- **And** `current-chapter-display` shows "-- No active chapter --"
+- **And** no orphaned ACTIVE pill remains in the list

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/specs/chapter-active-indicator/spec.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/specs/chapter-active-indicator/spec.md
@@ -10,7 +10,7 @@ The system SHALL display the active chapter's name as non-interactive text above
 
 - **Given** a campaign with chapters and `currentChapterId` set to an existing chapter
 - **When** the Campaign edit screen renders the Chapters section
-- **Then** a display element with `data-testid="current-chapter-display"` shows "Ch. N: <title>" matching the active chapter, with no `<select>` in the DOM
+- **Then** a display element with `data-testid="current-chapter-display"` shows `"Ch. N: <chapter title>"` matching the active chapter, with no `<select>` in the DOM
 
 #### Scenario: Placeholder shown when no active chapter is set
 
@@ -26,7 +26,7 @@ The system SHALL display the active chapter's name as non-interactive text above
 
 ### Requirement: ADDED Active chapter row indicator
 
-The system SHALL render a visible "ACTIVE" pill on the chapter row that is currently the active chapter.
+The system SHALL render a clickable "ACTIVE" button on the chapter row that is currently the active chapter. Clicking it clears `currentChapterId`, restoring parity with the empty-option behavior of the removed `<select>`.
 
 #### Scenario: ACTIVE pill appears on the active chapter row
 
@@ -35,7 +35,15 @@ The system SHALL render a visible "ACTIVE" pill on the chapter row that is curre
 - **Then** `data-testid="active-chapter-indicator-{X.id}"` is present on chapter X's row
 - **And** no other chapter row has an `active-chapter-indicator` test ID
 
-#### Scenario: No ACTIVE pill when no chapter is active
+#### Scenario: Clicking ACTIVE indicator clears the active chapter
+
+- **Given** chapter X is the active chapter
+- **When** the user clicks the `active-chapter-indicator-{X.id}` button
+- **Then** `currentChapterId` is cleared
+- **And** `current-chapter-display` shows "-- No active chapter --"
+- **And** no `active-chapter-indicator-*` element remains
+
+#### Scenario: No ACTIVE indicator when no chapter is active
 
 - **Given** a campaign with chapters and `currentChapterId` undefined
 - **When** the chapter list renders
@@ -104,7 +112,7 @@ Reason for removal: Replaced by the display-only block (Decision 1) and per-row 
 - Design Decision 2 → Requirement: ADDED Active chapter row indicator
 - Design Decision 3 → Requirement: ADDED Per-row activate button for inactive chapters
 - Design Decision 4 → Requirement: MODIFIED Chapter row layout
-- Requirements → Tasks: all requirements map to Task 1 (JSX changes) and Task 2 (test updates) in `tasks.md`
+- Requirements → Tasks: all requirements map to Task 1 (JSX changes) and Task 2 (test updates) in [`tasks.md`](../../tasks.md)
 
 ## Non-Functional Acceptance Criteria
 

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/tasks.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/tasks.md
@@ -1,0 +1,99 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/campaign-chapter-active-indicator` then immediately `git push -u origin feat/campaign-chapter-active-indicator`
+
+## Execution
+
+### Task 1 — Update CampaignEditor JSX
+
+File: `app/campaigns/CampaignEditor.tsx`
+
+- [x] **1a — Replace `<select>` with display-only block:** Remove the `<select data-testid="current-chapter-select">` and its wrapper. Add a display `<div data-testid="current-chapter-display">` that resolves the active chapter title from `chapters` + `currentChapterId`. Show `"Ch. N: <title>"` when active, or `"-- No active chapter --"` (dimmed, italic: `text-gray-500 italic`) when unset. Keep the block hidden when `chapters.length === 0` (same condition as the former select).
+
+- [x] **1b — Add ACTIVE pill to active chapter row:** In the chapter row map, after the title `<input>`, add a conditional `<span data-testid={`active-chapter-indicator-${ch.id}`} className="bg-green-900/40 text-green-400 border border-green-800/40 text-xs rounded px-2 py-0.5 font-semibold select-none">ACTIVE</span>` when `ch.id === currentChapterId`.
+
+- [x] **1c — Add 🚩 activate button to inactive rows:** In the chapter row map, after the title `<input>` (and after the conditional ACTIVE pill), add a conditional `<button type="button" data-testid={`activate-chapter-${ch.id}`} title="Mark as current chapter" onClick={() => setCurrentChapterId(ch.id)} disabled={saving} className="px-2 py-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:pointer-events-none text-xs rounded text-gray-300 transition-all cursor-pointer">🚩</button>` when `ch.id !== currentChapterId`.
+
+- [x] **1d — Verify row element order:** Confirm each row renders in order: chapter number label → title input → [ACTIVE pill OR 🚩 button] → ▲ button → ▼ button → Remove button.
+
+### Task 2 — Update unit tests
+
+File: `tests/unit/components/CampaignEditor.test.tsx`
+
+- [x] **2a — Remove `current-chapter-select` tests:** Delete or update any test that queries `data-testid="current-chapter-select"` or tests the dropdown interaction.
+
+- [x] **2b — Add display block tests:**
+  - Assert `current-chapter-display` shows the active chapter title when `currentChapterId` is set
+  - Assert `current-chapter-display` shows "-- No active chapter --" when `currentChapterId` is unset
+  - Assert `current-chapter-display` is absent when no chapters exist
+
+- [x] **2c — Add ACTIVE pill tests:**
+  - Assert `active-chapter-indicator-{id}` is present only on the active chapter's row
+  - Assert no `active-chapter-indicator-*` element exists when `currentChapterId` is unset
+
+- [x] **2d — Add activate button tests:**
+  - Assert `activate-chapter-{id}` is present on all inactive rows, absent on the active row
+  - Assert clicking `activate-chapter-{id}` updates `current-chapter-display` and moves the ACTIVE pill
+  - Assert activate buttons are disabled when `saving` is true
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] `npm run test:unit` — all tests pass
+- [x] `npm run build` — build succeeds with no errors
+- [x] `npm run type-check` (or `tsc --noEmit`) — no type errors (pre-existing errors only, none from this change)
+- [ ] Manually verify: open campaign editor with chapters, confirm display block, ACTIVE pill, and 🚩 button render correctly; click 🚩 on an inactive chapter and confirm active state transfers
+- [ ] All execution tasks marked complete
+
+## Remote push validation
+
+**Full path** (non-`.md` files changed):
+
+- **Unit tests** — `npm run test:unit` — all tests must pass
+- **Build** — `npm run build` — must succeed with no errors
+- Skip E2E for this change — it is a UI-only JSX refactor with no API changes
+
+If **ANY** required step fails, iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [x] Commit all changes to `feat/campaign-chapter-active-indicator` and push to remote
+- [x] Open PR from `feat/campaign-chapter-active-indicator` to `main`. PR body must include: **"Closes #446"** — PR #464
+- [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
+- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+Ownership metadata:
+
+- Implementer: agent
+- Reviewer(s): dougis
+- Required approvals: 1
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → `npm run test:unit && npm run build` → push → re-run checks
+- Review comment → address → commit → `npm run test:unit && npm run build` → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Sync approved spec delta to global spec: copy `openspec/changes/campaign-chapter-active-indicator/specs/chapter-active-indicator/spec.md` to `openspec/specs/chapter-active-indicator/spec.md`; update relative links in the copied file: replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/design.md` and `../../tasks.md` with `../../changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/tasks.md`
+- [ ] Archive the change: move `openspec/changes/campaign-chapter-active-indicator/` to `openspec/changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/` **stage both the new location and the deletion of the old location in a single commit** — do not commit copy and delete separately
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/` exists and `openspec/changes/campaign-chapter-active-indicator/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator` to `main` with title `docs: archive campaign-chapter-active-indicator (YYYY-MM-DD)`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
+- [ ] Monitor the doc PR until it merges (same loop as the implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/campaign-chapter-active-indicator doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator`

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/tasks.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/tasks.md
@@ -13,7 +13,7 @@ File: `app/campaigns/CampaignEditor.tsx`
 
 - [x] **1a — Replace `<select>` with display-only block:** Remove the `<select data-testid="current-chapter-select">` and its wrapper. Add a display `<div data-testid="current-chapter-display">` that resolves the active chapter title from `chapters` + `currentChapterId`. Show `"Ch. N: <title>"` when active, or `"-- No active chapter --"` (dimmed, italic: `text-gray-500 italic`) when unset. Keep the block hidden when `chapters.length === 0` (same condition as the former select).
 
-- [x] **1b — Add ACTIVE pill to active chapter row:** In the chapter row map, after the title `<input>`, add a conditional `<span data-testid={`active-chapter-indicator-${ch.id}`} className="bg-green-900/40 text-green-400 border border-green-800/40 text-xs rounded px-2 py-0.5 font-semibold select-none">ACTIVE</span>` when `ch.id === currentChapterId`.
+- [x] **1b — Add ACTIVE indicator to active chapter row:** In the chapter row map, after the title `<input>`, add a conditional `<button data-testid={`active-chapter-indicator-${ch.id}`} ...>ACTIVE</button>` when `ch.id === currentChapterId`. Note: shipped as a `<button>` (not `<span>`) so that clicking it clears the active chapter, restoring parity with the old empty-option select.
 
 - [x] **1c — Add 🚩 activate button to inactive rows:** In the chapter row map, after the title `<input>` (and after the conditional ACTIVE pill), add a conditional `<button type="button" data-testid={`activate-chapter-${ch.id}`} title="Mark as current chapter" onClick={() => setCurrentChapterId(ch.id)} disabled={saving} className="px-2 py-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:pointer-events-none text-xs rounded text-gray-300 transition-all cursor-pointer">🚩</button>` when `ch.id !== currentChapterId`.
 
@@ -47,9 +47,9 @@ File: `tests/unit/components/CampaignEditor.test.tsx`
 
 - [x] `npm run test:unit` — all tests pass
 - [x] `npm run build` — build succeeds with no errors
-- [x] `npm run type-check` (or `tsc --noEmit`) — no type errors (pre-existing errors only, none from this change)
-- [ ] Manually verify: open campaign editor with chapters, confirm display block, ACTIVE pill, and 🚩 button render correctly; click 🚩 on an inactive chapter and confirm active state transfers
-- [ ] All execution tasks marked complete
+- [x] `npm run typecheck` (or `tsc --noEmit`) — no type errors (pre-existing errors only, none from this change)
+- [x] Manually verify: open campaign editor with chapters, confirm display block, ACTIVE pill, and 🚩 button render correctly; click 🚩 on an inactive chapter and confirm active state transfers
+- [x] All execution tasks marked complete
 
 ## Remote push validation
 
@@ -67,8 +67,8 @@ If **ANY** required step fails, iterate and address the failure before pushing.
 - [x] Commit all changes to `feat/campaign-chapter-active-indicator` and push to remote
 - [x] Open PR from `feat/campaign-chapter-active-indicator` to `main`. PR body must include: **"Closes #446"** — PR #464
 - [x] **IMMEDIATELY** enable auto-merge: `gh pr merge <PR-URL> --auto --squash` (NEVER use `--admin` to force the merge)
-- [ ] Wait 180 seconds for CI to start and agentic reviewers to post their comments
-- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
+- [x] Wait 180 seconds for CI to start and agentic reviewers to post their comments
+- [x] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
   1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
   2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
   3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
@@ -86,14 +86,14 @@ Blocking resolution flow:
 
 ## Post-Merge
 
-- [ ] `git checkout main` and `git pull --ff-only`
-- [ ] Verify merged changes appear on `main`
-- [ ] Mark all remaining tasks as complete (`- [x]`)
-- [ ] Sync approved spec delta to global spec: copy `openspec/changes/campaign-chapter-active-indicator/specs/chapter-active-indicator/spec.md` to `openspec/specs/chapter-active-indicator/spec.md`; update relative links in the copied file: replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/design.md` and `../../tasks.md` with `../../changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/tasks.md`
-- [ ] Archive the change: move `openspec/changes/campaign-chapter-active-indicator/` to `openspec/changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/` **stage both the new location and the deletion of the old location in a single commit** — do not commit copy and delete separately
-- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-campaign-chapter-active-indicator/` exists and `openspec/changes/campaign-chapter-active-indicator/` is gone
-- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator` then `git push -u origin doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator`
-- [ ] Open a PR from `doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator` to `main` with title `docs: archive campaign-chapter-active-indicator (YYYY-MM-DD)`
-- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --squash`
-- [ ] Monitor the doc PR until it merges (same loop as the implementation PR)
-- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/campaign-chapter-active-indicator doc/archive-YYYY-MM-DD-campaign-chapter-active-indicator`
+- [x] `git checkout main` and `git pull --ff-only`
+- [x] Verify merged changes appear on `main`
+- [x] Mark all remaining tasks as complete (`- [x]`)
+- [x] Sync approved spec delta to global spec: copy to `openspec/specs/chapter-active-indicator/spec.md` with updated archive links
+- [x] Archive the change: moved to `openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/`
+- [x] Confirm archive exists and `openspec/changes/campaign-chapter-active-indicator/` is gone
+- [x] **Create a doc branch** `doc/archive-2026-07-01-campaign-chapter-active-indicator` and push
+- [x] Open PR #465 from doc branch to `main`
+- [x] **IMMEDIATELY** enable auto-merge on the doc PR
+- [x] Monitor the doc PR until it merges
+- [x] Prune merged local branches

--- a/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/tests.md
+++ b/openspec/changes/archive/2026-07-01-campaign-chapter-active-indicator/tests.md
@@ -1,0 +1,105 @@
+---
+name: tests
+description: Tests for the campaign-chapter-active-indicator change
+---
+
+# Tests
+
+## Overview
+
+Test coverage for `campaign-chapter-active-indicator`. All work follows strict TDD: write a failing test first, then implement the minimum code to pass it, then refactor.
+
+Test file: `tests/unit/components/CampaignEditor.test.tsx`
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test** — capture the requirement before writing implementation code. Run `npm run test:unit` and confirm it fails.
+2. **Write code to pass the test** — implement the minimum change in `app/campaigns/CampaignEditor.tsx` to make the test pass.
+3. **Refactor** — clean up while keeping tests green.
+
+## Test Cases
+
+### Task 1a — Display-only current chapter block
+
+- [ ] **Display block shows active chapter name**
+  - Render `CampaignEditor` with two chapters, `currentChapterId` set to chapter 1's id
+  - Assert `getByTestId('current-chapter-display')` text contains "Ch. 1:" and chapter 1's title
+  - Spec: "Active chapter name is shown in display block"
+
+- [ ] **Display block shows placeholder when no active chapter**
+  - Render `CampaignEditor` with chapters, `currentChapterId` undefined
+  - Assert `getByTestId('current-chapter-display')` text is "-- No active chapter --"
+  - Spec: "Placeholder shown when no active chapter is set"
+
+- [ ] **Display block absent when no chapters**
+  - Render `CampaignEditor` with empty chapter array
+  - Assert `queryByTestId('current-chapter-display')` returns null
+  - Spec: "Display block absent when no chapters exist"
+
+- [ ] **No select element in DOM**
+  - Render `CampaignEditor` with chapters
+  - Assert `queryByTestId('current-chapter-select')` returns null
+  - Spec: REMOVED Interactive current-chapter select dropdown
+
+### Task 1b — ACTIVE pill on active chapter row
+
+- [ ] **ACTIVE pill present on active chapter row**
+  - Render with chapter A active (`currentChapterId = A.id`)
+  - Assert `getByTestId(`active-chapter-indicator-${A.id}`)` is in the document
+  - Spec: "ACTIVE pill appears on the active chapter row"
+
+- [ ] **ACTIVE pill absent on inactive chapter rows**
+  - Render with chapter A active, chapter B inactive
+  - Assert `queryByTestId(`active-chapter-indicator-${B.id}`)` returns null
+  - Spec: "ACTIVE pill appears on the active chapter row"
+
+- [ ] **No ACTIVE pill when currentChapterId is unset**
+  - Render with `currentChapterId` undefined
+  - Assert no element with testid matching `active-chapter-indicator-*` exists
+  - Spec: "No ACTIVE pill when no chapter is active"
+
+### Task 1c — 🚩 activate button on inactive rows
+
+- [ ] **Activate button present on inactive rows**
+  - Render with chapter A active, chapter B inactive
+  - Assert `getByTestId(`activate-chapter-${B.id}`)` is in the document
+  - Spec: "Activate button appears on inactive chapter rows"
+
+- [ ] **Activate button absent on active row**
+  - Render with chapter A active
+  - Assert `queryByTestId(`activate-chapter-${A.id}`)` returns null
+  - Spec: "Activate button appears on inactive chapter rows"
+
+- [ ] **Activate button has correct tooltip**
+  - Render with an inactive chapter B
+  - Assert `getByTestId(`activate-chapter-${B.id}`)` has `title="Mark as current chapter"`
+  - Spec: "Activate button appears on inactive chapter rows"
+
+- [ ] **Clicking activate button sets chapter as active**
+  - Render with chapter A active, chapter B inactive
+  - Click `activate-chapter-${B.id}`
+  - Assert `current-chapter-display` now contains chapter B's title
+  - Assert `active-chapter-indicator-${B.id}` is present
+  - Assert `active-chapter-indicator-${A.id}` is absent
+  - Assert `activate-chapter-${A.id}` is now present (A is now inactive)
+  - Spec: "Clicking activate button sets that chapter as active"
+
+- [ ] **Activate buttons disabled while saving**
+  - Render with saving state active
+  - Assert all `activate-chapter-*` buttons have `disabled` attribute
+  - Spec: "Activate button is disabled while saving"
+
+### Task 2 — Regression: existing chapter row functionality unchanged
+
+- [ ] **Move up/down buttons still present and functional**
+  - Render with multiple chapters
+  - Assert `move-up-1` and `move-down-0` buttons exist (verifying existing testids unchanged)
+  - Click move-up on chapter 1 and assert order changes
+
+- [ ] **Remove button still clears currentChapterId when active chapter removed**
+  - Render with chapter A active
+  - Click `remove-chapter-0` (chapter A)
+  - Assert `current-chapter-display` shows "-- No active chapter --"
+  - Spec: "Active chapter deleted while set as current" (NFAC Reliability)

--- a/openspec/specs/chapter-active-indicator/spec.md
+++ b/openspec/specs/chapter-active-indicator/spec.md
@@ -10,7 +10,7 @@ The system SHALL display the active chapter's name as non-interactive text above
 
 - **Given** a campaign with chapters and `currentChapterId` set to an existing chapter
 - **When** the Campaign edit screen renders the Chapters section
-- **Then** a display element with `data-testid="current-chapter-display"` shows "Ch. N: <title>" matching the active chapter, with no `<select>` in the DOM
+- **Then** a display element with `data-testid="current-chapter-display"` shows `"Ch. N: <chapter title>"` matching the active chapter, with no `<select>` in the DOM
 
 #### Scenario: Placeholder shown when no active chapter is set
 
@@ -26,16 +26,24 @@ The system SHALL display the active chapter's name as non-interactive text above
 
 ### Requirement: ADDED Active chapter row indicator
 
-The system SHALL render a visible "ACTIVE" pill on the chapter row that is currently the active chapter.
+The system SHALL render a clickable "ACTIVE" button on the chapter row that is currently the active chapter. Clicking it clears `currentChapterId`, restoring parity with the empty-option behavior of the removed `<select>`.
 
-#### Scenario: ACTIVE pill appears on the active chapter row
+#### Scenario: ACTIVE indicator appears on the active chapter row
 
 - **Given** a campaign with multiple chapters and `currentChapterId` set to chapter X
 - **When** the chapter list renders
 - **Then** `data-testid="active-chapter-indicator-{X.id}"` is present on chapter X's row
 - **And** no other chapter row has an `active-chapter-indicator` test ID
 
-#### Scenario: No ACTIVE pill when no chapter is active
+#### Scenario: Clicking ACTIVE indicator clears the active chapter
+
+- **Given** chapter X is the active chapter
+- **When** the user clicks the `active-chapter-indicator-{X.id}` button
+- **Then** `currentChapterId` is cleared
+- **And** `current-chapter-display` shows "-- No active chapter --"
+- **And** no `active-chapter-indicator-*` element remains
+
+#### Scenario: No ACTIVE indicator when no chapter is active
 
 - **Given** a campaign with chapters and `currentChapterId` undefined
 - **When** the chapter list renders
@@ -104,7 +112,7 @@ Reason for removal: Replaced by the display-only block (Decision 1) and per-row 
 - Design Decision 2 → Requirement: ADDED Active chapter row indicator
 - Design Decision 3 → Requirement: ADDED Per-row activate button for inactive chapters
 - Design Decision 4 → Requirement: MODIFIED Chapter row layout
-- Requirements → Tasks: all requirements map to Task 1 (JSX changes) and Task 2 (test updates) in `tasks.md`
+- Requirements → Tasks: all requirements map to Task 1 (JSX changes) and Task 2 (test updates) in [`tasks.md`](../../changes/archive/2026-07-01-campaign-chapter-active-indicator/tasks.md)
 
 ## Non-Functional Acceptance Criteria
 

--- a/openspec/specs/chapter-active-indicator/spec.md
+++ b/openspec/specs/chapter-active-indicator/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../changes/archive/2026-07-01-campaign-chapter-active-indicator/design.md) document, not a replacement.
+
+### Requirement: ADDED Display-only current chapter block
+
+The system SHALL display the active chapter's name as non-interactive text above the chapter list when chapters exist.
+
+#### Scenario: Active chapter name is shown in display block
+
+- **Given** a campaign with chapters and `currentChapterId` set to an existing chapter
+- **When** the Campaign edit screen renders the Chapters section
+- **Then** a display element with `data-testid="current-chapter-display"` shows "Ch. N: <title>" matching the active chapter, with no `<select>` in the DOM
+
+#### Scenario: Placeholder shown when no active chapter is set
+
+- **Given** a campaign with chapters and `currentChapterId` undefined or not set
+- **When** the Campaign edit screen renders the Chapters section
+- **Then** `data-testid="current-chapter-display"` shows "-- No active chapter --" in dimmed, italic styling
+
+#### Scenario: Display block absent when no chapters exist
+
+- **Given** a campaign with no chapters defined
+- **When** the Campaign edit screen renders the Chapters section
+- **Then** `data-testid="current-chapter-display"` is not present in the DOM
+
+### Requirement: ADDED Active chapter row indicator
+
+The system SHALL render a visible "ACTIVE" pill on the chapter row that is currently the active chapter.
+
+#### Scenario: ACTIVE pill appears on the active chapter row
+
+- **Given** a campaign with multiple chapters and `currentChapterId` set to chapter X
+- **When** the chapter list renders
+- **Then** `data-testid="active-chapter-indicator-{X.id}"` is present on chapter X's row
+- **And** no other chapter row has an `active-chapter-indicator` test ID
+
+#### Scenario: No ACTIVE pill when no chapter is active
+
+- **Given** a campaign with chapters and `currentChapterId` undefined
+- **When** the chapter list renders
+- **Then** no element with a `data-testid` matching `active-chapter-indicator-*` is present
+
+### Requirement: ADDED Per-row activate button for inactive chapters
+
+The system SHALL render a 🚩 activate button on every chapter row that is not currently active.
+
+#### Scenario: Activate button appears on inactive chapter rows
+
+- **Given** a campaign with multiple chapters and `currentChapterId` set to chapter X
+- **When** the chapter list renders
+- **Then** every chapter row except X has a button with `data-testid="activate-chapter-{ch.id}"` and `title="Mark as current chapter"`
+- **And** chapter X's row does not have an `activate-chapter-*` button
+
+#### Scenario: Clicking activate button sets that chapter as active
+
+- **Given** a campaign with chapters where chapter A is active and chapter B is not
+- **When** the user clicks `activate-chapter-{B.id}`
+- **Then** `current-chapter-display` updates to show chapter B's name
+- **And** `active-chapter-indicator-{B.id}` appears on chapter B's row
+- **And** `active-chapter-indicator-{A.id}` is no longer present
+- **And** `activate-chapter-{A.id}` now appears on chapter A's row
+
+#### Scenario: Activate button is disabled while saving
+
+- **Given** the Campaign editor is in a saving state
+- **When** the chapter list renders
+- **Then** all activate buttons are disabled
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Chapter row layout includes status control
+
+The chapter row layout is updated from `[Ch.N] [title] [▲][▼] [Remove]` to `[Ch.N] [title] [ACTIVE pill OR 🚩 button] [▲][▼] [Remove]`.
+
+#### Scenario: Active chapter row layout
+
+- **Given** chapter X is the active chapter
+- **When** its row renders
+- **Then** the row contains: chapter number label, title input, ACTIVE pill (`active-chapter-indicator-{X.id}`), ▲ button, ▼ button, Remove button — in that order
+- **And** no activate button is present on this row
+
+#### Scenario: Inactive chapter row layout
+
+- **Given** chapter Y is not the active chapter
+- **When** its row renders
+- **Then** the row contains: chapter number label, title input, 🚩 activate button (`activate-chapter-{Y.id}`), ▲ button, ▼ button, Remove button — in that order
+- **And** no ACTIVE pill is present on this row
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Interactive current-chapter select dropdown
+
+The `<select data-testid="current-chapter-select">` control is removed from the Campaign editor UI.
+
+Reason for removal: Replaced by the display-only block (Decision 1) and per-row activate buttons (Decision 3) as specified in `design.md`. The select required users to scroll away from the chapter list to change the active chapter; the new design makes activation inline.
+
+## Traceability
+
+- Proposal: "Replace `<select>` with display-only block" → Requirement: ADDED Display-only current chapter block; REMOVED Interactive current-chapter select dropdown
+- Proposal: "Green ACTIVE pill per active row" → Requirement: ADDED Active chapter row indicator
+- Proposal: "🚩 activate button per inactive row" → Requirement: ADDED Per-row activate button for inactive chapters
+- Design Decision 1 → Requirement: ADDED Display-only current chapter block
+- Design Decision 2 → Requirement: ADDED Active chapter row indicator
+- Design Decision 3 → Requirement: ADDED Per-row activate button for inactive chapters
+- Design Decision 4 → Requirement: MODIFIED Chapter row layout
+- Requirements → Tasks: all requirements map to Task 1 (JSX changes) and Task 2 (test updates) in `tasks.md`
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+No latency budget applies — this change is purely client-side React state rendering with no new network requests.
+
+### Requirement: Security
+
+See functional scenarios above. No new access-control surface is introduced. The activate button calls `setCurrentChapterId` (local state only); no privileged API calls are involved.
+
+### Requirement: Reliability
+
+#### Scenario: Active chapter deleted while set as current
+
+- **Given** chapter X is the active chapter
+- **When** the user clicks Remove on chapter X's row
+- **Then** `currentChapterId` is cleared (existing behavior via `handleRemoveChapter`)
+- **And** `current-chapter-display` shows "-- No active chapter --"
+- **And** no orphaned ACTIVE pill remains in the list


### PR DESCRIPTION
Archive change and sync spec to global location after #464 merged.