### PR TITLE
fix: validate monster import JSON shape and guard sync response fields

### DIFF
--- a/app/monsters/import/page.tsx
+++ b/app/monsters/import/page.tsx
@@ -33,6 +33,10 @@ function MonsterImportContent() {
       setLoading(true);
       const text = await file.text();
       const data = JSON.parse(text);
+      if (!data || !Array.isArray(data.monsters)) {
+        setError('Invalid file format. The JSON must have a "monsters" array.');
+        return;
+      }
 
       const response = await fetch("/api/monsters/upload", {
         method: "POST",
@@ -99,7 +103,15 @@ function MonsterImportContent() {
         throw new Error(result.error || "Failed to sync monsters");
       }
 
-      const { monsters } = result;
+      const monsters = result?.monsters;
+      if (
+        !monsters ||
+        typeof monsters.inserted !== "number" ||
+        typeof monsters.skipped !== "number" ||
+        typeof monsters.errors !== "number"
+      ) {
+        throw new Error("Unexpected sync response");
+      }
       setSyncMessage(
         `Sync complete: ${monsters.inserted} inserted, ${monsters.skipped} skipped, ${monsters.errors} errors`
       );

--- a/tests/unit/components/MonsterImportPage.test.tsx
+++ b/tests/unit/components/MonsterImportPage.test.tsx
@@ -63,6 +63,68 @@ async function renderAndUpload(fileContent: unknown) {
 
 const VALID_BODY = { monsters: [{ name: "A", maxHp: 5 }, { maxHp: 10 }] };
 
+// ─── Client-side JSON schema validation ──────────────────────────────────────
+
+describe("MonsterImportPage — client-side JSON schema validation", () => {
+  it("shows error when uploaded JSON lacks a monsters array", async () => {
+    global.fetch = jest.fn() as typeof fetch;
+
+    await renderAndUpload({ notMonsters: [] });
+
+    expect(
+      await screen.findByText(/invalid file format/i)
+    ).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows error when uploaded JSON is a primitive (no monsters key)", async () => {
+    const user = userEvent.setup();
+    render(<MonsterImportPage />);
+    const file = new File([JSON.stringify(42)], "monsters.json", {
+      type: "application/json",
+    });
+    const input = screen.getByLabelText(/select json file/i);
+    await user.upload(input, file);
+    await user.click(screen.getByRole("button", { name: /^import monsters/i }));
+
+    expect(
+      await screen.findByText(/invalid file format/i)
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── Sync response shape validation ──────────────────────────────────────────
+
+describe("MonsterImportPage — sync response validation", () => {
+  it("shows error when sync response lacks the monsters field", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse({ unexpected: true }, 200)
+    ) as typeof fetch;
+
+    const user = userEvent.setup();
+    render(<MonsterImportPage />);
+    await user.click(screen.getByRole("button", { name: /sync from open5e/i }));
+
+    expect(
+      await screen.findByText(/unexpected sync response/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows sync success message when response is valid", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse({ monsters: { inserted: 5, skipped: 2, errors: 0 } }, 200)
+    ) as typeof fetch;
+
+    const user = userEvent.setup();
+    render(<MonsterImportPage />);
+    await user.click(screen.getByRole("button", { name: /sync from open5e/i }));
+
+    expect(
+      await screen.findByText(/sync complete: 5 inserted, 2 skipped, 0 errors/i)
+    ).toBeInTheDocument();
+  });
+});
+
 // ─── 207 partial-success handler ─────────────────────────────────────────────
 
 describe("MonsterImportPage — 207 partial-success handler", () => {


### PR DESCRIPTION
Fixes two runtime validation gaps in the monster import page identified by Verity post-merge:

- Reject uploads where the parsed JSON lacks a `monsters` array before sending to the API, giving the user a clear error message
- Guard `result.monsters` field access before composing the sync success message to prevent crashes on unexpected API response shapes