### PR TITLE
feat: auto-create default party on campaign creation

### DIFF
--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -24,7 +24,11 @@ export const POST = withAuth(async (request, auth) => {
   }
 
   try {
-    const { name, moduleName, status, notes, chapters, currentChapterId } = body as Record<string, any>;
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return NextResponse.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+    }
+
+    const { name, moduleName, status, notes, chapters, currentChapterId } = body as Record<string, unknown>;
 
     if (typeof name !== 'string' || name.trim() === '') {
       return NextResponse.json({ error: 'Campaign name is required' }, { status: 400 });
@@ -37,7 +41,10 @@ export const POST = withAuth(async (request, auth) => {
     const sanitizedChapters = sanitizeChapters(chapters);
     const sanitizedCurrentChapterId = sanitizeCurrentChapterId(currentChapterId, sanitizedChapters);
 
-    const resolvedStatus = CAMPAIGN_STATUSES.includes(status) ? status : 'active';
+    const resolvedStatus: (typeof CAMPAIGN_STATUSES)[number] =
+      typeof status === 'string' && CAMPAIGN_STATUSES.includes(status as (typeof CAMPAIGN_STATUSES)[number])
+        ? (status as (typeof CAMPAIGN_STATUSES)[number])
+        : 'active';
 
     const campaign: Campaign = {
       id: crypto.randomUUID(),

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
-import { Campaign, CAMPAIGN_STATUSES, CampaignMember, Party } from '@/lib/types';
+import { CAMPAIGN_STATUSES } from '@/lib/types';
+import type { Campaign, Party } from '@/lib/types';
 import { sanitizeChapters, sanitizeCurrentChapterId } from '@/lib/utils/campaign';
 
 export const GET = withAuth(async (_request, auth) => {

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -15,9 +15,15 @@ export const GET = withAuth(async (_request, auth) => {
 });
 
 export const POST = withAuth(async (request, auth) => {
+  let body: unknown;
   try {
-    const body = await request.json();
-    const { name, moduleName, status, notes, chapters, currentChapterId } = body;
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  try {
+    const { name, moduleName, status, notes, chapters, currentChapterId } = body as Record<string, any>;
 
     if (typeof name !== 'string' || name.trim() === '') {
       return NextResponse.json({ error: 'Campaign name is required' }, { status: 400 });

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/middleware';
 import { storage } from '@/lib/storage';
-import { Campaign, CAMPAIGN_STATUSES, CampaignMember } from '@/lib/types';
+import { Campaign, CAMPAIGN_STATUSES, CampaignMember, Party } from '@/lib/types';
 import { sanitizeChapters, sanitizeCurrentChapterId } from '@/lib/utils/campaign';
 
 export const GET = withAuth(async (_request, auth) => {
@@ -47,6 +47,28 @@ export const POST = withAuth(async (request, auth) => {
 
     await storage.saveCampaign(campaign);
 
+    const party: Party = {
+      id: crypto.randomUUID(),
+      userId: auth.userId,
+      name: 'Main Party',
+      description: '',
+      members: [],
+      campaignId: campaign.id,
+      createdAt: campaign.createdAt,
+      updatedAt: campaign.updatedAt,
+    };
+
+    try {
+      await storage.saveParty(party);
+    } catch (partyError) {
+      try {
+        await storage.deleteCampaign(campaign.id, auth.userId);
+      } catch (rollbackError) {
+        console.error('Failed to rollback campaign creation:', rollbackError);
+      }
+      throw partyError;
+    }
+
     try {
       await storage.addMember({
         id: crypto.randomUUID(),
@@ -57,6 +79,11 @@ export const POST = withAuth(async (request, auth) => {
         history: [{ action: 'active' as const, by: auth.userId, at: new Date() }],
       });
     } catch (memberError) {
+      try {
+        await storage.deleteParty(party.id, auth.userId);
+      } catch (rollbackError) {
+        console.error('Failed to rollback party creation:', rollbackError);
+      }
       try {
         await storage.deleteCampaign(campaign.id, auth.userId);
       } catch (rollbackError) {

--- a/openspec/changes/auto-create-default-party/.openspec.yaml
+++ b/openspec/changes/auto-create-default-party/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-07-06

--- a/openspec/changes/auto-create-default-party/design.md
+++ b/openspec/changes/auto-create-default-party/design.md
@@ -1,0 +1,101 @@
+## Context
+
+- Relevant architecture: Next.js route handler `app/api/campaigns/route.ts` (`POST`), wrapped in `withAuth`. Persistence goes through the singleton `storage` object in `lib/storage.ts` (`saveCampaign`, `deleteCampaign`, `addMember`, `saveParty`, `deleteParty`). Types live in `lib/types.ts` (`Campaign`, `CampaignMember`, `Party`, `PartyMember`).
+- Dependencies: `Party` model and its storage functions (`storage.saveParty`, `storage.deleteParty`) already exist and are exercised today by `app/api/parties/route.ts`. No new model or storage function is required.
+- Interfaces/contracts touched: only the internal implementation of `POST /api/campaigns`. Request and response shapes for that endpoint are unchanged.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Every campaign created via `POST /api/campaigns` ends up with exactly one `Party` (named "Main Party") linked via `campaignId`.
+- Creation is atomic from the caller's perspective: either campaign + party + member all exist, or none do.
+- No change to the `POST /api/campaigns` request or response contract.
+
+### Non-Goals
+
+- Backfilling parties for campaigns created before this ships (#479).
+- Cascading deletes for `Party`/`CampaignMember` on campaign deletion (#480).
+- Any UI change.
+
+## Decisions
+
+### Decision 1: Extend the existing three-step saga, party before member
+
+- Chosen: Insert party creation between campaign save and member save: `saveCampaign` → `saveParty` → `addMember`. On failure of `addMember`, roll back by deleting the party then the campaign. On failure of `saveParty`, roll back by deleting the campaign. This mirrors the existing single-step rollback (member failure → delete campaign) by extending it one level, in the same nested try/catch style already present in the route.
+- Alternatives considered:
+  - Member before party: rejected — no functional difference in outcome, but party-before-member reads more naturally as "set up the campaign's structures, then add the person to it," and keeps the diff smaller since the existing member-rollback block only needs to grow by one extra delete call rather than being reordered around a new block.
+  - Wrap all three saves in a single generic try/catch with a rollback list built dynamically (e.g. push cleanup functions onto a stack and pop-and-run on any failure): rejected as over-engineering for three fixed, sequential steps; the existing code already uses explicit nested try/catch for the two-step case, and this change should extend that shape rather than introduce a new abstraction for a three-step case.
+- Rationale: Matches the project's established precedent of matching existing route patterns exactly rather than introducing new transaction abstractions (see campaign-copy route decision log).
+- Trade-offs: Nesting one more level of try/catch is slightly more verbose than a generic rollback-stack helper, but keeps the change minimal and consistent with existing code the next reader will already recognize.
+
+### Decision 2: Party shape — fixed name, empty members, campaignId set, userId = creator
+
+- Chosen: `{ id: crypto.randomUUID(), userId: auth.userId, name: 'Main Party', description: '', members: [], campaignId: campaign.id, createdAt: now, updatedAt: now }`, saved via `storage.saveParty`.
+- Alternatives considered: Deriving name from campaign name (e.g. `${campaign.name} Party`) — rejected per explicit decision; keeps naming simple and predictable, and the party can be renamed later through existing party-editing flows.
+- Rationale: Matches the shape already produced by `POST /api/parties` (`app/api/parties/route.ts`) for consistency, minus `characterIds` (none exist yet).
+- Trade-offs: None significant; DM must rename manually if "Main Party" isn't desired, which is an accepted, low-cost trade-off.
+
+### Decision 3: No response contract change
+
+- Chosen: `POST /api/campaigns` continues to return the `Campaign` object only (201). The created `Party` is not included in the response body.
+- Alternatives considered: Returning `{ campaign, party }` — rejected to avoid breaking existing consumers (`CampaignEditor.tsx`, `tests/unit/api/campaigns/route.test.ts`, `tests/integration/campaigns.integration.test.ts`) that currently expect the response body to be the campaign itself.
+- Rationale: Explicit decision from exploration; the party is discoverable via `GET /api/parties` or `GET /api/campaigns/[id]` contexts already used elsewhere (e.g. `CampaignContext.parties`).
+- Trade-offs: Client that wants to show the new party immediately after creating a campaign must make a follow-up fetch; acceptable since no current UI flow needs this yet.
+
+## Proposal to Design Mapping
+
+- Proposal element: Extend `POST /api/campaigns` to create a default "Main Party"
+  - Design decision: Decision 1, Decision 2
+  - Validation approach: Integration test asserting a `Party` with `campaignId` equal to the new campaign's id and `name: 'Main Party'` exists after a successful `POST /api/campaigns` call.
+- Proposal element: Rollback on partial failure
+  - Design decision: Decision 1
+  - Validation approach: Unit tests mocking `storage.addMember` and `storage.saveParty` to reject, asserting `storage.deleteParty`/`storage.deleteCampaign` are called with the right arguments and the route still returns a 500.
+- Proposal element: No response contract change
+  - Design decision: Decision 3
+  - Validation approach: Existing `tests/unit/api/campaigns/route.test.ts` / `tests/integration/campaigns.integration.test.ts` continue to assert the response body equals the `Campaign` shape with no added `party` key; add an explicit assertion that the response does not include a `party` field to lock in the contract.
+
+## Functional Requirements Mapping
+
+- Requirement: A default `Party` named "Main Party" is created and linked to every new campaign.
+  - Design element: Decision 1, Decision 2
+  - Acceptance criteria reference: specs — "default party creation"
+  - Testability notes: Directly assertable via integration test querying parties by `campaignId` after campaign creation.
+- Requirement: Failure of any creation step rolls back all previously completed steps.
+  - Design element: Decision 1
+  - Acceptance criteria reference: specs — "rollback on partial failure"
+  - Testability notes: Requires mocking `storage` methods to simulate failure at each step (party save fails, member save fails) and asserting cleanup calls and final DB state.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: reliability
+  - Requirement: No orphaned `Campaign`, `Party`, or `CampaignMember` rows after a failed creation attempt.
+  - Design element: Decision 1 (ordered rollback)
+  - Acceptance criteria reference: specs — "rollback on partial failure"
+  - Testability notes: Integration test simulating downstream failure and then querying storage directly to confirm no rows remain for the attempted campaign id.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Rollback itself can fail (e.g. `deleteParty` throws during cleanup after `addMember` failed).
+  - Impact: Orphaned `Party` and/or `Campaign` rows, same class of issue the existing code already accepts for the member-rollback case (it logs and continues rather than retrying).
+  - Mitigation: Match existing behavior exactly — log the rollback error via `console.error` and continue re-throwing the original error, same as the current `catch (memberError)` block does for `rollbackError`. Not a regression; consistent with current risk acceptance.
+
+## Rollback / Mitigation
+
+- Rollback trigger: `storage.saveParty` throws, or `storage.addMember` throws, during `POST /api/campaigns`.
+- Rollback steps:
+  1. If `addMember` fails: call `storage.deleteParty(party.id, auth.userId)`, then `storage.deleteCampaign(campaign.id, auth.userId)`, each in its own try/catch that logs on failure without swallowing the original error.
+  2. If `saveParty` fails: call `storage.deleteCampaign(campaign.id, auth.userId)` in a try/catch that logs on failure without swallowing the original error.
+- Data migration considerations: None — no schema change, no existing data touched.
+- Verification after rollback: Integration tests assert that after a simulated downstream failure, no `Campaign`, `Party`, or `CampaignMember` row exists for the attempted creation.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Fix the failing test/lint before merge; this is a small, self-contained route change with no infra dependency, so CI failures should block merge until resolved.
+- If security checks fail: Treat as blocking; re-review the rollback logging to ensure no sensitive data (e.g. raw error objects containing user input) is logged in a way that violates existing sanitization practices.
+- If required reviews are blocked/stale: Follow standard repo PR process — no special exception for this change.
+- Escalation path and timeout: Standard team PR review process; no dedicated on-call impact since this is not a production-incident-triggering path.
+
+## Open Questions
+
+None — see proposal.md Open Questions section.

--- a/openspec/changes/auto-create-default-party/proposal.md
+++ b/openspec/changes/auto-create-default-party/proposal.md
@@ -1,0 +1,73 @@
+## GitHub Issues
+
+- #474
+- #470 (epic: Party-Centric Character Sharing)
+
+## Why
+
+- Problem statement: `POST /api/campaigns` creates a `Campaign` and a `CampaignMember` (the creating DM), but no `Party`. There is no default place to share characters into a freshly created campaign.
+- Why now: Epic #470 is migrating character sharing from the campaign-level `CampaignCharacterShare` abstraction to party-level sharing. Every campaign needs at least one `Party` for that model to work; without this change, every new campaign is born without one.
+- Business/user impact: DMs currently have to remember to manually create a party after creating a campaign before they can share characters into it. This closes that gap for newly created campaigns.
+
+## Problem Space
+
+- Current behavior: `POST /api/campaigns` (`app/api/campaigns/route.ts`) saves the `Campaign`, then creates a `CampaignMember` for the DM. If member creation fails, the campaign is rolled back (deleted). No `Party` is created.
+- Desired behavior: `POST /api/campaigns` additionally creates a default `Party` named "Main Party", linked to the new campaign via `campaignId`, owned by the creating user. If any step in the creation saga fails, all prior steps are rolled back so no partial campaign/party/member state is left behind.
+- Constraints:
+  - Must reuse the existing `Party` model and `storage.saveParty` / `storage.deleteParty` (already implemented for `app/api/parties/route.ts`); no new Party concept.
+  - Must not change the `POST /api/campaigns` response contract — response body remains the `Campaign` object only, matching current client expectations (`CampaignEditor.tsx`, existing tests).
+  - Must follow the existing saga/rollback pattern in the route (build entity → save → on later failure, roll back what was already saved), per prior "match existing pattern exactly" precedent used for the campaign-copy route.
+- Assumptions:
+  - "Main Party" is a fixed, hardcoded string — not derived from campaign name or localized.
+  - The default party starts with an empty `members` array (no characters exist yet at campaign-creation time).
+  - Party ordering: created after the `Campaign` save, before the `CampaignMember` save (party before member).
+- Edge cases considered:
+  - Party save fails after campaign save succeeds → roll back (delete) the campaign.
+  - Member save fails after campaign + party both succeeded → roll back (delete) the party, then the campaign.
+  - Pre-existing campaigns (created before this ships) will not retroactively get a default party — tracked separately in #479.
+  - Campaign deletion does not currently cascade to delete associated `Party`/`CampaignMember` rows; this change adds one more piece of state that can be orphaned this way — tracked separately in #480.
+
+## Scope
+
+### In Scope
+
+- Modify `POST /api/campaigns` (`app/api/campaigns/route.ts`) to create a default "Main Party" for every newly created campaign.
+- Extend the existing rollback logic to unwind the party (and campaign) if a later step fails.
+- Unit/integration test coverage for the new creation and rollback paths.
+
+### Out of Scope
+
+- Backfilling a default party for campaigns created before this change ships (tracked in #479).
+- Cascading deletion of `Party`/`CampaignMember` records when a campaign is deleted (tracked in #480).
+- Any change to `POST /api/campaigns` response shape or to `GET`/other campaign endpoints.
+- Any change to `app/api/parties/route.ts` or manual party creation/editing flows.
+- Configurable or campaign-name-derived party naming.
+
+## What Changes
+
+- `app/api/campaigns/route.ts`: `POST` handler creates a `Party` (name: "Main Party", `campaignId` set to the new campaign's id, `userId` set to the creating user, empty `members`) immediately after saving the campaign and before creating the `CampaignMember`. Failure at any step rolls back all previously-completed steps in reverse order.
+
+## Risks
+
+- Risk: Extending the rollback chain incorrectly could leave orphaned `Party` or `Campaign` rows on partial failure.
+  - Impact: Data inconsistency; orphaned records visible to the user or consuming other flows (e.g. sharing UI referencing a campaign that no longer exists).
+  - Mitigation: Explicit, ordered rollback (reverse of creation order) with each rollback step independently try/caught and logged, matching the existing member-rollback pattern in the current code.
+- Risk: Silent party creation (no contract change) could surprise a DM who expects to name their own initial party.
+  - Impact: Low — "Main Party" can be renamed via existing party-editing UI/API after creation.
+  - Mitigation: None needed; explicitly accepted per scope decision.
+
+## Open Questions
+
+None — all decisions needed to implement this change were resolved during exploration (see #474 discussion): rollback ordering (party before member, reverse-order rollback), no API contract change, fixed "Main Party" name, and backfill/cascade-delete concerns deferred to #479/#480.
+
+## Non-Goals
+
+- Retroactively creating parties for existing campaigns.
+- Cleaning up orphaned records on campaign deletion.
+- Supporting multiple default parties or per-campaign party templates.
+- Any change to how characters are added to a party.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/auto-create-default-party/specs/campaign-crud/spec.md
+++ b/openspec/changes/auto-create-default-party/specs/campaign-crud/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Campaign creation auto-creates a default party
+
+The system SHALL create a default `Party` named "Main Party", linked to the new campaign via `campaignId` and owned by the creating user, whenever a campaign is created via `POST /api/campaigns`.
+
+#### Scenario: Creating a campaign creates a linked default party
+
+- **Given** an authenticated user
+- **When** they POST `/api/campaigns` with `{ name: "My Campaign" }`
+- **Then** the response is 201 with the campaign object (unchanged shape); a `Party` exists with `name: "Main Party"`, `campaignId` equal to the new campaign's `id`, `userId` equal to the authenticated user's id, and an empty `members` array
+
+#### Scenario: Default party is created before the DM member record
+
+- **Given** an authenticated user creating a campaign
+- **When** the campaign is created
+- **Then** the `Party` is saved after the `Campaign` is saved and before the `CampaignMember` (DM) record is saved
+
+### Requirement: ADDED Campaign creation rolls back the default party on later failure
+
+The system SHALL delete the newly created `Party` (and the newly created `Campaign`) if a later step in campaign creation fails, so no partial state persists.
+
+#### Scenario: Member creation fails after party creation succeeds
+
+- **Given** an authenticated user
+- **When** they POST `/api/campaigns` and `storage.addMember` throws after the campaign and default party were both saved
+- **Then** the response is 500; the newly created `Party` no longer exists; the newly created `Campaign` no longer exists
+
+#### Scenario: Party creation fails after campaign creation succeeds
+
+- **Given** an authenticated user
+- **When** they POST `/api/campaigns` and `storage.saveParty` throws after the campaign was saved
+- **Then** the response is 500; the newly created `Campaign` no longer exists; no `CampaignMember` record was created for it
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Creating a campaign with all fields
+
+The system SHALL provide authenticated REST API endpoints to create, read, update, and delete campaigns scoped to the authenticated user, and creating a campaign SHALL additionally result in a default `Party` linked to it.
+
+#### Scenario: Creating a campaign with all fields
+
+- **Given** an authenticated user
+- **When** they POST `/api/campaigns` with `{ name, moduleName, status, notes, chapters, currentChapterId }`
+- **Then** the campaign is persisted with a generated `id`, the supplied `userId`, and `createdAt`/`updatedAt` timestamps; the response is 201 with the full campaign object; a linked default `Party` and a `CampaignMember` (DM) record are also created
+
+## Traceability
+
+- Proposal element: "Extend `POST /api/campaigns` to create a default 'Main Party'" -> Requirement: "ADDED Campaign creation auto-creates a default party"
+- Proposal element: "Rollback on partial failure" -> Requirement: "ADDED Campaign creation rolls back the default party on later failure"
+- Design decision: Decision 1 (extend saga, party before member) -> Requirement: "ADDED Campaign creation auto-creates a default party" (ordering scenario), "ADDED Campaign creation rolls back the default party on later failure"
+- Design decision: Decision 2 (party shape) -> Requirement: "ADDED Campaign creation auto-creates a default party"
+- Design decision: Decision 3 (no response contract change) -> Requirement: "MODIFIED Creating a campaign with all fields"
+- Requirement: "ADDED Campaign creation auto-creates a default party" -> Task(s): implement party creation in POST handler; integration test for linked party
+- Requirement: "ADDED Campaign creation rolls back the default party on later failure" -> Task(s): implement ordered rollback; unit tests mocking storage failures
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No orphaned records after partial failure
+
+- **Given** a `POST /api/campaigns` request where a downstream step (party save or member save) throws
+- **When** the request completes with a 500 response
+- **Then** no `Campaign`, `Party`, or `CampaignMember` row exists in storage for the attempted creation
+
+### Requirement: Security
+
+See functional scenarios: "Member creation fails after party creation succeeds", "Party creation fails after campaign creation succeeds" — access remains scoped to the authenticated user's own records throughout; no new access-control surface is introduced by this change.

--- a/openspec/changes/auto-create-default-party/tasks.md
+++ b/openspec/changes/auto-create-default-party/tasks.md
@@ -1,0 +1,107 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b feat/auto-create-default-party` then immediately `git push -u origin feat/auto-create-default-party`
+
+## Preflight
+
+- [x] **Verify `pr-review-toolkit:review-pr` is available** — check the available skills list for `pr-review-toolkit:review-pr`. If the skill is not listed, halt immediately, inform the user that the plugin is required, provide installation guidance, and do not proceed until the user confirms it is installed.
+
+## Execution
+
+- [x] **Issue lifecycle: mark in-progress**: run `gh issue edit 474 --add-label "in-progress"`. Then discover the GitHub Project linked to `dougis-org/session-combat` (`gh project list --owner dougis-org --format json`), resolve the status field option semantically matching "In Progress" (`gh project field-list <project-number> --owner dougis-org --format json`), and move the project item via `gh project item-edit`. If no project item is found, log a warning and continue. If the `gh` token lacks the `project` scope, surface a message instructing the user to run `gh auth refresh -s project` and skip the project-item update (issue label update still proceeds).
+  - NOTE: labels `in-progress`/`in-review` did not exist in this repo — created them. `gh` token lacks `project` scope; project-item update skipped per instructions (user needs to run `gh auth refresh -s project`).
+- [x] Read `app/api/campaigns/route.ts` and `app/api/parties/route.ts` in full before editing, to confirm the current shapes have not drifted since the design was written
+- [x] In `app/api/campaigns/route.ts`, after `storage.saveCampaign(campaign)` succeeds and before the existing `storage.addMember(...)` call, construct and save a default `Party`:
+  - `{ id: crypto.randomUUID(), userId: auth.userId, name: 'Main Party', description: '', members: [], campaignId: campaign.id, createdAt: <same timestamp as campaign.createdAt>, updatedAt: <same timestamp>, }`
+  - Save via `storage.saveParty(party)`
+  - Wrap in its own try/catch: on failure, attempt `storage.deleteCampaign(campaign.id, auth.userId)` (log and continue on rollback failure, matching the existing member-rollback style), then re-throw the original error
+- [x] Extend the existing `try { await storage.addMember(...) } catch (memberError) { ... }` block so the rollback on member failure also deletes the newly created party (`storage.deleteParty(party.id, auth.userId)`) before deleting the campaign, logging (not swallowing) any rollback step that itself fails
+- [x] Confirm the `POST /api/campaigns` response body is unchanged (still the bare `Campaign` object, no `party` key added)
+- [x] Look for existing tooling or functions in the codebase that can be reused or extended before writing new logic from scratch (reuse `Party`/`PartyMember` types and `storage.saveParty`/`storage.deleteParty` as-is; do not introduce new storage functions)
+- [x] Confirm acceptance criteria in `openspec/changes/auto-create-default-party/specs/campaign-crud/spec.md` are covered by the implementation
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+  - NOTE: sub-agent hit a session usage limit before completing; ran `openspec-review-code` directly in the primary agent instead. Findings: None (diff matches existing rollback pattern, no new abstractions).
+
+## Validation
+
+- [x] Add/extend `tests/unit/api/campaigns/route.test.ts` to cover: default party created on success; party created before member (call-order assertion); no `party` key in response body
+- [x] Add/extend `tests/integration/campaigns.integration.test.ts` to cover: a `Party` with `campaignId` equal to the new campaign's id and `name: 'Main Party'` exists after `POST /api/campaigns`
+- [x] Add rollback unit tests: `storage.saveParty` mocked to throw → campaign is deleted, no member is created; `storage.addMember` mocked to throw → party is deleted, then campaign is deleted
+- [x] Run unit/integration tests: `npm run test:unit`
+- [x] Run E2E tests (if applicable): none required — no UI change in this scope
+- [x] Run type checks
+- [x] Run build
+- [x] Run security/code quality checks required by project standards (`npm run lint`: 0 errors, 7 pre-existing warnings unrelated to this change)
+- [x] All completed tasks marked as complete
+- [x] All steps in [Remote push validation]
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` (or compare the working branch against the base branch) and check whether every changed file ends in `.md`. If yes, apply the docs-only path; otherwise apply the full path.
+
+**Full path** (any non-`.md` file changed):
+
+- **Unit tests** — run the project's unit test suite (`npm run test:unit`); all tests must pass
+- **Integration tests** — run the project's integration test suite; all tests must pass
+- **Regression / E2E tests** — run the project's end-to-end or regression test suite; all tests must pass
+- **Build** — run the project's build script; build must succeed with no errors
+
+**Docs-only path** (every changed file is `.md`):
+
+- **Build** — run the project's build script; build must succeed with no errors
+- Skip integration and regression/E2E tests — they are not required when no code changed
+
+If **ANY** required step fails, you **MUST** iterate and address the failure before pushing.
+
+Use the project's documented commands for each of the above (see project README or CLAUDE.md / AGENTS.md). Note: this repo has no `npm test` script — always use `npm run test:unit`.
+
+## PR and Merge
+
+- [x] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `feat/auto-create-default-party` to `main`. The PR body MUST include `Closes #474`.
+- [ ] **Issue lifecycle: mark in-review**: run `gh issue edit 474 --add-label "in-review" --remove-label "in-progress"`. Then move the project item to the status column semantically matching "In Review" via `gh project item-edit` (same project/field/option discovery as the in-progress lifecycle step above; warn and skip if not found).
+- [ ] Wait 60 seconds for CI to start
+- [ ] Spawn a sub-agent to run `pr-review-toolkit:review-pr`; address all findings (commit, push, re-run) until zero findings remain. If findings persist after three or more iterations with no progress, report the stall with remaining findings listed and wait for human guidance before continuing.
+- [ ] **Enable auto-merge only after the review gate passes (zero findings):** `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved (reply, then resolve via GraphQL `resolveReviewThread`)
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: assignee of #474
+- Reviewer(s): repository default code owners / PR reviewers
+- Required approvals: per repository branch protection rules
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (none expected beyond spec sync)
+- [ ] Sync approved spec deltas into `openspec/specs/campaign-crud/spec.md`. After copying, update all relative links that pointed into the change directory so they resolve from the archive location — replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-auto-create-default-party/design.md`, and similarly for `../../tasks.md` and any other relative paths into the change directory.
+- [ ] Archive the change: move `openspec/changes/auto-create-default-party/` to `openspec/changes/archive/YYYY-MM-DD-auto-create-default-party/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-auto-create-default-party/` exists and `openspec/changes/auto-create-default-party/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-auto-create-default-party` then `git push -u origin doc/archive-YYYY-MM-DD-auto-create-default-party`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-auto-create-default-party` to `main` with title `docs: archive auto-create-default-party (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge; use `--squash` per repo ruleset)
+- [ ] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D feat/auto-create-default-party doc/archive-YYYY-MM-DD-auto-create-default-party`
+
+Required cleanup after archive: `git fetch --prune` and `git branch -D feat/auto-create-default-party doc/archive-YYYY-MM-DD-auto-create-default-party`

--- a/openspec/changes/auto-create-default-party/tests.md
+++ b/openspec/changes/auto-create-default-party/tests.md
@@ -1,0 +1,39 @@
+---
+name: tests
+description: Tests for the change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `auto-create-default-party` change. All work should follow a strict TDD (Test-Driven Development) process.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1.  **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2.  **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3.  **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### Unit — `tests/unit/api/campaigns/route.test.ts`
+
+- [x] Test case: `POST /api/campaigns` with valid `name` calls `storage.saveParty` with `{ name: 'Main Party', campaignId: <new campaign id>, userId: <auth.userId>, members: [] }` — maps to tasks.md "construct and save a default Party"; spec scenario "Creating a campaign creates a linked default party"
+- [x] Test case: `storage.saveParty` is called after `storage.saveCampaign` and before `storage.addMember` (assert mock call order) — maps to tasks.md "after storage.saveCampaign succeeds and before... addMember"; spec scenario "Default party is created before the DM member record"
+- [x] Test case: Successful `POST /api/campaigns` response body is exactly the `Campaign` object — no `party` key present — maps to tasks.md "Confirm the response body is unchanged"; spec scenario "MODIFIED Creating a campaign with all fields"
+- [x] Test case: `storage.saveParty` mocked to reject → response is 500; `storage.deleteCampaign` is called with the new campaign's id and `auth.userId`; `storage.addMember` is never called — maps to tasks.md "Wrap in its own try/catch... on failure, attempt storage.deleteCampaign"; spec scenario "Party creation fails after campaign creation succeeds"
+- [x] Test case: `storage.addMember` mocked to reject (party save succeeded) → response is 500; `storage.deleteParty` is called with the new party's id and `auth.userId`, followed by `storage.deleteCampaign` with the new campaign's id and `auth.userId` — maps to tasks.md "Extend the existing... rollback on member failure also deletes the newly created party"; spec scenario "Member creation fails after party creation succeeds"
+- [x] Test case: `storage.deleteParty` mocked to reject during member-failure rollback → the original `memberError` is still thrown/logged (not swallowed), and `storage.deleteCampaign` is still attempted — maps to tasks.md "logging (not swallowing) any rollback step that itself fails"; design.md "Risks / Trade-offs"
+
+### Integration — `tests/integration/campaigns.integration.test.ts`
+
+- [x] Test case: After a successful `POST /api/campaigns`, `storage.loadPartiesByCampaign(campaignId)` (or equivalent query) returns exactly one `Party` with `name: 'Main Party'` and `campaignId` equal to the new campaign's id — maps to tasks.md "extend campaigns.integration.test.ts"; spec scenario "Creating a campaign creates a linked default party" (implemented via `GET /api/parties` filtered by `campaignId`)
+- [x] Test case: After a simulated downstream failure (party or member save throws), querying storage directly confirms no `Campaign`, `Party`, or `CampaignMember` row exists for the attempted creation — maps to tasks.md "Add rollback unit tests"; NFAC "No orphaned records after partial failure" (covered at the unit level via mocked `storage` rejections, since the live integration server does not expose fault injection into `storage`)
+
+## Traceability to Tasks
+
+- All unit test cases above map to the `Execution` section items in `tasks.md` under `app/api/campaigns/route.ts` changes.
+- All integration test cases above map to the `Validation` section item "Add/extend `tests/integration/campaigns.integration.test.ts`" in `tasks.md`.

--- a/tests/integration/campaigns.integration.test.ts
+++ b/tests/integration/campaigns.integration.test.ts
@@ -290,6 +290,17 @@ describe("Campaign API Integration Tests", () => {
     expect(party.campaignId).toBeUndefined();
   });
 
+  it("creating a campaign creates a linked default 'Main Party'", async () => {
+    const campaign = await createCampaign("Default Party Campaign");
+
+    const partiesRes = await fetch(`${baseUrl}/api/parties`, { headers: authed() });
+    expect(partiesRes.status).toBe(200);
+    const parties = await partiesRes.json() as { id: string; name: string; campaignId?: string }[];
+    const defaultParty = parties.find(p => p.campaignId === campaign.id);
+    expect(defaultParty).toBeDefined();
+    expect(defaultParty?.name).toBe("Main Party");
+  });
+
   it("deleting a campaign does not delete associated parties", async () => {
     const campaign = await createCampaign("Campaign To Delete");
 

--- a/tests/unit/api/campaigns/route.test.ts
+++ b/tests/unit/api/campaigns/route.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { GET, POST } from "@/app/api/campaigns/route";
 import { GET as GET_ONE, PATCH, DELETE } from "@/app/api/campaigns/[id]/route";
 import { storage } from "@/lib/storage";
@@ -101,6 +101,16 @@ describe("POST /api/campaigns", () => {
   });
 
   itReturns401(POST, () => makePostRequest({ name: "Test" }));
+
+  it("returns 400 for malformed JSON body", async () => {
+    const request = new NextRequest(BASE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie: "auth-token=t" },
+      body: "not-json",
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+  });
 
   it("returns 400 when name is missing", async () => {
     const response = await POST(makePostRequest({ moduleName: "X" }));

--- a/tests/unit/api/campaigns/route.test.ts
+++ b/tests/unit/api/campaigns/route.test.ts
@@ -112,6 +112,21 @@ describe("POST /api/campaigns", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 400 when JSON body is not an object (array)", async () => {
+    const response = await POST(makePostRequest(["not", "an", "object"]));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when JSON body is not an object (null)", async () => {
+    const response = await POST(makePostRequest(null));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when JSON body is not an object (string)", async () => {
+    const response = await POST(makePostRequest("just a string"));
+    expect(response.status).toBe(400);
+  });
+
   it("returns 400 when name is missing", async () => {
     const response = await POST(makePostRequest({ moduleName: "X" }));
     expect(response.status).toBe(400);
@@ -267,6 +282,17 @@ describe("POST /api/campaigns", () => {
       expect.any(String),
       "user-123"
     );
+    expect(mockedStorage.addMember).not.toHaveBeenCalled();
+  });
+
+  it("still returns 500 for the original error when deleteCampaign rollback itself fails after saveParty fails", async () => {
+    mockedStorage.saveParty.mockRejectedValue(new Error("party save failed"));
+    mockedStorage.deleteCampaign.mockRejectedValue(new Error("delete campaign failed"));
+
+    const response = await POST(makePostRequest({ name: "Doomed" }));
+
+    expect(response.status).toBe(500);
+    expect(mockedStorage.deleteCampaign).toHaveBeenCalled();
     expect(mockedStorage.addMember).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/api/campaigns/route.test.ts
+++ b/tests/unit/api/campaigns/route.test.ts
@@ -24,6 +24,8 @@ jest.mock("@/lib/storage", () => ({
     saveCampaign: jest.fn(),
     deleteCampaign: jest.fn(),
     addMember: jest.fn().mockResolvedValue(undefined),
+    saveParty: jest.fn().mockResolvedValue(undefined),
+    deleteParty: jest.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -93,6 +95,9 @@ describe("POST /api/campaigns", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedStorage.saveCampaign.mockResolvedValue(undefined as any);
+    mockedStorage.saveParty.mockResolvedValue(undefined as any);
+    mockedStorage.deleteParty.mockResolvedValue(undefined as any);
+    mockedStorage.addMember.mockResolvedValue(undefined as any);
   });
 
   itReturns401(POST, () => makePostRequest({ name: "Test" }));
@@ -203,6 +208,86 @@ describe("POST /api/campaigns", () => {
     expect(response.status).toBe(201);
     const body = await response.json();
     expect(body.currentChapterId).toBeUndefined();
+  });
+
+  it("creates a default 'Main Party' linked to the new campaign", async () => {
+    const response = await POST(makePostRequest({ name: "Dragon Heist" }));
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(mockedStorage.saveParty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Main Party",
+        campaignId: body.id,
+        userId: "user-123",
+        members: [],
+      })
+    );
+  });
+
+  it("saves the party after the campaign and before the member", async () => {
+    const calls: string[] = [];
+    mockedStorage.saveCampaign.mockImplementation(async () => {
+      calls.push("saveCampaign");
+    });
+    mockedStorage.saveParty.mockImplementation(async () => {
+      calls.push("saveParty");
+    });
+    mockedStorage.addMember.mockImplementation(async () => {
+      calls.push("addMember");
+    });
+
+    await POST(makePostRequest({ name: "Dragon Heist" }));
+
+    expect(calls).toEqual(["saveCampaign", "saveParty", "addMember"]);
+  });
+
+  it("does not include a party key in the response body", async () => {
+    const response = await POST(makePostRequest({ name: "Dragon Heist" }));
+    const body = await response.json();
+    expect(body).not.toHaveProperty("party");
+  });
+
+  it("rolls back the campaign when saveParty fails", async () => {
+    mockedStorage.saveParty.mockRejectedValue(new Error("party save failed"));
+
+    const response = await POST(makePostRequest({ name: "Doomed" }));
+
+    expect(response.status).toBe(500);
+    expect(mockedStorage.deleteCampaign).toHaveBeenCalledWith(
+      expect.any(String),
+      "user-123"
+    );
+    expect(mockedStorage.addMember).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the party then the campaign when addMember fails", async () => {
+    mockedStorage.addMember.mockRejectedValue(new Error("member save failed"));
+
+    const response = await POST(makePostRequest({ name: "Doomed" }));
+
+    expect(response.status).toBe(500);
+    expect(mockedStorage.deleteParty).toHaveBeenCalledWith(
+      expect.any(String),
+      "user-123"
+    );
+    expect(mockedStorage.deleteCampaign).toHaveBeenCalledWith(
+      expect.any(String),
+      "user-123"
+    );
+  });
+
+  it("still rolls back the campaign and rethrows when deleteParty itself fails during member-failure rollback", async () => {
+    mockedStorage.addMember.mockRejectedValue(new Error("member save failed"));
+    mockedStorage.deleteParty.mockRejectedValue(new Error("delete party failed"));
+
+    const response = await POST(makePostRequest({ name: "Doomed" }));
+
+    expect(response.status).toBe(500);
+    expect(mockedStorage.deleteParty).toHaveBeenCalled();
+    expect(mockedStorage.deleteCampaign).toHaveBeenCalledWith(
+      expect.any(String),
+      "user-123"
+    );
   });
 
   itReturns500(


### PR DESCRIPTION
## Summary
- `POST /api/campaigns` now creates a default `Party` named "Main Party" linked to the new campaign via `campaignId`, saved after the `Campaign` and before the `CampaignMember` (DM) record.
- Failure of `storage.saveParty` rolls back the campaign; failure of `storage.addMember` rolls back the party then the campaign. Each rollback step is independently try/caught and logged (not swallowed), matching the existing member-rollback pattern.
- No change to the `POST /api/campaigns` response contract (still the bare `Campaign` object).

## Test plan
- Unit tests: default party creation, call-order assertion (saveCampaign → saveParty → addMember), no `party` key in response, rollback on `saveParty` failure, rollback on `addMember` failure, rollback continues even if `deleteParty` itself fails.
- Integration test: after `POST /api/campaigns`, a `Party` named "Main Party" with matching `campaignId` is discoverable via `GET /api/parties`.
- `npm run test:unit` (2626 tests), `npm run test:integration` (318 tests), `tsc --noEmit`, `npm run build`, `npm run lint` all pass.

Closes #474