### PR TITLE
Add party membership panel for campaign members

### DIFF
--- a/app/api/campaigns/[id]/parties/route.ts
+++ b/app/api/campaigns/[id]/parties/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { withAuthAndParams } from '@/lib/middleware';
+import { storage } from '@/lib/storage';
+
+type Params = { id: string };
+
+export const GET = withAuthAndParams<Params>(async (_request, auth, { id: campaignId }) => {
+  try {
+    const member = await storage.getMember(campaignId, auth.userId);
+    if (!member || member.status !== 'active') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const parties = await storage.loadPartiesByCampaign(campaignId);
+    return NextResponse.json(parties);
+  } catch (error) {
+    console.error('Error loading campaign parties:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+});

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -166,6 +166,7 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
   const [members, setMembers] = useState<EnrichedMember[]>([]);
   const [parties, setParties] = useState<Party[]>([]);
   const [myCharacters, setMyCharacters] = useState<Character[]>([]);
+  const [charactersUnavailable, setCharactersUnavailable] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -199,9 +200,11 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
 
       if (charactersRes.ok) {
         setMyCharacters(await charactersRes.json());
+        setCharactersUnavailable(false);
       } else {
         console.error('Failed to load characters:', charactersRes.status);
         setMyCharacters([]);
+        setCharactersUnavailable(true);
         setError('Failed to load your characters');
       }
     } catch {
@@ -274,6 +277,7 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
                 party={party}
                 characters={myCharacters}
                 userId={currentUserId}
+                charactersUnavailable={charactersUnavailable}
               />
             ))}
           </>

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ProtectedRoute } from '@/lib/components/ProtectedRoute';
+import { PartyMembershipPanel } from '@/lib/components/PartyMembershipPanel';
 import { ErrorBanner, LoadingState, textInputClass } from '@/lib/components/ui';
 import { useAuth } from '@/lib/hooks/useAuth';
-import type { MemberRole, MemberStatus } from '@/lib/types';
+import type { Character, MemberRole, MemberStatus, Party } from '@/lib/types';
 
 interface EnrichedMember {
   id: string;
@@ -163,15 +164,19 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
   const { user } = useAuth();
   const [campaignName, setCampaignName] = useState<string>('');
   const [members, setMembers] = useState<EnrichedMember[]>([]);
+  const [parties, setParties] = useState<Party[]>([]);
+  const [myCharacters, setMyCharacters] = useState<Character[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     setError(null);
     try {
-      const [campaignRes, membersRes] = await Promise.all([
+      const [campaignRes, membersRes, partiesRes, charactersRes] = await Promise.all([
         fetch(`/api/campaigns/${campaignId}`),
         fetch(`/api/campaigns/${campaignId}/members`),
+        fetch(`/api/campaigns/${campaignId}/parties`),
+        fetch('/api/characters'),
       ]);
       if (!campaignRes.ok || !membersRes.ok) {
         setError('Failed to load campaign data');
@@ -183,6 +188,8 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
       ]);
       setCampaignName(campaignData.name ?? '');
       setMembers(membersData.members ?? []);
+      setParties(partiesRes.ok ? await partiesRes.json() : []);
+      setMyCharacters(charactersRes.ok ? await charactersRes.json() : []);
     } catch {
       setError('Failed to load campaign data');
     } finally {
@@ -245,6 +252,15 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
             {isDM && (
               <InviteSection campaignId={campaignId} onInvited={fetchData} />
             )}
+
+            {parties.map(party => (
+              <PartyMembershipPanel
+                key={party.id}
+                campaignId={campaignId}
+                party={party}
+                characters={myCharacters}
+              />
+            ))}
           </>
         )}
       </div>

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -202,7 +202,7 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
       } else {
         console.error('Failed to load characters:', charactersRes.status);
         setMyCharacters([]);
-        setError('Failed to load party information');
+        setError('Failed to load your characters');
       }
     } catch {
       setError('Failed to load campaign data');
@@ -273,6 +273,7 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
                 campaignId={campaignId}
                 party={party}
                 characters={myCharacters}
+                userId={currentUserId}
               />
             ))}
           </>

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -188,8 +188,22 @@ function CampaignMembersContent({ campaignId }: { campaignId: string }) {
       ]);
       setCampaignName(campaignData.name ?? '');
       setMembers(membersData.members ?? []);
-      setParties(partiesRes.ok ? await partiesRes.json() : []);
-      setMyCharacters(charactersRes.ok ? await charactersRes.json() : []);
+
+      if (partiesRes.ok) {
+        setParties(await partiesRes.json());
+      } else {
+        console.error('Failed to load campaign parties:', partiesRes.status);
+        setParties([]);
+        setError('Failed to load party information');
+      }
+
+      if (charactersRes.ok) {
+        setMyCharacters(await charactersRes.json());
+      } else {
+        console.error('Failed to load characters:', charactersRes.status);
+        setMyCharacters([]);
+        setError('Failed to load party information');
+      }
     } catch {
       setError('Failed to load campaign data');
     } finally {

--- a/lib/components/PartyMembershipPanel.tsx
+++ b/lib/components/PartyMembershipPanel.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Character, Party } from '@/lib/types';
+import type { Character, Party } from '@/lib/types';
 
 interface Props {
   campaignId: string;
   party: Party;
   characters: Character[];
   userId: string;
+  charactersUnavailable?: boolean;
 }
 
 function computeActiveIds(party: Party, characters: Character[]): Set<string> {
@@ -19,7 +20,7 @@ function computeActiveIds(party: Party, characters: Character[]): Set<string> {
   );
 }
 
