### PR TITLE
fix: deliver message/roll/session events cross-instance (#443)

### DIFF
--- a/.verity/memory/decisions/n031-validate-scenecomposer-file-and-campaign-inputs-be.md
+++ b/.verity/memory/decisions/n031-validate-scenecomposer-file-and-campaign-inputs-be.md
@@ -1,0 +1,26 @@
+---
+schema: 1
+id: n031-validate-scenecomposer-file-and-campaign-inputs-be
+kind: decision
+title: "Validate SceneComposer file and campaign inputs before upload"
+domains: ["uploads", "validation", "ui"]
+file_globs:
+  - "**/SceneComposer*"
+  - "**/*SceneComposer*/**"
+confidence: 0.79
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-02T12:52:54.713122+00:00
+updated_at: 2026-07-02T12:52:54.624+00:00
+related: []
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Validate SceneComposer file and campaign inputs before upload
+
+SceneComposer must reject obviously invalid file selections and campaign IDs before attempting an upload. This is a correctness constraint, not just UX polish: sending malformed inputs downstream can trigger avoidable server errors and hide the real failure from the user. Apply this any time SceneComposer assembles an upload request or campaign reference, so validation happens at the boundary rather than after the request is in flight.

--- a/.verity/memory/decisions/n032-mark-monster-import-failures-as-alerts.md
+++ b/.verity/memory/decisions/n032-mark-monster-import-failures-as-alerts.md
@@ -1,0 +1,24 @@
+---
+schema: 1
+id: n032-mark-monster-import-failures-as-alerts
+kind: decision
+title: "Mark monster import failures as alerts"
+domains: ["accessibility", "e2e", "monster-import"]
+file_globs: []
+confidence: 0.83
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-04T16:10:52.082559+00:00
+updated_at: 2026-07-04T16:10:51.99+00:00
+related: []
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Mark monster import failures as alerts
+
+The monster import error state must use `role="alert"` so assistive tech announces the failure immediately and the E2E suite has a stable semantic hook for asserting the rejection path. This is a constraint on any import-error UI in the monster import flow: if the message is not exposed as an alert, both accessibility and regression coverage become unreliable.

--- a/.verity/memory/decisions/n033-use-data-testid-when-playwright-role-selectors-are.md
+++ b/.verity/memory/decisions/n033-use-data-testid-when-playwright-role-selectors-are.md
@@ -1,0 +1,24 @@
+---
+schema: 1
+id: n033-use-data-testid-when-playwright-role-selectors-are
+kind: decision
+title: "Use `data-testid` when Playwright role selectors are ambiguous"
+domains: ["testing", "playwright", "monster-import"]
+file_globs: []
+confidence: 0.87
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-04T16:58:14.892529+00:00
+updated_at: 2026-07-04T16:58:14.784+00:00
+related: []
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Use `data-testid` when Playwright role selectors are ambiguous
+
+In monster-import E2E tests, prefer `data-testid` over role-based queries for the import error banner when the page can render multiple `role=alert` elements. Playwright strict mode will treat that selector as ambiguous and fail the test even when the UI is correct. This constraint applies anywhere a test needs a specific alert/banner among multiple same-role elements: use a unique test id or another disambiguating locator rather than a broad role selector.

--- a/.verity/memory/decisions/n034-assert-route-matches-with-an-end-of-path-regex-not.md
+++ b/.verity/memory/decisions/n034-assert-route-matches-with-an-end-of-path-regex-not.md
@@ -1,0 +1,24 @@
+---
+schema: 1
+id: n034-assert-route-matches-with-an-end-of-path-regex-not
+kind: decision
+title: "Assert route matches with an end-of-path regex, not substring containment"
+domains: ["testing", "routing", "e2e"]
+file_globs: []
+confidence: 0.81
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-04T17:35:22.223285+00:00
+updated_at: 2026-07-04T17:35:22.135+00:00
+related: []
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Assert route matches with an end-of-path regex, not substring containment
+
+When an E2E test is verifying navigation to a specific route, the assertion must match the full pathname/end of path rather than a loose substring. Substring checks can pass on unrelated pages that happen to include the same segment, creating false positives and masking regressions in routing. Use this pattern anywhere a test is intended to prove arrival at a concrete route, especially for monster-import flows.

--- a/.verity/memory/decisions/n035-preserve-party-membership-history-on-rejoin.md
+++ b/.verity/memory/decisions/n035-preserve-party-membership-history-on-rejoin.md
@@ -1,0 +1,24 @@
+---
+schema: 1
+id: n035-preserve-party-membership-history-on-rejoin
+kind: decision
+title: "Preserve party membership history on rejoin"
+domains: ["party", "membership", "data-model"]
+file_globs: []
+confidence: 0.9
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-05T21:47:20.65315+00:00
+updated_at: 2026-07-05T21:47:20.507+00:00
+related: []
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Preserve party membership history on rejoin
+
+When a member leaves and later rejoins, do not overwrite the old membership row. Keep the prior record by setting `leftAt` and create a new active membership entry for the rejoin. This is required to preserve participation history; collapsing the records would destroy the audit trail and make it impossible to distinguish prior membership from the current active state.

--- a/.verity/memory/decisions/n036-allow-membership-changes-by-self-or-active-dm-only.md
+++ b/.verity/memory/decisions/n036-allow-membership-changes-by-self-or-active-dm-only.md
@@ -1,0 +1,30 @@
+---
+schema: 1
+id: n036-allow-membership-changes-by-self-or-active-dm-only
+kind: decision
+title: "Allow membership changes by self or active DM only"
+domains: ["party", "authorization", "security"]
+file_globs: []
+confidence: 0.84
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-05T21:47:21.06193+00:00
+updated_at: 2026-07-05T21:47:20.957+00:00
+related: ["n035-preserve-party-membership-history-on-rejoin"]
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Allow membership changes by self or active DM only
+
+Authorize party membership updates only for the member themself or an active DM membership. This protects party membership from unauthorized edits while still supporting self-service changes and GM-managed adjustments. Any code path that mutates another member’s party membership must enforce one of those two principals, or it is a security bug.
+
+## Related
+
+**Related:**
+- [[n035-preserve-party-membership-history-on-rejoin]]
+

--- a/.verity/memory/decisions/n037-treat-http-207-as-partial-success-and-keep-the-err.md
+++ b/.verity/memory/decisions/n037-treat-http-207-as-partial-success-and-keep-the-err.md
@@ -1,0 +1,24 @@
+---
+schema: 1
+id: n037-treat-http-207-as-partial-success-and-keep-the-err
+kind: decision
+title: "Treat HTTP 207 as partial success and keep the error message visible"
+domains: ["imports", "error-handling", "ui"]
+file_globs: []
+confidence: 0.88
+status: active
+source: extractor
+created_by: decision-promoter@gpt-5.4-mini
+created_at: 2026-07-06T02:43:58.770583+00:00
+updated_at: 2026-07-06T02:43:58.672+00:00
+related: []
+supersedes: []
+superseded_by: null
+contradicts: []
+caused_by: []
+example_of: []
+---
+
+# Treat HTTP 207 as partial success and keep the error message visible
+
+When an import returns HTTP 207, the UI must treat it as a partial-success outcome rather than a full success that immediately navigates away. The rationale is that some items may have failed while others succeeded, and leaving the page too early would hide per-item errors and prevent the user from correcting or retrying them. Apply this anywhere batch-import flows can return mixed results.

--- a/.verity/memory/index.md
+++ b/.verity/memory/index.md
@@ -4,7 +4,7 @@
 
 > If you are an AI coding agent reading this via CLAUDE.md: scan the catalog below for any node whose title, kind, or file scope is relevant to the task the user just asked you to do. Open the matching files via the Read tool before writing code. Most projects accumulate dozens to hundreds of nodes — do not read them all; pick the few that fit the current change.
 
-## decisions/ (16)
+## decisions/ (23)
 
 - [[n015-model-session-lifecycle-as-its-own-campaign-stream]] — **Model session lifecycle as its own campaign stream event variant**
   *decision* · 84%
@@ -38,6 +38,20 @@
   *decision* · 84%
 - [[n030-clear-invalid-currentchapterid-before-persisting-c]] — **Clear invalid currentChapterId before persisting campaign edits**
   *decision* · 90%
+- [[n031-validate-scenecomposer-file-and-campaign-inputs-be]] — **Validate SceneComposer file and campaign inputs before upload**
+  *decision* · 79% · scope: `**/SceneComposer*`, `**/*SceneComposer*/**`
+- [[n032-mark-monster-import-failures-as-alerts]] — **Mark monster import failures as alerts**
+  *decision* · 83%
+- [[n033-use-data-testid-when-playwright-role-selectors-are]] — **Use `data-testid` when Playwright role selectors are ambiguous**
+  *decision* · 87%
+- [[n034-assert-route-matches-with-an-end-of-path-regex-not]] — **Assert route matches with an end-of-path regex, not substring containment**
+  *decision* · 81%
+- [[n035-preserve-party-membership-history-on-rejoin]] — **Preserve party membership history on rejoin**
+  *decision* · 90%
+- [[n036-allow-membership-changes-by-self-or-active-dm-only]] — **Allow membership changes by self or active DM only**
+  *decision* · 84%
+- [[n037-treat-http-207-as-partial-success-and-keep-the-err]] — **Treat HTTP 207 as partial success and keep the error message visible**
+  *decision* · 88%
 
 ## domain/ (4)
 

--- a/docs/multi-user-campaigns/04-realtime-transport.md
+++ b/docs/multi-user-campaigns/04-realtime-transport.md
@@ -12,6 +12,24 @@ plumbing everything else plugs into.
 
 ## Component layout
 
+Each server instance is independent (Fly.io can run more than one machine
+concurrently), so the transport has two delivery paths that run side by side:
+
+- **Same-instance fast path:** the route handler that processed a write
+  (`messages`, `rolls`, `sessions/active`) calls `emitFiltered()` synchronously,
+  reaching same-instance subscribers with near-zero latency.
+- **Cross-instance-safe path:** a single **database-level** change stream (or,
+  on standalone Mongo, a since-timestamp poll) per instance independently
+  observes writes to `campaigns`, `campaignMessages`, and `campaignRolls` —
+  regardless of which instance made the write — and re-delivers the
+  corresponding event to that instance's own subscribers.
+
+Because a write can be observed via both paths, the client (`CampaignChat`'s
+`seenIds`-keyed dedup) drops the second, redundant delivery by id. `session`
+events are derived from `activeSessionId` field-level changes on `campaigns`
+documents rather than being their own collection, and are idempotent to
+re-apply.
+
 ```mermaid
 flowchart TB
     subgraph Browser
@@ -21,22 +39,28 @@ flowchart TB
         Dock --> Hook --> ES
     end
     subgraph Server["Next.js instance (Fly.io)"]
+        ROUTE["messages/rolls/sessions route handlers"]
         SSE["GET /campaigns/:id/stream (4a)"]
         AUTH["assertCampaignAccess (1e)"]
-        REG["Subscriber registry<br/>(demux by campaignId)"]
-        TA["Transport abstraction<br/>subscribe(campaignId, onEvent)"]
+        REG["Subscriber registry<br/>(demux by campaignId + collection)"]
+        TA["Transport abstraction<br/>subscribe(campaignId, userId, onEvent)"]
+        ROUTE -->|"fast path: emitFiltered()"| REG
         SSE --> AUTH
         SSE --> TA
         TA --> REG
     end
     subgraph Mongo["MongoDB"]
-        CS["ONE shared change stream<br/>per instance (Atlas)"]
-        POLL["since-timestamp poll (local dev)"]
+        CS["ONE shared db-level watch()<br/>per instance (Atlas) — campaigns,<br/>campaignMessages, campaignRolls"]
+        POLL["since-timestamp poll of all three<br/>collections (local dev)"]
+        SESS["activeSessionId field-diff<br/>→ derived 'session' event"]
     end
     ES -- "HTTP text/event-stream" --> SSE
     REG -->|prod · single cursor| CS
     REG -->|fallback| POLL
-    CS -. "events demux'd to all<br/>campaigns + connections" .-> REG
+    CS -. "change/message/roll events<br/>demux'd by ns.coll + campaignId,<br/>visibility-filtered per subscriber" .-> REG
+    CS --> SESS
+    POLL --> SESS
+    SESS -. "cross-instance-safe path<br/>(dedup'd client-side against<br/>the fast path above)" .-> REG
 ```
 
 ## Transport selection (4a)
@@ -45,16 +69,29 @@ The same `subscribe()` interface picks its source at runtime so clients never ch
 
 ```mermaid
 flowchart TD
-    start(["subscribe(campaignId)"]) --> q{"Mongo is a<br/>replica set?"}
-    q -->|yes · Atlas| cs["one shared watch() per instance<br/>(unfiltered) → demux by campaignId"]
-    q -->|no · standalone dev| poll["poll collections since<br/>last-seen timestamp"]
-    cs --> emit["emit typed campaign events"]
-    poll --> emit
+    start(["subscribe(campaignId, userId)"]) --> q{"Mongo is a<br/>replica set?"}
+    q -->|yes · Atlas| cs["one shared db.watch() per instance<br/>(campaigns + campaignMessages +<br/>campaignRolls) → demux by ns.coll + campaignId"]
+    q -->|no · standalone dev| poll["poll all three collections since<br/>last-seen timestamp, per subscription"]
+    cs --> sess{"activeSessionId<br/>changed?"}
+    poll --> sess
+    sess -->|yes| sessEvt["emit derived 'session' event"]
+    sess -->|no| vis
+    sessEvt --> vis{"message/roll?"}
+    vis -->|yes| filt["canSeeMessage / canSeeRoll<br/>per subscriber"]
+    vis -->|no · change| emit
+    filt --> emit["emit typed campaign event"]
     emit --> sse["write SSE frames + heartbeat"]
     sse --> close{"client<br/>disconnected?"}
     close -->|no| emit
-    close -->|yes| teardown["close cursor / stop poll"]
+    close -->|yes| teardown["close cursor / stop poll;<br/>drop per-campaign session state<br/>if last subscriber"]
 ```
+
+Route handlers (`messages`, `rolls`, `sessions/active`) additionally call
+`emitFiltered()` synchronously right after their write, as a same-instance
+fast path that runs independently of (and faster than) the diagram above.
+The client dedups by event id so a same-instance subscriber that receives
+both the fast-path delivery and the later Mongo-observed delivery only
+renders the item once.
 
 ## Deliverables (sub-issues)
 

--- a/docs/multi-user-campaigns/04-realtime-transport.md
+++ b/docs/multi-user-campaigns/04-realtime-transport.md
@@ -40,7 +40,7 @@ flowchart TB
     end
     subgraph Server["Next.js instance (Fly.io)"]
         ROUTE["messages/rolls/sessions route handlers"]
-        SSE["GET /campaigns/:id/stream (4a)"]
+        SSE["GET /api/campaigns/[id]/stream (4a)"]
         AUTH["assertCampaignAccess (1e)"]
         REG["Subscriber registry<br/>(demux by campaignId + collection)"]
         TA["Transport abstraction<br/>subscribe(campaignId, userId, onEvent)"]

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -300,8 +300,10 @@ async function pollCampaigns(
     const { campaignId: _cid, id: _id, ...rest } = doc;
     handler({ type: 'change', campaignId, data: rest });
 
-    // Polling subscribers aren't in `registry` (that's Atlas-only), so the session event
-    // must be delivered directly to this poll's own handler rather than via emitToRegistry.
+    // This poll cycle is scoped to one subscription, so the session event is delivered
+    // directly to its own handler rather than fanned out via emitToRegistry — even
+    // though polling subscribers are also registered in `registry` for the emitFiltered()
+    // fast path, that path is a separate, independent delivery mechanism from polling.
     // `sessionState` is private to this subscription (see shouldEmitSession's comment).
     const activeSessionId = (doc['activeSessionId'] ?? null) as string | null;
     if (shouldEmitSession(sessionState, campaignId, activeSessionId)) {
@@ -364,26 +366,41 @@ export function emitFiltered(
   emitToRegistry(campaignId, event, canReceive);
 }
 
+// Registers a subscription in `registry` so emitFiltered()'s same-instance fast path can
+// reach it, regardless of transport mode. Atlas subscribers are already in `registry` for
+// change-stream demux purposes; polling subscribers previously weren't registered at all,
+// which meant emitFiltered() silently never reached them in standalone/local-dev Mongo —
+// the "fast path" was Atlas-only in practice despite being documented as mode-independent.
+// Returns a teardown that removes just this subscription's registry entry.
+function registerInRegistry(campaignId: string, userId: string, handler: EventHandler): () => void {
+  if (!registry.has(campaignId)) {
+    registry.set(campaignId, new Map());
+  }
+  const subId = `${userId}:${++nextSubId}`;
+  registry.get(campaignId)!.set(subId, { userId, handler });
+
+  return () => {
+    registry.get(campaignId)?.delete(subId);
+    if (registry.get(campaignId)?.size === 0) {
+      registry.delete(campaignId);
+    }
+  };
+}
+
 export async function subscribe(campaignId: string, userId: string, onEvent: EventHandler): Promise<() => void> {
   const atlasMode = await detectReplicaSet();
+  const unregister = registerInRegistry(campaignId, userId, onEvent);
 
   if (atlasMode) {
-    if (!registry.has(campaignId)) {
-      registry.set(campaignId, new Map());
-    }
-    const subId = `${userId}:${++nextSubId}`;
-    registry.get(campaignId)!.set(subId, { userId, handler: onEvent });
     subscriberCount++;
-
     const streamPromise = openStream();
 
     let torn = false;
     return () => {
       if (torn) return;
       torn = true;
-      registry.get(campaignId)?.delete(subId);
-      if (registry.get(campaignId)?.size === 0) {
-        registry.delete(campaignId);
+      unregister();
+      if (!registry.has(campaignId)) {
         lastKnownActiveSessionId.delete(campaignId);
       }
       subscriberCount = Math.max(0, subscriberCount - 1);
@@ -415,6 +432,7 @@ export async function subscribe(campaignId: string, userId: string, onEvent: Eve
       if (torn) return;
       torn = true;
       clearInterval(intervalId);
+      unregister();
     };
   }
 }

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -1,6 +1,9 @@
 import type { ChangeStream } from 'mongodb';
 import { connectToDatabase, getDatabase } from '@/lib/db';
-import type { CampaignStreamEvent } from '@/lib/types';
+import { storage } from '@/lib/storage';
+import { canSeeMessage } from '@/lib/utils/campaignMessages';
+import { canSeeRoll } from '@/lib/utils/campaignRolls';
+import type { CampaignMember, CampaignMessage, CampaignRoll, CampaignStreamEvent } from '@/lib/types';
 
 type EventHandler = (event: CampaignStreamEvent) => void;
 
@@ -9,13 +12,22 @@ interface Subscription {
   handler: EventHandler;
 }
 
-// Module-level singletons — process-scoped state (safe on Fly.io single-process)
+// Module-level singletons — process-scoped state (safe on Fly.io single-process,
+// cross-instance-safe delivery is handled by the shared change-stream/poll observing
+// writes made by *any* instance, not by this in-memory state itself).
 let openPromise: Promise<ChangeStream> | null = null;
 let sharedCursor: ChangeStream | null = null;
 let subscriberCount = 0;
 // Keyed by a per-subscription token so the same user can hold multiple concurrent
 // subscriptions (e.g. multiple browser tabs) without overwriting each other.
 const registry = new Map<string, Map<string, Subscription>>();
+// Last-observed activeSessionId per campaignId, used to derive `session` events from
+// field-level changes on the `campaigns` collection (Decision 3). Cleaned up when the
+// last subscriber for a campaign tears down.
+const lastKnownActiveSessionId = new Map<string, string | null>();
+// Per-campaign polling subscriber count, used to know when to clear
+// lastKnownActiveSessionId in the polling path (mirrors the registry-based count above).
+const pollSubscriberCount = new Map<string, number>();
 let nextSubId = 0;
 let isReplicaSet: boolean | null = null;
 let detectPromise: Promise<boolean> | null = null;
@@ -53,19 +65,104 @@ async function detectReplicaSet(): Promise<boolean> {
   return detectPromise;
 }
 
-function demux(doc: { fullDocument?: { campaignId?: string; id?: string } & Record<string, unknown> }) {
-  const campaignId = doc.fullDocument?.campaignId ?? doc.fullDocument?.id;
-  if (!campaignId) return;
+async function activeMembers(campaignId: string): Promise<CampaignMember[]> {
+  const members = await storage.listMembersForCampaign(campaignId);
+  return members.filter(m => m.status === 'active');
+}
+
+function emitToRegistry(
+  campaignId: string,
+  event: CampaignStreamEvent,
+  canReceive?: (userId: string) => boolean
+) {
   const handlers = registry.get(campaignId);
   if (!handlers) return;
-  const { campaignId: _cid, id: _id, ...rest } = doc.fullDocument ?? {};
-  const event: CampaignStreamEvent = {
-    type: 'change',
-    campaignId,
-    data: rest,
-  };
   for (const sub of handlers.values()) {
+    if (canReceive && !canReceive(sub.userId)) continue;
     try { sub.handler(event); } catch { /* handler errors don't break the stream */ }
+  }
+}
+
+// Compares against the last-known activeSessionId for a campaign, updates the map, and
+// reports whether a `session` event should be emitted. Shared by the change-stream path
+// (which dispatches via emitToRegistry) and the polling path (which dispatches directly
+// to its own subscription handler, since poll subscribers aren't in `registry`).
+function shouldEmitSession(campaignId: string, activeSessionId: string | null): boolean {
+  if (lastKnownActiveSessionId.get(campaignId) === activeSessionId) return false;
+  lastKnownActiveSessionId.set(campaignId, activeSessionId);
+  return true;
+}
+
+// Builds a `{ type, campaignId, data }` event per doc and hands it to `dispatch` along
+// with a per-doc visibility predicate. `dispatch` decides how delivery actually happens:
+// the change-stream path fans out to every registry subscriber via emitToRegistry, the
+// polling path checks the single subscription's own userId before calling its handler.
+function emitVisible<T>(
+  campaignId: string,
+  type: 'message' | 'roll',
+  docs: T[],
+  members: CampaignMember[],
+  canSee: (doc: T, userId: string, members: CampaignMember[]) => boolean,
+  dispatch: (event: CampaignStreamEvent, canReceive: (userId: string) => boolean) => void
+) {
+  for (const doc of docs) {
+    dispatch(
+      { type, campaignId, data: doc } as CampaignStreamEvent,
+      uid => canSee(doc, uid, members)
+    );
+  }
+}
+
+type ChangeDoc = {
+  ns?: { coll?: string };
+  fullDocument?: Record<string, unknown>;
+  updateDescription?: { updatedFields?: Record<string, unknown> };
+};
+
+async function demuxCampaignDoc(doc: ChangeDoc, campaignId: string, fullDocument: Record<string, unknown>) {
+  const { campaignId: _cid, id: _id, ...rest } = fullDocument;
+  emitToRegistry(campaignId, { type: 'change', campaignId, data: rest });
+
+  const changedFields = doc.updateDescription?.updatedFields ?? fullDocument;
+  if ('activeSessionId' in changedFields) {
+    const activeSessionId = (fullDocument['activeSessionId'] ?? null) as string | null;
+    if (shouldEmitSession(campaignId, activeSessionId)) {
+      emitToRegistry(campaignId, { type: 'session', campaignId, data: { activeSessionId } });
+    }
+  }
+}
+
+async function demuxMessageDoc(campaignId: string, fullDocument: Record<string, unknown>) {
+  if (!registry.get(campaignId)?.size) return;
+  const message = fullDocument as unknown as CampaignMessage;
+  const members = await activeMembers(campaignId);
+  emitVisible(campaignId, 'message', [message], members, canSeeMessage,
+    (event, canReceive) => emitToRegistry(campaignId, event, canReceive));
+}
+
+async function demuxRollDoc(campaignId: string, fullDocument: Record<string, unknown>) {
+  if (!registry.get(campaignId)?.size) return;
+  const roll = fullDocument as unknown as CampaignRoll;
+  const members = await activeMembers(campaignId);
+  emitVisible(campaignId, 'roll', [roll], members, canSeeRoll,
+    (event, canReceive) => emitToRegistry(campaignId, event, canReceive));
+}
+
+async function demux(doc: ChangeDoc): Promise<void> {
+  const fullDocument = doc.fullDocument;
+  if (!fullDocument) return;
+  const campaignId = (fullDocument['campaignId'] ?? fullDocument['id']) as string | undefined;
+  if (!campaignId) return;
+  if (!registry.has(campaignId)) return;
+
+  const coll = doc.ns?.coll;
+  if (coll === 'campaignMessages') {
+    await demuxMessageDoc(campaignId, fullDocument);
+  } else if (coll === 'campaignRolls') {
+    await demuxRollDoc(campaignId, fullDocument);
+  } else {
+    // Undefined ns.coll (legacy/mocked collection-level watch) or 'campaigns' itself.
+    await demuxCampaignDoc(doc, campaignId, fullDocument);
   }
 }
 
@@ -90,14 +187,14 @@ async function openStream(): Promise<ChangeStream> {
   if (openPromise) return openPromise;
   openPromise = (async () => {
     const { client } = await connectToDatabase();
-    const cursor = client.db().collection('campaigns').watch([], { fullDocument: 'updateLookup' }) as ChangeStream;
+    const cursor = client.db().watch([], { fullDocument: 'updateLookup' }) as ChangeStream;
     sharedCursor = cursor;
 
     // Start async iteration in background
     (async () => {
       try {
-        for await (const doc of cursor as AsyncIterable<{ fullDocument?: { campaignId?: string } & Record<string, unknown> }>) {
-          demux(doc);
+        for await (const doc of cursor as AsyncIterable<ChangeDoc>) {
+          await demux(doc);
         }
       } catch (err) {
         const isInvalidated =
@@ -129,8 +226,48 @@ async function openStream(): Promise<ChangeStream> {
   return openPromise;
 }
 
+async function pollCampaigns(campaignId: string, handler: EventHandler, since: Date, db: Awaited<ReturnType<typeof getDatabase>>) {
+  const docs = await db
+    .collection('campaigns')
+    .find({
+      $or: [
+        { id: campaignId, updatedAt: { $gt: since } },
+        { campaignId, createdAt: { $gt: since } },
+      ],
+    })
+    .toArray() as Array<Record<string, unknown>>;
+
+  for (const doc of docs) {
+    const docCampaignId = (doc['campaignId'] ?? doc['id']) as string | undefined;
+    if (docCampaignId !== campaignId) continue;
+    const { campaignId: _cid, id: _id, ...rest } = doc;
+    handler({ type: 'change', campaignId, data: rest });
+
+    // Polling subscribers aren't in `registry` (that's Atlas-only), so the session event
+    // must be delivered directly to this poll's own handler rather than via emitToRegistry.
+    const activeSessionId = (doc['activeSessionId'] ?? null) as string | null;
+    if (shouldEmitSession(campaignId, activeSessionId)) {
+      handler({ type: 'session', campaignId, data: { activeSessionId } });
+    }
+  }
+}
+
+async function pollCollection<T>(
+  collectionName: string,
+  campaignId: string,
+  since: Date,
+  db: Awaited<ReturnType<typeof getDatabase>>
+): Promise<T[]> {
+  const docs = await db
+    .collection(collectionName)
+    .find({ campaignId, createdAt: { $gt: since } })
+    .toArray();
+  return docs as unknown as T[];
+}
+
 async function pollFn(
   campaignId: string,
+  userId: string,
   handler: EventHandler,
   sinceRef: { value: number }
 ) {
@@ -139,26 +276,19 @@ async function pollFn(
   try {
     const db = await getDatabase();
     const since = new Date(sinceRef.value);
-    const docs = await db
-      .collection('campaigns')
-      .find({
-        $or: [
-          { id: campaignId, updatedAt: { $gt: since } },
-          { campaignId, createdAt: { $gt: since } },
-        ],
-      })
-      .toArray() as Array<Record<string, unknown>>;
 
-    for (const doc of docs) {
-      const docCampaignId = (doc['campaignId'] ?? doc['id']) as string | undefined;
-      if (docCampaignId !== campaignId) continue;
-      const { campaignId: _cid, id: _id, ...rest } = doc;
-      const event: CampaignStreamEvent = {
-        type: 'change',
-        campaignId,
-        data: rest,
+    await pollCampaigns(campaignId, handler, since, db);
+
+    const messages = await pollCollection<CampaignMessage>('campaignMessages', campaignId, since, db);
+    const rolls = await pollCollection<CampaignRoll>('campaignRolls', campaignId, since, db);
+
+    if (messages.length || rolls.length) {
+      const members = await activeMembers(campaignId);
+      const dispatch = (event: CampaignStreamEvent, canReceive: (userId: string) => boolean) => {
+        if (canReceive(userId)) handler(event);
       };
-      handler(event);
+      emitVisible(campaignId, 'message', messages, members, canSeeMessage, dispatch);
+      emitVisible(campaignId, 'roll', rolls, members, canSeeRoll, dispatch);
     }
 
     sinceRef.value = pollStart;
@@ -172,13 +302,7 @@ export function emitFiltered(
   event: CampaignStreamEvent,
   canReceive: (userId: string) => boolean
 ): void {
-  const handlers = registry.get(campaignId);
-  if (!handlers) return;
-  for (const sub of handlers.values()) {
-    if (canReceive(sub.userId)) {
-      try { sub.handler(event); } catch { /* handler errors don't break dispatch */ }
-    }
-  }
+  emitToRegistry(campaignId, event, canReceive);
 }
 
 export async function subscribe(campaignId: string, userId: string, onEvent: EventHandler): Promise<() => void> {
@@ -199,15 +323,19 @@ export async function subscribe(campaignId: string, userId: string, onEvent: Eve
       if (torn) return;
       torn = true;
       registry.get(campaignId)?.delete(subId);
-      if (registry.get(campaignId)?.size === 0) registry.delete(campaignId);
+      if (registry.get(campaignId)?.size === 0) {
+        registry.delete(campaignId);
+        lastKnownActiveSessionId.delete(campaignId);
+      }
       subscriberCount = Math.max(0, subscriberCount - 1);
       if (subscriberCount === 0) {
         streamPromise.then(() => closeStream()).catch(() => closeStream());
       }
     };
   } else {
+    pollSubscriberCount.set(campaignId, (pollSubscriberCount.get(campaignId) ?? 0) + 1);
     const sinceRef = { value: Date.now() };
-    const intervalId = setInterval(() => pollFn(campaignId, onEvent, sinceRef), 2000);
+    const intervalId = setInterval(() => pollFn(campaignId, userId, onEvent, sinceRef), 2000);
     (intervalId as unknown as { unref?: () => void }).unref?.();
 
     let torn = false;
@@ -215,6 +343,13 @@ export async function subscribe(campaignId: string, userId: string, onEvent: Eve
       if (torn) return;
       torn = true;
       clearInterval(intervalId);
+      const remaining = (pollSubscriberCount.get(campaignId) ?? 1) - 1;
+      if (remaining <= 0) {
+        pollSubscriberCount.delete(campaignId);
+        lastKnownActiveSessionId.delete(campaignId);
+      } else {
+        pollSubscriberCount.set(campaignId, remaining);
+      }
     };
   }
 }

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -313,7 +313,7 @@ async function pollFn(
 
     sinceRef.value = pollStart;
   } catch (err) {
-    console.error('transport poll error:', err);
+    console.error(`transport poll error (campaign=${campaignId}):`, err);
   }
 }
 

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -160,8 +160,13 @@ async function demux(doc: ChangeDoc): Promise<void> {
     await demuxMessageDoc(campaignId, fullDocument);
   } else if (coll === 'campaignRolls') {
     await demuxRollDoc(campaignId, fullDocument);
-  } else {
-    // Undefined ns.coll (legacy/mocked collection-level watch) or 'campaigns' itself.
+  } else if (coll === 'campaigns' || coll === undefined) {
+    // Undefined ns.coll covers the legacy/mocked collection-level watch shape; a real
+    // db-level watch always sets ns.coll. Any other collection name is explicitly
+    // ignored below — the watch is unfiltered at the Mongo level (db-wide), so without
+    // this allowlist a write to an unrelated collection sharing an `id`/`campaignId`
+    // field would otherwise be broadcast to that campaign's subscribers as a `change`
+    // event, leaking data outside the three collections this transport is meant to serve.
     await demuxCampaignDoc(doc, campaignId, fullDocument);
   }
 }

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -139,9 +139,18 @@ async function demuxCampaignDoc(doc: ChangeDoc, campaignId: string, fullDocument
   }
 }
 
+// Raw Mongo documents carry `_id` (an ObjectId); the same-instance emitFiltered() fast
+// path never has one (routes construct CampaignMessage/CampaignRoll without it before
+// insert). Strip it here so the Mongo-observed path's payload shape matches the fast
+// path's exactly, regardless of which one a given subscriber's event happens to take.
+function stripMongoId<T extends { _id?: unknown }>(doc: T): Omit<T, '_id'> {
+  const { _id: _ignored, ...rest } = doc;
+  return rest;
+}
+
 async function demuxMessageDoc(campaignId: string, fullDocument: Record<string, unknown>) {
   if (!registry.get(campaignId)?.size) return;
-  const message = fullDocument as unknown as CampaignMessage;
+  const message = stripMongoId(fullDocument as unknown as CampaignMessage);
   const members = await activeMembers(campaignId);
   emitVisible(campaignId, 'message', [message], members, canSeeMessage,
     (event, canReceive) => emitToRegistry(campaignId, event, canReceive));
@@ -149,7 +158,7 @@ async function demuxMessageDoc(campaignId: string, fullDocument: Record<string, 
 
 async function demuxRollDoc(campaignId: string, fullDocument: Record<string, unknown>) {
   if (!registry.get(campaignId)?.size) return;
-  const roll = fullDocument as unknown as CampaignRoll;
+  const roll = stripMongoId(fullDocument as unknown as CampaignRoll);
   const members = await activeMembers(campaignId);
   emitVisible(campaignId, 'roll', [roll], members, canSeeRoll,
     (event, canReceive) => emitToRegistry(campaignId, event, canReceive));
@@ -195,11 +204,20 @@ async function closeStream() {
   }
 }
 
+// Server-side $match narrows the change stream to the three collections this transport
+// serves, so Mongo itself filters out irrelevant collections instead of every document
+// in the database being shipped to this process just to be discarded by demux()'s
+// in-process ns.coll allowlist.
+const WATCHED_COLLECTIONS = ['campaigns', 'campaignMessages', 'campaignRolls'];
+
 async function openStream(): Promise<ChangeStream> {
   if (openPromise) return openPromise;
-  openPromise = (async () => {
+  const promise = (async () => {
     const { client } = await connectToDatabase();
-    const cursor = client.db().watch([], { fullDocument: 'updateLookup' }) as ChangeStream;
+    const cursor = client.db().watch(
+      [{ $match: { 'ns.coll': { $in: WATCHED_COLLECTIONS } } }],
+      { fullDocument: 'updateLookup' }
+    ) as ChangeStream;
     sharedCursor = cursor;
 
     // Start async iteration in background
@@ -235,7 +253,13 @@ async function openStream(): Promise<ChangeStream> {
     return cursor;
   })();
 
-  return openPromise;
+  openPromise = promise;
+  // If connectToDatabase()/watch() itself throws (before the background iteration even
+  // starts), clear openPromise so the next subscribe() retries instead of permanently
+  // reusing this rejected promise.
+  promise.catch(() => { if (openPromise === promise) openPromise = null; });
+
+  return promise;
 }
 
 async function pollCampaigns(
@@ -271,7 +295,7 @@ async function pollCampaigns(
   }
 }
 
-async function pollCollection<T>(
+async function pollCollection<T extends { _id?: unknown }>(
   collectionName: string,
   campaignId: string,
   since: Date,
@@ -281,7 +305,7 @@ async function pollCollection<T>(
     .collection(collectionName)
     .find({ campaignId, createdAt: { $gt: since } })
     .toArray();
-  return docs as unknown as T[];
+  return (docs as unknown as T[]).map(stripMongoId) as T[];
 }
 
 async function pollFn(

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -179,10 +179,12 @@ async function demux(doc: ChangeDoc): Promise<void> {
   } else if (coll === 'campaigns' || coll === undefined) {
     // Undefined ns.coll covers the legacy/mocked collection-level watch shape; a real
     // db-level watch always sets ns.coll. Any other collection name is explicitly
-    // ignored below — the watch is unfiltered at the Mongo level (db-wide), so without
-    // this allowlist a write to an unrelated collection sharing an `id`/`campaignId`
-    // field would otherwise be broadcast to that campaign's subscribers as a `change`
-    // event, leaking data outside the three collections this transport is meant to serve.
+    // ignored below. The server-side $match in openStream() already restricts the watch
+    // to the three collections above, but this allowlist stays as defense in depth —
+    // without it, a bug in that pipeline (or a future change to it) that let an
+    // unrelated collection's write through would otherwise be broadcast to that
+    // campaign's subscribers as a `change` event, leaking data outside the three
+    // collections this transport is meant to serve.
     await demuxCampaignDoc(doc, campaignId, fullDocument);
   }
 }
@@ -224,12 +226,25 @@ async function openStream(): Promise<ChangeStream> {
     (async () => {
       try {
         for await (const doc of cursor as AsyncIterable<ChangeDoc>) {
-          await demux(doc);
+          // A single malformed/unexpected document (e.g. a members lookup or visibility
+          // predicate throwing on unexpected shape) must not tear down the shared cursor
+          // — that would kill cross-instance delivery for every campaign, not just the
+          // one document that failed to process.
+          try {
+            await demux(doc);
+          } catch (err) {
+            console.error('transport demux error (document skipped, stream continues):', err);
+          }
         }
       } catch (err) {
         const isInvalidated =
           err instanceof Error &&
           (err.name === 'ChangeStreamInvalidatedError' || err.message.includes('ChangeStreamInvalidated'));
+
+        // Log even the expected-invalidation case (not just genuine failures) — this is
+        // the shared cursor for every campaign on the instance dying, silently or not,
+        // and an operator needs to see it happened even if a reconnect follows.
+        console.error('transport change stream terminated:', err);
 
         // Close the cursor before clearing references to release server-side resources.
         try { await cursor.close(); } catch { /* ignore */ }
@@ -382,7 +397,17 @@ export async function subscribe(campaignId: string, userId: string, onEvent: Eve
     // can't share session-tracking state across subscriptions the way registry-backed
     // change-stream delivery can.
     const sessionState = new Map<string, string | null>();
-    const intervalId = setInterval(() => pollFn(campaignId, userId, onEvent, sinceRef, sessionState), 2000);
+    // Guards against overlapping poll cycles: pollFn now issues four sequential queries
+    // (campaigns, messages, rolls, members) instead of one, so a slow DB round-trip can
+    // take longer than the 2s interval. Without this guard, setInterval would start a
+    // new pollFn call on top of one still in flight, doubling DB load and — because both
+    // calls would compute an overlapping `since` window — redelivering the same events.
+    let pollInFlight = false;
+    const intervalId = setInterval(() => {
+      if (pollInFlight) return;
+      pollInFlight = true;
+      pollFn(campaignId, userId, onEvent, sinceRef, sessionState).finally(() => { pollInFlight = false; });
+    }, 2000);
     (intervalId as unknown as { unref?: () => void }).unref?.();
 
     let torn = false;

--- a/lib/server/transport.ts
+++ b/lib/server/transport.ts
@@ -25,9 +25,6 @@ const registry = new Map<string, Map<string, Subscription>>();
 // field-level changes on the `campaigns` collection (Decision 3). Cleaned up when the
 // last subscriber for a campaign tears down.
 const lastKnownActiveSessionId = new Map<string, string | null>();
-// Per-campaign polling subscriber count, used to know when to clear
-// lastKnownActiveSessionId in the polling path (mirrors the registry-based count above).
-const pollSubscriberCount = new Map<string, number>();
 let nextSubId = 0;
 let isReplicaSet: boolean | null = null;
 let detectPromise: Promise<boolean> | null = null;
@@ -83,13 +80,23 @@ function emitToRegistry(
   }
 }
 
-// Compares against the last-known activeSessionId for a campaign, updates the map, and
-// reports whether a `session` event should be emitted. Shared by the change-stream path
-// (which dispatches via emitToRegistry) and the polling path (which dispatches directly
-// to its own subscription handler, since poll subscribers aren't in `registry`).
-function shouldEmitSession(campaignId: string, activeSessionId: string | null): boolean {
-  if (lastKnownActiveSessionId.get(campaignId) === activeSessionId) return false;
-  lastKnownActiveSessionId.set(campaignId, activeSessionId);
+// Compares against the last-known activeSessionId for a campaign in the given tracking
+// map, updates it, and reports whether a `session` event should be emitted.
+//
+// The change-stream path uses the shared `lastKnownActiveSessionId` map, since one
+// observed write there fans out to every registry subscriber via a single
+// emitToRegistry call — there's no risk of one subscriber's observation suppressing
+// another's. The polling path instead gives each subscription its own private map:
+// each subscription polls independently, so sharing state across subscriptions for the
+// same campaign would let whichever subscription's poll happens to run first "consume"
+// the transition and starve every other subscriber of that campaign's session event.
+function shouldEmitSession(
+  map: Map<string, string | null>,
+  campaignId: string,
+  activeSessionId: string | null
+): boolean {
+  if (map.get(campaignId) === activeSessionId) return false;
+  map.set(campaignId, activeSessionId);
   return true;
 }
 
@@ -126,7 +133,7 @@ async function demuxCampaignDoc(doc: ChangeDoc, campaignId: string, fullDocument
   const changedFields = doc.updateDescription?.updatedFields ?? fullDocument;
   if ('activeSessionId' in changedFields) {
     const activeSessionId = (fullDocument['activeSessionId'] ?? null) as string | null;
-    if (shouldEmitSession(campaignId, activeSessionId)) {
+    if (shouldEmitSession(lastKnownActiveSessionId, campaignId, activeSessionId)) {
       emitToRegistry(campaignId, { type: 'session', campaignId, data: { activeSessionId } });
     }
   }
@@ -231,7 +238,13 @@ async function openStream(): Promise<ChangeStream> {
   return openPromise;
 }
 
-async function pollCampaigns(campaignId: string, handler: EventHandler, since: Date, db: Awaited<ReturnType<typeof getDatabase>>) {
+async function pollCampaigns(
+  campaignId: string,
+  handler: EventHandler,
+  since: Date,
+  db: Awaited<ReturnType<typeof getDatabase>>,
+  sessionState: Map<string, string | null>
+) {
   const docs = await db
     .collection('campaigns')
     .find({
@@ -250,8 +263,9 @@ async function pollCampaigns(campaignId: string, handler: EventHandler, since: D
 
     // Polling subscribers aren't in `registry` (that's Atlas-only), so the session event
     // must be delivered directly to this poll's own handler rather than via emitToRegistry.
+    // `sessionState` is private to this subscription (see shouldEmitSession's comment).
     const activeSessionId = (doc['activeSessionId'] ?? null) as string | null;
-    if (shouldEmitSession(campaignId, activeSessionId)) {
+    if (shouldEmitSession(sessionState, campaignId, activeSessionId)) {
       handler({ type: 'session', campaignId, data: { activeSessionId } });
     }
   }
@@ -274,7 +288,8 @@ async function pollFn(
   campaignId: string,
   userId: string,
   handler: EventHandler,
-  sinceRef: { value: number }
+  sinceRef: { value: number },
+  sessionState: Map<string, string | null>
 ) {
   // Capture start time before querying so documents created during the query window are not skipped.
   const pollStart = Date.now();
@@ -282,7 +297,7 @@ async function pollFn(
     const db = await getDatabase();
     const since = new Date(sinceRef.value);
 
-    await pollCampaigns(campaignId, handler, since, db);
+    await pollCampaigns(campaignId, handler, since, db, sessionState);
 
     const messages = await pollCollection<CampaignMessage>('campaignMessages', campaignId, since, db);
     const rolls = await pollCollection<CampaignRoll>('campaignRolls', campaignId, since, db);
@@ -338,9 +353,12 @@ export async function subscribe(campaignId: string, userId: string, onEvent: Eve
       }
     };
   } else {
-    pollSubscriberCount.set(campaignId, (pollSubscriberCount.get(campaignId) ?? 0) + 1);
     const sinceRef = { value: Date.now() };
-    const intervalId = setInterval(() => pollFn(campaignId, userId, onEvent, sinceRef), 2000);
+    // Private to this subscription — see shouldEmitSession's comment for why polling
+    // can't share session-tracking state across subscriptions the way registry-backed
+    // change-stream delivery can.
+    const sessionState = new Map<string, string | null>();
+    const intervalId = setInterval(() => pollFn(campaignId, userId, onEvent, sinceRef, sessionState), 2000);
     (intervalId as unknown as { unref?: () => void }).unref?.();
 
     let torn = false;
@@ -348,13 +366,6 @@ export async function subscribe(campaignId: string, userId: string, onEvent: Eve
       if (torn) return;
       torn = true;
       clearInterval(intervalId);
-      const remaining = (pollSubscriberCount.get(campaignId) ?? 1) - 1;
-      if (remaining <= 0) {
-        pollSubscriberCount.delete(campaignId);
-        lastKnownActiveSessionId.delete(campaignId);
-      } else {
-        pollSubscriberCount.set(campaignId, remaining);
-      }
     };
   }
 }

--- a/openspec/changes/fix-cross-instance-transport-delivery/.openspec.yaml
+++ b/openspec/changes/fix-cross-instance-transport-delivery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-07-09

--- a/openspec/changes/fix-cross-instance-transport-delivery/design.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/design.md
@@ -71,17 +71,17 @@
 
 - Requirement: A `session` event reaches a subscriber on a different instance than the one that started/ended the session
   - Design element: Decision 1 (db-level watch/poll observes `campaigns` writes from any instance), Decision 3 (session derivation)
-  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` (to be authored) — scenario "Session event delivered cross-instance"
+  - Acceptance criteria reference: `specs/transport/spec.md` (to be authored) — scenario "Session event delivered cross-instance"
   - Testability notes: Simulate two `transport.ts` module instances (via `jest.isolateModules` or two separately constructed registries) sharing a mocked Mongo change-stream/poll source; write `activeSessionId` "from" instance A, assert instance B's registered handler receives a `session` event.
 
 - Requirement: A `roll`/`message` event reaches a subscriber on a different instance than the one that handled the POST
   - Design element: Decision 1, Decision 2, Decision 4
-  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenarios "Roll event delivered cross-instance", "Message event delivered cross-instance"
+  - Acceptance criteria reference: `specs/transport/spec.md` — scenarios "Roll event delivered cross-instance", "Message event delivered cross-instance"
   - Testability notes: Same two-instance simulation; assert the cross-instance subscriber receives the event and that a DM-only roll/message is withheld from a non-DM cross-instance subscriber (visibility still enforced).
 
 - Requirement: No duplicate feed entries when both delivery paths fire for the same write
   - Design element: Decision 2, existing `seenIds` dedup in `CampaignChat.tsx`
-  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenario "Duplicate delivery deduped by id"
+  - Acceptance criteria reference: `specs/transport/spec.md` — scenario "Duplicate delivery deduped by id"
   - Testability notes: Unit test delivering the same roll/message id twice through `onStreamEvent`; assert feed length increases by exactly one.
 
 ## Non-Functional Requirements Mapping
@@ -89,19 +89,19 @@
 - Requirement category: performance
   - Requirement: Db-level watch/broadened poll must not materially increase per-instance CPU/memory or add unbounded per-campaign state
   - Design element: Decision 1 (single shared cursor, same "one per instance" pattern), Decision 3 (bounded last-seen-`activeSessionId` map, cleaned up with registry teardown)
-  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenario "Shared cursor count stays at one per instance after broadening scope"
+  - Acceptance criteria reference: `specs/transport/spec.md` — scenario "Shared cursor count stays at one per instance after broadening scope"
   - Testability notes: Existing tests already assert "first subscribe opens exactly one cursor" / "second subscribe reuses cursor" — extend assertions to cover the broadened watch target; add a test that per-campaign session state is removed when the last subscriber for that campaign tears down.
 
 - Requirement category: reliability
   - Requirement: Visibility (DM-only vs group) is enforced identically regardless of which delivery path an event took
   - Design element: Decision 4
-  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenario "DM-only content withheld via Mongo-observed path"
+  - Acceptance criteria reference: `specs/transport/spec.md` — scenario "DM-only content withheld via Mongo-observed path"
   - Testability notes: Unit test asserting a non-DM subscriber's handler is never called with a DM-only roll/message delivered via the change-stream/poll path.
 
 - Requirement category: reliability
   - Requirement: Behavior is correct in both `detectReplicaSet()` outcomes (Atlas and standalone/local dev)
   - Design element: Decision 1 (both branches broadened in parallel)
-  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenarios duplicated for both "replica-set path" and "polling path"
+  - Acceptance criteria reference: `specs/transport/spec.md` — scenarios duplicated for both "replica-set path" and "polling path"
   - Testability notes: Mirror every new cross-instance scenario under both `detectReplicaSet` mock outcomes, matching the existing test file's pattern of parallel replica-set/polling test blocks.
 
 ## Risks / Trade-offs

--- a/openspec/changes/fix-cross-instance-transport-delivery/design.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/design.md
@@ -1,0 +1,140 @@
+## Context
+
+- Relevant architecture: `lib/server/transport.ts` is the single transport abstraction behind `GET /api/campaigns/[id]/stream`. It exposes `subscribe(campaignId, userId, onEvent)` and `emitFiltered(campaignId, event, canReceive)`. Two delivery mechanisms exist today:
+  - A **shared, per-instance change-stream cursor** on the `campaigns` collection only (`openStream`/`demux`), used when `detectReplicaSet()` is true (Atlas). This is inherently cross-instance-safe: every instance independently observes every write to `campaigns`, regardless of which instance made it.
+  - A **per-subscriber polling loop** (`pollFn`, one `setInterval` per `subscribe()` call) against the `campaigns` collection only, used when `detectReplicaSet()` is false (local/standalone Mongo).
+  - A **direct, synchronous `emitFiltered()` call** made by the `messages`, `rolls`, and `sessions/active` route handlers immediately after a successful write. This walks only the calling process's in-memory `registry` Map — it is *not* cross-instance-safe. This is the root cause of reopened #443: a `session`/`roll`/`message` event never reaches a subscriber whose SSE connection is held by a different Fly machine than the one that handled the write.
+- Dependencies: `lib/types.ts` (`CampaignStreamEvent` union), `lib/utils/campaignMessages.ts` (`canSeeMessage`), `lib/utils/campaignRolls.ts` (`canSeeRoll`), `storage.listMembersForCampaign`, MongoDB driver `ChangeStream`/`db.watch()`.
+- Interfaces/contracts touched:
+  - `lib/server/transport.ts`: `openStream`/`demux` broadened from collection-level to db-level watch across `campaigns`, `campaignMessages`, `campaignRolls`; `pollFn` broadened to poll all three collections; new per-`campaignId` "last known `activeSessionId`" state for deriving `session` events.
+  - `app/api/campaigns/[id]/messages/route.ts`, `.../rolls/route.ts`, `.../sessions/active/route.ts`: direct `emitFiltered()` calls are kept as-is (same-instance fast path), unchanged in shape.
+  - `lib/components/CampaignChat.tsx`: no contract change — `seenIds`-based dedup already exists for messages/rolls; `onSessionChange` is already idempotent for repeated identical values.
+
+## Goals / Non-Goals
+
+### Goals
+
+- `message`, `roll`, and `session` events reach every subscriber of a campaign regardless of which server instance handled the originating write, in both Atlas (change-stream) and standalone (polling) transport modes.
+- No change in delivery latency for the common single-instance/local-dev case (same-instance fast path preserved).
+- No duplicate items rendered in the UI when an event is observed via both the fast path and the Mongo-observed path.
+- Visibility enforcement (`canSeeMessage`, `canSeeRoll`) remains server-owned in every delivery path — no unfiltered broadcast of DM-only content.
+- Test coverage proves cross-instance delivery for both transport modes (currently zero coverage of this failure mode).
+
+### Non-Goals
+
+- No new shared-state infrastructure (Redis, etc.).
+- No change to the `activeSessionId`-gates-rolls business rule.
+- No change to `assertCampaignAccess`/authorization, only to delivery reliability.
+- No guarantee of message ordering/delivery beyond what already exists (`createdAt`-ordered append, at-least-once within an open connection's lifetime).
+
+## Decisions
+
+### Decision 1: Broaden the existing shared cursor/poll to cover all three collections, not just `campaigns`
+
+- Chosen: In the Atlas branch, replace the collection-level `client.db().collection('campaigns').watch(...)` with a **database-level** `client.db().watch(...)` (one shared cursor per instance, as today), scoped via pipeline to the three relevant collections (`campaigns`, `campaignMessages`, `campaignRolls`). In the polling branch, extend `pollFn` to additionally query `campaignMessages` and `campaignRolls` by `campaignId` + `createdAt > since`, alongside the existing `campaigns` query.
+- Alternatives considered: (a) One `watch()`/poll-interval per collection — rejected, triples Atlas change-stream/connection count per instance and violates the documented "keep the count of streams to Mongo as low as possible" principle (`docs/multi-user-campaigns/04-realtime-transport.md`). (b) Redis pub/sub for cross-instance fanout — rejected per proposal Non-Goals; MongoDB-only approach not yet exhausted and adds a new operational dependency.
+- Trade-offs: `demux` must now branch on which collection a change event came from (`event.ns.coll`) to build the correct `CampaignStreamEvent` shape (`change` vs `message` vs `roll`), rather than assuming `campaigns`. Db-level watch requires the MongoDB driver/server to support it (available on any replica set, same requirement as collection-level watch, so `detectReplicaSet()` remains valid).
+
+### Decision 2: Keep the direct `emitFiltered` same-instance fast path; the Mongo-observed path is the cross-instance-correct fallback; dedupe client-side
+
+- Chosen: Route handlers keep calling `emitFiltered()` synchronously after a write (near-zero latency for same-instance subscribers). The broadened change-stream/poll pipeline *also* observes the same write and re-emits the same logical event to every instance's registry, including the originating instance — where it arrives as a harmless duplicate.
+- Alternatives considered: Remove direct `emitFiltered`, rely solely on Mongo-observed delivery for everything — rejected: it would add change-stream lag (typically sub-second, but non-zero) or up-to-poll-interval lag (2s today) to the common single-instance case, for no correctness benefit there.
+- Trade-offs: Every subscriber can now receive the same `message`/`roll` up to twice (immediate same-instance + delayed Mongo-observed), and `session` state changes up to twice. `CampaignChat.tsx`'s existing `seenIds` ref (keyed by message/roll `id`) already absorbs message/roll duplicates without a code change. `session` events are naturally idempotent (`setActiveSessionId(x)` called twice with the same `x` is a no-op re-render) so no dedup logic is needed there.
+
+### Decision 3: Derive `session` events from `activeSessionId` field-level changes on the `campaigns` document
+
+- Chosen: Track a small in-memory map of last-observed `activeSessionId` per `campaignId` inside `transport.ts` (seeded lazily from the first observed document for that campaign). When a newly-observed `campaigns` document's `activeSessionId` differs from the last-known value, emit `{ type: 'session', campaignId, data: { activeSessionId } }` in addition to the generic `change` event, via the same demux/poll pipeline. In the change-stream branch, use `updateDescription.updatedFields` (already available via `fullDocument: 'updateLookup'`) to cheaply detect that `activeSessionId` was part of the write before comparing; in the polling branch, compare the polled document's `activeSessionId` against the remembered value unconditionally (poll volume is already bounded by campaign + 2s interval).
+- Alternatives considered: A separate `sessionEvents` collection written by `sessions/active` and watched independently — rejected, adds a new collection and a second write per session-lifecycle action for no benefit, since `activeSessionId` already lives on, and is already observed on, the `campaigns` document.
+- Trade-offs: Introduces small persistent (process-lifetime) state in `transport.ts` beyond the existing `sinceRef`/registry state. Must be cleaned up when a campaign has no more registered subscribers (mirroring existing registry cleanup) to avoid unbounded growth across many distinct campaigns over a long-running process.
+
+### Decision 4: Replicate message/roll visibility filtering in the Mongo-observed path
+
+- Chosen: The db-level `demux` function and the extended `pollFn`, when handling a `campaignMessages`/`campaignRolls` document, apply the same `canSeeMessage`/`canSeeRoll` predicates used by the direct-emit path today, evaluated per-subscriber: the change-stream branch iterates `registry.get(campaignId)` (each subscription already carries its `userId`) and calls the predicate per subscriber before invoking `sub.handler`; the polling branch (one interval per subscription) is given its subscription's `userId` and filters before invoking its single `handler`. Both branches fetch active members via `storage.listMembersForCampaign(campaignId)` (already used by the route handlers) to build the predicate's member list, memoized per poll/change-batch to avoid redundant DB round-trips when multiple subscribers or multiple events are being processed together.
+- Alternatives considered: Broadcast unfiltered via the Mongo-observed path and rely on the client to hide DM-only content — rejected outright; the roll-share-ui spec's Security requirement is explicit that visibility enforcement is server-owned, and this would leak DM-only roll/message payloads over the wire to unauthorized clients even if the UI hides them.
+- Trade-offs: `lib/server/transport.ts`, previously pure infra, now imports domain visibility logic (`canSeeMessage`, `canSeeRoll`) and calls `storage.listMembersForCampaign`. This is a layering compromise — acceptable at current project size and consistent with `emitFiltered`'s existing `canReceive` callback already encoding this same coupling at the call site; flagged under Risks.
+
+## Proposal to Design Mapping
+
+- Proposal element: "Making `session`/`roll`/`message` event delivery cross-instance-safe"
+  - Design decision: Decision 1 (broadened watch/poll), Decision 2 (dual-path + dedupe), Decision 3 (session derivation), Decision 4 (visibility replication)
+  - Validation approach: New unit tests in `tests/unit/server/transport.test.ts` simulating two independent `registry`/module instances (see Testability notes below); existing `CampaignChat.test.tsx`/`CampaignLayout.test.tsx` dedup tests extended to cover double-delivery.
+
+- Proposal element: "Preserving the direct-emitFiltered fast path with dedup guaranteed at the client"
+  - Design decision: Decision 2
+  - Validation approach: Unit test that same-instance delivery still fires synchronously (no added latency) alongside a separate test proving a second, delayed delivery of the same id is a no-op in the feed.
+
+- Proposal element: "Updating docs/multi-user-campaigns/04-realtime-transport.md"
+  - Design decision: Decision 1, Decision 3 (diagram/description updated to show db-level watch and derived session events)
+  - Validation approach: Doc review only (no automated check).
+
+## Functional Requirements Mapping
+
+- Requirement: A `session` event reaches a subscriber on a different instance than the one that started/ended the session
+  - Design element: Decision 1 (db-level watch/poll observes `campaigns` writes from any instance), Decision 3 (session derivation)
+  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` (to be authored) — scenario "Session event delivered cross-instance"
+  - Testability notes: Simulate two `transport.ts` module instances (via `jest.isolateModules` or two separately constructed registries) sharing a mocked Mongo change-stream/poll source; write `activeSessionId` "from" instance A, assert instance B's registered handler receives a `session` event.
+
+- Requirement: A `roll`/`message` event reaches a subscriber on a different instance than the one that handled the POST
+  - Design element: Decision 1, Decision 2, Decision 4
+  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenarios "Roll event delivered cross-instance", "Message event delivered cross-instance"
+  - Testability notes: Same two-instance simulation; assert the cross-instance subscriber receives the event and that a DM-only roll/message is withheld from a non-DM cross-instance subscriber (visibility still enforced).
+
+- Requirement: No duplicate feed entries when both delivery paths fire for the same write
+  - Design element: Decision 2, existing `seenIds` dedup in `CampaignChat.tsx`
+  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenario "Duplicate delivery deduped by id"
+  - Testability notes: Unit test delivering the same roll/message id twice through `onStreamEvent`; assert feed length increases by exactly one.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: performance
+  - Requirement: Db-level watch/broadened poll must not materially increase per-instance CPU/memory or add unbounded per-campaign state
+  - Design element: Decision 1 (single shared cursor, same "one per instance" pattern), Decision 3 (bounded last-seen-`activeSessionId` map, cleaned up with registry teardown)
+  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenario "Shared cursor count stays at one per instance after broadening scope"
+  - Testability notes: Existing tests already assert "first subscribe opens exactly one cursor" / "second subscribe reuses cursor" — extend assertions to cover the broadened watch target; add a test that per-campaign session state is removed when the last subscriber for that campaign tears down.
+
+- Requirement category: reliability
+  - Requirement: Visibility (DM-only vs group) is enforced identically regardless of which delivery path an event took
+  - Design element: Decision 4
+  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenario "DM-only content withheld via Mongo-observed path"
+  - Testability notes: Unit test asserting a non-DM subscriber's handler is never called with a DM-only roll/message delivered via the change-stream/poll path.
+
+- Requirement category: reliability
+  - Requirement: Behavior is correct in both `detectReplicaSet()` outcomes (Atlas and standalone/local dev)
+  - Design element: Decision 1 (both branches broadened in parallel)
+  - Acceptance criteria reference: `specs/cross-instance-transport/spec.md` — scenarios duplicated for both "replica-set path" and "polling path"
+  - Testability notes: Mirror every new cross-instance scenario under both `detectReplicaSet` mock outcomes, matching the existing test file's pattern of parallel replica-set/polling test blocks.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: `lib/server/transport.ts` gains a dependency on domain visibility logic (`canSeeMessage`, `canSeeRoll`, `storage.listMembersForCampaign`), breaking its previous "pure infra" boundary.
+  - Impact: Slightly higher coupling; a future visibility-rule change now has two call sites to update (the route's direct `emitFiltered` call and `transport.ts`'s demux/poll filtering) instead of one.
+  - Mitigation: Keep both call sites calling the *same* exported predicate functions (no duplicated logic) so a rule change is still a single-function edit; add a shared unit test fixture exercised by both call sites to prevent drift.
+- Risk/trade-off: Broadening from collection-level to db-level `watch()` changes the shape of observed change-stream documents (need to branch on `ns.coll`), and multiplies the *volume* of events each instance's demux must inspect (previously only `campaigns` writes, now also every message and roll).
+  - Impact: More per-event branching/filtering work per instance; possible latency/CPU regression under high message/roll volume.
+  - Mitigation: Filtering stays in-process and cheap (id/collection checks before the more expensive visibility predicate); if load testing later shows this is material, a MongoDB-side pipeline stage on `watch()` (matching `ns.coll` and/or `campaignId`) can narrow the stream server-side without changing the client-facing contract.
+- Risk/trade-off: Dual-path delivery (fast path + Mongo-observed) means a subscriber can now receive the same event twice, relying on client-side dedup being correct.
+  - Impact: A dedup bug would surface as visibly duplicated messages/rolls in the feed rather than a silent drop (opposite failure mode from today).
+  - Mitigation: `seenIds` dedup already exists and is unit-tested; add explicit new tests for the double-delivery case introduced by this change (not just history/stream overlap, which is what's tested today).
+- Risk/trade-off: We have not directly confirmed prod actually runs >1 Fly machine (carried over from proposal's Open Questions).
+  - Impact: If prod is currently single-machine, this change is prophylactic rather than an active prod fix today.
+  - Mitigation: Proceed regardless per stated goal ("so when we do scale up it works properly"); the fix is correctness-neutral-or-positive for the single-instance case (Decision 2 preserves today's latency) so there's no downside to shipping it before multi-machine operation is confirmed.
+
+## Rollback / Mitigation
+
+- Rollback trigger: The broadened db-level watch/poll causes a measurable latency or resource regression in production (e.g. SSE heartbeat delays, elevated CPU on the Fly instance, Atlas change-stream/connection limit pressure), or the dual-path delivery introduces visible duplicate messages/rolls that dedup does not catch.
+- Rollback steps: Revert `lib/server/transport.ts`, the three route files, and `CampaignChat.tsx` changes to the pre-change versions (collection-level `campaigns`-only watch/poll, `session` event only from the existing same-instance fast path). The `campaignMessages`/`campaignRolls` collections and their existing routes/history endpoints are unaffected and need no data migration.
+- Data migration considerations: None — this change is purely additive to the transport layer; no schema or persisted-document changes.
+- Verification after rollback: Confirm chat messages and rolls still send/receive correctly within a single instance (today's baseline behavior); confirm no JS errors in `CampaignChat`; re-confirm issue #443 reproduces only in the (documented, pre-existing) multi-instance case.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Do not merge. Fix the failing check — in particular, do not skip or weaken the new cross-instance simulation tests to make CI green.
+- If security checks fail: Do not merge. Given Decision 4 touches visibility enforcement, treat any security-tool finding on `transport.ts`, the route files, or `campaignMessages.ts`/`campaignRolls.ts` as blocking until investigated.
+- If required reviews are blocked/stale: Ping reviewer after 24 hours; escalate to repo owner after 48 hours.
+- Escalation path and timeout: Repo owner (dougis) is the escalation path; no external stakeholders for this change.
+
+## Open Questions
+
+- Carried from proposal.md (non-blocking): Can we directly confirm prod's current Fly machine count via `fly status`/`fly machine list` before or alongside implementation? Useful for prioritization/validation, not required to proceed.
+- Should the per-campaign "last known `activeSessionId`" state (Decision 3) live inside `lib/server/transport.ts` alongside `registry`, or be pulled out into its own small module? Leaning toward keeping it colocated with `registry` for now (same lifecycle, same file, minimal surface) — revisit only if `transport.ts` grows unwieldy.
+- Is a MongoDB-side `$match` pipeline stage on the db-level `watch()` (narrowing to relevant `ns.coll` values at the server) worth adding now versus deferring until load testing shows it's needed? Leaning toward deferring (per Risks/Mitigation above) to keep this change's diff focused on correctness, not premature optimization.

--- a/openspec/changes/fix-cross-instance-transport-delivery/proposal.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/proposal.md
@@ -1,0 +1,97 @@
+## GitHub Issues
+
+- #443
+
+## Why
+
+- Problem statement: `message`, `roll`, and `session` `CampaignStreamEvent`s are delivered by calling `emitFiltered()` directly from the API route handler that processed the write. `emitFiltered()` only walks the in-memory `registry` Map of the process that ran the handler (`lib/server/transport.ts:12`, comment: "Module-level singletons — process-scoped state (safe on Fly.io single-process)"). When more than one Fly machine is running, a subscriber whose SSE connection is held by a different instance than the one that handled the write never receives the event — silently, with no error or log. This most visibly breaks the roll-entry strip: it stays hard-disabled ("No active session") until an `activeSessionId`-carrying `session` event arrives, which may never happen cross-instance.
+- Why now: Filed as #443, "fixed" once already in PR #454 (merged 2026-06-28), and reopened 2026-07-07. The prior fix added the `session` event type and wiring end-to-end but only closed the same-instance case — it did not address that `emitFiltered` is process-local. Fly.io is configured with `min_machines_running = 0` and `auto_start_machines = true` (`fly.toml`), so multi-machine operation is an expected, not hypothetical, condition; the bug will keep recurring as usage scales.
+- Business/user impact: Dice rolling — a core session-play feature — silently stops working for some fraction of players whenever the app is running on more than one machine, with no error surfaced to the DM or the affected player. The user experience is confusing (messages work, rolls don't, no visible cause) and erodes trust that a previously "closed" bug is actually fixed.
+
+## Problem Space
+
+- Current behavior:
+  - `change` events are cross-instance-safe today: each server instance opens its own MongoDB change-stream `watch()` on the `campaigns` collection (`openStream`/`demux` in `lib/server/transport.ts`). A DB write is observed independently by every instance, so every instance's local registry receives the event regardless of which instance made the write.
+  - `message`, `roll`, and `session` events are NOT cross-instance-safe: they are emitted via a direct, synchronous `emitFiltered(campaignId, event, canReceive)` call from within the route handler (`app/api/campaigns/[id]/messages/route.ts`, `app/api/campaigns/[id]/rolls/route.ts`, `app/api/campaigns/[id]/sessions/active/route.ts`). This function only iterates `registry.get(campaignId)` on the instance where the call executes.
+  - `CampaignChat` (`lib/components/CampaignChat.tsx`) only treats `session` events specially to update `activeSessionId`; `change` events are otherwise ignored for that purpose. It also gives the *acting* user an optimistic local update on their own successful POST (`onRollPosted`, message append), which masks the cross-instance gap for the actor while leaving every other connected user un-notified.
+- Desired behavior: Every subscriber to a campaign's stream receives `message`, `roll`, and `session` events regardless of which server instance handled the originating write, with the same reliability `change` events already have. Local/single-instance and CI/test behavior must be unaffected. No duplicate items should appear in the feed if an event is observed by more than one delivery path.
+- Constraints:
+  - No new infrastructure dependency (e.g. Redis pub/sub) unless justified — Fly deployment and cost profile currently assumes only MongoDB as shared state.
+  - Must work correctly in both `detectReplicaSet()` outcomes: Atlas/replica-set (change streams) and local/standalone Mongo (since-timestamp polling fallback).
+  - Must preserve existing latency characteristics as closely as possible for the common single-instance/local-dev case — do not introduce a fixed poll-only delay where a low-latency path exists today.
+  - Existing dedup mechanisms (`seenIds` ref in `CampaignChat.tsx` for messages/rolls; layout's `activeSessionId` being idempotently set) must be sufficient to absorb any double-delivery introduced by running two delivery paths.
+- Assumptions:
+  - Fly.io can run more than one machine for this app at least transiently (deploys, autoscale-under-load), even if `min_machines_running = 0` normally keeps it at zero-or-one; this is confirmed as the working theory for reopened #443 in prod, not yet confirmed by direct observation of Fly's machine count.
+  - The `campaigns` collection is not the only collection that needs cross-instance-safe change observation — messages and rolls live in their own collections and are not currently watched at all by the shared change stream.
+  - `SessionLog`/session lifecycle writes (`storage.claimActiveCampaignSession` / `storage.setActiveCampaignSession`) already `$set` `activeSessionId` on the `campaigns` document, meaning the existing `campaigns` change-stream watch already observes session start/end cross-instance today — it's just not translated into a `session`-shaped (or otherwise consumable) event for the client.
+- Edge cases considered:
+  - Duplicate delivery when both a direct `emitFiltered` (same-instance fast path) and a Mongo-observed path fire for the same underlying write.
+  - Standalone/local-dev Mongo (no change streams) must still get session/roll/message updates via the existing polling fallback, extended the same way as the replica-set path.
+  - A message/roll/session write occurring on an instance with zero current subscribers for that campaign (no one to notify) must not error.
+  - Multiple browser tabs/subscriptions for the same user (existing per-subscription-token registry design) must each independently receive events exactly once.
+
+## Scope
+
+### In Scope
+
+- Making `session` event delivery (activeSessionId changes) cross-instance-safe.
+- Making `roll` event delivery cross-instance-safe.
+- Making `message` event delivery cross-instance-safe.
+- Extending or adding change-stream/poll coverage in `lib/server/transport.ts` for the collections backing messages and rolls, and/or the `activeSessionId` field on the `campaigns` collection, to serve as the cross-instance-correct source of truth.
+- Preserving (or explicitly deciding to drop) the current direct-`emitFiltered` calls as a same-instance low-latency fast path, with dedup guaranteed at the client.
+- Unit test coverage that exercises delivery across two independent registry/process simulations (currently zero coverage of this failure mode), for both the replica-set and polling transport branches.
+- Updating `docs/multi-user-campaigns/04-realtime-transport.md` to reflect the corrected architecture.
+
+### Out of Scope
+
+- Introducing a new shared-state dependency (Redis, etc.) for pub/sub — first attempt should exhaust the MongoDB-only approach already used for `change` events.
+- Changing the `activeSessionId`-gates-rolls business rule itself (confirmed correct and intentional during exploration — rolls are session-scoped by design; messages are not).
+- Any UI/UX changes to `RollEntryStrip` or `CampaignChat` beyond what's needed to consume the corrected event source (e.g. no redesign of the disabled-state messaging).
+- Fixing or altering `assertCampaignAccess`/visibility filtering logic (`canReceive`/`canSeeRoll`) — this change is about delivery reliability, not authorization.
+- Deploy/infra changes to pin Fly to a single machine — the fix should make the app correct under its existing/expected multi-machine configuration, not work around it by constraining scaling.
+
+## What Changes
+
+- `lib/server/transport.ts`: broaden cross-instance-safe delivery beyond the `campaigns` collection to also cover message and roll writes (mechanism to be finalized in `design.md` — options include widening the existing change-stream watch to additional collections, or a db-level watch, mirrored in the polling fallback), and ensure `activeSessionId` changes observed via the `campaigns` watch/poll are translated into an event the client can act on.
+- `app/api/campaigns/[id]/messages/route.ts`, `app/api/campaigns/[id]/rolls/route.ts`, `app/api/campaigns/[id]/sessions/active/route.ts`: decide whether direct `emitFiltered` calls remain (as a same-instance fast path) alongside the new cross-instance-safe path, or are removed in favor of it exclusively.
+- `lib/components/CampaignChat.tsx`: ensure the client correctly dedups when the same logical event can arrive via two paths (same-instance fast path + Mongo-observed path), and correctly derives `activeSessionId` updates from whichever path is authoritative.
+- `tests/unit/server/transport.test.ts`: add coverage simulating two independent process/registry instances to prove cross-instance delivery.
+- `docs/multi-user-campaigns/04-realtime-transport.md`: update the architecture diagram/description to match.
+
+## Risks
+
+- Risk: Broadening the change-stream watch (e.g. to a db-level watch or multiple collections) increases the volume of change events each instance must filter/demux, which could add CPU/memory overhead per instance.
+  - Impact: Possible latency or resource regression under load, especially with many concurrent campaigns/messages.
+  - Mitigation: Keep the "one shared cursor per instance, demuxed in-process" pattern already used for `campaigns`; measure/test with realistic event volume; filter server-side (query/pipeline) where possible rather than relying purely on in-process filtering.
+- Risk: Running both a same-instance fast path and a Mongo-observed path introduces duplicate-delivery bugs if dedup isn't airtight.
+  - Impact: Duplicate messages/rolls in the feed, or a session event applied twice (idempotent, so lower risk) causing visual glitches or confusing double-notifications.
+  - Mitigation: Rely on and extend existing `seenIds`-style dedup by stable id; add explicit unit tests for double-delivery scenarios.
+- Risk: The polling fallback (non-replica-set/local dev) needs the same fix applied in parallel to the change-stream path, doubling the surface area to get right.
+  - Impact: Fix could work in prod (Atlas) but leave local dev/CI still broken for cross-instance-shaped tests, or vice versa.
+  - Mitigation: Design and test both branches explicitly; do not consider the change done until both are covered.
+- Risk: We have not directly confirmed (via `fly status` or Fly dashboard) that prod is currently running more than one machine.
+  - Impact: If prod is in fact always a single machine, the actual root cause of the reopened #443 report might be something else, and this change would not fix it.
+  - Mitigation: Treat as the leading, well-evidenced hypothesis (matches the intermittent/session-dependent bug shape, the `fly.toml` autoscale config, and the explicit "single-process" comment in the code); flagged as an open question below — worth a direct confirmation before/alongside implementation, but the architecture gap is real and worth closing regardless since it's a latent correctness issue independent of whether it's actively firing in prod today.
+
+## Open Questions
+
+- Question: Can we directly confirm prod is/has been running multiple Fly machines concurrently (e.g. via `fly status`, `fly machine list`, or Fly metrics/logs) to validate the root-cause hypothesis before implementing?
+  - Needed from: repo owner (Fly account access)
+  - Blocker for apply: no — the architecture gap is a real latent bug regardless of current confirmed machine count, and closing it is worthwhile prophylactically per the user's stated goal ("so when we do scale up it works properly").
+- Question: Should the direct `emitFiltered` same-instance fast path be kept (dual delivery + dedup) or removed entirely in favor of routing everything through the Mongo-observed path?
+  - Needed from: design decision — will be resolved in `design.md`, leaning toward keep-as-fast-path-with-dedup to preserve today's low latency in the common case, but worth stating explicitly for review.
+  - Blocker for apply: no — resolvable in design.
+- Question: Is a single shared db-level `watch()` (covering campaigns, messages, and rolls collections in one cursor) preferable to three separate per-collection watches, given the "keep the count of streams to Mongo as low as possible" principle already documented in `docs/multi-user-campaigns/04-realtime-transport.md`?
+  - Needed from: design decision — will be resolved in `design.md`.
+  - Blocker for apply: no.
+
+## Non-Goals
+
+- Redesigning the transport abstraction beyond what's needed to fix cross-instance delivery (e.g. no move to a different real-time technology, no WebSocket migration).
+- Adding delivery guarantees beyond "eventually consistent, deduped, at-least-once within the lifetime of an open connection" — no durable event log, no replay-from-arbitrary-point guarantee beyond what history endpoints already provide.
+- Load-testing or capacity-planning the transport layer beyond confirming the fix doesn't regress the existing single-instance case.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/fix-cross-instance-transport-delivery/specs/transport/spec.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/specs/transport/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Cross-instance delivery for message, roll, and session events
+
+The system SHALL deliver `message`, `roll`, and `session` `CampaignStreamEvent`s to every subscriber of a campaign regardless of which server process handled the write that produced the event, in both the change-stream (Atlas) and polling (standalone Mongo) transport paths.
+
+#### Scenario: Session event delivered cross-instance (change-stream path)
+
+- **Given** two independent transport instances (simulating two Fly machines) each with their own `registry`, both observing the same replica-set MongoDB via db-level `watch()`
+- **And** a subscriber with `userId: "player-1"` is registered on instance B for campaign "camp-1"
+- **When** the `sessions/active` POST handler running on instance A sets `activeSessionId` on the `campaigns` document for "camp-1" (instance A never calls instance B's `emitFiltered` directly)
+- **Then** instance B's change-stream demux observes the write independently and instance B's registered handler for "player-1" is called with `{ type: 'session', campaignId: 'camp-1', data: { activeSessionId: <new id> } }`
+
+#### Scenario: Roll event delivered cross-instance (change-stream path)
+
+- **Given** the same two-instance setup as above, with a subscriber registered on instance B
+- **When** the `rolls` POST handler running on instance A inserts a new document into `campaignRolls` for "camp-1"
+- **Then** instance B's demux observes the insert independently and instance B's subscriber receives a `{ type: 'roll', ... }` event carrying the same roll data instance A persisted
+
+#### Scenario: Message event delivered cross-instance (change-stream path)
+
+- **Given** the same two-instance setup as above, with a subscriber registered on instance B
+- **When** the `messages` POST handler running on instance A inserts a new document into `campaignMessages` for "camp-1"
+- **Then** instance B's demux observes the insert independently and instance B's subscriber receives a `{ type: 'message', ... }` event carrying the same message data instance A persisted
+
+#### Scenario: Session, roll, and message events delivered cross-instance (polling path)
+
+- **Given** two independent transport instances, each in polling mode (non-replica-set), each polling `campaigns`, `campaignMessages`, and `campaignRolls` on its own `sinceRef`-scoped interval
+- **When** a session start/end, a roll insert, or a message insert occurs "on instance A" (i.e. is written to the shared underlying store)
+- **Then** instance B's next poll cycle observes the change and delivers the corresponding `session`/`roll`/`message` event to instance B's subscribers
+
+---
+
+### Requirement: ADDED Same-instance fast path preserved alongside cross-instance delivery
+
+The system SHALL continue to deliver `message`, `roll`, and `session` events to same-instance subscribers via the existing synchronous `emitFiltered()` call, in addition to (not instead of) the cross-instance-safe change-stream/poll-derived delivery.
+
+#### Scenario: Same-instance subscriber receives the fast-path delivery immediately
+
+- **Given** a subscriber is registered on the same instance that handles a roll POST
+- **When** the POST handler calls `emitFiltered()` synchronously after persisting the roll
+- **Then** the subscriber's handler is invoked before the handler returns the HTTP response (no dependency on the change-stream/poll cycle completing)
+
+#### Scenario: Duplicate delivery from both paths is deduped by id
+
+- **Given** a subscriber is registered on the same instance that handles a roll POST
+- **When** `emitFiltered()` delivers the roll immediately, and the change-stream/poll-derived path later also observes and re-delivers the same roll (same `id`) to the same subscriber
+- **Then** the client-side feed (`CampaignChat.tsx`'s `seenIds`-based dedup) contains exactly one entry for that roll `id`
+
+---
+
+### Requirement: ADDED Session event derivation from activeSessionId field changes
+
+The system SHALL derive `session` events from observed changes to the `activeSessionId` field on a `campaigns` document, rather than requiring a separately-emitted event type in the change-stream/poll pipeline.
+
+#### Scenario: Unrelated campaign field change does not emit a spurious session event
+
+- **Given** the transport has last observed `activeSessionId: "session-1"` for campaign "camp-1"
+- **When** a `campaigns` document write changes only an unrelated field (e.g. `name`) and `activeSessionId` remains `"session-1"`
+- **Then** no `session` event is emitted for that write (a `change` event may still be emitted as today)
+
+#### Scenario: activeSessionId change emits a session event
+
+- **Given** the transport has last observed `activeSessionId: null` for campaign "camp-1"
+- **When** a `campaigns` document write sets `activeSessionId` to `"session-2"`
+- **Then** a `{ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-2' } }` event is emitted to all subscribers of "camp-1"
+- **And** the transport's last-known value for "camp-1" updates to `"session-2"`
+
+#### Scenario: Per-campaign session state is cleaned up when the last subscriber tears down
+
+- **Given** campaign "camp-1" has exactly one registered subscriber, and the transport holds last-known `activeSessionId` state for "camp-1"
+- **When** that subscriber's teardown function is called
+- **Then** the transport's last-known `activeSessionId` state for "camp-1" is removed (no unbounded growth across long-running processes)
+
+---
+
+### Requirement: ADDED Visibility enforcement in the change-stream/poll-derived delivery path
+
+The system SHALL apply the same `canSeeMessage`/`canSeeRoll` visibility predicates to message/roll events delivered via the change-stream/poll-derived path as are already applied to the direct `emitFiltered` fast path — no unfiltered broadcast of DM-only content over either path.
+
+#### Scenario: DM-only roll withheld from a non-DM subscriber via the change-stream path
+
+- **Given** a roll with `visibility: { scope: 'dm-only' }` is inserted into `campaignRolls` on instance A
+- **And** a non-DM subscriber ("player-1") is registered on instance B
+- **When** instance B's demux observes the insert
+- **Then** `canSeeRoll` is evaluated for "player-1" before delivery, and "player-1"'s handler is NOT called with that roll
+
+#### Scenario: DM-only roll delivered to the DM subscriber via the change-stream path
+
+- **Given** the same DM-only roll insert as above
+- **And** a subscriber with the DM role for the campaign is registered on instance B
+- **When** instance B's demux observes the insert
+- **Then** the DM subscriber's handler IS called with the roll event
+
+#### Scenario: Visibility enforcement applies identically in the polling path
+
+- **Given** the same DM-only roll scenario, but instance B is in polling mode (non-replica-set)
+- **When** instance B's poll cycle observes the new roll document for the DM-only-subscribed campaign
+- **Then** `canSeeRoll` is evaluated per-subscription before delivery, with the same withhold/deliver outcome as the change-stream path
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Transport abstraction — change stream path (Atlas)
+
+The system SHALL, when running against a replica-set MongoDB, open a single shared **database-level** change stream per process (not collection-level, and not one cursor per collection) covering the `campaigns`, `campaignMessages`, and `campaignRolls` collections, and route incoming change documents to the correct per-campaign subscriber set based on both `campaignId` and source collection.
+
+#### Scenario: Single shared cursor covers all three collections
+
+- **Given** the process is connected to a replica-set MongoDB
+- **And** no change stream is currently open
+- **When** `subscribe()` is called for the first time
+- **Then** exactly one `MongoClient.db().watch()` cursor is opened (not one per collection)
+- **And** writes to `campaigns`, `campaignMessages`, or `campaignRolls` for a subscribed campaign are all observed via that single cursor
+
+#### Scenario: Event routed to correct campaign subscribers regardless of source collection
+
+- **Given** subscribers exist for campaign A and campaign B
+- **When** the shared cursor emits a change document from `campaignRolls` with `fullDocument.campaignId === 'A'`
+- **Then** all handlers registered under campaign A are called with a `{ type: 'roll', ... }` event
+- **And** handlers registered under campaign B are NOT called
+
+---
+
+### Requirement: MODIFIED Transport abstraction — polling path (standalone Mongo)
+
+The system SHALL, when running against a standalone (non-replica-set) MongoDB, poll `campaigns`, `campaignMessages`, and `campaignRolls` (by `campaignId` + `createdAt`/`updatedAt` greater than the subscription's `since` timestamp) on each subscription's existing polling interval, in addition to the previously-polled `campaigns`-only behavior.
+
+#### Scenario: Polling observes new messages and rolls, not just campaign changes
+
+- **Given** a subscriber is registered with polling mode active, `sinceTimestamp` is T0
+- **When** the poll interval fires and a new document exists in `campaignMessages` with `createdAt > T0` for the subscribed campaign
+- **Then** the subscriber handler is called with a `{ type: 'message', ... }` event
+- **And** `sinceTimestamp` advances to the current time, covering all three polled collections
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element: "Making session/roll/message event delivery cross-instance-safe" → Requirement: ADDED Cross-instance delivery for message, roll, and session events
+- Proposal element: "Preserving direct-emitFiltered as a same-instance fast path" → Requirement: ADDED Same-instance fast path preserved alongside cross-instance delivery
+- Design Decision 1 (broadened db-level watch/poll) → Requirement: MODIFIED Transport — change stream path; MODIFIED Transport — polling path
+- Design Decision 2 (dual-path + client dedup) → Requirement: ADDED Same-instance fast path preserved; Scenario: Duplicate delivery deduped by id
+- Design Decision 3 (session derivation from activeSessionId) → Requirement: ADDED Session event derivation from activeSessionId field changes
+- Design Decision 4 (visibility replication) → Requirement: ADDED Visibility enforcement in the change-stream/poll-derived delivery path
+
+- Requirements → Tasks: all requirements map to the implementation tasks in `tasks.md` covering `lib/server/transport.ts` broadening, route-handler-unchanged verification, and `CampaignChat.tsx` dedup verification — see `tasks.md`.
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Performance
+
+#### Scenario: Cursor count stays bounded to one per process after broadening scope
+
+- **Given** N SSE connections are open (N ≥ 2) across M campaigns (M ≥ 1) on Atlas, subscribed to a mix of message, roll, and session activity
+- **When** the transport is running with the broadened db-level watch
+- **Then** exactly one `MongoClient.db().watch()` cursor exists in the process (same bound as before this change; see `openspec/specs/transport/spec.md` — "Cursor count bounded to one per process")
+
+### Requirement: Security
+
+See functional scenarios: "DM-only roll withheld from a non-DM subscriber via the change-stream path", "DM-only roll delivered to the DM subscriber via the change-stream path", "Visibility enforcement applies identically in the polling path". No additional NFAC scenario needed — these functional scenarios fully cover the access-control property for this change.
+
+### Requirement: Reliability
+
+#### Scenario: Behavior verified in both transport modes
+
+- **Given** the full set of cross-instance delivery, dedup, session-derivation, and visibility scenarios above
+- **When** each is exercised under both `detectReplicaSet() === true` (change-stream) and `detectReplicaSet() === false` (polling) mocks
+- **Then** the outcome (delivered / withheld / deduped) is identical between the two modes for equivalent inputs

--- a/openspec/changes/fix-cross-instance-transport-delivery/tasks.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/tasks.md
@@ -81,9 +81,9 @@ Before running, determine whether the current change is **docs-only**: run `git 
 
 **Full path**:
 
-- **Unit tests** — `npm test` (or project-documented unit test command); all tests must pass
-- **Integration tests** — run the project's integration test suite; all tests must pass
-- **Regression / E2E tests** — run the project's end-to-end or regression test suite; all tests must pass
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — `npm run test:integration`; all tests must pass
+- **Regression / E2E tests** — `npm run test:regression` (Playwright); all tests must pass
 - **Build** — `npm run build`; build must succeed with no errors
 
 If **ANY** required step fails, you **MUST** iterate and address the failure before pushing.

--- a/openspec/changes/fix-cross-instance-transport-delivery/tasks.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/tasks.md
@@ -1,0 +1,134 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** `git checkout main` and `git pull --ff-only`
+- [x] **Step 2 — Create and publish working branch:** `git checkout -b fix/issue-443-cross-instance-transport` then immediately `git push -u origin fix/issue-443-cross-instance-transport`
+
+## Preflight
+
+- [x] **Verify `pr-review-toolkit:review-pr` is available** — check the available skills list for `pr-review-toolkit:review-pr`. If the skill is not listed, halt immediately, inform the user that the plugin is required, provide installation guidance, and do not proceed until the user confirms it is installed.
+
+## Execution
+
+- [x] **Issue lifecycle: mark in-progress**: run `gh issue edit 443 --add-label "in-progress"`. Then discover the GitHub Project linked to `dougis-org/session-combat` (`gh project list --owner dougis-org --format json`), resolve the status field option semantically matching "In Progress" (`gh project field-list <project-number> --owner dougis-org --format json`), and move the project item for issue #443 via `gh project item-edit`. If no project item is found, log a warning and continue. If the `gh` token lacks the `project` scope, surface a message instructing the user to run `gh auth refresh -s project` and skip the project-item update (issue label update still proceeds).
+
+### T1 — `transport.test.ts`: two-instance simulation harness (test infra only)
+
+- [x] Add a test helper in `tests/unit/server/transport.test.ts` that constructs two independent instances of the transport module (e.g. via `jest.isolateModules` twice, each with its own mocked Mongo client/cursor/collection stubs) sharing a single fake underlying "database" (an in-memory doc store the mocks read/write through), so a write made against instance A's mocked collection is visible to instance B's mocked `watch()`/poll query.
+- [x] Verify the harness alone (no product code changes yet) can prove two separate `registry` Maps exist and are independent — write a throwaway assertion, then remove it once confirmed.
+
+### T2 — Broaden the Atlas change-stream path (Decision 1)
+
+- [x] Write failing tests (BDD, per `specs/transport/spec.md`): "Single shared cursor covers all three collections", "Event routed to correct campaign subscribers regardless of source collection", "Session event delivered cross-instance (change-stream path)", "Roll event delivered cross-instance (change-stream path)", "Message event delivered cross-instance (change-stream path)".
+- [x] Implement: change `openStream()` in `lib/server/transport.ts` from `client.db().collection('campaigns').watch(...)` to `client.db().watch(...)` (db-level), and update `demux()` to branch on `event.ns.coll` (`'campaigns'` / `'campaignMessages'` / `'campaignRolls'`) to build the correct `CampaignStreamEvent` shape (`change` / `message` / `roll`) instead of assuming `campaigns`.
+- [x] Confirm existing scenarios "First subscription opens the shared change stream", "Subsequent subscriptions reuse the existing stream", "Cursor count bounded to one per process" (from `openspec/specs/transport/spec.md`) still pass unmodified against the db-level watch.
+- [x] Run the new tests; iterate until green.
+
+### T3 — Broaden the polling path (Decision 1)
+
+- [x] Write failing tests: "Session, roll, and message events delivered cross-instance (polling path)", "Polling observes new messages and rolls, not just campaign changes".
+- [x] Implement: extend `pollFn()` in `lib/server/transport.ts` to additionally query `campaignMessages` and `campaignRolls` by `campaignId` + `createdAt > since`, alongside the existing `campaigns` query, and emit the corresponding typed events.
+- [x] Confirm existing scenarios "Polling emits new events since last check", "Polling skips events for other campaigns", "Polling teardown stops the interval" still pass.
+- [x] Run the new tests; iterate until green.
+
+### T4 — Session event derivation from `activeSessionId` (Decision 3)
+
+- [x] Write failing tests: "Unrelated campaign field change does not emit a spurious session event", "activeSessionId change emits a session event", "Per-campaign session state is cleaned up when the last subscriber tears down" — for both the change-stream and polling branches.
+- [x] Implement: add a per-`campaignId` last-known-`activeSessionId` map in `lib/server/transport.ts`, colocated with `registry` (per Decision 3/Open Questions — same file, same lifecycle). In the change-stream branch, use `updateDescription.updatedFields` (available via `fullDocument: 'updateLookup'`, already in use) to detect `activeSessionId` was part of the write before comparing/emitting. In the polling branch, compare the polled `campaigns` document's `activeSessionId` against the remembered value unconditionally. Remove the per-campaign entry when the last subscriber for that campaign tears down (mirror existing registry cleanup in the teardown function returned by `subscribe()`).
+- [x] Run the new tests; iterate until green.
+
+### T5 — Visibility replication in the Mongo-observed path (Decision 4)
+
+- [x] Write failing tests: "DM-only roll withheld from a non-DM subscriber via the change-stream path", "DM-only roll delivered to the DM subscriber via the change-stream path", "Visibility enforcement applies identically in the polling path" (mirror for messages using `canSeeMessage`).
+- [x] Implement: in `demux()` (change-stream branch) and the extended `pollFn()` (polling branch), when handling a `campaignMessages`/`campaignRolls` document, call `storage.listMembersForCampaign(campaignId)` (memoized per poll/change-batch to avoid redundant DB round-trips) and evaluate `canSeeMessage`/`canSeeRoll` per-subscriber (`sub.userId` in the registry case; the subscription's own `userId` in the polling case) before invoking the handler.
+- [x] Run the new tests; iterate until green.
+
+### T6 — Same-instance fast path + client-side dedup (Decision 2)
+
+- [x] Confirm (no production code change expected here) that `app/api/campaigns/[id]/messages/route.ts`, `.../rolls/route.ts`, `.../sessions/active/route.ts` keep their existing direct `emitFiltered()` calls unchanged.
+- [x] Write failing tests in `tests/unit/server/transport.test.ts`: "Same-instance subscriber receives the fast-path delivery immediately" (assert the handler is called synchronously within the `emitFiltered()` call, independent of any change-stream/poll cycle).
+- [x] Write failing tests in `tests/unit/components/CampaignChat.test.tsx`: "Duplicate delivery deduped by id" — deliver the same roll/message `id` twice through `onStreamEvent` (simulating fast-path + Mongo-observed redelivery) and assert the feed length increases by exactly one.
+- [x] Verify `onSessionChange`/`setActiveSessionId` is naturally idempotent under redelivery of the same `activeSessionId` value (add a small assertion/test if not already covered) — no new dedup logic expected to be needed here.
+- [x] Run the new tests; iterate until green.
+
+### T7 — Update architecture docs
+
+- [x] Update `docs/multi-user-campaigns/04-realtime-transport.md`: revise the "Component layout" and "Transport selection" mermaid diagrams and surrounding text to reflect the db-level watch across `campaigns`/`campaignMessages`/`campaignRolls`, the derived `session` event, and the dual-path (fast path + cross-instance-safe path) delivery model with client-side dedup.
+
+### General
+
+- [x] Look for existing tooling or functions in the codebase that can be reused or extended before writing new logic from scratch (in particular: reuse `canSeeMessage`/`canSeeRoll`/`storage.listMembersForCampaign` as-is rather than re-implementing visibility logic in `transport.ts`).
+- [x] Confirm all acceptance criteria in `specs/transport/spec.md` (this change's delta) are covered by passing tests.
+
+## Pre-Commit Code Review
+
+- [x] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. The primary agent must automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [x] Run unit/integration tests
+- [x] Run E2E tests (if applicable) — not applicable: no existing E2E specs cover chat/rolls/sessions transport
+- [x] Run type checks
+- [x] Run build
+- [x] Run security/code quality checks required by project standards — `npm run lint` clean (0 errors), no new dependencies
+- [x] All completed tasks marked as complete
+- [ ] All steps in [Remote push validation]
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` (or compare the working branch against the base branch) and check whether every changed file ends in `.md`. This change touches `lib/server/transport.ts`, route/test files, and `CampaignChat.tsx`, so the **full path** applies.
+
+**Full path**:
+
+- **Unit tests** — `npm test` (or project-documented unit test command); all tests must pass
+- **Integration tests** — run the project's integration test suite; all tests must pass
+- **Regression / E2E tests** — run the project's end-to-end or regression test suite; all tests must pass
+- **Build** — `npm run build`; build must succeed with no errors
+
+If **ANY** required step fails, you **MUST** iterate and address the failure before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `fix/issue-443-cross-instance-transport` to `main`. The PR body MUST include `Closes #443`.
+- [ ] **Issue lifecycle: mark in-review**: run `gh issue edit 443 --add-label "in-review" --remove-label "in-progress"`. Then move the project item to the status column semantically matching "In Review" via `gh project item-edit` (same project/field/option discovery as the in-progress lifecycle step above; warn and skip if not found).
+- [ ] Wait 60 seconds for CI to start
+- [ ] Spawn a sub-agent to run `pr-review-toolkit:review-pr`; address all findings (commit, push, re-run) until zero findings remain. If findings persist after three or more iterations with no progress, report the stall with remaining findings listed and wait for human guidance before continuing.
+- [ ] **Enable auto-merge only after the review gate passes (zero findings):** `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if it returns `CLOSED` exit and notify the user — **never wait for a human to report the merge; never force-merge**:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: dougis (or assigned agent session)
+- Reviewer(s): `pr-review-toolkit:review-pr` automated gate; repo owner (dougis) for final approval
+- Required approvals: 1 (repo owner) plus automated review gate at zero findings
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (confirm `docs/multi-user-campaigns/04-realtime-transport.md` update from T7 landed)
+- [ ] Sync approved spec deltas into `openspec/specs/`: copy `openspec/changes/fix-cross-instance-transport-delivery/specs/transport/spec.md` merged content into `openspec/specs/transport/spec.md` (merging ADDED/MODIFIED requirements into the existing capability spec, not overwriting unrelated existing requirements). Update relative links that pointed into the change directory so they resolve from the archive location — replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-fix-cross-instance-transport-delivery/design.md`, and similarly for `../../tasks.md`.
+- [ ] Archive the change: move `openspec/changes/fix-cross-instance-transport-delivery/` to `openspec/changes/archive/YYYY-MM-DD-fix-cross-instance-transport-delivery/` **and stage both the new location and the deletion of the old location in a single commit** — do not commit the copy and delete separately
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-fix-cross-instance-transport-delivery/` exists and `openspec/changes/fix-cross-instance-transport-delivery/` is gone
+- [ ] **Create a doc branch** for the archive and spec updates: `git checkout -b doc/archive-YYYY-MM-DD-fix-cross-instance-transport-delivery` then `git push -u origin doc/archive-YYYY-MM-DD-fix-cross-instance-transport-delivery`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-fix-cross-instance-transport-delivery` to `main` with title `docs: archive fix-cross-instance-transport-delivery (YYYY-MM-DD)` — **do NOT push directly to `main`**
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] Monitor the doc PR until it merges (same loop as the implementation PR — address comments and CI failures, push to the same doc branch, repeat)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D fix/issue-443-cross-instance-transport doc/archive-YYYY-MM-DD-fix-cross-instance-transport-delivery`
+
+Required cleanup after archive: `git fetch --prune` and `git branch -D fix/issue-443-cross-instance-transport doc/archive-YYYY-MM-DD-fix-cross-instance-transport-delivery`

--- a/openspec/changes/fix-cross-instance-transport-delivery/tests.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/tests.md
@@ -1,0 +1,85 @@
+---
+name: tests
+description: Tests for the change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `fix-cross-instance-transport-delivery` change. All work should follow a strict TDD (Test-Driven Development) process.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1.  **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2.  **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3.  **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### T1 — Two-instance simulation harness (`tests/unit/server/transport.test.ts`)
+
+- [ ] Harness constructs two independent transport module instances (`jest.isolateModules` or equivalent), each with its own mocked Mongo client/cursor/collection stubs, sharing one fake underlying doc store so a write via instance A's mocks is visible to instance B's mocked `watch()`/poll query
+- [ ] Harness proves the two instances' `registry` Maps are independent (throwaway assertion removed once confirmed; not a permanent test case)
+
+### T2 — Broaden the Atlas change-stream path
+
+Maps to spec scenarios in `specs/transport/spec.md`: "Single shared cursor covers all three collections", "Event routed to correct campaign subscribers regardless of source collection", "Session event delivered cross-instance (change-stream path)", "Roll event delivered cross-instance (change-stream path)", "Message event delivered cross-instance (change-stream path)".
+
+- [ ] Test: first `subscribe()` on a replica-set-mocked instance opens exactly one `db().watch()` cursor (not `collection('campaigns').watch()`) — fails before T2 implementation, passes after
+- [ ] Test: a change document from `campaignRolls` with `fullDocument.campaignId === 'A'` is routed only to campaign A's handlers, built as a `{ type: 'roll', ... }` event
+- [ ] Test: a change document from `campaignMessages` with `fullDocument.campaignId === 'A'` is routed only to campaign A's handlers, built as a `{ type: 'message', ... }` event
+- [ ] Test (two-instance harness): instance A sets `activeSessionId` on a `campaigns` doc for "camp-1"; instance B's registered subscriber for "camp-1" receives a `session` event without instance A calling instance B directly
+- [ ] Test (two-instance harness): instance A inserts a `campaignRolls` doc for "camp-1"; instance B's subscriber receives the corresponding `roll` event
+- [ ] Test (two-instance harness): instance A inserts a `campaignMessages` doc for "camp-1"; instance B's subscriber receives the corresponding `message` event
+- [ ] Regression: existing scenarios "First subscription opens the shared change stream (Atlas)", "Subsequent subscriptions reuse the existing stream", "Concurrent subscriptions during lazy open do not race", "Teardown removes subscriber", "Last subscriber drop closes the shared stream", "Last subscriber drops while open is in flight", "Change stream cursor invalidation triggers one reconnect" still pass unmodified against the db-level watch
+
+### T3 — Broaden the polling path
+
+Maps to spec scenarios: "Session, roll, and message events delivered cross-instance (polling path)", "Polling observes new messages and rolls, not just campaign changes".
+
+- [ ] Test: polling subscriber with `sinceTimestamp` T0 receives a `message` event when a new `campaignMessages` doc with `createdAt > T0` appears for its campaign
+- [ ] Test: polling subscriber receives a `roll` event when a new `campaignRolls` doc with `createdAt > T0` appears for its campaign
+- [ ] Test: `sinceTimestamp` advances to current time after a poll cycle covering all three collections
+- [ ] Test (two-instance harness, both polling): a session start/end, roll insert, or message insert made "via instance A" is observed by instance B's next poll cycle and delivered to instance B's subscribers
+- [ ] Regression: existing scenarios "Replica-set detection selects polling path", "Detection result is cached", "Polling emits new events since last check", "Polling skips events for other campaigns", "Polling teardown stops the interval", "Transport does not crash the process on poll DB error" still pass
+
+### T4 — Session event derivation from `activeSessionId`
+
+Maps to spec scenarios: "Unrelated campaign field change does not emit a spurious session event", "activeSessionId change emits a session event", "Per-campaign session state is cleaned up when the last subscriber tears down".
+
+- [ ] Test (change-stream branch): a `campaigns` write changing only `name` (with `activeSessionId` unchanged) emits no `session` event; a `change` event may still be emitted
+- [ ] Test (change-stream branch): a `campaigns` write changing `activeSessionId` from `null` to `"session-2"` emits `{ type: 'session', campaignId, data: { activeSessionId: 'session-2' } }`, and the transport's last-known value updates
+- [ ] Test (polling branch): same two scenarios above, mirrored under polling mode
+- [ ] Test: after the last subscriber for a campaign tears down, the transport's last-known `activeSessionId` state for that campaign is removed (assert via re-subscribing and confirming the "unrelated field change" test's baseline behavior, i.e. no stale state leaks into a fresh subscription)
+
+### T5 — Visibility replication in the Mongo-observed path
+
+Maps to spec scenarios: "DM-only roll withheld from a non-DM subscriber via the change-stream path", "DM-only roll delivered to the DM subscriber via the change-stream path", "Visibility enforcement applies identically in the polling path" (and message equivalents).
+
+- [ ] Test (change-stream branch): a `dm-only` roll inserted on instance A is NOT delivered to a non-DM subscriber ("player-1") registered on instance B
+- [ ] Test (change-stream branch): the same `dm-only` roll IS delivered to a DM-role subscriber registered on instance B
+- [ ] Test (change-stream branch): message equivalent of the above two cases using `canSeeMessage`
+- [ ] Test (polling branch): same withhold/deliver outcomes as the change-stream branch, for both rolls and messages
+- [ ] Test: `storage.listMembersForCampaign` is called at most once per poll/change-batch when filtering multiple events/subscribers for the same campaign (memoization check)
+
+### T6 — Same-instance fast path + client-side dedup
+
+Maps to spec scenarios: "Same-instance subscriber receives the fast-path delivery immediately", "Duplicate delivery deduped by id".
+
+- [ ] Test (`tests/unit/server/transport.test.ts`): a same-instance subscriber's handler is invoked synchronously within `emitFiltered()`, independent of any change-stream/poll cycle having run
+- [ ] Test (`tests/unit/components/CampaignChat.test.tsx`): delivering the same roll `id` twice through `onStreamEvent` (simulating fast-path + Mongo-observed redelivery) results in the feed containing exactly one entry for that id
+- [ ] Test (`tests/unit/components/CampaignChat.test.tsx`): delivering the same message `id` twice through `onStreamEvent` results in the feed containing exactly one entry for that id
+- [ ] Test: delivering the same `activeSessionId` value twice via `onSessionChange` does not cause incorrect state (idempotent; assert final state is correct, not necessarily that a second call is suppressed)
+- [ ] Regression: existing route handler tests (`tests/unit/api/campaigns/[id]/sessions/active.route.test.ts` and equivalents for messages/rolls) still pass with `emitFiltered` called unchanged
+
+### T7 — Architecture docs
+
+- [ ] Manual review: `docs/multi-user-campaigns/04-realtime-transport.md` diagrams and text accurately describe the db-level watch across `campaigns`/`campaignMessages`/`campaignRolls`, the derived `session` event, and the dual-path delivery model (no automated test; verified during PR review)
+
+## Non-Functional Test Cases
+
+- [ ] Test: with N ≥ 2 SSE connections across M ≥ 1 campaigns on a replica-set-mocked instance, exactly one `db().watch()` cursor exists in the process after the broadened watch (extends existing "Cursor count bounded to one per process" coverage)
+- [ ] Test: every cross-instance/dedup/session-derivation/visibility scenario above is run under both `detectReplicaSet() === true` and `detectReplicaSet() === false` mocks, asserting identical delivered/withheld/deduped outcomes for equivalent inputs

--- a/openspec/changes/fix-cross-instance-transport-delivery/tests.md
+++ b/openspec/changes/fix-cross-instance-transport-delivery/tests.md
@@ -21,65 +21,65 @@ For each task in `tasks.md`:
 
 ### T1 — Two-instance simulation harness (`tests/unit/server/transport.test.ts`)
 
-- [ ] Harness constructs two independent transport module instances (`jest.isolateModules` or equivalent), each with its own mocked Mongo client/cursor/collection stubs, sharing one fake underlying doc store so a write via instance A's mocks is visible to instance B's mocked `watch()`/poll query
-- [ ] Harness proves the two instances' `registry` Maps are independent (throwaway assertion removed once confirmed; not a permanent test case)
+- [x] Harness constructs two independent transport module instances (`jest.isolateModules` or equivalent), each with its own mocked Mongo client/cursor/collection stubs, sharing one fake underlying doc store so a write via instance A's mocks is visible to instance B's mocked `watch()`/poll query
+- [x] Harness proves the two instances' `registry` Maps are independent (throwaway assertion removed once confirmed; not a permanent test case)
 
 ### T2 — Broaden the Atlas change-stream path
 
 Maps to spec scenarios in `specs/transport/spec.md`: "Single shared cursor covers all three collections", "Event routed to correct campaign subscribers regardless of source collection", "Session event delivered cross-instance (change-stream path)", "Roll event delivered cross-instance (change-stream path)", "Message event delivered cross-instance (change-stream path)".
 
-- [ ] Test: first `subscribe()` on a replica-set-mocked instance opens exactly one `db().watch()` cursor (not `collection('campaigns').watch()`) — fails before T2 implementation, passes after
-- [ ] Test: a change document from `campaignRolls` with `fullDocument.campaignId === 'A'` is routed only to campaign A's handlers, built as a `{ type: 'roll', ... }` event
-- [ ] Test: a change document from `campaignMessages` with `fullDocument.campaignId === 'A'` is routed only to campaign A's handlers, built as a `{ type: 'message', ... }` event
-- [ ] Test (two-instance harness): instance A sets `activeSessionId` on a `campaigns` doc for "camp-1"; instance B's registered subscriber for "camp-1" receives a `session` event without instance A calling instance B directly
-- [ ] Test (two-instance harness): instance A inserts a `campaignRolls` doc for "camp-1"; instance B's subscriber receives the corresponding `roll` event
-- [ ] Test (two-instance harness): instance A inserts a `campaignMessages` doc for "camp-1"; instance B's subscriber receives the corresponding `message` event
-- [ ] Regression: existing scenarios "First subscription opens the shared change stream (Atlas)", "Subsequent subscriptions reuse the existing stream", "Concurrent subscriptions during lazy open do not race", "Teardown removes subscriber", "Last subscriber drop closes the shared stream", "Last subscriber drops while open is in flight", "Change stream cursor invalidation triggers one reconnect" still pass unmodified against the db-level watch
+- [x] Test: first `subscribe()` on a replica-set-mocked instance opens exactly one `db().watch()` cursor (not `collection('campaigns').watch()`) — fails before T2 implementation, passes after
+- [x] Test: a change document from `campaignRolls` with `fullDocument.campaignId === 'A'` is routed only to campaign A's handlers, built as a `{ type: 'roll', ... }` event
+- [x] Test: a change document from `campaignMessages` with `fullDocument.campaignId === 'A'` is routed only to campaign A's handlers, built as a `{ type: 'message', ... }` event
+- [x] Test (two-instance harness): instance A sets `activeSessionId` on a `campaigns` doc for "camp-1"; instance B's registered subscriber for "camp-1" receives a `session` event without instance A calling instance B directly
+- [x] Test (two-instance harness): instance A inserts a `campaignRolls` doc for "camp-1"; instance B's subscriber receives the corresponding `roll` event
+- [x] Test (two-instance harness): instance A inserts a `campaignMessages` doc for "camp-1"; instance B's subscriber receives the corresponding `message` event
+- [x] Regression: existing scenarios "First subscription opens the shared change stream (Atlas)", "Subsequent subscriptions reuse the existing stream", "Concurrent subscriptions during lazy open do not race", "Teardown removes subscriber", "Last subscriber drop closes the shared stream", "Last subscriber drops while open is in flight", "Change stream cursor invalidation triggers one reconnect" still pass unmodified against the db-level watch
 
 ### T3 — Broaden the polling path
 
 Maps to spec scenarios: "Session, roll, and message events delivered cross-instance (polling path)", "Polling observes new messages and rolls, not just campaign changes".
 
-- [ ] Test: polling subscriber with `sinceTimestamp` T0 receives a `message` event when a new `campaignMessages` doc with `createdAt > T0` appears for its campaign
-- [ ] Test: polling subscriber receives a `roll` event when a new `campaignRolls` doc with `createdAt > T0` appears for its campaign
-- [ ] Test: `sinceTimestamp` advances to current time after a poll cycle covering all three collections
-- [ ] Test (two-instance harness, both polling): a session start/end, roll insert, or message insert made "via instance A" is observed by instance B's next poll cycle and delivered to instance B's subscribers
-- [ ] Regression: existing scenarios "Replica-set detection selects polling path", "Detection result is cached", "Polling emits new events since last check", "Polling skips events for other campaigns", "Polling teardown stops the interval", "Transport does not crash the process on poll DB error" still pass
+- [x] Test: polling subscriber with `sinceTimestamp` T0 receives a `message` event when a new `campaignMessages` doc with `createdAt > T0` appears for its campaign
+- [x] Test: polling subscriber receives a `roll` event when a new `campaignRolls` doc with `createdAt > T0` appears for its campaign
+- [x] Test: `sinceTimestamp` advances to current time after a poll cycle covering all three collections
+- [x] Test (two-instance harness, both polling): a session start/end, roll insert, or message insert made "via instance A" is observed by instance B's next poll cycle and delivered to instance B's subscribers
+- [x] Regression: existing scenarios "Replica-set detection selects polling path", "Detection result is cached", "Polling emits new events since last check", "Polling skips events for other campaigns", "Polling teardown stops the interval", "Transport does not crash the process on poll DB error" still pass
 
 ### T4 — Session event derivation from `activeSessionId`
 
 Maps to spec scenarios: "Unrelated campaign field change does not emit a spurious session event", "activeSessionId change emits a session event", "Per-campaign session state is cleaned up when the last subscriber tears down".
 
-- [ ] Test (change-stream branch): a `campaigns` write changing only `name` (with `activeSessionId` unchanged) emits no `session` event; a `change` event may still be emitted
-- [ ] Test (change-stream branch): a `campaigns` write changing `activeSessionId` from `null` to `"session-2"` emits `{ type: 'session', campaignId, data: { activeSessionId: 'session-2' } }`, and the transport's last-known value updates
-- [ ] Test (polling branch): same two scenarios above, mirrored under polling mode
-- [ ] Test: after the last subscriber for a campaign tears down, the transport's last-known `activeSessionId` state for that campaign is removed (assert via re-subscribing and confirming the "unrelated field change" test's baseline behavior, i.e. no stale state leaks into a fresh subscription)
+- [x] Test (change-stream branch): a `campaigns` write changing only `name` (with `activeSessionId` unchanged) emits no `session` event; a `change` event may still be emitted
+- [x] Test (change-stream branch): a `campaigns` write changing `activeSessionId` from `null` to `"session-2"` emits `{ type: 'session', campaignId, data: { activeSessionId: 'session-2' } }`, and the transport's last-known value updates
+- [x] Test (polling branch): same two scenarios above, mirrored under polling mode
+- [x] Test: after the last subscriber for a campaign tears down, the transport's last-known `activeSessionId` state for that campaign is removed (assert via re-subscribing and confirming the "unrelated field change" test's baseline behavior, i.e. no stale state leaks into a fresh subscription)
 
 ### T5 — Visibility replication in the Mongo-observed path
 
 Maps to spec scenarios: "DM-only roll withheld from a non-DM subscriber via the change-stream path", "DM-only roll delivered to the DM subscriber via the change-stream path", "Visibility enforcement applies identically in the polling path" (and message equivalents).
 
-- [ ] Test (change-stream branch): a `dm-only` roll inserted on instance A is NOT delivered to a non-DM subscriber ("player-1") registered on instance B
-- [ ] Test (change-stream branch): the same `dm-only` roll IS delivered to a DM-role subscriber registered on instance B
-- [ ] Test (change-stream branch): message equivalent of the above two cases using `canSeeMessage`
-- [ ] Test (polling branch): same withhold/deliver outcomes as the change-stream branch, for both rolls and messages
-- [ ] Test: `storage.listMembersForCampaign` is called at most once per poll/change-batch when filtering multiple events/subscribers for the same campaign (memoization check)
+- [x] Test (change-stream branch): a `dm-only` roll inserted on instance A is NOT delivered to a non-DM subscriber ("player-1") registered on instance B
+- [x] Test (change-stream branch): the same `dm-only` roll IS delivered to a DM-role subscriber registered on instance B
+- [x] Test (change-stream branch): message equivalent of the above two cases using `canSeeMessage`
+- [x] Test (polling branch): same withhold/deliver outcomes as the change-stream branch, for both rolls and messages
+- [x] Test: `storage.listMembersForCampaign` is called at most once per poll/change-batch when filtering multiple events/subscribers for the same campaign (memoization check)
 
 ### T6 — Same-instance fast path + client-side dedup
 
 Maps to spec scenarios: "Same-instance subscriber receives the fast-path delivery immediately", "Duplicate delivery deduped by id".
 
-- [ ] Test (`tests/unit/server/transport.test.ts`): a same-instance subscriber's handler is invoked synchronously within `emitFiltered()`, independent of any change-stream/poll cycle having run
-- [ ] Test (`tests/unit/components/CampaignChat.test.tsx`): delivering the same roll `id` twice through `onStreamEvent` (simulating fast-path + Mongo-observed redelivery) results in the feed containing exactly one entry for that id
-- [ ] Test (`tests/unit/components/CampaignChat.test.tsx`): delivering the same message `id` twice through `onStreamEvent` results in the feed containing exactly one entry for that id
-- [ ] Test: delivering the same `activeSessionId` value twice via `onSessionChange` does not cause incorrect state (idempotent; assert final state is correct, not necessarily that a second call is suppressed)
-- [ ] Regression: existing route handler tests (`tests/unit/api/campaigns/[id]/sessions/active.route.test.ts` and equivalents for messages/rolls) still pass with `emitFiltered` called unchanged
+- [x] Test (`tests/unit/server/transport.test.ts`): a same-instance subscriber's handler is invoked synchronously within `emitFiltered()`, independent of any change-stream/poll cycle having run
+- [x] Test (`tests/unit/components/CampaignChat.test.tsx`): delivering the same roll `id` twice through `onStreamEvent` (simulating fast-path + Mongo-observed redelivery) results in the feed containing exactly one entry for that id
+- [x] Test (`tests/unit/components/CampaignChat.test.tsx`): delivering the same message `id` twice through `onStreamEvent` results in the feed containing exactly one entry for that id
+- [x] Test: delivering the same `activeSessionId` value twice via `onSessionChange` does not cause incorrect state (idempotent; assert final state is correct, not necessarily that a second call is suppressed)
+- [x] Regression: existing route handler tests (`tests/unit/api/campaigns/[id]/sessions/active.route.test.ts` and equivalents for messages/rolls) still pass with `emitFiltered` called unchanged
 
 ### T7 — Architecture docs
 
-- [ ] Manual review: `docs/multi-user-campaigns/04-realtime-transport.md` diagrams and text accurately describe the db-level watch across `campaigns`/`campaignMessages`/`campaignRolls`, the derived `session` event, and the dual-path delivery model (no automated test; verified during PR review)
+- [x] Manual review: `docs/multi-user-campaigns/04-realtime-transport.md` diagrams and text accurately describe the db-level watch across `campaigns`/`campaignMessages`/`campaignRolls`, the derived `session` event, and the dual-path delivery model (no automated test; verified during PR review)
 
 ## Non-Functional Test Cases
 
-- [ ] Test: with N ≥ 2 SSE connections across M ≥ 1 campaigns on a replica-set-mocked instance, exactly one `db().watch()` cursor exists in the process after the broadened watch (extends existing "Cursor count bounded to one per process" coverage)
-- [ ] Test: every cross-instance/dedup/session-derivation/visibility scenario above is run under both `detectReplicaSet() === true` and `detectReplicaSet() === false` mocks, asserting identical delivered/withheld/deduped outcomes for equivalent inputs
+- [x] Test: with N ≥ 2 SSE connections across M ≥ 1 campaigns on a replica-set-mocked instance, exactly one `db().watch()` cursor exists in the process after the broadened watch (extends existing "Cursor count bounded to one per process" coverage)
+- [x] Test: every cross-instance/dedup/session-derivation/visibility scenario above is run under both `detectReplicaSet() === true` and `detectReplicaSet() === false` mocks, asserting identical delivered/withheld/deduped outcomes for equivalent inputs

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -339,6 +339,44 @@ it('T3-12: polling teardown clears interval', async () => {
   clearIntervalSpy.mockRestore();
 });
 
+// --- T3-15: Overlapping poll cycles are guarded against ---
+
+it('T3-15: a slow poll cycle is not overlapped by the next interval tick', async () => {
+  jest.useFakeTimers();
+  mockWatch = jest.fn().mockImplementationOnce(() => {
+    throw new Error('not running with --replSet');
+  });
+
+  // getDatabase() never resolves on its own — simulates a poll cycle slower than the
+  // 2s interval. If pollFn lacked an in-flight guard, the second interval tick would
+  // start a second, fully independent getDatabase() call on top of the first.
+  let resolveGetDatabase: (() => void) | null = null;
+  mockGetDatabase = jest.fn(() => new Promise(resolve => {
+    resolveGetDatabase = () => resolve({
+      collection: () => ({ find: () => ({ toArray: () => Promise.resolve([]) }) }),
+    });
+  }));
+
+  const teardown = await transport.subscribe('c1', 'user-c1', jest.fn());
+
+  jest.advanceTimersByTime(2001); // first poll starts, hangs on getDatabase()
+  await Promise.resolve();
+  expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+
+  jest.advanceTimersByTime(2001); // second interval tick — must be skipped, still in flight
+  await Promise.resolve();
+  expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+
+  resolveGetDatabase!();
+  await flushMicrotasks();
+
+  jest.advanceTimersByTime(2001); // now that the first cycle finished, a new one is allowed
+  await flushMicrotasks();
+  expect(mockGetDatabase).toHaveBeenCalledTimes(2);
+
+  teardown();
+});
+
 // --- T3-13: Cursor invalidation triggers one reconnect attempt ---
 
 it('T3-13: cursor invalidation triggers one reconnect attempt', async () => {
@@ -424,11 +462,13 @@ describe('T2 — db-level watch and collection routing', () => {
     teardown();
   });
 
-  it('a change document from an unrelated collection is ignored (db-level watch is unfiltered at the Mongo level)', async () => {
+  it('a change document from an unrelated collection is ignored (defense in depth beyond the server-side $match)', async () => {
     // Documents from a collection outside {campaigns, campaignMessages, campaignRolls}
     // must never be broadcast as a `change` event, even if they happen to carry an
-    // `id`/`campaignId` field matching a subscribed campaign — otherwise a db-level
-    // watch() (which observes every collection) would leak unrelated document data.
+    // `id`/`campaignId` field matching a subscribed campaign. openStream()'s $match
+    // pipeline already restricts the real watch to those three collections server-side —
+    // this test exercises demux()'s in-process allowlist directly (as if the pipeline
+    // weren't applied), proving it independently guards against the same leak.
     async function* yieldOnce() {
       yield { ns: { coll: 'users' }, fullDocument: { id: 'A', email: 'someone@example.com' } };
       await new Promise(() => {});

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -1,9 +1,14 @@
+import type { CampaignMember } from '@/lib/types';
+
 // --- Mock infrastructure ---
 
 let mockWatch: jest.Mock;
 let mockCursorClose: jest.Mock;
-let mockToArray: jest.Mock;
+let mockToArray: jest.Mock; // campaigns collection
+let mockMessagesToArray: jest.Mock;
+let mockRollsToArray: jest.Mock;
 let mockGetDatabase: jest.Mock;
+let mockListMembers: jest.Mock;
 
 async function* makeCursorIterator(this: { pendingEvents?: Array<unknown>; shouldInvalidate?: boolean }) {
   // hang (stream stays open — tests override watch to return custom cursors)
@@ -20,10 +25,43 @@ function makeStreamCursor() {
   return { close: mockCursorClose, [Symbol.asyncIterator]: makeCursorIterator };
 }
 
+// A cursor whose async iterator can be fed documents on demand via push(), simulating
+// a live MongoDB change-stream cursor that independently observes writes made by any process.
+function createPushableCursor() {
+  const queue: unknown[] = [];
+  let resolveNext: ((v: IteratorResult<unknown>) => void) | null = null;
+  const close = jest.fn().mockResolvedValue(undefined);
+  return {
+    push(doc: unknown) {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: doc, done: false });
+      } else {
+        queue.push(doc);
+      }
+    },
+    cursor: {
+      close,
+      [Symbol.asyncIterator]() {
+        return {
+          next(): Promise<IteratorResult<unknown>> {
+            if (queue.length > 0) {
+              return Promise.resolve({ value: queue.shift(), done: false });
+            }
+            return new Promise<IteratorResult<unknown>>(resolve => { resolveNext = resolve; });
+          },
+        };
+      },
+    },
+  };
+}
+
 jest.mock('@/lib/db', () => ({
   connectToDatabase: jest.fn(async () => ({
     client: {
       db: () => ({
+        watch: (...args: unknown[]) => mockWatch(...args),
         collection: () => ({
           watch: (...args: unknown[]) => mockWatch(...args),
         }),
@@ -33,13 +71,26 @@ jest.mock('@/lib/db', () => ({
   getDatabase: jest.fn((...args: unknown[]) => mockGetDatabase(...args)),
 }));
 
+jest.mock('@/lib/storage', () => ({
+  storage: {
+    listMembersForCampaign: (...args: unknown[]) => mockListMembers(...args),
+  },
+}));
+
 function resetMocks() {
   mockCursorClose = jest.fn().mockResolvedValue(undefined);
   mockToArray = jest.fn().mockResolvedValue([]);
+  mockMessagesToArray = jest.fn().mockResolvedValue([]);
+  mockRollsToArray = jest.fn().mockResolvedValue([]);
+  mockListMembers = jest.fn().mockResolvedValue([]);
   mockGetDatabase = jest.fn(async () => ({
-    collection: () => ({
+    collection: (name: string) => ({
       find: (...args: unknown[]) => ({
-        toArray: () => mockToArray(...args),
+        toArray: () => {
+          if (name === 'campaignMessages') return mockMessagesToArray(...args);
+          if (name === 'campaignRolls') return mockRollsToArray(...args);
+          return mockToArray(...args);
+        },
       }),
     }),
   }));
@@ -47,6 +98,23 @@ function resetMocks() {
   mockWatch = jest.fn()
     .mockImplementationOnce(() => makeProbeCursor())
     .mockImplementation(() => makeStreamCursor());
+}
+
+// Poll cycles now chain several sequential awaits (campaigns + messages + rolls + members
+// lookup); flush enough microtask ticks for fake timers to settle fully.
+async function flushMicrotasks(times = 10) {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+function member(userId: string, role: 'dm' | 'player' = 'player'): CampaignMember {
+  return {
+    id: `m-${userId}`,
+    campaignId: 'camp-1',
+    userId,
+    role,
+    status: 'active',
+    history: [],
+  };
 }
 
 // Reload transport module before each test to reset module-level singletons.
@@ -341,4 +409,514 @@ it('T3-14: poll DB error is caught and logged; interval continues', async () => 
 
   teardown();
   consoleSpy.mockRestore();
+});
+
+// ============================================================================
+// T2 — Broaden the Atlas change-stream path (db-level watch, ns.coll routing)
+// ============================================================================
+
+describe('T2 — db-level watch and collection routing', () => {
+  it('opens a single database-level watch cursor (not one per collection)', async () => {
+    const teardown = await transport.subscribe('c1', 'user-c1', jest.fn());
+    await new Promise(r => setTimeout(r, 10));
+    // Same call-count contract as before: probe (1) + single shared real cursor (1) = 2.
+    expect(mockWatch).toHaveBeenCalledTimes(2);
+    teardown();
+  });
+
+  it('a campaignRolls change document is routed as a roll event to the right campaign', async () => {
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
+    const rollDoc = {
+      id: 'roll-1', campaignId: 'A', rollerId: 'player-1', rollerName: 'P1',
+      formula: '1d20', rolls: [15], total: 15, visibility: { scope: 'group' }, createdAt: new Date(),
+    };
+
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignRolls' }, fullDocument: rollDoc };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handlerA = jest.fn();
+    const handlerB = jest.fn();
+    const tdA = await transport.subscribe('A', 'player-1', handlerA);
+    const tdB = await transport.subscribe('B', 'player-1', handlerB);
+
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handlerA).toHaveBeenCalledWith(expect.objectContaining({ type: 'roll', campaignId: 'A', data: rollDoc }));
+    expect(handlerB).not.toHaveBeenCalled();
+    tdA(); tdB();
+  });
+
+  it('a campaignMessages change document is routed as a message event', async () => {
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
+    const msgDoc = {
+      id: 'msg-1', campaignId: 'A', senderId: 'player-1', senderName: 'P1',
+      text: 'hi', visibility: { scope: 'group' }, createdAt: new Date(),
+    };
+
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignMessages' }, fullDocument: msgDoc };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('A', 'player-1', handler);
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', campaignId: 'A', data: msgDoc }));
+    td();
+  });
+
+  describe('two-instance simulation (Atlas / change-stream)', () => {
+    it('registry maps are independent across two isolated transport module instances', () => {
+      let transportA: typeof import('@/lib/server/transport');
+      let transportB: typeof import('@/lib/server/transport');
+      jest.isolateModules(() => {
+        transportA = require('@/lib/server/transport');
+      });
+      jest.isolateModules(() => {
+        transportB = require('@/lib/server/transport');
+      });
+      expect(transportA!).not.toBe(transportB!);
+    });
+
+    it('session event written "by instance A" is delivered to instance B\'s subscriber without A calling B directly', async () => {
+      const cursors: ReturnType<typeof createPushableCursor>[] = [];
+      mockWatch = jest.fn().mockImplementation((_arg: unknown, opts: Record<string, unknown> | undefined) => {
+        if (opts && 'maxAwaitTimeMS' in opts) return makeProbeCursor();
+        const c = createPushableCursor();
+        cursors.push(c);
+        return c.cursor;
+      });
+
+      let transportA: typeof import('@/lib/server/transport');
+      let transportB: typeof import('@/lib/server/transport');
+      jest.isolateModules(() => { transportA = require('@/lib/server/transport'); });
+      jest.isolateModules(() => { transportB = require('@/lib/server/transport'); });
+
+      const handlerB = jest.fn();
+      await transportA!.subscribe('camp-1', 'dm-1', jest.fn());
+      await transportB!.subscribe('camp-1', 'player-1', handlerB);
+      await new Promise(r => setTimeout(r, 10));
+
+      expect(cursors.length).toBe(2); // one shared cursor per instance
+
+      // Instance A's write is observed independently by both cursors (simulating a
+      // real shared MongoDB change stream), not routed through transportB directly.
+      const writeDoc = {
+        ns: { coll: 'campaigns' },
+        fullDocument: { id: 'camp-1', activeSessionId: 'session-9' },
+        updateDescription: { updatedFields: { activeSessionId: 'session-9' } },
+      };
+      cursors.forEach(c => c.push(writeDoc));
+      await new Promise(r => setTimeout(r, 20));
+
+      expect(handlerB).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-9' } });
+    });
+
+    it('roll insert "by instance A" is delivered to instance B\'s subscriber', async () => {
+      mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
+      const cursors: ReturnType<typeof createPushableCursor>[] = [];
+      mockWatch = jest.fn().mockImplementation((_arg: unknown, opts: Record<string, unknown> | undefined) => {
+        if (opts && 'maxAwaitTimeMS' in opts) return makeProbeCursor();
+        const c = createPushableCursor();
+        cursors.push(c);
+        return c.cursor;
+      });
+
+      let transportA: typeof import('@/lib/server/transport');
+      let transportB: typeof import('@/lib/server/transport');
+      jest.isolateModules(() => { transportA = require('@/lib/server/transport'); });
+      jest.isolateModules(() => { transportB = require('@/lib/server/transport'); });
+
+      const handlerB = jest.fn();
+      await transportA!.subscribe('camp-1', 'dm-1', jest.fn());
+      await transportB!.subscribe('camp-1', 'player-1', handlerB);
+      await new Promise(r => setTimeout(r, 10));
+
+      const rollDoc = {
+        id: 'roll-9', campaignId: 'camp-1', rollerId: 'dm-1', rollerName: 'DM',
+        formula: '1d20', rolls: [12], total: 12, visibility: { scope: 'group' }, createdAt: new Date(),
+      };
+      cursors.forEach(c => c.push({ ns: { coll: 'campaignRolls' }, fullDocument: rollDoc }));
+      await new Promise(r => setTimeout(r, 20));
+
+      expect(handlerB).toHaveBeenCalledWith(expect.objectContaining({ type: 'roll', campaignId: 'camp-1', data: rollDoc }));
+    });
+
+    it('message insert "by instance A" is delivered to instance B\'s subscriber', async () => {
+      mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
+      const cursors: ReturnType<typeof createPushableCursor>[] = [];
+      mockWatch = jest.fn().mockImplementation((_arg: unknown, opts: Record<string, unknown> | undefined) => {
+        if (opts && 'maxAwaitTimeMS' in opts) return makeProbeCursor();
+        const c = createPushableCursor();
+        cursors.push(c);
+        return c.cursor;
+      });
+
+      let transportA: typeof import('@/lib/server/transport');
+      let transportB: typeof import('@/lib/server/transport');
+      jest.isolateModules(() => { transportA = require('@/lib/server/transport'); });
+      jest.isolateModules(() => { transportB = require('@/lib/server/transport'); });
+
+      const handlerB = jest.fn();
+      await transportA!.subscribe('camp-1', 'dm-1', jest.fn());
+      await transportB!.subscribe('camp-1', 'player-1', handlerB);
+      await new Promise(r => setTimeout(r, 10));
+
+      const msgDoc = {
+        id: 'msg-9', campaignId: 'camp-1', senderId: 'dm-1', senderName: 'DM',
+        text: 'hello from A', visibility: { scope: 'group' }, createdAt: new Date(),
+      };
+      cursors.forEach(c => c.push({ ns: { coll: 'campaignMessages' }, fullDocument: msgDoc }));
+      await new Promise(r => setTimeout(r, 20));
+
+      expect(handlerB).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', campaignId: 'camp-1', data: msgDoc }));
+    });
+  });
+});
+
+// ============================================================================
+// T3 — Broaden the polling path
+// ============================================================================
+
+describe('T3 — polling observes messages and rolls', () => {
+  it('polling subscriber receives a message event for a new campaignMessages doc', async () => {
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementationOnce(() => {
+      throw new Error('not running with --replSet');
+    });
+    mockListMembers = jest.fn().mockResolvedValue([member('user-c1')]);
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+    const msgDoc = {
+      id: 'msg-1', campaignId: 'c1', senderId: 'user-c1', senderName: 'U1',
+      text: 'hi', visibility: { scope: 'group' }, createdAt: new Date(now + 1000),
+    };
+    mockMessagesToArray = jest.fn().mockResolvedValue([msgDoc]);
+
+    const handler = jest.fn();
+    const teardown = await transport.subscribe('c1', 'user-c1', handler);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    teardown();
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', campaignId: 'c1', data: msgDoc }));
+  });
+
+  it('polling subscriber receives a roll event for a new campaignRolls doc', async () => {
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementationOnce(() => {
+      throw new Error('not running with --replSet');
+    });
+    mockListMembers = jest.fn().mockResolvedValue([member('user-c1')]);
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+    const rollDoc = {
+      id: 'roll-1', campaignId: 'c1', rollerId: 'user-c1', rollerName: 'U1',
+      formula: '1d20', rolls: [7], total: 7, visibility: { scope: 'group' }, createdAt: new Date(now + 1000),
+    };
+    mockRollsToArray = jest.fn().mockResolvedValue([rollDoc]);
+
+    const handler = jest.fn();
+    const teardown = await transport.subscribe('c1', 'user-c1', handler);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    teardown();
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'roll', campaignId: 'c1', data: rollDoc }));
+  });
+
+  it('two-instance polling: a write "by instance A" is observed by instance B\'s next poll cycle', async () => {
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementation(() => {
+      throw new Error('not running with --replSet');
+    });
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+
+    let transportA: typeof import('@/lib/server/transport');
+    let transportB: typeof import('@/lib/server/transport');
+    jest.isolateModules(() => { transportA = require('@/lib/server/transport'); });
+    jest.isolateModules(() => { transportB = require('@/lib/server/transport'); });
+
+    const handlerB = jest.fn();
+    await transportA!.subscribe('camp-1', 'dm-1', jest.fn());
+    const teardownB = await transportB!.subscribe('camp-1', 'player-1', handlerB);
+
+    // Simulate "instance A wrote a roll" by making it show up in the shared underlying store
+    // that both instances' polls query against.
+    const rollDoc = {
+      id: 'roll-shared', campaignId: 'camp-1', rollerId: 'dm-1', rollerName: 'DM',
+      formula: '1d20', rolls: [3], total: 3, visibility: { scope: 'group' }, createdAt: new Date(now + 500),
+    };
+    mockRollsToArray = jest.fn().mockResolvedValue([rollDoc]);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    teardownB();
+
+    expect(handlerB).toHaveBeenCalledWith(expect.objectContaining({ type: 'roll', campaignId: 'camp-1', data: rollDoc }));
+  });
+});
+
+// ============================================================================
+// T4 — Session event derivation from activeSessionId
+// ============================================================================
+
+describe('T4 — session event derivation', () => {
+  it('change-stream: unrelated field change does not emit a spurious session event', async () => {
+    async function* yieldTwice() {
+      yield {
+        ns: { coll: 'campaigns' },
+        fullDocument: { id: 'camp-1', activeSessionId: 'session-1' },
+        updateDescription: { updatedFields: { activeSessionId: 'session-1' } },
+      };
+      yield {
+        ns: { coll: 'campaigns' },
+        fullDocument: { id: 'camp-1', activeSessionId: 'session-1', name: 'renamed' },
+        updateDescription: { updatedFields: { name: 'renamed' } },
+      };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldTwice };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('camp-1', 'user-1', handler);
+    await new Promise(r => setTimeout(r, 30));
+
+    const sessionCalls = handler.mock.calls.filter(([e]) => e.type === 'session');
+    expect(sessionCalls).toHaveLength(1); // only the first (seeding) write emits
+    td();
+  });
+
+  it('change-stream: activeSessionId change emits a session event', async () => {
+    async function* yieldOnce() {
+      yield {
+        ns: { coll: 'campaigns' },
+        fullDocument: { id: 'camp-1', activeSessionId: 'session-2' },
+        updateDescription: { updatedFields: { activeSessionId: 'session-2' } },
+      };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('camp-1', 'user-1', handler);
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handler).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-2' } });
+    td();
+  });
+
+  it('polling: activeSessionId change emits a session event', async () => {
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementationOnce(() => {
+      throw new Error('not running with --replSet');
+    });
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+    mockToArray = jest.fn().mockResolvedValue([
+      { id: 'camp-1', activeSessionId: 'session-2', updatedAt: new Date(now + 1000) },
+    ]);
+
+    const handler = jest.fn();
+    const teardown = await transport.subscribe('camp-1', 'user-1', handler);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    teardown();
+
+    expect(handler).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-2' } });
+  });
+
+  it('per-campaign session state is cleaned up when the last subscriber tears down', async () => {
+    async function* yieldOnce() {
+      yield {
+        ns: { coll: 'campaigns' },
+        fullDocument: { id: 'camp-1', activeSessionId: 'session-1' },
+        updateDescription: { updatedFields: { activeSessionId: 'session-1' } },
+      };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handler1 = jest.fn();
+    const td1 = await transport.subscribe('camp-1', 'user-1', handler1);
+    await new Promise(r => setTimeout(r, 20));
+    expect(handler1).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-1' } });
+    td1(); // last subscriber for camp-1 tears down — state should be cleared
+
+    // Re-subscribe: a fresh cursor observing the SAME activeSessionId should emit again,
+    // proving no stale "already-seen" state leaked across the subscription lifecycle.
+    async function* yieldOnceAgain() {
+      yield {
+        ns: { coll: 'campaigns' },
+        fullDocument: { id: 'camp-1', activeSessionId: 'session-1' },
+        updateDescription: { updatedFields: { activeSessionId: 'session-1' } },
+      };
+      await new Promise(() => {});
+    }
+    const realCursor2 = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnceAgain };
+    mockWatch = jest.fn().mockImplementationOnce(() => realCursor2);
+
+    const handler2 = jest.fn();
+    const td2 = await transport.subscribe('camp-1', 'user-2', handler2);
+    await new Promise(r => setTimeout(r, 20));
+    expect(handler2).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-1' } });
+    td2();
+  });
+});
+
+// ============================================================================
+// T5 — Visibility replication in the Mongo-observed path
+// ============================================================================
+
+describe('T5 — visibility enforcement in change-stream/poll delivery', () => {
+  it('change-stream: dm-only roll is withheld from a non-DM subscriber', async () => {
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1', 'player'), member('dm-1', 'dm')]);
+    const rollDoc = {
+      id: 'roll-dm', campaignId: 'camp-1', rollerId: 'dm-1', rollerName: 'DM',
+      formula: '1d20', rolls: [1], total: 1, visibility: { scope: 'dm-only' }, createdAt: new Date(),
+    };
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignRolls' }, fullDocument: rollDoc };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handlerPlayer = jest.fn();
+    const handlerDm = jest.fn();
+    const td1 = await transport.subscribe('camp-1', 'player-1', handlerPlayer);
+    const td2 = await transport.subscribe('camp-1', 'dm-1', handlerDm);
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handlerPlayer).not.toHaveBeenCalled();
+    expect(handlerDm).toHaveBeenCalledWith(expect.objectContaining({ type: 'roll', data: rollDoc }));
+    td1(); td2();
+  });
+
+  it('change-stream: dm-only message is withheld from a non-DM subscriber unless addressed to them', async () => {
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1', 'player'), member('dm-1', 'dm')]);
+    const msgDoc = {
+      id: 'msg-dm', campaignId: 'camp-1', senderId: 'dm-1', senderName: 'DM',
+      text: 'secret', visibility: { scope: 'dm-only' }, createdAt: new Date(),
+    };
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignMessages' }, fullDocument: msgDoc };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handlerPlayer = jest.fn();
+    const handlerDm = jest.fn();
+    const td1 = await transport.subscribe('camp-1', 'player-1', handlerPlayer);
+    const td2 = await transport.subscribe('camp-1', 'dm-1', handlerDm);
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handlerPlayer).not.toHaveBeenCalled();
+    expect(handlerDm).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', data: msgDoc }));
+    td1(); td2();
+  });
+
+  it('polling: dm-only roll is withheld from a non-DM subscriber', async () => {
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementation(() => {
+      throw new Error('not running with --replSet');
+    });
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1', 'player')]);
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+    const rollDoc = {
+      id: 'roll-dm', campaignId: 'camp-1', rollerId: 'dm-1', rollerName: 'DM',
+      formula: '1d20', rolls: [1], total: 1, visibility: { scope: 'dm-only' }, createdAt: new Date(now + 1000),
+    };
+    mockRollsToArray = jest.fn().mockResolvedValue([rollDoc]);
+
+    const handler = jest.fn();
+    const teardown = await transport.subscribe('camp-1', 'player-1', handler);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    teardown();
+
+    expect(handler).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'roll' }));
+  });
+
+  it('listMembersForCampaign is memoized per change/poll batch when filtering multiple subscribers', async () => {
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1'), member('player-2')]);
+    const rollDoc = {
+      id: 'roll-batch', campaignId: 'camp-1', rollerId: 'player-1', rollerName: 'P1',
+      formula: '1d20', rolls: [5], total: 5, visibility: { scope: 'group' }, createdAt: new Date(),
+    };
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignRolls' }, fullDocument: rollDoc };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const td1 = await transport.subscribe('camp-1', 'player-1', jest.fn());
+    const td2 = await transport.subscribe('camp-1', 'player-2', jest.fn());
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(mockListMembers).toHaveBeenCalledTimes(1);
+    td1(); td2();
+  });
+});
+
+// ============================================================================
+// T6 — Same-instance fast path preserved
+// ============================================================================
+
+describe('T6 — fast path', () => {
+  it('emitFiltered invokes the same-instance subscriber synchronously', async () => {
+    const handler = jest.fn();
+    const td = await transport.subscribe('camp-1', 'player-1', handler);
+
+    transport.emitFiltered('camp-1', { type: 'roll', campaignId: 'camp-1', data: {} as never }, () => true);
+
+    // No await/timer advance — must already have fired.
+    expect(handler).toHaveBeenCalledTimes(1);
+    td();
+  });
 });

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -498,6 +498,45 @@ describe('T2 — db-level watch and collection routing', () => {
     td();
   });
 
+  it('multi-campaign isolation: a shared cursor with 3 campaigns registered routes each event to only its own campaign', async () => {
+    // The single db-level watch cursor is shared across every subscribed campaign in
+    // this process. This proves the registry-keyed lookup in demux()/emitToRegistry()
+    // doesn't cross-contaminate when several campaigns have live subscribers at once —
+    // not just "one campaign in play, one campaign not," but three simultaneously.
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1'), member('player-2'), member('player-3')]);
+    const msgForB = {
+      id: 'msg-b', campaignId: 'campB', senderId: 'player-2', senderName: 'P2',
+      text: 'hi from B', visibility: { scope: 'group' }, createdAt: new Date(),
+    };
+
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignMessages' }, fullDocument: msgForB };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handlerA = jest.fn();
+    const handlerB = jest.fn();
+    const handlerC = jest.fn();
+    const tdA = await transport.subscribe('campA', 'player-1', handlerA);
+    const tdB = await transport.subscribe('campB', 'player-2', handlerB);
+    const tdC = await transport.subscribe('campC', 'player-3', handlerC);
+    await new Promise(r => setTimeout(r, 10));
+
+    // All three subscriptions share exactly one cursor (probe + one real stream call).
+    expect(mockWatch).toHaveBeenCalledTimes(2);
+
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handlerB).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', campaignId: 'campB', data: msgForB }));
+    expect(handlerA).not.toHaveBeenCalled();
+    expect(handlerC).not.toHaveBeenCalled();
+    tdA(); tdB(); tdC();
+  });
+
   describe('two-instance simulation (Atlas / change-stream)', () => {
     it('registry maps are independent across two isolated transport module instances', () => {
       let transportA: typeof import('@/lib/server/transport');

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -1121,4 +1121,36 @@ describe('T6 — fast path', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     td();
   });
+
+  it('emitFiltered reaches polling-mode subscribers too (fast path is not Atlas-only)', async () => {
+    // Regression: polling subscribers must be registered in `registry` so the
+    // same-instance emitFiltered() fast path reaches them, not just Atlas subscribers —
+    // previously polling subscriptions were never added to `registry` at all, so in
+    // standalone/local-dev Mongo the "fast path" silently never fired.
+    mockWatch = jest.fn().mockImplementationOnce(() => {
+      throw new Error('not running with --replSet');
+    });
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('camp-1', 'player-1', handler);
+
+    transport.emitFiltered('camp-1', { type: 'roll', campaignId: 'camp-1', data: {} as never }, () => true);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    td();
+  });
+
+  it('teardown of a polling subscriber removes it from the registry (emitFiltered no longer reaches it)', async () => {
+    mockWatch = jest.fn().mockImplementationOnce(() => {
+      throw new Error('not running with --replSet');
+    });
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('camp-1', 'player-1', handler);
+    td();
+
+    transport.emitFiltered('camp-1', { type: 'roll', campaignId: 'camp-1', data: {} as never }, () => true);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -424,6 +424,28 @@ describe('T2 — db-level watch and collection routing', () => {
     teardown();
   });
 
+  it('a change document from an unrelated collection is ignored (db-level watch is unfiltered at the Mongo level)', async () => {
+    // Documents from a collection outside {campaigns, campaignMessages, campaignRolls}
+    // must never be broadcast as a `change` event, even if they happen to carry an
+    // `id`/`campaignId` field matching a subscribed campaign — otherwise a db-level
+    // watch() (which observes every collection) would leak unrelated document data.
+    async function* yieldOnce() {
+      yield { ns: { coll: 'users' }, fullDocument: { id: 'A', email: 'someone@example.com' } };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('A', 'user-A', handler);
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(handler).not.toHaveBeenCalled();
+    td();
+  });
+
   it('a campaignRolls change document is routed as a roll event to the right campaign', async () => {
     mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
     const rollDoc = {

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -498,6 +498,36 @@ describe('T2 — db-level watch and collection routing', () => {
     td();
   });
 
+  it('strips Mongo _id from message/roll payloads so they match the same-instance emitFiltered() shape', async () => {
+    // Raw Mongo documents carry _id (an ObjectId); the same-instance emitFiltered() fast
+    // path never has one (routes build CampaignMessage/CampaignRoll before insert). The
+    // Mongo-observed path must strip it so a subscriber can't tell which path delivered
+    // a given event from its shape.
+    mockListMembers = jest.fn().mockResolvedValue([member('player-1')]);
+    const rollDocWithMongoId = {
+      _id: 'mongo-object-id', id: 'roll-1', campaignId: 'A', rollerId: 'player-1', rollerName: 'P1',
+      formula: '1d20', rolls: [15], total: 15, visibility: { scope: 'group' }, createdAt: new Date(),
+    };
+
+    async function* yieldOnce() {
+      yield { ns: { coll: 'campaignRolls' }, fullDocument: rollDocWithMongoId };
+      await new Promise(() => {});
+    }
+    const realCursor = { close: jest.fn().mockResolvedValue(undefined), [Symbol.asyncIterator]: yieldOnce };
+    mockWatch = jest.fn()
+      .mockImplementationOnce(() => makeProbeCursor())
+      .mockImplementationOnce(() => realCursor);
+
+    const handler = jest.fn();
+    const td = await transport.subscribe('A', 'player-1', handler);
+    await new Promise(r => setTimeout(r, 30));
+
+    const [event] = handler.mock.calls[0];
+    expect(event.data).not.toHaveProperty('_id');
+    expect(event.data.id).toBe('roll-1');
+    td();
+  });
+
   it('multi-campaign isolation: a shared cursor with 3 campaigns registered routes each event to only its own campaign', async () => {
     // The single db-level watch cursor is shared across every subscribed campaign in
     // this process. This proves the registry-keyed lookup in demux()/emitToRegistry()
@@ -675,6 +705,34 @@ describe('T3 — polling observes messages and rolls', () => {
     teardown();
 
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', campaignId: 'c1', data: msgDoc }));
+  });
+
+  it('polling: strips Mongo _id from message/roll payloads', async () => {
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementationOnce(() => {
+      throw new Error('not running with --replSet');
+    });
+    mockListMembers = jest.fn().mockResolvedValue([member('user-c1')]);
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+    const msgDocWithMongoId = {
+      _id: 'mongo-object-id', id: 'msg-1', campaignId: 'c1', senderId: 'user-c1', senderName: 'U1',
+      text: 'hi', visibility: { scope: 'group' }, createdAt: new Date(now + 1000),
+    };
+    mockMessagesToArray = jest.fn().mockResolvedValue([msgDocWithMongoId]);
+
+    const handler = jest.fn();
+    const teardown = await transport.subscribe('c1', 'user-c1', handler);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    teardown();
+
+    const [event] = handler.mock.calls.find(([e]) => e.type === 'message')!;
+    expect(event.data).not.toHaveProperty('_id');
+    expect(event.data.id).toBe('msg-1');
   });
 
   it('polling subscriber receives a roll event for a new campaignRolls doc', async () => {

--- a/tests/unit/server/transport.test.ts
+++ b/tests/unit/server/transport.test.ts
@@ -817,6 +817,49 @@ describe('T4 — session event derivation', () => {
     expect(handler2).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-1' } });
     td2();
   });
+
+  it('polling: two independent subscribers to the same campaign each receive the session event (no shared-state suppression)', async () => {
+    // Regression: session-derivation state must be tracked per-subscription in polling
+    // mode, not shared per-campaignId — otherwise whichever subscription's poll cycle
+    // happens to run first "consumes" the transition and the other subscriber's poll,
+    // observing the identical document, would incorrectly see no change and never emit.
+    jest.useFakeTimers();
+    mockWatch = jest.fn().mockImplementation(() => {
+      throw new Error('not running with --replSet');
+    });
+
+    const now = Date.now();
+    jest.setSystemTime(now);
+    mockToArray = jest.fn().mockResolvedValue([
+      { id: 'camp-1', activeSessionId: 'session-1', updatedAt: new Date(now + 1000) },
+    ]);
+
+    const handler1 = jest.fn();
+    const handler2 = jest.fn();
+    const teardown1 = await transport.subscribe('camp-1', 'user-1', handler1);
+    const teardown2 = await transport.subscribe('camp-1', 'user-2', handler2);
+
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    expect(handler1).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-1' } });
+    expect(handler2).toHaveBeenCalledWith({ type: 'session', campaignId: 'camp-1', data: { activeSessionId: 'session-1' } });
+
+    // Non-terminal teardown: one of two subscribers for camp-1 disconnects. The
+    // surviving subscriber's poll cycle should keep running unaffected.
+    teardown1();
+
+    handler2.mockClear();
+    // Same activeSessionId observed again — no new session event for the surviving
+    // subscriber, since its own per-subscription state already recorded 'session-1'.
+    jest.advanceTimersByTime(2001);
+    await flushMicrotasks();
+
+    const sessionCalls = handler2.mock.calls.filter(([e]) => e.type === 'session');
+    expect(sessionCalls).toHaveLength(0);
+
+    teardown2();
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Description
Broadens `lib/server/transport.ts` from a `campaigns`-only, collection-level MongoDB change-stream watch to a **database-level** watch/poll covering `campaigns`, `campaignMessages`, and `campaignRolls`. Fixes reopened #443: on a multi-Fly-machine deployment, `message`/`roll`/`session` events were only delivered via a direct, synchronous `emitFiltered()` call from the route handler that processed the write — a subscriber connected to a *different* instance never received them (most visibly, the roll-entry strip staying stuck on "No active session").

### What changed
- `openStream()`: `client.db().watch()` (db-level) instead of `collection('campaigns').watch()`; `demux()` branches on `event.ns.coll` to build the correct `change`/`message`/`roll` event shape.
- `pollFn()` (standalone/local-dev fallback): extended to also poll `campaignMessages`/`campaignRolls` alongside `campaigns`.
- `session` events are now **derived** from `activeSessionId` field-level changes on `campaigns` documents (change-stream branch uses `updateDescription.updatedFields`; polling branch diffs against a remembered per-campaign value), tracked in a small map cleaned up when the last subscriber for a campaign tears down.
- Message/roll delivery via the change-stream/poll path now applies `canSeeMessage`/`canSeeRoll` per-subscriber — the same visibility predicates the existing same-instance fast path already uses — so DM-only content is never broadcast unfiltered.
- The existing same-instance `emitFiltered()` fast path is **unchanged** (kept for low latency); the client's existing `seenIds`-based dedup in `CampaignChat.tsx` absorbs the resulting double-delivery when both paths fire for the same write.

### Testing Approach
Added a two-independent-module-instance Jest harness (`jest.isolateModules`, two separately-required copies of `lib/server/transport.ts` sharing mocked Mongo cursor/query stubs) that proves cross-instance delivery without one instance calling the other's handler directly — for both the change-stream (Atlas) and polling (standalone Mongo) branches. Also added coverage for `ns.coll` routing, session-event derivation (including the "no spurious event on unrelated field change" case and per-campaign cleanup on teardown), and DM-only visibility enforcement in the Mongo-observed path.

- [x] Bug fix (non-breaking change which fixes an issue)

### Integration Tests Consideration
- [x] I am using mocks instead of integration tests

**Why mocks instead of integration tests:** this change is entirely about in-process MongoDB change-stream/poll demuxing and registry fan-out logic; a two-instance simulation against a real Mongo replica set isn't practical in CI, and the existing test file's established pattern already mocks the driver (`connectToDatabase`/`getDatabase`). The two-module-instance harness is the closest practical equivalent to an integration test for this specific "two processes, one DB" scenario.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (`docs/multi-user-campaigns/04-realtime-transport.md`)
- [x] My changes generate no new warnings (lint clean, typecheck clean, build clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (2675/2675)

## Related Issues
Closes #443

## Additional Notes
Full proposal/design/spec/tasks tracked at `openspec/changes/fix-cross-instance-transport-delivery/`.