-export function PartyMembershipPanel({ campaignId, party, characters, userId }: Props) {
+export function PartyMembershipPanel({ campaignId, party, characters, userId, charactersUnavailable = false }: Props) {
   const [activeIds, setActiveIds] = useState<Set<string>>(() => computeActiveIds(party, characters));
   const [toggling, setToggling] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
@@ -71,7 +72,9 @@ export function PartyMembershipPanel({ campaignId, party, characters, userId }: 
 
       <div className="mt-3 space-y-2">
         {characters.length === 0 ? (
-          <p className="text-gray-400 text-sm">No characters to add.</p>
+          <p className="text-gray-400 text-sm">
+            {charactersUnavailable ? 'Could not load your characters.' : 'No characters to add.'}
+          </p>
         ) : (
           characters.map((character) => (
             <label

--- a/lib/components/PartyMembershipPanel.tsx
+++ b/lib/components/PartyMembershipPanel.tsx
@@ -1,27 +1,32 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Character, Party } from '@/lib/types';
 
 interface Props {
   campaignId: string;
   party: Party;
   characters: Character[];
+  userId: string;
 }
 
-export function PartyMembershipPanel({ campaignId, party, characters }: Props) {
+function computeActiveIds(party: Party, characters: Character[]): Set<string> {
   const ownCharacterIds = new Set(characters.map((c) => c.id));
-  const initialActiveIds = new Set(
+  return new Set(
     party.members
       .filter((m) => !m.leftAt && ownCharacterIds.has(m.characterId))
       .map((m) => m.characterId)
   );
+}
 
-  const [activeIds, setActiveIds] = useState<Set<string>>(initialActiveIds);
+export function PartyMembershipPanel({ campaignId, party, characters, userId }: Props) {
+  const [activeIds, setActiveIds] = useState<Set<string>>(() => computeActiveIds(party, characters));
   const [toggling, setToggling] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
 
-  const myUserId = characters[0]?.userId;
+  useEffect(() => {
+    setActiveIds(computeActiveIds(party, characters));
+  }, [party, characters]);
 
   const handleToggle = async (character: Character) => {
     const id = character.id;
@@ -35,7 +40,7 @@ export function PartyMembershipPanel({ campaignId, party, characters }: Props) {
 
     try {
       const res = await fetch(
-        `/api/campaigns/${campaignId}/members/${myUserId}/parties/${party.id}`,
+        `/api/campaigns/${campaignId}/members/${userId}/parties/${party.id}`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },

--- a/lib/components/PartyMembershipPanel.tsx
+++ b/lib/components/PartyMembershipPanel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import { Character, Party } from '@/lib/types';
+
+interface Props {
+  campaignId: string;
+  party: Party;
+  characters: Character[];
+}
+
+export function PartyMembershipPanel({ campaignId, party, characters }: Props) {
+  const ownCharacterIds = new Set(characters.map((c) => c.id));
+  const initialActiveIds = new Set(
+    party.members
+      .filter((m) => !m.leftAt && ownCharacterIds.has(m.characterId))
+      .map((m) => m.characterId)
+  );
+
+  const [activeIds, setActiveIds] = useState<Set<string>>(initialActiveIds);
+  const [toggling, setToggling] = useState<Set<string>>(new Set());
+
+  const myUserId = characters[0]?.userId;
+
+  const handleToggle = async (character: Character) => {
+    const id = character.id;
+    const prevIds = activeIds;
+    const nextIds = new Set(activeIds);
+    if (nextIds.has(id)) { nextIds.delete(id); } else { nextIds.add(id); }
+
+    setToggling((prev) => new Set(prev).add(id));
+    setActiveIds(nextIds);
+
+    try {
+      const res = await fetch(
+        `/api/campaigns/${campaignId}/members/${myUserId}/parties/${party.id}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ characterIds: Array.from(nextIds) }),
+        }
+      );
+      if (!res.ok) throw new Error('toggle failed');
+    } catch {
+      setActiveIds(prevIds);
+    } finally {
+      setToggling((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    }
+  };
+
+  return (
+    <div className="mt-4 bg-gray-700 rounded-lg p-4">
+      <p className="font-semibold text-sm text-gray-200">{party.name}</p>
+
+      <div className="mt-3 space-y-2">
+        {characters.length === 0 ? (
+          <p className="text-gray-400 text-sm">No characters to add.</p>
+        ) : (
+          characters.map((character) => (
+            <label
+              key={character.id}
+              className="flex items-center gap-3 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                aria-label={character.name}
+                checked={activeIds.has(character.id)}
+                disabled={toggling.has(character.id)}
+                onChange={() => handleToggle(character)}
+                className="w-4 h-4"
+              />
+              <span className="text-sm text-gray-200">{character.name}</span>
+            </label>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/components/PartyMembershipPanel.tsx
+++ b/lib/components/PartyMembershipPanel.tsx
@@ -19,15 +19,17 @@ export function PartyMembershipPanel({ campaignId, party, characters }: Props) {
 
   const [activeIds, setActiveIds] = useState<Set<string>>(initialActiveIds);
   const [toggling, setToggling] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
 
   const myUserId = characters[0]?.userId;
 
   const handleToggle = async (character: Character) => {
     const id = character.id;
-    const prevIds = activeIds;
+    const wasActive = activeIds.has(id);
     const nextIds = new Set(activeIds);
-    if (nextIds.has(id)) { nextIds.delete(id); } else { nextIds.add(id); }
+    if (wasActive) { nextIds.delete(id); } else { nextIds.add(id); }
 
+    setError(null);
     setToggling((prev) => new Set(prev).add(id));
     setActiveIds(nextIds);
 
@@ -40,9 +42,18 @@ export function PartyMembershipPanel({ campaignId, party, characters }: Props) {
           body: JSON.stringify({ characterIds: Array.from(nextIds) }),
         }
       );
-      if (!res.ok) throw new Error('toggle failed');
-    } catch {
-      setActiveIds(prevIds);
+      if (!res.ok) throw new Error(`toggle failed: ${res.status}`);
+    } catch (err) {
+      console.error('Failed to update party membership:', err);
+      // Revert only this character's membership, not the whole set — another
+      // character's toggle may have committed to `activeIds` while this
+      // request was in flight, and that change must not be clobbered.
+      setActiveIds((prev) => {
+        const reverted = new Set(prev);
+        if (wasActive) { reverted.add(id); } else { reverted.delete(id); }
+        return reverted;
+      });
+      setError('Could not update party membership. Please try again.');
     } finally {
       setToggling((prev) => { const next = new Set(prev); next.delete(id); return next; });
     }
@@ -51,6 +62,7 @@ export function PartyMembershipPanel({ campaignId, party, characters }: Props) {
   return (
     <div className="mt-4 bg-gray-700 rounded-lg p-4">
       <p className="font-semibold text-sm text-gray-200">{party.name}</p>
+      {error && <p className="text-red-400 text-sm mt-1">{error}</p>}
 
       <div className="mt-3 space-y-2">
         {characters.length === 0 ? (

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1119,7 +1119,7 @@ export const storage = {
       return parties.map(normalizeStoredEntityId).map(migrateParty);
     } catch (error) {
       console.error("Error loading parties by campaign:", error);
-      return [];
+      throw error;
     }
   },
 

--- a/openspec/changes/party-membership-panel/.openspec.yaml
+++ b/openspec/changes/party-membership-panel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-07-06

--- a/openspec/changes/party-membership-panel/design.md
+++ b/openspec/changes/party-membership-panel/design.md
@@ -1,0 +1,119 @@
+## Context
+
+- Relevant architecture: Next.js App Router API routes under `app/api/**`, wrapped with `withAuth` / `withAuthAndParams` (`lib/middleware.ts`). Storage access goes through the `storage` singleton (`lib/storage.ts`). Party data model is `Party` / `PartyMember` (`lib/types.ts`), already supporting multi-party membership with `addedAt`/`leftAt` history.
+- Dependencies: #471 (merged) — `PUT /api/campaigns/[id]/members/[userId]/parties/[partyId]/route.ts` already implements self-service character-to-party updates with ownership and authorization checks. This change adds a read path and UI on top; it does not modify that route.
+- Interfaces/contracts touched:
+  - New: `GET /api/campaigns/[id]/parties/route.ts`
+  - New: client component `lib/components/PartyMembershipPanel.tsx`
+  - Modified: `app/campaigns/[id]/page.tsx` (render the new panel)
+  - Untouched: `lib/components/SharedCharactersPanel.tsx`, `CampaignCharacterShare`-related routes/types (#473 scope)
+
+## Goals / Non-Goals
+
+### Goals
+
+- Any active campaign member can retrieve the list of parties in that campaign, regardless of party ownership.
+- Each party in the campaign gets its own independent character multi-select for the current player's own characters.
+- Toggling a character's membership in one party has no effect on any other party.
+- Reuse the existing PUT endpoint from #471 exactly as-is (no changes to its contract or authorization).
+
+### Non-Goals
+
+- Changing `/api/parties` (owner-scoped) or `PartyEditor` on `/parties`.
+- Real-time sync across tabs/users (SSE) for party membership changes.
+- Removing `SharedCharactersPanel` or `CampaignCharacterShare` (tracked in #473).
+
+## Decisions
+
+### Decision 1: New GET route authorized by "active campaign member," not by party ownership
+
+- Chosen: `app/api/campaigns/[id]/parties/route.ts` exports `GET = withAuthAndParams<{ id: string }>(...)`. Handler calls `storage.getMember(campaignId, auth.userId)` and requires `member && member.status === 'active'` (any role) before calling `storage.loadPartiesByCampaign(campaignId)` and returning the result.
+- Alternatives considered:
+  1. Reuse `/api/parties` and filter/expand client-side to include non-owned parties — rejected, would require loosening `loadParties(auth.userId)` globally and leaking non-campaign parties.
+  2. Mirror the PUT route's `isAuthorized` (self-or-active-DM) — rejected, that check is about mutating a specific *other* member's data; listing parties has no "target member," so the correct check is simply campaign membership.
+- Rationale: Matches how party membership visibility is scoped elsewhere (a campaign's parties are visible to its members) without touching ownership semantics used by `/api/parties`.
+- Trade-offs: Introduces a second way to fetch parties (by campaign vs by owner); acceptable since they serve different audiences (DM-authoring view vs player-joining view).
+
+### Decision 2: One independent panel instance per `Party`, keyed by `party.id`
+
+- Chosen: New component `PartyMembershipPanel` takes a single `party: Party` and the player's own `characters: Character[]`. The campaign page fetches `GET /api/campaigns/{id}/parties` once, then renders `parties.map(party => <PartyMembershipPanel key={party.id} party={party} characters={myCharacters} campaignId={id} />)`.
+- Alternatives considered:
+  1. Single combined component managing a map of `partyId -> Set<characterId>` — rejected, adds shared-state complexity for no benefit since parties are independent; a per-party component keeps each instance's `toggling`/optimistic state isolated for free (same pattern `SharedCharactersPanel` already uses internally).
+- Rationale: Matches the confirmed requirement that a character may join multiple parties in a campaign independently, and keeps each panel's request lifecycle self-contained.
+- Trade-offs: N components mounted for N parties in a campaign; acceptable given campaigns typically have few parties.
+
+### Decision 3: Optimistic toggle with per-character in-flight guard, PUT sends full active-character-id set for that party
+
+- Chosen: Each panel keeps local state `activeIds: Set<string>` (derived from `party.members` filtered to the player's own character ids with no `leftAt`) and `toggling: Set<string>`. On toggle: optimistically update `activeIds`, add the character id to `toggling` (disabling its checkbox), `PUT` the full `Array.from(activeIds)` for that party+member, and on failure revert `activeIds` to the pre-toggle value. This exactly mirrors the existing pattern in `SharedCharactersPanel.tsx`.
+- Alternatives considered:
+  1. Send only the delta (single character id + add/remove flag) — rejected, the PUT contract from #471 takes a full `characterIds` array and merges by diff internally; sending a partial set would incorrectly mark other already-active characters as left.
+  2. Disable the whole panel during any in-flight request — rejected, unnecessarily blocks unrelated character toggles within the same party.
+- Rationale: Reuses a request contract and UI pattern already proven in this codebase; avoids introducing a new interaction model.
+- Trade-offs: Two rapid toggles on the *same* character before the first PUT resolves could still race; mitigated by disabling that specific character's checkbox while its request is in flight (same as `SharedCharactersPanel`).
+
+## Proposal to Design Mapping
+
+- Proposal element: New `GET /api/campaigns/{id}/parties` endpoint, active-member auth
+  - Design decision: Decision 1
+  - Validation approach: Integration test — active member of any role gets 200 with parties; non-member gets 403/404; inactive member gets 403/404.
+- Proposal element: One panel per party, independent per-party state, multi-party membership allowed
+  - Design decision: Decision 2
+  - Validation approach: Unit test — two parties rendered from the same character list; toggling a character in party A does not change party B's checkbox state.
+- Proposal element: Toggle wired to existing PUT endpoint, full characterIds per request
+  - Design decision: Decision 3
+  - Validation approach: Unit test — toggle fires PUT with the full expected characterIds array; failed PUT reverts the checkbox.
+
+## Functional Requirements Mapping
+
+- Requirement: Active campaign member can list all parties in the campaign.
+  - Design element: Decision 1 (`GET /api/campaigns/[id]/parties/route.ts`)
+  - Acceptance criteria reference: specs/party-membership-panel/spec.md — "member can list campaign parties"
+  - Testability notes: Integration test hitting the route with active/inactive/non-member auth contexts.
+- Requirement: Player can independently add/remove their own characters to/from each party in the campaign.
+  - Design element: Decisions 2 and 3 (`PartyMembershipPanel`)
+  - Acceptance criteria reference: specs/party-membership-panel/spec.md — "player toggles character membership per party"
+  - Testability notes: Component test simulating checkbox toggles and asserting fetch calls / reverted state on failure.
+- Requirement: A character may be an active member of multiple parties in the same campaign simultaneously.
+  - Design element: Decision 2
+  - Acceptance criteria reference: specs/party-membership-panel/spec.md — "multi-party membership is independent"
+  - Testability notes: Component test with two parties sharing a character where one shows checked and the other unchecked.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: security
+  - Requirement: A player must not be able to view or modify parties/characters outside their own campaign membership or character ownership.
+  - Design element: Decision 1 (GET auth check); existing PUT auth/ownership checks from #471 are reused unchanged.
+  - Acceptance criteria reference: specs/party-membership-panel/spec.md — "authorization boundaries"
+  - Testability notes: Integration tests asserting 403/404 for non-members and for characters not owned by the caller (already covered by #471's existing tests for the PUT path; new tests only needed for the GET path).
+- Requirement category: reliability
+  - Requirement: A failed toggle request must not leave the UI showing an incorrect membership state.
+  - Design element: Decision 3 (optimistic update + revert on failure)
+  - Acceptance criteria reference: specs/party-membership-panel/spec.md — "toggle failure reverts UI"
+  - Testability notes: Component test mocking a failed fetch and asserting the checkbox reverts.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: New GET route duplicates some logic conceptually present in the PUT route's membership check (`storage.getMember` + active status).
+  - Impact: Minor duplication of an auth check across two route files.
+  - Mitigation: Acceptable at this scale; if a third route needs the same check, extract a shared helper then (not now — avoids premature abstraction).
+- Risk/trade-off: Rendering N panels for N parties could clutter the campaign page if a campaign has many parties.
+  - Impact: Visual noise for campaigns with unusually many parties.
+  - Mitigation: Out of scope for this change; campaigns in practice have few parties. Revisit only if it becomes a real problem.
+
+## Rollback / Mitigation
+
+- Rollback trigger: New GET route or panel causes errors on the campaign page, or leaks party data across campaigns.
+- Rollback steps: Revert the two new files (`route.ts`, `PartyMembershipPanel.tsx`) and the render call added to `app/campaigns/[id]/page.tsx`. No data migration involved — no schema or stored-data changes are introduced by this change.
+- Data migration considerations: None. This change only adds a read endpoint and UI; it reuses the existing `PartyMember`/`Party` shapes and the already-merged PUT endpoint unchanged.
+- Verification after rollback: Campaign page loads without the new panel; existing `/parties` DM flow and #471's PUT endpoint continue to work (unaffected by this change or its rollback).
+
+## Operational Blocking Policy
+
+- If CI checks fail: Fix the failing check before merging; do not bypass with admin merge or skip flags.
+- If security checks fail: Treat as blocking — review the specific finding (e.g. authorization gap in the new GET route) and fix before proceeding; do not suppress.
+- If required reviews are blocked/stale: Follow up with the reviewer; do not merge without required approvals.
+- Escalation path and timeout: If blocked for more than one business day with no reviewer response, flag to the repo owner (dougis) directly.
+
+## Open Questions
+
+- None blocking. All prior open questions from proposal.md were resolved during exploration (auth model for GET, per-party UI shape, multi-party independence, #473 boundary).

--- a/openspec/changes/party-membership-panel/proposal.md
+++ b/openspec/changes/party-membership-panel/proposal.md
@@ -1,0 +1,76 @@
+## GitHub Issues
+
+- #472
+- #470 (Epic)
+- #471 (dependency, merged)
+
+## Why
+
+- Problem statement: Players cannot directly choose which of their own characters join a given party within a campaign. The only self-service endpoint for this (`PUT /api/campaigns/{id}/members/{userId}/parties/{partyId}`, added in #471) is unreachable from the UI today because nothing renders it, and there is no way for a non-owner campaign member to even discover which parties exist in the campaign.
+- Why now: #471 (the backend) is merged and unused. Completing #472 is the last functional piece blocking the party-centric sharing epic (#470) before `CampaignCharacterShare` can be deprecated in #473.
+- Business/user impact: Removes the DM as a required intermediary for players joining a party's roster, matching the target UX described in the epic.
+
+## Problem Space
+
+- Current behavior:
+  - `SharedCharactersPanel` exists but is not rendered anywhere in the app (dead code) and operates on the old `CampaignCharacterShare` model.
+  - `useCampaignContext` fetches `/api/parties`, which is scoped to `storage.loadParties(auth.userId)` — parties the caller **owns**. A player who is an active campaign member but not the party's creator never sees that party, so they have no `partyId` to act on.
+  - `PUT /api/campaigns/{id}/members/{userId}/parties/{partyId}` (merged, #471) already supports self-service updates: caller must be the target member or an active DM, and only characters the target member owns may be added.
+- Desired behavior: Any active campaign member can see every party in that campaign and independently choose which of their own characters are active members of each one.
+- Constraints:
+  - Must not expose or let a player modify another player's characters within a party.
+  - A campaign may contain multiple parties; a character may be an active member of more than one party in the same campaign at once — each party's membership is independent.
+  - Must not change authorization or behavior of the existing PUT endpoint from #471.
+- Assumptions:
+  - Caller must be an active member (any role) of the campaign to list its parties.
+  - The existing `PartyMember` history model (`addedAt`/`leftAt`) is sufficient and unchanged.
+- Edge cases considered:
+  - Campaign has zero parties yet (panel section shows empty/no-parties state).
+  - Player has zero characters (panel shows a message, no crash).
+  - Player is not an active member of the campaign (no parties returned, panel does not render or shows nothing to join).
+  - Toggling a character while a previous toggle's PUT is in flight for the same party (must not race / clobber the in-flight request's payload).
+
+## Scope
+
+### In Scope
+
+- New route `GET /api/campaigns/{id}/parties` returning all parties for that campaign (`storage.loadPartiesByCampaign`), gated on the caller being an active member of the campaign (any role).
+- New UI section on the campaign page rendering one panel per party in the campaign, each showing a multi-select of the current player's own characters with checkboxes reflecting active (`!leftAt`) membership in that specific party.
+- Wiring the new panel's toggle handler to `PUT /api/campaigns/{id}/members/{userId}/parties/{partyId}` (existing, #471), sending the full set of the player's currently-checked character IDs for that one party per request.
+
+### Out of Scope
+
+- Deleting or modifying `SharedCharactersPanel.tsx` or any `CampaignCharacterShare` code, routes, or types — tracked separately in #473.
+- Changing `/api/parties` or the DM-facing `PartyEditor` on `/parties`.
+- Restricting a character to a single party per campaign (multiple is explicitly allowed).
+- Real-time/multi-tab sync of party membership changes (e.g. via SSE); a page refresh is sufficient for this change.
+
+## What Changes
+
+- Add `app/api/campaigns/[id]/parties/route.ts` with a `GET` handler.
+- Add a new client component (e.g. `PartyMembershipPanel`) rendering one section per party, using the player's own character list and the new GET endpoint.
+- Render the new panel on the campaign page (`app/campaigns/[id]/page.tsx`), additive alongside existing content.
+
+## Risks
+
+- Risk: New GET endpoint accidentally leaks parties or membership details belonging to non-members.
+  - Impact: Privacy/data exposure across campaigns.
+  - Mitigation: Reuse the campaign-membership check already used elsewhere (`storage.getMember(campaignId, callerId)` must be active) before calling `loadPartiesByCampaign`.
+- Risk: Rapid toggling sends overlapping PUT requests for the same party, causing a stale response to overwrite a newer selection.
+  - Impact: A character's join/leave action appears to silently revert.
+  - Mitigation: Serialize or de-dupe in-flight requests per party (e.g. disable checkboxes for that party while a request is pending, mirroring `SharedCharactersPanel`'s existing `toggling` set pattern).
+
+## Open Questions
+
+- None blocking. Auth model for the new GET (any active campaign member, mirroring the "is this member active in the campaign" check rather than the PUT's "self or active DM" check) and UI shape (one panel per party, independent per-party state) were confirmed during exploration.
+
+## Non-Goals
+
+- Deprecating or removing `CampaignCharacterShare` (issue #473).
+- Changing how parties are created, renamed, or deleted.
+- Supporting DM-side bulk management of player characters from this new panel (that remains on `/parties`).
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/party-membership-panel/specs/party-management/spec.md
+++ b/openspec/changes/party-membership-panel/specs/party-management/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Campaign-scoped party listing for active members
+
+The system SHALL allow any active member of a campaign (any role) to retrieve all parties belonging to that campaign via `GET /api/campaigns/{id}/parties`, regardless of whether the caller owns those parties.
+
+#### Scenario: Active member lists campaign parties
+
+- **Given** a user is an active member (any role) of campaign C, which has parties P1 and P2 owned by other users
+- **When** the user sends `GET /api/campaigns/C/parties`
+- **Then** a 200 OK is returned with an array containing P1 and P2
+
+#### Scenario: Non-member denied
+
+- **Given** a user is not a member of campaign C
+- **When** the user sends `GET /api/campaigns/C/parties`
+- **Then** a 403 Forbidden or 404 Not Found is returned and no party data is included in the response
+
+#### Scenario: Inactive member denied
+
+- **Given** a user's membership in campaign C has `status` other than `active` (e.g. `left` or `removed`)
+- **When** the user sends `GET /api/campaigns/C/parties`
+- **Then** a 403 Forbidden or 404 Not Found is returned and no party data is included in the response
+
+#### Scenario: Campaign with no parties
+
+- **Given** an active member of campaign C, which has zero parties
+- **When** the user sends `GET /api/campaigns/C/parties`
+- **Then** a 200 OK is returned with an empty array
+
+## Traceability
+
+- Proposal element -> Requirement: New `GET /api/campaigns/{id}/parties` endpoint -> ADDED Campaign-scoped party listing for active members
+- Design decision -> Requirement: Decision 1 -> ADDED Campaign-scoped party listing for active members
+- Requirement -> Task(s): See `tasks.md` in `party-membership-panel`.
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Latency budget
+
+- **Given** a standard API request under normal load
+- **When** a campaign's parties are listed
+- **Then** the endpoint returns within 500ms
+
+### Requirement: Security
+
+See functional scenarios: "Non-member denied", "Inactive member denied".
+
+### Requirement: Reliability
+
+#### Scenario: Storage read failure
+
+- **Given** the underlying party storage read throws an error
+- **When** `GET /api/campaigns/{id}/parties` is called
+- **Then** a 500 Internal Server Error is returned with a generic error body (no stack trace or internal detail leaked)

--- a/openspec/changes/party-membership-panel/specs/party-membership-panel/spec.md
+++ b/openspec/changes/party-membership-panel/specs/party-membership-panel/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Per-party character membership panel on the campaign page
+
+The system SHALL render one membership panel per party in the current campaign on the campaign page, each showing a multi-select of the current player's own characters, allowing the player to independently toggle their characters' active membership in that specific party.
+
+#### Scenario: Panel renders one section per party
+
+- **Given** a campaign with parties P1 and P2, and the current player is an active member of the campaign
+- **When** the player views the campaign page
+- **Then** two membership panel sections are rendered, one for P1 and one for P2
+
+#### Scenario: Player adds own character to a party
+
+- **Given** the player owns character X, which is not currently an active member of party P1
+- **When** the player checks X's checkbox in P1's panel
+- **Then** a `PUT /api/campaigns/{id}/members/{myUserId}/parties/{P1}` request is sent including X in `characterIds`, and X's checkbox reflects the checked state
+
+#### Scenario: Player removes own character from a party
+
+- **Given** the player owns character X, which is currently an active member of party P1
+- **When** the player unchecks X's checkbox in P1's panel
+- **Then** a `PUT /api/campaigns/{id}/members/{myUserId}/parties/{P1}` request is sent with `characterIds` excluding X, and X's checkbox reflects the unchecked state
+
+#### Scenario: Multi-party membership is independent
+
+- **Given** the player owns character X, active in party P1 but not in party P2
+- **When** the player views the campaign page
+- **Then** X's checkbox is checked in P1's panel and unchecked in P2's panel
+
+#### Scenario: Toggling in one party does not affect another
+
+- **Given** the player owns character X, active in both P1 and P2
+- **When** the player unchecks X in P1's panel
+- **Then** only the P1 request is sent; X remains checked in P2's panel and no request is sent for P2
+
+#### Scenario: Toggle failure reverts UI state
+
+- **Given** the player unchecks character X in party P1's panel
+- **When** the resulting PUT request fails (non-2xx response or network error)
+- **Then** X's checkbox reverts to its previous (checked) state
+
+#### Scenario: Player has no characters
+
+- **Given** the player owns zero characters
+- **When** the player views a party's panel
+- **Then** the panel shows a message indicating there are no characters to add, and no checkboxes are rendered
+
+#### Scenario: Campaign has no parties
+
+- **Given** the campaign has zero parties
+- **When** the player views the campaign page
+- **Then** no membership panel sections are rendered (or an empty-state message is shown)
+
+## Traceability
+
+- Proposal element -> Requirement: New UI section, one panel per party, wired to existing PUT endpoint -> ADDED Per-party character membership panel on the campaign page
+- Design decision -> Requirement: Decisions 2 & 3 -> ADDED Per-party character membership panel on the campaign page
+- Requirement -> Task(s): See `tasks.md` in `party-membership-panel`.
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Latency budget
+
+- **Given** a campaign page load under normal conditions
+- **When** the campaign's parties are fetched to render the panels
+- **Then** the parties list request completes within 500ms under normal load
+
+### Requirement: Security
+
+See functional scenarios in [`specs/party-management/spec.md`](../party-management/spec.md): "Non-member denied", "Inactive member denied". The panel itself performs no authorization decisions client-side; all access control is enforced server-side by the GET and PUT endpoints.
+
+### Requirement: Reliability
+
+See functional scenario above: "Toggle failure reverts UI state".

--- a/openspec/changes/party-membership-panel/tasks.md
+++ b/openspec/changes/party-membership-panel/tasks.md
@@ -1,0 +1,101 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feature/party-membership-panel` then immediately `git push -u origin feature/party-membership-panel`
+
+## Preflight
+
+- [x] **Verify `pr-review-toolkit:review-pr` is available** — check the available skills list for `pr-review-toolkit:review-pr`. If the skill is not listed, halt immediately, inform the user that the plugin is required, provide installation guidance, and do not proceed until the user confirms it is installed.
+
+## Execution
+
+- [x] **Issue lifecycle: mark in-progress**: run `gh issue edit 472 --repo dougis-org/session-combat --add-label "in-progress"`. Then discover the GitHub Project linked to the repo (`gh project list --owner dougis-org --format json`), resolve the status field option semantically matching "In Progress" (`gh project field-list <project-number> --owner dougis-org --format json`), and move the item via `gh project item-edit`. If no project item is found, log a warning and continue. If the `gh` token lacks the `project` scope, surface a message instructing the user to run `gh auth refresh -s project` and skip the project-item update (issue label update still proceeds). **Note:** `in-progress` label does not exist in this repo and `gh` token lacks `project` scope — both logged as warnings, non-blocking.
+- [x] **Add `GET /api/campaigns/[id]/parties/route.ts`**: `withAuthAndParams<{ id: string }>` handler; require `storage.getMember(id, auth.userId)` to exist with `status === 'active'` (any role) or return 403/404; on success return `storage.loadPartiesByCampaign(id)` as JSON; on storage error return 500 with a generic body. (Design Decision 1; specs/party-management/spec.md)
+- [x] **Write tests for the GET route first** (integration test, following existing patterns in `tests/integration/api/campaignPartyMembers.test.ts`): active member of any role gets 200 with parties array; non-member gets 403/404 with empty body; inactive member gets 403/404; campaign with zero parties gets 200 with `[]`; storage failure gets 500.
+- [x] **Add `lib/components/PartyMembershipPanel.tsx`**: props `{ campaignId: string; party: Party; characters: Character[] }` (characters = the current player's own characters only). Derive `activeIds` from `party.members` filtered to the player's own character ids with no `leftAt`. Render a checkbox list; on toggle, optimistically update local state, disable the toggled character's checkbox while in flight, `PUT /api/campaigns/{campaignId}/members/{myUserId}/parties/{party.id}` with the full updated `characterIds` array, revert on failure. Mirror the existing optimistic-update pattern already used in `lib/components/SharedCharactersPanel.tsx`. (Design Decisions 2 & 3; specs/party-membership-panel/spec.md)
+- [x] **Write component tests first** for `PartyMembershipPanel` (following `tests/unit/components/SharedCharactersPanel.test.tsx` conventions): renders a checkbox per own character; checking calls PUT with expected `characterIds`; unchecking calls PUT excluding the character; failed PUT reverts the checkbox; two independent `PartyMembershipPanel` instances (two parties) do not affect each other's state; empty-characters state renders a message with no checkboxes.
+- [x] **Wire the panel into the campaign page** (`app/campaigns/[id]/page.tsx`): fetch `GET /api/campaigns/{id}/parties` and the player's own characters (existing `/api/characters` filtered to `userId === auth.userId`, or reuse an existing characters fetch already on the page if present); render one `PartyMembershipPanel` per party, keyed by `party.id`. If the campaign has zero parties, render nothing or an empty-state message (no crash).
+- [x] **Write/extend a test for the campaign page render** confirming one panel section appears per party and that the section is absent when there are zero parties.
+- [x] Look for existing tooling or functions in the codebase that can be reused or extended before writing new logic from scratch (confirmed reuse: `withAuthAndParams`, `storage.getMember`, `storage.loadPartiesByCampaign`, the existing PUT endpoint from #471, and the optimistic-toggle pattern from `SharedCharactersPanel`).
+- [x] Confirm all acceptance criteria in `specs/party-management/spec.md` and `specs/party-membership-panel/spec.md` are covered by the tests written above.
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit. **Result:** zero complexity/duplication/quality issues found.
+
+## Validation
+
+- [x] Run unit/integration tests
+- [x] Run E2E tests (if applicable) — ran `campaigns.spec.ts` and `parties.spec.ts` as targeted regression, 32/32 passed
+- [x] Run type checks
+- [x] Run build
+- [x] Run security/code quality checks required by project standards — `npm run lint` clean (0 errors)
+- [x] All completed tasks marked as complete
+- [x] All steps in [Remote push validation]
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` (or compare the working branch against the base branch) and check whether every changed file ends in `.md`. This change is expected to be code-affecting (new route + component), so apply the full path unless the diff review shows otherwise.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — run the project's unit test suite; all tests must pass
+- **Integration tests** — run the project's integration test suite; all tests must pass
+- **Regression / E2E tests** — run the project's end-to-end or regression test suite; all tests must pass
+- **Build** — run the project's build script; build must succeed with no errors
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — run the project's build script; build must succeed with no errors
+- Skip integration and regression/E2E tests — they are not required when no code changed
+
+If **ANY** required step fails, you **MUST** iterate and address the failure before pushing.
+
+Use the project's documented commands for each of the above (see project README or CLAUDE.md / AGENTS.md).
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `feature/party-membership-panel` to `main`. The PR body MUST include `Closes #472`.
+- [ ] **Issue lifecycle: mark in-review**: run `gh issue edit 472 --repo dougis-org/session-combat --add-label "in-review" --remove-label "in-progress"`. Then move the project item to the status column semantically matching "In Review" via `gh project item-edit` (same project/field/option discovery as the in-progress lifecycle step above; warn and skip if not found).
+- [ ] Wait 60 seconds for CI to start
+- [ ] Spawn a sub-agent to run `pr-review-toolkit:review-pr`; address all findings (commit, push, re-run) until zero findings remain. If findings persist after three or more iterations with no progress, report the stall with remaining findings listed and wait for human guidance before continuing.
+- [ ] **Enable auto-merge only after the review gate passes (zero findings):** `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: dougis
+- Reviewer(s): pr-review-toolkit:review-pr (automated), dougis (final approval)
+- Required approvals: 1 (per repo branch protection)
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (none expected beyond OpenSpec artifacts; confirm no README/CLAUDE.md references need updating)
+- [ ] Sync approved spec deltas into `openspec/specs/`: copy `specs/party-management/spec.md` requirement additions into `openspec/specs/party-management/spec.md`, and create `openspec/specs/party-membership-panel/spec.md` from `specs/party-membership-panel/spec.md`. Update relative links that pointed into the change directory so they resolve from the archive location — replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-party-membership-panel/design.md`, and similarly for `../../tasks.md`.
+- [ ] Archive the change: move `openspec/changes/party-membership-panel/` to `openspec/changes/archive/YYYY-MM-DD-party-membership-panel/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-party-membership-panel/` exists and `openspec/changes/party-membership-panel/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-party-membership-panel` then `git push -u origin doc/archive-YYYY-MM-DD-party-membership-panel`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-party-membership-panel` to `main` with title `docs: archive party-membership-panel (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feature/party-membership-panel doc/archive-YYYY-MM-DD-party-membership-panel`
+
+Required cleanup after archive: `git fetch --prune` and `git branch -D feature/party-membership-panel doc/archive-YYYY-MM-DD-party-membership-panel`

--- a/openspec/changes/party-membership-panel/tests.md
+++ b/openspec/changes/party-membership-panel/tests.md
@@ -27,7 +27,7 @@ For each task in `tasks.md`:
 - [x] Member with `status !== 'active'` receives 403 or 404 with no party data. (specs/party-management/spec.md — "Inactive member denied")
 - [x] Campaign with zero parties returns 200 with `[]`. (specs/party-management/spec.md — "Campaign with no parties")
 - [x] Storage read failure returns 500 with a generic error body (no internal details leaked). (specs/party-management/spec.md — "Storage read failure")
-- [x] Response returns within the documented latency budget under normal test conditions. (specs/party-management/spec.md — "Latency budget")
+- [ ] Response returns within the documented latency budget under normal test conditions. (specs/party-management/spec.md — "Latency budget") — no explicit timing assertion was added; not tested.
 
 ### `PartyMembershipPanel` component (Task: Add component)
 

--- a/openspec/changes/party-membership-panel/tests.md
+++ b/openspec/changes/party-membership-panel/tests.md
@@ -1,0 +1,50 @@
+---
+name: tests
+description: Tests for the change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `party-membership-panel` change. All work should follow a strict TDD (Test-Driven Development) process: write a failing test, write the minimal code to pass it, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1.  **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2.  **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3.  **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### `GET /api/campaigns/[id]/parties` (Task: Add GET route)
+
+- [x] Active member (role `player`, status `active`) receives 200 with all parties in the campaign, including parties they do not own. (specs/party-management/spec.md — "Active member lists campaign parties")
+- [x] Active member with role `dm` receives 200 with all parties in the campaign. (specs/party-management/spec.md — "Active member lists campaign parties")
+- [x] Non-member of the campaign receives 403 or 404 with no party data. (specs/party-management/spec.md — "Non-member denied")
+- [x] Member with `status !== 'active'` receives 403 or 404 with no party data. (specs/party-management/spec.md — "Inactive member denied")
+- [x] Campaign with zero parties returns 200 with `[]`. (specs/party-management/spec.md — "Campaign with no parties")
+- [x] Storage read failure returns 500 with a generic error body (no internal details leaked). (specs/party-management/spec.md — "Storage read failure")
+- [x] Response returns within the documented latency budget under normal test conditions. (specs/party-management/spec.md — "Latency budget")
+
+### `PartyMembershipPanel` component (Task: Add component)
+
+- [x] Renders a checkbox for each of the player's own characters passed in. (specs/party-membership-panel/spec.md — "Panel renders one section per party")
+- [x] Checkbox is checked when the character has an active (`!leftAt`) `PartyMember` entry for this party, unchecked otherwise. (specs/party-membership-panel/spec.md — "Multi-party membership is independent")
+- [x] Checking an unchecked character sends `PUT /api/campaigns/{campaignId}/members/{myUserId}/parties/{party.id}` with `characterIds` including the newly checked character alongside all previously-active ones. (specs/party-membership-panel/spec.md — "Player adds own character to a party")
+- [x] Unchecking a checked character sends the same PUT with `characterIds` excluding that character. (specs/party-membership-panel/spec.md — "Player removes own character from a party")
+- [x] While a toggle's PUT is in flight, that character's checkbox is disabled; other characters' checkboxes in the same panel remain interactive.
+- [x] A failing PUT response (non-2xx or thrown/network error) reverts the checkbox to its pre-toggle state.
+- [x] Two `PartyMembershipPanel` instances rendered for two different parties (same character shared, different membership state) show independent checked/unchecked state and toggling one does not send a request or change state for the other. (specs/party-membership-panel/spec.md — "Toggling in one party does not affect another")
+- [x] When the player has zero characters, the panel renders a "no characters" message and no checkboxes. (specs/party-membership-panel/spec.md — "Player has no characters")
+
+### Campaign page integration (Task: Wire panel into campaign page)
+
+- [x] Campaign page renders one `PartyMembershipPanel` per party returned from `GET /api/campaigns/{id}/parties`. (specs/party-membership-panel/spec.md — "Panel renders one section per party")
+- [x] Campaign page with zero parties renders no panel sections (or an empty-state message) without crashing. (specs/party-membership-panel/spec.md — "Campaign has no parties")
+
+## Traceability Confirmation
+
+Every scenario in `specs/party-management/spec.md` and `specs/party-membership-panel/spec.md` has at least one corresponding test case above. No functional or non-functional acceptance scenario is left uncovered.

--- a/tests/integration/api/campaignParties.test.ts
+++ b/tests/integration/api/campaignParties.test.ts
@@ -1,5 +1,4 @@
 import fetch from "node-fetch";
-import { MongoClient } from "mongodb";
 import { makeAuthedHeaders } from "../helpers/server";
 import { registerTestUser } from "../helpers/users";
 
@@ -50,27 +49,16 @@ describe("GET /api/campaigns/[id]/parties Integration Tests", () => {
 
   const authed = (cookie: string) => makeAuthedHeaders(cookie);
 
-  it("returns 200 with an empty array when the campaign has no parties", async () => {
+  it("returns 200 with only the auto-created default party for a freshly created campaign", async () => {
     const res = await fetch(`${baseUrl}/api/campaigns/${campaignId}/parties`, {
       headers: authed(playerCookie),
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
-    if (Array.isArray(body) && body.length > 0) {
-      const client = new MongoClient(process.env.MONGODB_URI!);
-      try {
-        await client.connect();
-        const db = client.db(process.env.MONGODB_DB);
-        const allParties = await db.collection("parties").find({}).toArray();
-        const allCampaigns = await db.collection("campaigns").find({}).toArray();
-        console.log("DEBUG campaignId (this test):", campaignId);
-        console.log("DEBUG ALL parties in DB:", JSON.stringify(allParties, null, 2));
-        console.log("DEBUG ALL campaigns in DB:", JSON.stringify(allCampaigns, null, 2));
-      } finally {
-        await client.close();
-      }
-    }
-    expect(body).toEqual([]);
+    const parties = (await res.json()) as Array<{ name: string }>;
+    // Campaign creation auto-creates a default "Main Party" (see #482); no
+    // other parties exist yet for a freshly created campaign.
+    expect(parties).toHaveLength(1);
+    expect(parties[0].name).toBe("Main Party");
   });
 
   it("active player member sees all parties in the campaign, including ones they don't own", async () => {

--- a/tests/integration/api/campaignParties.test.ts
+++ b/tests/integration/api/campaignParties.test.ts
@@ -87,4 +87,29 @@ describe("GET /api/campaigns/[id]/parties Integration Tests", () => {
     });
     expect([403, 404]).toContain(res.status);
   });
+
+  it("does not include parties belonging to a different campaign", async () => {
+    const otherCampRes = await fetch(`${baseUrl}/api/campaigns`, {
+      method: "POST",
+      headers: authed(gmCookie),
+      body: JSON.stringify({ name: "Other Campaign", status: "active" }),
+    });
+    expect(otherCampRes.status).toBe(201);
+    const otherCampaign = (await otherCampRes.json()) as { id: string };
+
+    const otherPartyRes = await fetch(`${baseUrl}/api/parties`, {
+      method: "POST",
+      headers: authed(gmCookie),
+      body: JSON.stringify({ name: "Other Campaign Party", campaignId: otherCampaign.id }),
+    });
+    expect(otherPartyRes.status).toBe(201);
+    const otherParty = (await otherPartyRes.json()) as { id: string };
+
+    const res = await fetch(`${baseUrl}/api/campaigns/${campaignId}/parties`, {
+      headers: authed(playerCookie),
+    });
+    expect(res.status).toBe(200);
+    const parties = (await res.json()) as Array<{ id: string }>;
+    expect(parties.some((p) => p.id === otherParty.id)).toBe(false);
+  });
 });

--- a/tests/integration/api/campaignParties.test.ts
+++ b/tests/integration/api/campaignParties.test.ts
@@ -1,0 +1,90 @@
+import fetch from "node-fetch";
+import { makeAuthedHeaders } from "../helpers/server";
+import { registerTestUser } from "../helpers/users";
+
+describe("GET /api/campaigns/[id]/parties Integration Tests", () => {
+  let baseUrl: string;
+  let gmCookie: string;
+  let playerCookie: string;
+  let outCookie: string;
+  let campaignId: string;
+
+  beforeAll(async () => {
+    baseUrl = process.env.TEST_BASE_URL!;
+    if (!baseUrl) throw new Error("TEST_BASE_URL not set");
+
+    const gmAuth = await registerTestUser(baseUrl, "campaign-parties-gm");
+    gmCookie = gmAuth.cookie;
+
+    const playerAuth = await registerTestUser(baseUrl, "campaign-parties-player");
+    playerCookie = playerAuth.cookie;
+    const playerUserId = playerAuth.userId;
+
+    const outAuth = await registerTestUser(baseUrl, "campaign-parties-out");
+    outCookie = outAuth.cookie;
+
+    const campRes = await fetch(`${baseUrl}/api/campaigns`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: gmCookie },
+      body: JSON.stringify({ name: "Campaign Parties Test Campaign", status: "active" }),
+    });
+    if (!campRes.ok) throw new Error(`Campaign creation failed: ${await campRes.text()}`);
+    const camp = (await campRes.json()) as { id: string };
+    campaignId = camp.id;
+
+    const inviteRes = await fetch(`${baseUrl}/api/campaigns/${campaignId}/members`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: gmCookie },
+      body: JSON.stringify({ userId: playerUserId }),
+    });
+    if (!inviteRes.ok) throw new Error(`Invite failed: ${await inviteRes.text()}`);
+
+    const acceptRes = await fetch(`${baseUrl}/api/campaigns/${campaignId}/members/me`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Cookie: playerCookie },
+      body: JSON.stringify({ action: "accept" }),
+    });
+    if (!acceptRes.ok) throw new Error(`Accept invite failed: ${await acceptRes.text()}`);
+  }, 30000);
+
+  const authed = (cookie: string) => makeAuthedHeaders(cookie);
+
+  it("returns 200 with an empty array when the campaign has no parties", async () => {
+    const res = await fetch(`${baseUrl}/api/campaigns/${campaignId}/parties`, {
+      headers: authed(playerCookie),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("active player member sees all parties in the campaign, including ones they don't own", async () => {
+    const partyRes = await fetch(`${baseUrl}/api/parties`, {
+      method: "POST",
+      headers: authed(gmCookie),
+      body: JSON.stringify({ name: "GM-owned Party", campaignId }),
+    });
+    expect(partyRes.status).toBe(201);
+    const party = (await partyRes.json()) as { id: string };
+
+    const res = await fetch(`${baseUrl}/api/campaigns/${campaignId}/parties`, {
+      headers: authed(playerCookie),
+    });
+    expect(res.status).toBe(200);
+    const parties = (await res.json()) as Array<{ id: string }>;
+    expect(parties.some((p) => p.id === party.id)).toBe(true);
+  });
+
+  it("active dm member sees all parties in the campaign", async () => {
+    const res = await fetch(`${baseUrl}/api/campaigns/${campaignId}/parties`, {
+      headers: authed(gmCookie),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("non-member is denied with 403 or 404 and no party data", async () => {
+    const res = await fetch(`${baseUrl}/api/campaigns/${campaignId}/parties`, {
+      headers: authed(outCookie),
+    });
+    expect([403, 404]).toContain(res.status);
+  });
+});

--- a/tests/integration/api/campaignParties.test.ts
+++ b/tests/integration/api/campaignParties.test.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { MongoClient } from "mongodb";
 import { makeAuthedHeaders } from "../helpers/server";
 import { registerTestUser } from "../helpers/users";
 
@@ -54,7 +55,22 @@ describe("GET /api/campaigns/[id]/parties Integration Tests", () => {
       headers: authed(playerCookie),
     });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual([]);
+    const body = await res.json();
+    if (Array.isArray(body) && body.length > 0) {
+      const client = new MongoClient(process.env.MONGODB_URI!);
+      try {
+        await client.connect();
+        const db = client.db(process.env.MONGODB_DB);
+        const allParties = await db.collection("parties").find({}).toArray();
+        const allCampaigns = await db.collection("campaigns").find({}).toArray();
+        console.log("DEBUG campaignId (this test):", campaignId);
+        console.log("DEBUG ALL parties in DB:", JSON.stringify(allParties, null, 2));
+        console.log("DEBUG ALL campaigns in DB:", JSON.stringify(allCampaigns, null, 2));
+      } finally {
+        await client.close();
+      }
+    }
+    expect(body).toEqual([]);
   });
 
   it("active player member sees all parties in the campaign, including ones they don't own", async () => {

--- a/tests/unit/api/campaigns/id.parties.route.test.ts
+++ b/tests/unit/api/campaigns/id.parties.route.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/campaigns/[id]/parties/route";
+import { storage } from "@/lib/storage";
+import {
+  makeRouteRequest,
+  itReturns401WithParams,
+  itReturns500WithParams,
+} from "@/tests/unit/helpers/route.test.helpers";
+
+jest.mock("@/lib/middleware", () => require("@/tests/unit/helpers/route.test.helpers").createMockMiddleware());
+
+jest.mock("@/lib/storage", () => ({
+  storage: {
+    getMember: jest.fn(),
+    loadPartiesByCampaign: jest.fn(),
+  },
+}));
+
+const mockedStorage = jest.mocked(storage);
+
+const BASE_URL = "http://localhost/api/campaigns/camp-1/parties";
+const makeGetRequest = () => makeRouteRequest(BASE_URL, "GET");
+const PARAMS = Promise.resolve({ id: "camp-1" });
+
+describe("GET /api/campaigns/[id]/parties", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStorage.getMember.mockResolvedValue({ status: "active", role: "player" } as any);
+    mockedStorage.loadPartiesByCampaign.mockResolvedValue([
+      { id: "party-1", members: [] },
+      { id: "party-2", members: [] },
+    ] as any);
+  });
+
+  itReturns401WithParams(GET, makeGetRequest, PARAMS);
+
+  it("returns 200 with all parties for an active player", async () => {
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(2);
+    expect(body.map((p: any) => p.id)).toEqual(["party-1", "party-2"]);
+  });
+
+  it("returns 200 with all parties for an active dm", async () => {
+    mockedStorage.getMember.mockResolvedValueOnce({ status: "active", role: "dm" } as any);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 when caller is not a campaign member", async () => {
+    mockedStorage.getMember.mockResolvedValueOnce(null as any);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 when caller's membership is not active", async () => {
+    mockedStorage.getMember.mockResolvedValueOnce({ status: "left", role: "player" } as any);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 200 with an empty array when the campaign has no parties", async () => {
+    mockedStorage.loadPartiesByCampaign.mockResolvedValue([]);
+    const response = await GET(makeGetRequest(), { params: PARAMS });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual([]);
+  });
+
+  itReturns500WithParams(
+    GET,
+    makeGetRequest,
+    PARAMS,
+    () => {
+      mockedStorage.getMember.mockRejectedValueOnce(new Error("DB error"));
+    },
+    "returns 500 when storage throws"
+  );
+});

--- a/tests/unit/components/CampaignMembersPage.test.tsx
+++ b/tests/unit/components/CampaignMembersPage.test.tsx
@@ -30,6 +30,11 @@ jest.mock('@/lib/hooks/useAuth', () => ({
   useAuth: jest.fn(),
 }));
 
+jest.mock('@/lib/components/PartyMembershipPanel', () => ({
+  PartyMembershipPanel: ({ party }: { party: { id: string; name: string } }) =>
+    React.createElement('div', { 'data-testid': `party-panel-${party.id}` }, party.name),
+}));
+
 import { useAuth } from '@/lib/hooks/useAuth';
 import CampaignMembersPage from '@/app/campaigns/[id]/page';
 
@@ -71,11 +76,17 @@ function mockPlayerAuth() {
   } as any);
 }
 
-function setupFetch(members = [DM_MEMBER, PLAYER_MEMBER]) {
+function setupFetch(members = [DM_MEMBER, PLAYER_MEMBER], parties: unknown[] = [], characters: unknown[] = []) {
   let callCount = 0;
   global.fetch = jest.fn(async (input: RequestInfo | URL) => {
     const url = input.toString();
     callCount++;
+    if (url.includes('/api/campaigns/camp-1/parties')) {
+      return jsonResponse(parties);
+    }
+    if (url.includes('/api/characters')) {
+      return jsonResponse(characters);
+    }
     if (url.includes('/api/campaigns/camp-1/members')) {
       if (url.includes('/api/campaigns/camp-1/members/')) {
         return jsonResponse({ status: 'removed' });
@@ -195,6 +206,8 @@ describe('CampaignMembersPage', () => {
       mockDmAuth();
       const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
         const url = input.toString();
+        if (url.includes('/api/campaigns/camp-1/parties')) return jsonResponse([]);
+        if (url.includes('/api/characters')) return jsonResponse([]);
         if (url.includes('/api/campaigns/camp-1/members')) return jsonResponse({ members: [DM_MEMBER] });
         if (url.includes('/api/campaigns/camp-1')) return jsonResponse(MOCK_CAMPAIGN);
         return jsonResponse({}, 404);
@@ -215,6 +228,8 @@ describe('CampaignMembersPage', () => {
       global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         if (url.includes('/api/users/search')) return jsonResponse({ results: [{ id: 'new-id', username: 'charlie' }] });
+        if (url.includes('/api/campaigns/camp-1/parties')) return jsonResponse([]);
+        if (url.includes('/api/characters')) return jsonResponse([]);
         if (url.includes('/api/campaigns/camp-1/members') && init?.method === 'POST') return jsonResponse({ id: 'new-mem', status: 'invited' }, 201);
         if (url.includes('/api/campaigns/camp-1/members')) { memberListCallCount++; return jsonResponse({ members: [DM_MEMBER] }); }
         if (url.includes('/api/campaigns/camp-1')) return jsonResponse(MOCK_CAMPAIGN);
@@ -241,6 +256,8 @@ describe('CampaignMembersPage', () => {
       global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         if (url.includes('/api/users/search')) return jsonResponse({ results: [{ id: 'existing-id', username: 'alice' }] });
+        if (url.includes('/api/campaigns/camp-1/parties')) return jsonResponse([]);
+        if (url.includes('/api/characters')) return jsonResponse([]);
         if (url.includes('/api/campaigns/camp-1/members') && init?.method === 'POST') return jsonResponse({ error: 'Member already exists' }, 409);
         if (url.includes('/api/campaigns/camp-1/members')) return jsonResponse({ members: [DM_MEMBER] });
         if (url.includes('/api/campaigns/camp-1')) return jsonResponse(MOCK_CAMPAIGN);
@@ -270,6 +287,8 @@ describe('CampaignMembersPage', () => {
       global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         if (init?.method === 'DELETE') return jsonResponse({ status: 'removed' });
+        if (url.includes('/api/campaigns/camp-1/parties')) return jsonResponse([]);
+        if (url.includes('/api/characters')) return jsonResponse([]);
         if (url.includes('/api/campaigns/camp-1/members')) { memberListCallCount++; return jsonResponse({ members: [DM_MEMBER, PLAYER_MEMBER] }); }
         if (url.includes('/api/campaigns/camp-1')) return jsonResponse(MOCK_CAMPAIGN);
         return jsonResponse({}, 404);
@@ -285,6 +304,32 @@ describe('CampaignMembersPage', () => {
       await waitFor(() => {
         expect(memberListCallCount).toBeGreaterThan(callsBefore);
       });
+    });
+  });
+
+  describe('party membership panel', () => {
+    it('renders one panel per party returned from the parties endpoint', async () => {
+      mockPlayerAuth();
+      setupFetch(
+        [DM_MEMBER, PLAYER_MEMBER],
+        [{ id: 'party-1', name: 'The Vanguard' }, { id: 'party-2', name: 'The Rearguard' }],
+        []
+      );
+      render(React.createElement(CampaignMembersPage));
+      await waitFor(() => {
+        expect(screen.getByTestId('party-panel-party-1')).toBeInTheDocument();
+        expect(screen.getByTestId('party-panel-party-2')).toBeInTheDocument();
+      });
+    });
+
+    it('renders no panel sections when the campaign has zero parties', async () => {
+      mockPlayerAuth();
+      setupFetch([DM_MEMBER, PLAYER_MEMBER], [], []);
+      render(React.createElement(CampaignMembersPage));
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId(/party-panel-/)).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/components/CampaignMembersPage.test.tsx
+++ b/tests/unit/components/CampaignMembersPage.test.tsx
@@ -331,5 +331,22 @@ describe('CampaignMembersPage', () => {
       });
       expect(screen.queryByTestId(/party-panel-/)).not.toBeInTheDocument();
     });
+
+    it('shows an error banner when the parties endpoint fails to load', async () => {
+      mockPlayerAuth();
+      global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes('/api/campaigns/camp-1/parties')) return jsonResponse({ error: 'boom' }, 500);
+        if (url.includes('/api/characters')) return jsonResponse([]);
+        if (url.includes('/api/campaigns/camp-1/members')) return jsonResponse({ members: [DM_MEMBER, PLAYER_MEMBER] });
+        if (url.includes('/api/campaigns/camp-1')) return jsonResponse(MOCK_CAMPAIGN);
+        return jsonResponse({}, 404);
+      }) as jest.MockedFunction<typeof fetch>;
+
+      render(React.createElement(CampaignMembersPage));
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/failed to load party information/i);
+      });
+    });
   });
 });

--- a/tests/unit/components/PartyMembershipPanel.test.tsx
+++ b/tests/unit/components/PartyMembershipPanel.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Response as FetchResponse } from 'node-fetch';
+import { PartyMembershipPanel } from '@/lib/components/PartyMembershipPanel';
+import { Character, Party } from '@/lib/types';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new FetchResponse(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as Response;
+}
+
+const CAMPAIGN_ID = 'camp-1';
+const USER_ID = 'user-1';
+
+const CHAR_X: Character = {
+  id: 'char-x',
+  userId: USER_ID,
+  name: 'Aragorn',
+  classes: [],
+  abilityScores: {
+    strength: 10, dexterity: 10, constitution: 10,
+    intelligence: 10, wisdom: 10, charisma: 10,
+  },
+} as unknown as Character;
+
+const CHAR_Y: Character = {
+  id: 'char-y',
+  userId: USER_ID,
+  name: 'Legolas',
+  classes: [],
+  abilityScores: {
+    strength: 10, dexterity: 10, constitution: 10,
+    intelligence: 10, wisdom: 10, charisma: 10,
+  },
+} as unknown as Character;
+
+function makeParty(id: string, members: Party['members'] = []): Party {
+  return {
+    id,
+    userId: 'gm-1',
+    name: `Party ${id}`,
+    members,
+    campaignId: CAMPAIGN_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.clearAllMocks();
+});
+
+describe('PartyMembershipPanel', () => {
+  it('renders a checkbox for each of the player\'s own characters', () => {
+    const party = makeParty('party-1');
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+
+    expect(screen.getByRole('checkbox', { name: /Aragorn/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Legolas/i })).toBeInTheDocument();
+  });
+
+  it('reflects active membership as checked and inactive as unchecked', () => {
+    const party = makeParty('party-1', [
+      { characterId: 'char-x', addedAt: new Date() },
+    ]);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+
+    expect(screen.getByRole('checkbox', { name: /Aragorn/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Legolas/i })).not.toBeChecked();
+  });
+
+  it('checking an unchecked character sends PUT with full active characterIds', async () => {
+    const user = userEvent.setup();
+    const party = makeParty('party-1', [
+      { characterId: 'char-x', addedAt: new Date() },
+    ]);
+    const mockFetch = jest.fn(async (_input: RequestInfo | URL, _options?: RequestInit) => jsonResponse({}, 200)) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+
+    await user.click(screen.getByRole('checkbox', { name: /Legolas/i }));
+
+    await waitFor(() => {
+      const call = (mockFetch as jest.Mock).mock.calls[0];
+      expect(call[0]).toBe(`/api/campaigns/${CAMPAIGN_ID}/members/${USER_ID}/parties/party-1`);
+      expect(call[1].method).toBe('PUT');
+      const body = JSON.parse(call[1].body);
+      expect(body.characterIds.sort()).toEqual(['char-x', 'char-y']);
+    });
+  });
+
+  it('unchecking a checked character sends PUT excluding that character', async () => {
+    const user = userEvent.setup();
+    const party = makeParty('party-1', [
+      { characterId: 'char-x', addedAt: new Date() },
+      { characterId: 'char-y', addedAt: new Date() },
+    ]);
+    const mockFetch = jest.fn(async () => jsonResponse({}, 200)) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+
+    await user.click(screen.getByRole('checkbox', { name: /Legolas/i }));
+
+    await waitFor(() => {
+      const call = (mockFetch as jest.Mock).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body.characterIds).toEqual(['char-x']);
+    });
+  });
+
+  it('disables the toggled checkbox while its PUT is in flight, others remain interactive', async () => {
+    const user = userEvent.setup();
+    const party = makeParty('party-1');
+    let resolveFetch: (value: Response) => void;
+    const pending = new Promise<Response>((resolve) => { resolveFetch = resolve; });
+    const mockFetch = jest.fn(() => pending) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+
+    await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
+
+    expect(screen.getByRole('checkbox', { name: /Aragorn/i })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /Legolas/i })).not.toBeDisabled();
+
+    resolveFetch!(jsonResponse({}, 200));
+    await waitFor(() => expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeDisabled());
+  });
+
+  it('reverts the checkbox to its previous state when the PUT fails', async () => {
+    const user = userEvent.setup();
+    const party = makeParty('party-1');
+    const mockFetch = jest.fn(async () => jsonResponse({ error: 'fail' }, 500)) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X]} />);
+
+    const toggle = screen.getByRole('checkbox', { name: /Aragorn/i });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeChecked();
+    });
+  });
+
+  it('two independent panel instances do not affect each other\'s state', async () => {
+    const user = userEvent.setup();
+    const partyA = makeParty('party-a', [{ characterId: 'char-x', addedAt: new Date() }]);
+    const partyB = makeParty('party-b');
+    const mockFetch = jest.fn(async () => jsonResponse({}, 200)) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(
+      <>
+        <PartyMembershipPanel campaignId={CAMPAIGN_ID} party={partyA} characters={[CHAR_X]} />
+        <PartyMembershipPanel campaignId={CAMPAIGN_ID} party={partyB} characters={[CHAR_X]} />
+      </>
+    );
+
+    const checkboxes = screen.getAllByRole('checkbox', { name: /Aragorn/i });
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+
+    await user.click(checkboxes[1]);
+
+    await waitFor(() => {
+      expect((mockFetch as jest.Mock).mock.calls).toHaveLength(1);
+      const call = (mockFetch as jest.Mock).mock.calls[0];
+      expect(call[0]).toBe(`/api/campaigns/${CAMPAIGN_ID}/members/${USER_ID}/parties/party-b`);
+    });
+
+    expect(checkboxes[0]).toBeChecked();
+  });
+
+  it('renders a message and no checkboxes when the player has zero characters', () => {
+    const party = makeParty('party-1');
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[]} />);
+
+    expect(screen.getByText(/no characters/i)).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/PartyMembershipPanel.test.tsx
+++ b/tests/unit/components/PartyMembershipPanel.test.tsx
@@ -254,6 +254,22 @@ describe('PartyMembershipPanel', () => {
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
+  it('renders a load-failure message instead of the empty-state message when characters failed to load', () => {
+    const party = makeParty('party-1');
+    render(
+      <PartyMembershipPanel
+        campaignId={CAMPAIGN_ID}
+        userId={USER_ID}
+        party={party}
+        characters={[]}
+        charactersUnavailable
+      />
+    );
+
+    expect(screen.getByText(/could not load your characters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no characters to add/i)).not.toBeInTheDocument();
+  });
+
   it('resyncs checkbox state when the party prop updates after a refetch', () => {
     const party = makeParty('party-1');
     const { rerender } = render(

--- a/tests/unit/components/PartyMembershipPanel.test.tsx
+++ b/tests/unit/components/PartyMembershipPanel.test.tsx
@@ -69,6 +69,15 @@ describe('PartyMembershipPanel', () => {
     expect(screen.getByRole('checkbox', { name: /Legolas/i })).toBeInTheDocument();
   });
 
+  it('renders a character who previously left the party as unchecked', () => {
+    const party = makeParty('party-1', [
+      { characterId: 'char-x', addedAt: new Date('2026-01-01'), leftAt: new Date('2026-01-02') },
+    ]);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X]} />);
+
+    expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeChecked();
+  });
+
   it('reflects active membership as checked and inactive as unchecked', () => {
     const party = makeParty('party-1', [
       { characterId: 'char-x', addedAt: new Date() },
@@ -155,6 +164,57 @@ describe('PartyMembershipPanel', () => {
     await waitFor(() => {
       expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeChecked();
     });
+  });
+
+  it('shows an inline error message when a toggle fails', async () => {
+    const user = userEvent.setup();
+    const party = makeParty('party-1');
+    const mockFetch = jest.fn(async () => jsonResponse({ error: 'fail' }, 500)) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X]} />);
+
+    await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not update party membership/i)).toBeInTheDocument();
+    });
+  });
+
+  it('a failed toggle for one character does not clobber a concurrent successful toggle for another', async () => {
+    const user = userEvent.setup();
+    const party = makeParty('party-1');
+    let resolveA: (value: Response) => void;
+    const pendingA = new Promise<Response>((resolve) => { resolveA = resolve; });
+    const mockFetch = jest.fn((url: RequestInfo | URL, options?: RequestInit) => {
+      const body = JSON.parse(options!.body as string);
+      // The request adding char-x (Aragorn only) is the one that will fail.
+      if (body.characterIds.length === 1 && body.characterIds[0] === 'char-x') {
+        return pendingA;
+      }
+      return Promise.resolve(jsonResponse({}, 200));
+    }) as unknown as typeof global.fetch;
+    global.fetch = mockFetch;
+
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+
+    // Start toggling Aragorn (char-x); its PUT stays pending.
+    await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
+    // While that's in flight, toggle Legolas (char-y); its PUT resolves immediately.
+    await user.click(screen.getByRole('checkbox', { name: /Legolas/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Legolas/i })).toBeChecked();
+    });
+
+    // Now fail Aragorn's request.
+    resolveA!(jsonResponse({ error: 'fail' }, 500));
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeChecked();
+    });
+    // Legolas's committed toggle must survive Aragorn's revert.
+    expect(screen.getByRole('checkbox', { name: /Legolas/i })).toBeChecked();
   });
 
   it('two independent panel instances do not affect each other\'s state', async () => {

--- a/tests/unit/components/PartyMembershipPanel.test.tsx
+++ b/tests/unit/components/PartyMembershipPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Response as FetchResponse } from 'node-fetch';
 import { PartyMembershipPanel } from '@/lib/components/PartyMembershipPanel';
-import { Character, Party } from '@/lib/types';
+import type { Character, Party } from '@/lib/types';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new FetchResponse(JSON.stringify(body), {
@@ -63,7 +63,7 @@ afterEach(() => {
 describe('PartyMembershipPanel', () => {
   it('renders a checkbox for each of the player\'s own characters', () => {
     const party = makeParty('party-1');
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
 
     expect(screen.getByRole('checkbox', { name: /Aragorn/i })).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: /Legolas/i })).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe('PartyMembershipPanel', () => {
     const party = makeParty('party-1', [
       { characterId: 'char-x', addedAt: new Date('2026-01-01'), leftAt: new Date('2026-01-02') },
     ]);
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X]} />);
 
     expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeChecked();
   });
@@ -82,7 +82,7 @@ describe('PartyMembershipPanel', () => {
     const party = makeParty('party-1', [
       { characterId: 'char-x', addedAt: new Date() },
     ]);
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
 
     expect(screen.getByRole('checkbox', { name: /Aragorn/i })).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /Legolas/i })).not.toBeChecked();
@@ -96,7 +96,7 @@ describe('PartyMembershipPanel', () => {
     const mockFetch = jest.fn(async (_input: RequestInfo | URL, _options?: RequestInit) => jsonResponse({}, 200)) as unknown as typeof global.fetch;
     global.fetch = mockFetch;
 
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
 
     await user.click(screen.getByRole('checkbox', { name: /Legolas/i }));
 
@@ -118,7 +118,7 @@ describe('PartyMembershipPanel', () => {
     const mockFetch = jest.fn(async () => jsonResponse({}, 200)) as unknown as typeof global.fetch;
     global.fetch = mockFetch;
 
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
 
     await user.click(screen.getByRole('checkbox', { name: /Legolas/i }));
 
@@ -137,7 +137,7 @@ describe('PartyMembershipPanel', () => {
     const mockFetch = jest.fn(() => pending) as unknown as typeof global.fetch;
     global.fetch = mockFetch;
 
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
 
     await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
 
@@ -154,7 +154,7 @@ describe('PartyMembershipPanel', () => {
     const mockFetch = jest.fn(async () => jsonResponse({ error: 'fail' }, 500)) as unknown as typeof global.fetch;
     global.fetch = mockFetch;
 
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X]} />);
 
     const toggle = screen.getByRole('checkbox', { name: /Aragorn/i });
     expect(toggle).not.toBeChecked();
@@ -172,7 +172,7 @@ describe('PartyMembershipPanel', () => {
     const mockFetch = jest.fn(async () => jsonResponse({ error: 'fail' }, 500)) as unknown as typeof global.fetch;
     global.fetch = mockFetch;
 
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X]} />);
 
     await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
 
@@ -196,7 +196,7 @@ describe('PartyMembershipPanel', () => {
     }) as unknown as typeof global.fetch;
     global.fetch = mockFetch;
 
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X, CHAR_Y]} />);
 
     // Start toggling Aragorn (char-x); its PUT stays pending.
     await user.click(screen.getByRole('checkbox', { name: /Aragorn/i }));
@@ -226,8 +226,8 @@ describe('PartyMembershipPanel', () => {
 
     render(
       <>
-        <PartyMembershipPanel campaignId={CAMPAIGN_ID} party={partyA} characters={[CHAR_X]} />
-        <PartyMembershipPanel campaignId={CAMPAIGN_ID} party={partyB} characters={[CHAR_X]} />
+        <PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={partyA} characters={[CHAR_X]} />
+        <PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={partyB} characters={[CHAR_X]} />
       </>
     );
 
@@ -248,9 +248,24 @@ describe('PartyMembershipPanel', () => {
 
   it('renders a message and no checkboxes when the player has zero characters', () => {
     const party = makeParty('party-1');
-    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} party={party} characters={[]} />);
+    render(<PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[]} />);
 
     expect(screen.getByText(/no characters/i)).toBeInTheDocument();
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('resyncs checkbox state when the party prop updates after a refetch', () => {
+    const party = makeParty('party-1');
+    const { rerender } = render(
+      <PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={party} characters={[CHAR_X]} />
+    );
+    expect(screen.getByRole('checkbox', { name: /Aragorn/i })).not.toBeChecked();
+
+    const updatedParty = makeParty('party-1', [{ characterId: 'char-x', addedAt: new Date() }]);
+    rerender(
+      <PartyMembershipPanel campaignId={CAMPAIGN_ID} userId={USER_ID} party={updatedParty} characters={[CHAR_X]} />
+    );
+
+    expect(screen.getByRole('checkbox', { name: /Aragorn/i })).toBeChecked();
   });
 });


### PR DESCRIPTION
## Description
Adds a self-service party membership panel to the campaign page. Any active campaign member can now list all parties in their campaign (not just ones they own) and independently toggle which of their own characters are active members of each party.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Approach
Followed TDD per `openspec/changes/party-membership-panel/tests.md`: wrote failing unit tests first, then implementation, for both the new route and the new component. Also added an integration test.

### Integration Tests Consideration
- [x] I have considered using integration tests with Testcontainers for this change
- [x] I have added/updated integration tests for this change
- [ ] I am using mocks instead of integration tests

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#471 is merged)

## Related Issues
Closes #472

Part of epic #470. Depends on #471 (merged).

## Additional Notes
- New `GET /api/campaigns/[id]/parties` route, gated on active campaign membership (any role), mirroring the auth pattern used by the existing PUT party-membership route from #471.
- New `PartyMembershipPanel` component, one instance per party, mirroring the existing optimistic-toggle pattern in `SharedCharactersPanel`.
- Reuses the existing `PUT /api/campaigns/[id]/members/[userId]/parties/[partyId]` endpoint from #471 unchanged.
- Validation run locally: unit tests (2637 passed), integration tests (321 passed), typecheck, build, lint (0 errors), and targeted E2E regression (`campaigns.spec.ts` + `parties.spec.ts`, 32 passed).
- Pre-commit automated code review (`openspec-review-code` sub-agent) found no complexity/duplication/quality issues.
