### PR TITLE
Storage blast-radius inventory + characterization tests (#500)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ regression-test-output.txt
 .verity/.last-reviewed-sha
 .verity/.snapshot/
 .codacy/generated/
+
+# OpenSpec change worktrees
+.worktrees/

--- a/docs/storage-refactor/inventory.json
+++ b/docs/storage-refactor/inventory.json
@@ -1,0 +1,1659 @@
+{
+  "schemaVersion": 1,
+  "generatedFrom": "lib/storage.ts",
+  "generatedAt": "2026-08-16T22:32:33.454Z",
+  "sourceLineCount": 1294,
+  "planDoc": "./plan.md",
+  "trackingIssues": ["#499", "#500"],
+  "methods": [
+    {
+      "method": "storage.loadEncounters",
+      "parent": null,
+      "domain": "encounters",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 86,
+      "callers": [
+        {
+          "file": "app/api/encounters/[id]/route.ts",
+          "fn": "GET",
+          "line": 8
+        },
+        {
+          "file": "app/api/encounters/[id]/route.ts",
+          "fn": "PUT",
+          "line": 36
+        },
+        {
+          "file": "app/api/encounters/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 78
+        },
+        {
+          "file": "app/api/encounters/route.ts",
+          "fn": "GET",
+          "line": 8
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadCharacters",
+      "parent": null,
+      "domain": "characters",
+      "behavior": "mixed",
+      "errorReturn": "[]",
+      "line": 116,
+      "callers": [
+        {
+          "file": "app/api/characters/import/route.ts",
+          "fn": "POST",
+          "line": 22
+        },
+        {
+          "file": "app/api/characters/[id]/route.ts",
+          "fn": "GET",
+          "line": 19
+        },
+        {
+          "file": "app/api/characters/[id]/route.ts",
+          "fn": "PUT",
+          "line": 73
+        },
+        {
+          "file": "app/api/characters/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 221
+        },
+        {
+          "file": "app/api/characters/route.ts",
+          "fn": "GET",
+          "line": 28
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/parties/[partyId]/route.ts",
+          "fn": "PUT",
+          "line": 92
+        }
+      ],
+      "existingTests": [
+        "tests/unit/import/characterImportRoute.test.ts",
+        "tests/unit/storage/storage.test.ts"
+      ],
+      "characterizationTest": "tests/unit/lib/storage.characterization.test.ts",
+      "notes": "Two-tier: primary query against the characters_active view has its own inner try/catch that falls back to a direct query against characters with an explicit deletedAt filter; that fallback path has its own independent try/catch swallowing to []. Motivating example for the mixed category."
+    },
+    {
+      "method": "storage.loadCombatState",
+      "parent": null,
+      "domain": "combatState",
+      "behavior": "swallow",
+      "errorReturn": "null",
+      "line": 145,
+      "callers": [],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadParties",
+      "parent": null,
+      "domain": "parties",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 159,
+      "callers": [
+        {
+          "file": "app/api/parties/[id]/route.ts",
+          "fn": "GET",
+          "line": 10
+        },
+        {
+          "file": "app/api/parties/[id]/route.ts",
+          "fn": "PUT",
+          "line": 27
+        },
+        {
+          "file": "app/api/parties/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 102
+        },
+        {
+          "file": "app/api/parties/route.ts",
+          "fn": "GET",
+          "line": 8
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadMonsterTemplates",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 174,
+      "callers": [
+        {
+          "file": "app/api/monsters/[id]/route.ts",
+          "fn": "loadUserTemplate",
+          "line": 7
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadGlobalMonsterTemplates",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 189,
+      "callers": [
+        {
+          "file": "app/api/monsters/global/[id]/route.ts",
+          "fn": "GET",
+          "line": 14
+        },
+        {
+          "file": "app/api/monsters/global/[id]/route.ts",
+          "fn": "PUT",
+          "line": 80
+        },
+        {
+          "file": "app/api/monsters/global/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 169
+        },
+        {
+          "file": "app/api/monsters/global/route.ts",
+          "fn": "GET",
+          "line": 13
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No own try/catch; delegates to loadMonsterTemplates(GLOBAL_USER_ID), which itself swallows."
+    },
+    {
+      "method": "storage.loadAllMonsterTemplates",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 194,
+      "callers": [
+        {
+          "file": "app/api/monsters/[id]/duplicate/route.ts",
+          "fn": "POST",
+          "line": 8
+        },
+        {
+          "file": "app/api/monsters/route.ts",
+          "fn": "GET",
+          "line": 10
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Wraps Promise.all of loadMonsterTemplates/loadGlobalMonsterTemplates, both of which already swallow internally; this outer catch is effectively unreachable via a DB error but is retained as written."
+    },
+    {
+      "method": "storage.loadGlobalCampaignTemplates",
+      "parent": null,
+      "domain": "campaignTemplates",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 208,
+      "callers": [
+        {
+          "file": "app/api/campaigns/global/route.ts",
+          "fn": "GET",
+          "line": 10
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadGlobalCampaignTemplateById",
+      "parent": null,
+      "domain": "campaignTemplates",
+      "behavior": "swallow",
+      "errorReturn": "null",
+      "line": 225,
+      "callers": [
+        {
+          "file": "app/api/campaigns/global/[id]/copy/route.ts",
+          "fn": "POST",
+          "line": 9
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveCampaignTemplate",
+      "parent": null,
+      "domain": "campaignTemplates",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 239,
+      "callers": [
+        {
+          "file": "app/api/campaigns/global/route.ts",
+          "fn": "POST",
+          "line": 62
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.deleteCampaignTemplate",
+      "parent": null,
+      "domain": "campaignTemplates",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 257,
+      "callers": [
+        {
+          "file": "app/api/campaigns/global/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 17
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Returns boolean (deletedCount > 0) on success; rethrows on DB error rather than returning false."
+    },
+    {
+      "method": "storage.loadCampaigns",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 271,
+      "callers": [
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "GET",
+          "line": 10
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadCampaignById",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "swallow",
+      "errorReturn": "null",
+      "line": 286,
+      "callers": [],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveCampaign",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 300,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/route.ts",
+          "fn": "PATCH",
+          "line": 77
+        },
+        {
+          "file": "app/api/campaigns/global/[id]/copy/route.ts",
+          "fn": "POST",
+          "line": 34
+        },
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "POST",
+          "line": 62
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.deleteCampaign",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 318,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 94
+        },
+        {
+          "file": "app/api/campaigns/global/[id]/copy/route.ts",
+          "fn": "POST",
+          "line": 47
+        },
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "POST",
+          "line": 79
+        },
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "POST",
+          "line": 102
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Cascades deletes across 7 collections before deleting the parent campaign document; any failure in the cascade rethrows."
+    },
+    {
+      "method": "storage.setActiveCampaignSession",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 349,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/active/route.ts",
+          "fn": "DELETE",
+          "line": 70
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.claimActiveCampaignSession",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 364,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/active/route.ts",
+          "fn": "POST",
+          "line": 23
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.load",
+      "parent": null,
+      "domain": "session",
+      "behavior": "swallow",
+      "errorReturn": "{ encounters: [], characters: [], parties: [], campaigns: [] }",
+      "line": 381,
+      "callers": [],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Aggregates 5 sub-loads via Promise.all; those sub-loads already swallow internally, so this outer catch is effectively unreachable via a DB error but is retained as written."
+    },
+    {
+      "method": "storage.saveEncounter",
+      "parent": null,
+      "domain": "encounters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 405,
+      "callers": [
+        {
+          "file": "app/api/encounters/[id]/route.ts",
+          "fn": "PUT",
+          "line": 63
+        },
+        {
+          "file": "app/api/encounters/route.ts",
+          "fn": "POST",
+          "line": 42
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveEncounters",
+      "parent": null,
+      "domain": "encounters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 434,
+      "callers": [],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Loops saveEncounter (itself rethrow) sequentially; first failure aborts the loop and rethrows."
+    },
+    {
+      "method": "storage.saveCharacter",
+      "parent": null,
+      "domain": "characters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 447,
+      "callers": [
+        {
+          "file": "app/api/characters/import/route.ts",
+          "fn": "POST",
+          "line": 57
+        },
+        {
+          "file": "app/api/characters/[id]/route.ts",
+          "fn": "PUT",
+          "line": 206
+        },
+        {
+          "file": "app/api/characters/route.ts",
+          "fn": "POST",
+          "line": 179
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveCharacters",
+      "parent": null,
+      "domain": "characters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 463,
+      "callers": [],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Loops saveCharacter (itself rethrow) sequentially; first failure aborts the loop and rethrows."
+    },
+    {
+      "method": "storage.saveCombatState",
+      "parent": null,
+      "domain": "combatState",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 476,
+      "callers": [],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Early-returns (no-op) when combatState is undefined, before the try/catch."
+    },
+    {
+      "method": "storage.deleteEncounter",
+      "parent": null,
+      "domain": "encounters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 495,
+      "callers": [
+        {
+          "file": "app/api/encounters/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 88
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.deleteCharacter",
+      "parent": null,
+      "domain": "characters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 530,
+      "callers": [
+        {
+          "file": "app/api/characters/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 231
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.characters.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Soft delete; throws a custom \"not found\" Error when matchedCount === 0 in addition to rethrowing DB errors. Party-membership cleanup after the soft delete is not covered by this method's own try/catch (see setPartyMemberLeftAt-style best-effort cleanup elsewhere)."
+    },
+    {
+      "method": "storage.saveParty",
+      "parent": null,
+      "domain": "parties",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 555,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/parties/[partyId]/route.ts",
+          "fn": "PUT",
+          "line": 107
+        },
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "POST",
+          "line": 76
+        },
+        {
+          "file": "app/api/parties/[id]/route.ts",
+          "fn": "PUT",
+          "line": 91
+        },
+        {
+          "file": "app/api/parties/route.ts",
+          "fn": "POST",
+          "line": 49
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/storage.test.ts",
+        "tests/integration/campaigns.members.integration.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveParties",
+      "parent": null,
+      "domain": "parties",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 575,
+      "callers": [],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Loops saveParty (itself rethrow) sequentially; first failure aborts the loop and rethrows."
+    },
+    {
+      "method": "storage.deleteParty",
+      "parent": null,
+      "domain": "parties",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 588,
+      "callers": [
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "POST",
+          "line": 97
+        },
+        {
+          "file": "app/api/parties/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 109
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveMonsterTemplate",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 599,
+      "callers": [
+        {
+          "file": "lib/import/dedupeEngine.ts",
+          "fn": "importMonsterSingle",
+          "line": 78
+        },
+        {
+          "file": "app/api/monsters/[id]/duplicate/route.ts",
+          "fn": "POST",
+          "line": 25
+        },
+        {
+          "file": "app/api/monsters/[id]/route.ts",
+          "fn": "PUT",
+          "line": 119
+        },
+        {
+          "file": "app/api/monsters/global/[id]/route.ts",
+          "fn": "PUT",
+          "line": 144
+        },
+        {
+          "file": "app/api/monsters/global/route.ts",
+          "fn": "POST",
+          "line": 120
+        },
+        {
+          "file": "app/api/monsters/global/route.ts",
+          "fn": "PUT",
+          "line": 163
+        },
+        {
+          "file": "app/api/monsters/upload/route.ts",
+          "fn": "POST",
+          "line": 57
+        },
+        {
+          "file": "app/api/monsters/route.ts",
+          "fn": "POST",
+          "line": 112
+        }
+      ],
+      "existingTests": [
+        "tests/unit/api/monsters/upload.route.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.deleteMonsterTemplate",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 615,
+      "callers": [
+        {
+          "file": "app/api/monsters/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 136
+        },
+        {
+          "file": "app/api/monsters/global/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 179
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadSpells",
+      "parent": null,
+      "domain": "spells",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 628,
+      "callers": [
+        {
+          "file": "app/api/spells/route.ts",
+          "fn": "GET",
+          "line": 16
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadSpellById",
+      "parent": null,
+      "domain": "spells",
+      "behavior": "swallow",
+      "errorReturn": "null",
+      "line": 649,
+      "callers": [
+        {
+          "file": "app/api/spells/[id]/route.ts",
+          "fn": "GET",
+          "line": 13
+        },
+        {
+          "file": "app/api/spells/[id]/route.ts",
+          "fn": "PUT",
+          "line": 37
+        },
+        {
+          "file": "app/api/spells/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 69
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": "tests/unit/lib/storage.characterization.test.ts",
+      "notes": "Swallows DB errors to null, which is indistinguishable from a genuine not-found (no matching document). Also short-circuits to null before any DB call when id fails a local shape check (missing/non-string/>64 chars) — that guard path is not a DB-error swallow but produces the same sentinel."
+    },
+    {
+      "method": "storage.saveSpellTemplate",
+      "parent": null,
+      "domain": "spells",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 666,
+      "callers": [
+        {
+          "file": "lib/import/dedupeEngine.ts",
+          "fn": "importSpellsFromOpen5E",
+          "line": 128
+        },
+        {
+          "file": "app/api/spells/[id]/route.ts",
+          "fn": "PUT",
+          "line": 49
+        },
+        {
+          "file": "app/api/spells/route.ts",
+          "fn": "POST",
+          "line": 57
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.deleteSpellTemplate",
+      "parent": null,
+      "domain": "spells",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 682,
+      "callers": [
+        {
+          "file": "app/api/spells/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 74
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No-op (early return, no DB call) when id fails the same local shape check as loadSpellById."
+    },
+    {
+      "method": "storage.spellExistsByNameAndSource",
+      "parent": null,
+      "domain": "spells",
+      "behavior": "swallow",
+      "errorReturn": "false",
+      "line": 698,
+      "callers": [
+        {
+          "file": "lib/import/dedupeEngine.ts",
+          "fn": "shouldImport",
+          "line": 26
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.monsterExistsByNameAndSource",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "swallow",
+      "errorReturn": "false",
+      "line": 715,
+      "callers": [],
+      "existingTests": [
+        "tests/unit/lib/storage.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.findMonsterByNameAndSource",
+      "parent": null,
+      "domain": "monsters",
+      "behavior": "swallow",
+      "errorReturn": "null",
+      "line": 731,
+      "callers": [
+        {
+          "file": "lib/import/dedupeEngine.ts",
+          "fn": "shouldImport",
+          "line": 30
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadSessionLogs",
+      "parent": null,
+      "domain": "sessionLogs",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 747,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/route.ts",
+          "fn": "GET",
+          "line": 15
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/sessionLog.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.getNextSessionNumber",
+      "parent": null,
+      "domain": "sessionLogs",
+      "behavior": "swallow",
+      "errorReturn": "1",
+      "line": 763,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/active/route.ts",
+          "fn": "POST",
+          "line": 33
+        },
+        {
+          "file": "app/api/campaigns/[id]/sessions/route.ts",
+          "fn": "POST",
+          "line": 43
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/sessionLog.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.saveSessionLog",
+      "parent": null,
+      "domain": "sessionLogs",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 777,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/active/route.ts",
+          "fn": "POST",
+          "line": 43
+        },
+        {
+          "file": "app/api/campaigns/[id]/sessions/route.ts",
+          "fn": "POST",
+          "line": 61
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/sessionLog.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.updateSessionLog",
+      "parent": null,
+      "domain": "sessionLogs",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 789,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/[sessionId]/route.ts",
+          "fn": "PATCH",
+          "line": 19
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/sessionLog.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Returns SessionLog | null; null means \"no matching document to update\" (findOneAndUpdate returned nothing), not a swallowed DB error — DB errors rethrow."
+    },
+    {
+      "method": "storage.deleteSessionLog",
+      "parent": null,
+      "domain": "sessionLogs",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 820,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/sessions/[sessionId]/route.ts",
+          "fn": "DELETE",
+          "line": 38
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/sessionLog.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.addMember",
+      "parent": null,
+      "domain": "campaignMembers",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 898,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/members/route.ts",
+          "fn": "POST",
+          "line": 81
+        },
+        {
+          "file": "app/api/campaigns/global/[id]/copy/route.ts",
+          "fn": "POST",
+          "line": 37
+        },
+        {
+          "file": "app/api/campaigns/route.ts",
+          "fn": "POST",
+          "line": 87
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.members.test.ts",
+        "tests/unit/api/campaigns/[id]/members/route.unit.test.ts",
+        "tests/integration/campaigns.members.integration.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Special-cases a Mongo duplicate-key error (code 11000) into a DuplicateMemberError before rethrowing; all other DB errors are logged and rethrown as-is."
+    },
+    {
+      "method": "storage.updateMemberStatus",
+      "parent": null,
+      "domain": "campaignMembers",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 914,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/route.ts",
+          "fn": "DELETE",
+          "line": 23
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/me/route.ts",
+          "fn": "PATCH",
+          "line": 44
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/me/route.ts",
+          "fn": "PATCH",
+          "line": 51
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/route.ts",
+          "fn": "POST",
+          "line": 96
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.members.test.ts",
+        "tests/unit/api/campaigns/[id]/members/[userId]/route.unit.test.ts",
+        "tests/unit/api/campaigns/[id]/members/me.test.ts",
+        "tests/unit/api/campaigns/[id]/members/route.unit.test.ts",
+        "tests/integration/campaigns.members.integration.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.listMembersForCampaign",
+      "parent": null,
+      "domain": "campaignMembers",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 937,
+      "callers": [
+        {
+          "file": "lib/server/transport.ts",
+          "fn": "activeMembers",
+          "line": 66
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/route.ts",
+          "fn": "GET",
+          "line": 17
+        },
+        {
+          "file": "app/api/campaigns/[id]/rolls/route.ts",
+          "fn": "POST",
+          "line": 83
+        },
+        {
+          "file": "app/api/campaigns/[id]/messages/route.ts",
+          "fn": "POST",
+          "line": 137
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaigns.members.test.ts",
+        "tests/unit/api/campaigns/[id]/members/route.unit.test.ts",
+        "tests/integration/campaigns.members.integration.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.getMember",
+      "parent": null,
+      "domain": "campaignMembers",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 955,
+      "callers": [
+        {
+          "file": "lib/utils/campaign.ts",
+          "fn": "assertCampaignAccess",
+          "line": 11
+        },
+        {
+          "file": "app/api/campaigns/[id]/characters/[cid]/route.ts",
+          "fn": "DELETE",
+          "line": 9
+        },
+        {
+          "file": "app/api/campaigns/[id]/characters/route.ts",
+          "fn": "POST",
+          "line": 25
+        },
+        {
+          "file": "app/api/campaigns/[id]/characters/route.ts",
+          "fn": "GET",
+          "line": 60
+        },
+        {
+          "file": "app/api/campaigns/[id]/parties/route.ts",
+          "fn": "GET",
+          "line": 9
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/parties/[partyId]/route.ts",
+          "fn": "isAuthorized",
+          "line": 11
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/parties/[partyId]/route.ts",
+          "fn": "PUT",
+          "line": 81
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/route.ts",
+          "fn": "DELETE",
+          "line": 9
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/route.ts",
+          "fn": "DELETE",
+          "line": 18
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/me/route.ts",
+          "fn": "GET",
+          "line": 7
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/me/route.ts",
+          "fn": "PATCH",
+          "line": 34
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/route.ts",
+          "fn": "GET",
+          "line": 12
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/route.ts",
+          "fn": "POST",
+          "line": 72
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/route.ts",
+          "fn": "POST",
+          "line": 77
+        },
+        {
+          "file": "app/api/campaigns/[id]/rolls/route.ts",
+          "fn": "POST",
+          "line": 51
+        },
+        {
+          "file": "app/api/campaigns/[id]/rolls/route.ts",
+          "fn": "GET",
+          "line": 101
+        },
+        {
+          "file": "app/api/campaigns/[id]/messages/route.ts",
+          "fn": "parseVisibility",
+          "line": 65
+        },
+        {
+          "file": "app/api/campaigns/[id]/messages/route.ts",
+          "fn": "POST",
+          "line": 99
+        },
+        {
+          "file": "app/api/campaigns/[id]/messages/route.ts",
+          "fn": "GET",
+          "line": 150
+        }
+      ],
+      "existingTests": [
+        "tests/unit/utils/assertCampaignAccess.test.ts",
+        "tests/unit/storage/campaignMembers.test.ts",
+        "tests/unit/api/campaigns/[id]/characters/[cid]/route.test.ts",
+        "tests/unit/api/campaigns/[id]/characters/route.test.ts",
+        "tests/unit/api/campaigns/[id]/members/[userId]/route.unit.test.ts",
+        "tests/unit/api/campaigns/[id]/members/me.test.ts",
+        "tests/unit/api/campaigns/[id]/members/route.unit.test.ts",
+        "tests/unit/api/campaigns/[id]/members/me.get.test.ts"
+      ],
+      "characterizationTest": "tests/unit/lib/storage.characterization.test.ts",
+      "notes": "Rethrows on DB error. Contrast with loadSpellById (swallow): callers such as lib/utils/campaign.ts assertCampaignAccess() have no local try/catch, so a DB blip becomes an unhandled throw here versus a silent null there."
+    },
+    {
+      "method": "storage.loadCampaignByIdAny",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 971,
+      "callers": [
+        {
+          "file": "lib/utils/campaign.ts",
+          "fn": "assertCampaignAccess",
+          "line": 13
+        }
+      ],
+      "existingTests": [
+        "tests/unit/utils/assertCampaignAccess.test.ts",
+        "tests/unit/storage/campaignMembers.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.listCampaignsForMember",
+      "parent": null,
+      "domain": "campaignMembers",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 984,
+      "callers": [],
+      "existingTests": [
+        "tests/unit/storage/campaigns.members.test.ts",
+        "tests/integration/campaigns.members.integration.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.getUserById",
+      "parent": null,
+      "domain": "users",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1009,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/rolls/route.ts",
+          "fn": "POST",
+          "line": 64
+        },
+        {
+          "file": "app/api/campaigns/[id]/messages/route.ts",
+          "fn": "POST",
+          "line": 109
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/users.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No try/catch around the DB call; DB errors propagate unhandled. Throws InvalidUserIdError synchronously (not a DB error) if userId is not a valid ObjectId."
+    },
+    {
+      "method": "storage.getUsersByIds",
+      "parent": null,
+      "domain": "users",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1019,
+      "callers": [
+        {
+          "file": "app/api/me/invitations/route.ts",
+          "fn": "GET",
+          "line": 31
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/users.test.ts",
+        "tests/unit/api/me/invitations.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No try/catch around the DB call; DB errors propagate unhandled. Returns {} early (no DB call) if no valid ObjectIds are present."
+    },
+    {
+      "method": "storage.listInvitationsForUser",
+      "parent": null,
+      "domain": "campaignMembers",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1039,
+      "callers": [
+        {
+          "file": "app/api/me/invitations/route.ts",
+          "fn": "GET",
+          "line": 15
+        }
+      ],
+      "existingTests": [
+        "tests/unit/storage/campaignMembers.test.ts",
+        "tests/unit/api/me/invitations.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No try/catch around the DB call; DB errors propagate unhandled."
+    },
+    {
+      "method": "storage.getCampaignsByIds",
+      "parent": null,
+      "domain": "campaigns",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1052,
+      "callers": [
+        {
+          "file": "app/api/me/invitations/route.ts",
+          "fn": "GET",
+          "line": 30
+        }
+      ],
+      "existingTests": [
+        "tests/unit/api/me/invitations.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No try/catch around the DB call; DB errors propagate unhandled. Returns [] early (no DB call) if campaignIds is empty."
+    },
+    {
+      "method": "storage.addShare",
+      "parent": null,
+      "domain": "campaignCharacterShares",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 1062,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/characters/route.ts",
+          "fn": "POST",
+          "line": 40
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Special-cases a Mongo duplicate-key error (code 11000) into a DuplicateShareError before rethrowing; all other DB errors are logged and rethrown as-is."
+    },
+    {
+      "method": "storage.removeShare",
+      "parent": null,
+      "domain": "campaignCharacterShares",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 1078,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/characters/[cid]/route.ts",
+          "fn": "DELETE",
+          "line": 23
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.listSharesForCampaign",
+      "parent": null,
+      "domain": "campaignCharacterShares",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 1091,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/characters/route.ts",
+          "fn": "GET",
+          "line": 70
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.listAllSharesForCampaign",
+      "parent": null,
+      "domain": "campaignCharacterShares",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 1109,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/route.ts",
+          "fn": "DELETE",
+          "line": 27
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.loadPartiesByCampaign",
+      "parent": null,
+      "domain": "parties",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 1127,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/parties/route.ts",
+          "fn": "GET",
+          "line": 14
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/parties/[partyId]/route.ts",
+          "fn": "PUT",
+          "line": 86
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.setPartyMemberLeftAt",
+      "parent": null,
+      "domain": "parties",
+      "behavior": "mixed",
+      "errorReturn": "undefined (void, no throw)",
+      "line": 1147,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/characters/[cid]/route.ts",
+          "fn": "DELETE",
+          "line": 28
+        },
+        {
+          "file": "app/api/campaigns/[id]/members/[userId]/route.ts",
+          "fn": "DELETE",
+          "line": 31
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Two independent error-handling layers: an inner try/catch around each this.saveParty() call inside the loop logs saveError and continues to the next party (does not rethrow, does not abort the loop); an outer try/catch around the whole method logs any other error (e.g. from loadPartiesByCampaign, which itself rethrows) and also does not rethrow. Net effect: this method never throws, but for a reason that differs at each layer — motivates mixed alongside loadCharacters."
+    },
+    {
+      "method": "storage.canAddToCampaignParty",
+      "parent": null,
+      "domain": "campaignCharacterShares",
+      "behavior": "swallow",
+      "errorReturn": "false",
+      "line": 1172,
+      "callers": [
+        {
+          "file": "app/api/parties/[id]/route.ts",
+          "fn": "PUT",
+          "line": 54
+        },
+        {
+          "file": "app/api/parties/route.ts",
+          "fn": "POST",
+          "line": 30
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.buildSharedCharacterEntries",
+      "parent": null,
+      "domain": "campaignCharacterShares",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1192,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/characters/route.ts",
+          "fn": "GET",
+          "line": 66
+        }
+      ],
+      "existingTests": [
+        "tests/unit/api/campaigns/[id]/characters/route.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No try/catch of its own; calls listAllSharesForCampaign (swallow) and getMember/loadCharacterById (rethrow/mixed) internally, so its effective error behavior depends entirely on those callees."
+    },
+    {
+      "method": "storage.loadCharacterById",
+      "parent": null,
+      "domain": "characters",
+      "behavior": "mixed",
+      "errorReturn": "null (view/fallback) but rethrows on outer error",
+      "line": 1208,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/characters/[cid]/route.ts",
+          "fn": "DELETE",
+          "line": 14
+        },
+        {
+          "file": "app/api/campaigns/[id]/characters/route.ts",
+          "fn": "POST",
+          "line": 30
+        }
+      ],
+      "existingTests": [
+        "tests/unit/lib/storage-shares.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "Two-tier like loadCharacters, but the outer catch rethrows instead of swallowing to a sentinel — inner try/catch falls back from characters_active view to a direct characters query silently (view failure produces no log at all, unlike loadCharacters' console.warn); an error from either query path, or the outer scope, propagates via throw."
+    },
+    {
+      "method": "storage.saveCampaignRoll",
+      "parent": null,
+      "domain": "campaignRolls",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1228,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/rolls/route.ts",
+          "fn": "POST",
+          "line": 81
+        }
+      ],
+      "existingTests": [
+        "tests/unit/api/campaigns/[id]/rolls.route.test.ts"
+      ],
+      "characterizationTest": null,
+      "notes": "No try/catch around the DB call; DB errors propagate unhandled."
+    },
+    {
+      "method": "storage.listCampaignRolls",
+      "parent": null,
+      "domain": "campaignRolls",
+      "behavior": "no-try",
+      "errorReturn": null,
+      "line": 1235,
+      "callers": [
+        {
+          "file": "app/api/campaigns/[id]/rolls/route.ts",
+          "fn": "GET",
+          "line": 125
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "No try/catch around the DB call; DB errors propagate unhandled."
+    },
+    {
+      "method": "storage.clear",
+      "parent": null,
+      "domain": "admin",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 1277,
+      "callers": [],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.savedContent.list",
+      "parent": "savedContent",
+      "domain": "savedContent",
+      "behavior": "swallow",
+      "errorReturn": "[]",
+      "line": 834,
+      "callers": [
+        {
+          "file": "app/api/content/route.ts",
+          "fn": "GET",
+          "line": 13
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.savedContent.create",
+      "parent": "savedContent",
+      "domain": "savedContent",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 849,
+      "callers": [
+        {
+          "file": "app/api/content/route.ts",
+          "fn": "POST",
+          "line": 42
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": null
+    },
+    {
+      "method": "storage.savedContent.update",
+      "parent": "savedContent",
+      "domain": "savedContent",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 868,
+      "callers": [
+        {
+          "file": "app/api/content/[id]/route.ts",
+          "fn": "PUT",
+          "line": 24
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Returns boolean (matchedCount > 0) on success; rethrows on DB error rather than returning false."
+    },
+    {
+      "method": "storage.savedContent.remove",
+      "parent": "savedContent",
+      "domain": "savedContent",
+      "behavior": "rethrow",
+      "errorReturn": null,
+      "line": 884,
+      "callers": [
+        {
+          "file": "app/api/content/[id]/route.ts",
+          "fn": "DELETE",
+          "line": 35
+        }
+      ],
+      "existingTests": [],
+      "characterizationTest": null,
+      "notes": "Returns boolean (deletedCount > 0) on success; rethrows on DB error rather than returning false."
+    }
+  ]
+}

--- a/docs/storage-refactor/plan.md
+++ b/docs/storage-refactor/plan.md
@@ -1,0 +1,101 @@
+# Storage error-handling inventory
+
+## Purpose
+
+`lib/storage.ts` exports a single `storage` object (~1294 lines, 68 methods:
+64 flat methods plus 4 nested under `storage.savedContent`) used by 36
+dependent files. Each method independently decides whether to catch a DB
+error and rethrow it, catch and swallow it (returning a non-throwing
+sentinel), do something in between, or not catch it at all. Nothing
+currently pins which of these behaviors is intentional versus incidental.
+
+This directory is the first milestone of the `#499` storage-decomposition
+epic (see [`#499`](https://github.com) parent tracking issue and
+[`#500`](https://github.com), the issue that scoped this specific change). It
+produces two artifacts `#499`'s planned `runStorageOp` design will consume:
+
+1. `inventory.json` — a point-in-time, machine-readable classification of
+   every method's current error-handling shape.
+2. Characterization tests (in `tests/unit/lib/storage.characterization.test.ts`)
+   for the three methods `#500` names explicitly — `loadSpellById`,
+   `getMember`, `loadCharacters` — pinning current behavior, including its
+   inconsistencies, so a later refactor can be checked against it.
+
+**No production code changes.** `lib/storage.ts` is unmodified by this
+change; see the proposal's Non-Goals.
+
+## The taxonomy
+
+Every entry in `inventory.json` has a `behavior` field with exactly one of
+four values:
+
+- **`swallow`** — the method catches a DB error, logs it, and returns a
+  non-throwing sentinel (`null`, `[]`, `false`, or similar). Callers cannot
+  distinguish "real empty/not-found result" from "the DB call failed."
+- **`rethrow`** — the method catches a DB error, logs it, and re-throws it
+  (usually the original `error`, occasionally wrapped in a custom error
+  type such as `DuplicateMemberError`). Callers see a rejected promise.
+- **`mixed`** — nested or multi-path error handling where sub-paths
+  diverge, most commonly a two-tier query with an inner fallback that has
+  its own independent try/catch. `loadCharacters` and `loadCharacterById`
+  are both `mixed`, but they resolve differently at the outer layer (one
+  swallows to `[]`, the other rethrows) — read each entry's `notes`, don't
+  assume `mixed` implies any particular outer behavior.
+- **`no-try`** — no try/catch is present around the DB call at all. This is
+  kept distinct from `rethrow`: a `no-try` method never *decided* to
+  propagate errors, it simply has no handling. `#499` will likely want to
+  wrap `no-try` methods in `runStorageOp` first, since they currently have
+  zero defensive behavior.
+
+## How to read `inventory.json`
+
+Top-level fields: `schemaVersion`, `generatedFrom` (always `lib/storage.ts`),
+`generatedAt` (ISO timestamp of generation), `sourceLineCount` (the line
+count of `lib/storage.ts` at generation time — see Staleness below), and
+`methods`, an array of per-method entries.
+
+Each entry in `methods`:
+
+| Field | Meaning |
+|---|---|
+| `method` | Fully qualified name, e.g. `storage.loadSpellById` or `storage.savedContent.list` |
+| `parent` | `null` for the ~64 flat methods, `"savedContent"` for the 4 nested ones |
+| `domain` | A grouping label (e.g. `spells`, `campaignMembers`, `characters`) previewing plausible per-domain module boundaries for `#499`. This is a grouping convenience only — it does not commit `#499` to these exact module names. |
+| `behavior` | One of the four taxonomy values above |
+| `errorReturn` | The sentinel value returned on swallow (e.g. `"null"`, `"[]"`, `"false"`); `null` when not applicable (`rethrow`/`no-try`, or `mixed` — see that entry's `notes`) |
+| `line` | Source line in `lib/storage.ts` where the method is defined |
+| `callers` | `{file, fn, line}` entries for every call site found in non-test source files. `fn` is a best-effort match of the nearest enclosing named function/handler above the call site; some entries fall back to `null` when no enclosing declaration pattern matched (e.g. call sites inside deeply nested closures) |
+| `existingTests` | Test file paths that already exercise this method (happy-path or otherwise), independent of whether they cover the error path |
+| `characterizationTest` | Path to a test file that specifically pins this method's error-handling behavior per this change's taxonomy, or `null` if none exists yet |
+| `notes` | Free-text explanation, used heavily for `mixed` entries and any method whose behavior isn't a clean instance of its category (e.g. methods that delegate to other swallowing/rethrowing methods without their own try/catch) |
+
+## Staleness warning
+
+**This inventory is a snapshot, not a live view.** It was generated against
+`lib/storage.ts` at `sourceLineCount: 1294` lines as of `generatedAt`. The
+moment `lib/storage.ts` changes — including `#499`'s own later milestones
+moving methods into per-domain files — every `line` and `callers` entry can
+drift out of date, and new methods added after this snapshot will have no
+entry at all.
+
+**`#499` must re-verify this inventory against the current source before
+designing `runStorageOp` against it — not blindly trust it.** At minimum,
+re-run the method-count check in `tasks.md` §6.4 (compare `inventory.json`'s
+entry count against the actual method count on `storage`) before relying on
+any classification here.
+
+## Coverage gap
+
+Per `#500`'s explicit scope, only three methods (`loadSpellById`, `getMember`,
+`loadCharacters`) have characterization tests. The remaining ~61 methods are
+inventoried (classified by direct source inspection) but not test-pinned —
+their `characterizationTest` field is `null`. This is a known, accepted gap,
+not an oversight; a later change can extend characterization coverage using
+this inventory as its worklist.
+
+## References
+
+- Parent tracking issue: `#499` (storage layer decomposition into per-domain
+  repos with centralized error handling via a planned `runStorageOp` helper)
+- This change's issue: `#500`
+- Machine-readable data: [`inventory.json`](./inventory.json)

--- a/openspec/changes/storage-blast-radius-inventory/.openspec.yaml
+++ b/openspec/changes/storage-blast-radius-inventory/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-08-16

--- a/openspec/changes/storage-blast-radius-inventory/design.md
+++ b/openspec/changes/storage-blast-radius-inventory/design.md
@@ -1,0 +1,177 @@
+## Context
+
+`lib/storage.ts` exports a single `storage` object (~1294 lines, ~64 methods)
+used by 36 dependent files. Each method independently wraps its DB call in a
+try/catch and either rethrows or swallows-and-logs on error; a few do neither
+cleanly. No test currently exercises the DB-error branch of any of these
+methods, so nothing pins which behavior is intentional versus incidental.
+
+This change produces two things #499's `runStorageOp` design will consume:
+
+1. `docs/storage-refactor/inventory.json` — a snapshot classification of
+   every method's current error-handling shape.
+2. Characterization tests for the three methods #500 names explicitly,
+   proving current behavior (including its inconsistencies) so a later
+   refactor can be checked against it.
+
+No production code changes. This is a documentation + test-pinning step only.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a fixed, 4-value behavior taxonomy (`swallow`, `rethrow`, `mixed`,
+  `no-try`) that #499 can design `runStorageOp` against without
+  renegotiating vocabulary later.
+- Produce a complete, per-method inventory (all flat methods + the nested
+  `savedContent` sub-object) in a machine-readable format.
+- Write characterization tests for `loadSpellById`, `getMember`, and
+  `loadCharacters` that pin current behavior, including the specific
+  ambiguity/inconsistency each demonstrates.
+
+**Non-Goals:**
+- Changing any behavior in `lib/storage.ts`.
+- Achieving full 64-method characterization coverage (three methods are the
+  required minimum; the inventory notes coverage gaps for the rest so a
+  later change can pick them up).
+- Designing `runStorageOp` itself, or deciding which behavior (swallow vs.
+  rethrow) each method *should* have going forward.
+
+## Decisions
+
+### 1. Taxonomy: four categories, not a boolean
+
+Considered a simple boolean (`swallows: true/false`), but `loadCharacters`
+doesn't fit: its try/catch nests, with the outer catch's fallback path having
+its own independent try/catch. Modeling that as a plain boolean would force
+a false choice or require a separate ad-hoc flag. Decision: four values —
+`swallow` (catch → log → return a non-throwing sentinel), `rethrow` (catch →
+log → `throw error`), `mixed` (nested/multi-path handling where sub-paths
+diverge, e.g. `loadCharacters`), `no-try` (no try/catch present; DB errors
+propagate unhandled by construction, distinct from an intentional rethrow).
+`no-try` is kept separate from `rethrow` because it represents an absence of
+handling, not a decision to rethrow — that distinction matters for #499,
+which will likely want to add `runStorageOp` wrapping specifically to
+`no-try` methods first since they currently have zero defensive behavior.
+
+Alternative considered: a free-text `notes`-only approach with no enum. Rejected because #499's `runStorageOp` needs to programmatically group methods by behavior class; free text can't be switched on.
+
+### 2. Inventory format: JSON, not just a Markdown table
+
+The requester specified JSON. Rationale beyond preference: a Markdown table
+in `docs/storage-refactor-plan.md` (the issue's suggested location) is
+readable but not consumable by tooling — and #499's `runStorageOp` milestone
+will plausibly want to script against "all `no-try` methods" or "all
+`swallow` methods returning `[]`" rather than hand-parse prose. `plan.md`
+stays a short narrative pointer; `inventory.json` is the source of truth.
+
+Schema (see `docs/storage-refactor/inventory.json` once written):
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedFrom": "lib/storage.ts",
+  "generatedAt": "<ISO date>",
+  "sourceLineCount": 1294,
+  "methods": [
+    {
+      "method": "string",
+      "parent": "string | null",
+      "domain": "string",
+      "behavior": "swallow | rethrow | mixed | no-try",
+      "errorReturn": "string | null",
+      "line": "number",
+      "callers": [{ "file": "string", "fn": "string", "line": "number" }],
+      "existingTests": ["string"],
+      "characterizationTest": "string | null",
+      "notes": "string | null"
+    }
+  ]
+}
+```
+
+`domain` values are chosen to preview plausible per-domain module boundaries
+for #499 (e.g. `spells`, `campaignMembers`, `characters`, `savedContent`),
+but this change does not commit #499 to those exact module names — it's a
+grouping convenience, not an API contract.
+
+### 3. Folder location: `docs/storage-refactor/`
+
+The issue allows either `docs/storage-refactor-plan.md` directly or "a
+linked doc." A dedicated folder is chosen over a single file because this
+change produces two artifacts of different character (narrative doc +
+machine-readable data) and #499's later milestones will likely add more
+docs to the same epic (e.g. the `runStorageOp` design itself, or a
+per-domain migration checklist) — a flat single file would need renaming or
+splitting at that point anyway.
+
+### 4. Characterization test strategy per behavior class
+
+- **`rethrow` (`getMember`)**: mock the underlying `db.collection().findOne`
+  to reject; assert `storage.getMember(...)` rejects with the same error.
+  Single test, single path — this is the simplest case and needs no special
+  treatment.
+- **`swallow` (`loadSpellById`)**: the interesting property isn't the return
+  value alone, it's that two different underlying conditions produce the
+  *same* observable result. Two tests: (a) mock `findOne` to reject, assert
+  `loadSpellById` resolves to `null`; (b) mock `findOne` to resolve `null`
+  (genuine not-found), assert it also resolves to `null`. A comment ties the
+  two together, stating explicitly that this pins the current
+  DB-error/not-found ambiguity as a known characteristic, not a design goal.
+- **`mixed` (`loadCharacters`)**: three tests corresponding to the three
+  code paths — (a) `characters_active` view query mock resolves normally →
+  assert those results are returned; (b) view query mock rejects, fallback
+  `characters` collection query mock resolves → assert fallback results are
+  returned (proves the fallback actually engages, not just that *a* result
+  came back); (c) view query mock rejects, fallback query mock also rejects
+  → assert the method resolves to `[]` rather than throwing (proves the
+  outer swallow catches the fallback's failure too). Mocking must use two
+  independently-controllable `db.collection(name)` mocks keyed by collection
+  name (`characters_active` vs `characters`) so path (b) can prove the
+  *specific* fallback ran, not just that some result was returned by
+  accident from a shared mock.
+
+### 5. Where characterization tests live
+
+Follow existing repo test-file conventions for `lib/storage.ts` coverage
+(colocated `__tests__`/`*.test.ts` pattern already used elsewhere in the
+repo) rather than introducing a new test directory — tasks.md will locate
+the exact existing pattern and target path during implementation.
+
+## Risks / Trade-offs
+
+- [Risk] Inventory JSON drifts from `lib/storage.ts` as soon as either file
+  changes (including this change's own PR, if later edits touch storage.ts
+  incidentally). → Mitigation: `sourceLineCount` and `generatedAt` fields
+  let a later consumer detect staleness by diffing against the current file;
+  `plan.md` states explicitly that #499 must re-verify, not blindly trust,
+  the inventory before designing against it.
+- [Risk] Hand-classifying ~64 methods by behavior is manual and error-prone
+  (a mis-classified `swallow` vs `mixed` method would mislead #499).
+  → Mitigation: the three required characterization tests double as
+  verification for those three entries; tasks.md should include a step to
+  spot-check a sample of the remaining classifications against the actual
+  source rather than trusting a single automated pass.
+- [Risk] Mocking MongoDB's driver for the two-collection `loadCharacters`
+  fallback path is more complex than the repo's typical single-collection
+  mock and could be written in a way that doesn't actually exercise the
+  fallback (e.g. both mocks resolving from the same stub, masking that the
+  wrong collection was queried). → Mitigation: decision 4 above specifies
+  per-collection-name mock control as a hard requirement, and test (b)'s
+  assertion must check *which* collection's data came back, not just that
+  data came back.
+- [Trade-off] Restricting characterization tests to three methods (per
+  #500's minimum) leaves ~61 methods' behavior inventoried but unpinned by
+  tests. Accepted per explicit issue scope — `characterizationTest: null`
+  entries in the inventory make the gap visible rather than hiding it.
+
+## Migration Plan
+
+Not applicable — this change adds new files only (`docs/storage-refactor/`
+and new test files) and modifies no existing production or test behavior.
+No deployment or rollback steps beyond normal PR merge.
+
+## Open Questions
+
+None outstanding — taxonomy, format, and location were confirmed by the
+requester prior to this design being written (see proposal.md's Open
+Questions section).

--- a/openspec/changes/storage-blast-radius-inventory/proposal.md
+++ b/openspec/changes/storage-blast-radius-inventory/proposal.md
@@ -1,0 +1,174 @@
+## GitHub Issues
+
+- #500
+- Parent tracking issue: #499
+
+## Why
+
+- Problem statement: `lib/storage.ts` (1294 lines, ~64 methods across a flat
+  object plus a nested `savedContent` sub-object) has no characterization
+  tests pinning its existing error-handling behavior. 33 methods rethrow
+  caught DB errors; 24 swallow them (returning `null`/`[]`/`false` and only
+  logging); a few do neither cleanly (e.g. `loadCharacters`'s nested
+  try/catch with a view-fallback path). This inconsistency is currently
+  unpinned by any test, so a refactor of the storage layer (#499) could
+  silently change error semantics for any of the 36 dependent files without
+  a single test failing.
+- Why now: #499 (decomposing `lib/storage.ts` into per-domain repos with
+  centralized error handling via a planned `runStorageOp` helper) cannot
+  safely begin until current behavior — including its inconsistencies — is
+  documented and pinned. This is explicitly the first milestone in that
+  epic.
+- Business/user impact: without this, the refactor risks turning a silent
+  DB blip that today returns a misleading-but-harmless empty result (e.g.
+  `loadSpellById` swallowing to `null`, indistinguishable from a real
+  404) into an unhandled 500, or vice versa — turning a currently-loud
+  failure (e.g. `getMember` rethrowing into `assertCampaignAccess`) into a
+  silently wrong authorization decision. Neither direction is safe to
+  introduce accidentally.
+
+## Problem Space
+
+- Current behavior: each `storage.*` method independently decides whether
+  to catch-and-rethrow or catch-and-swallow on DB error. Confirmed via direct
+  inspection of `lib/storage.ts`:
+  - `loadSpellById` (line 649): swallows to `null`. `app/api/spells/[id]/route.ts`
+    cannot distinguish a DB error from a real "not found" — both produce
+    `404 Spell not found`.
+  - `getMember` (line 955): rethrows. `lib/utils/campaign.ts`'s
+    `assertCampaignAccess()` (line 11) calls it with no local try/catch, so
+    the same class of DB failure that's silently swallowed for spells
+    becomes an unhandled throw here.
+  - `loadCharacters` (line 116): two-tier — the primary query against the
+    `characters_active` view is wrapped in an inner try/catch that falls
+    back to a direct query against `characters` with an explicit
+    `deletedAt: null` filter; that fallback's own try/catch swallows to
+    `[]`. Three distinct failure paths, one observable behavior.
+  - `storage.savedContent` (lines ~993+): a nested sub-object, not a peer
+    method on the flat `storage` object, with its own independent
+    swallow/rethrow split (`list` swallows, `create`/`update`/`remove`
+    rethrow). Any inventory that only counts flat methods will
+    undercount or mis-scope this.
+- Desired behavior (for this change only): existing behavior is not changed.
+  The desired end-state is a machine-readable inventory of all 64+4 methods'
+  current behavior, plus a fixed taxonomy other work (#499's `runStorageOp`)
+  can design against, plus characterization tests proving the current
+  (including inconsistent) behavior for the three methods above.
+- Constraints:
+  - No production code in `lib/storage.ts` may change as part of this
+    change — see Non-Goals.
+  - The taxonomy defined here is the first definition in the #499 chain;
+    there is no prior taxonomy to reconcile against.
+- Assumptions:
+  - Mocking the MongoDB driver/collection layer (consistent with existing
+    test patterns in this repo) is sufficient to force DB-error paths
+    without a real database.
+  - "Current behavior" is defined by what the code does today, not by what
+    it should do — inconsistencies are pinned as-is, not fixed.
+- Edge cases considered:
+  - Methods with no try/catch at all (`no-try`) — DB errors propagate
+    unhandled by construction; still worth inventorying so #499 knows which
+    methods currently have zero defensive handling.
+  - Methods where the "swallow" value is not `null`/`[]` but `false` or
+    `undefined` (e.g. boolean-returning update/delete methods) — the
+    taxonomy must capture the actual sentinel, not assume a single shape.
+  - `loadCharacters`'s two-tier shape doesn't fit a binary swallow/rethrow
+    label — it's the motivating example for a `mixed` category.
+
+## Scope
+
+### In Scope
+
+- A complete inventory of all `storage.*` methods (flat + nested
+  `savedContent`) as `docs/storage-refactor/inventory.json`, covering:
+  method name, parent (null or `savedContent`), domain, behavior
+  classification, error-return sentinel, source line, caller list,
+  existing test coverage, and free-text notes.
+- A short narrative doc, `docs/storage-refactor/plan.md`, explaining the
+  taxonomy, how to read `inventory.json`, and pointing back to #499/#500.
+- A fixed 4-value behavior taxonomy: `swallow`, `rethrow`, `mixed`,
+  `no-try`.
+- Characterization tests pinning current behavior for, at minimum:
+  `loadSpellById` (swallow), `getMember` (rethrow), `loadCharacters`
+  (mixed, three sub-paths: view succeeds; view throws → fallback
+  succeeds; view throws → fallback throws → swallows to `[]`).
+- For each of those three, tests must prove the *ambiguity itself* where
+  relevant — e.g. for `loadSpellById`, a test asserting a thrown DB error
+  and a genuine "no matching document" both resolve to `null`, not just a
+  single happy-path pin.
+
+### Out of Scope
+
+- Characterization tests for the remaining ~61 methods beyond the three
+  required ones (explicitly "ideally extend to all 64" but not
+  non-negotiable per #500).
+- Designing or implementing `runStorageOp` or any other #499 foundation
+  work — this change only produces the taxonomy and inventory that work
+  will consume.
+- Fixing any of the identified inconsistencies (e.g. making `loadSpellById`
+  rethrow, or `getMember` swallow) — that is explicitly reserved for later
+  #499 milestones.
+
+## What Changes
+
+- New directory `docs/storage-refactor/` containing `plan.md` and
+  `inventory.json`.
+- New test file(s) under the existing test directory structure adding
+  characterization tests for `loadSpellById`, `getMember`, and
+  `loadCharacters`.
+- No changes to `lib/storage.ts` or any other production file.
+
+## Risks
+
+- Risk: the inventory becomes stale the moment `lib/storage.ts` changes
+  again (e.g. a new method added, or #499 begins moving methods into
+  per-domain files).
+  - Impact: `runStorageOp` design work could rely on an inventory that no
+    longer matches the code, reintroducing the exact blind spot this
+    change exists to close.
+  - Mitigation: `plan.md` states the inventory is a point-in-time snapshot
+    tied to a specific commit/line count of `lib/storage.ts`, and that
+    #499's next milestone must re-verify (not blindly trust) the inventory
+    before designing against it.
+- Risk: characterization tests that pin *inconsistent* behavior could be
+  misread later as "this is the desired behavior" rather than "this is
+  what happens today."
+  - Impact: a future contributor "fixes" the inconsistency by editing
+    `lib/storage.ts` without realizing the tests were deliberately pinning
+    a bug class, or conversely treats the pinned bug as sacred and refuses
+    a legitimate fix.
+  - Mitigation: each characterization test carries a comment stating it
+    pins current (possibly buggy) behavior, not desired behavior, and
+    references #499 as the place that behavior will be intentionally
+    changed.
+- Risk: mocking the MongoDB layer for `loadCharacters`'s two-tier
+  view-then-fallback path is more involved than a single-collection mock
+  and could be gotten subtly wrong (e.g. not actually exercising the
+  fallback).
+  - Impact: a test that appears to cover the fallback path but doesn't
+    would give false confidence going into #499.
+  - Mitigation: design.md specifies the exact mock sequencing needed to
+    force the view query to throw before the fallback query runs.
+
+## Open Questions
+
+None — this change was preceded by an explore-mode session (`/opsx:explore`
+against #500) in which the test-pinning approach, the JSON inventory format
+and its `docs/storage-refactor/` location, and the taxonomy-ownership
+question (confirmed: this change defines the taxonomy from scratch, nothing
+in #499 predates it) were each raised and resolved by the requester before
+this proposal was generated.
+
+## Non-Goals
+
+- Not a production refactor of `lib/storage.ts`.
+- Not a decision about which behavior (swallow vs. rethrow) is "correct"
+  per method — that judgment call belongs to a later #499 milestone informed
+  by this inventory.
+- Not full 64-method characterization test coverage — three methods are the
+  non-negotiable minimum per #500.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/storage-blast-radius-inventory/specs/storage-error-behavior-inventory/spec.md
+++ b/openspec/changes/storage-blast-radius-inventory/specs/storage-error-behavior-inventory/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Complete storage method behavior inventory
+The system SHALL provide a machine-readable inventory,
+`docs/storage-refactor/inventory.json`, containing one entry for every
+method on the `storage` object exported by `lib/storage.ts`, including
+methods nested under sub-objects such as `storage.savedContent`. Each entry
+SHALL record: method name, parent (`null` for flat methods, the sub-object
+name otherwise), domain, behavior classification, error-return sentinel
+(when applicable), source line number, caller list, existing test coverage,
+characterization test reference (or `null`), and free-text notes.
+
+#### Scenario: Every storage method is represented
+- **WHEN** the number of entries in `inventory.json` is compared against the
+  number of methods defined on `storage` (flat methods plus nested
+  `savedContent` methods) in `lib/storage.ts`
+- **THEN** the counts match, with no method missing an entry
+
+#### Scenario: Nested sub-object methods are not conflated with flat methods
+- **WHEN** an entry's `method` field is one of `storage.savedContent`'s
+  methods (`list`, `create`, `update`, `remove`)
+- **THEN** that entry's `parent` field is `"savedContent"`, distinguishing it
+  from the ~60 flat top-level methods where `parent` is `null`
+
+### Requirement: Fixed four-value error-handling taxonomy
+The system SHALL classify every inventoried method's `behavior` field using
+exactly one of four values: `swallow` (catches a DB error, logs it, and
+returns a non-throwing sentinel), `rethrow` (catches, logs, and re-throws),
+`mixed` (nested or multi-path error handling where sub-paths diverge, e.g. a
+fallback query with its own independent try/catch), or `no-try` (no
+try/catch present around the DB call).
+
+#### Scenario: No fifth category is introduced
+- **WHEN** the `behavior` field of any entry in `inventory.json` is inspected
+- **THEN** its value is one of `swallow`, `rethrow`, `mixed`, or `no-try`,
+  with no other value present anywhere in the file
+
+#### Scenario: A two-tier fallback method is classified as mixed, not swallow
+- **WHEN** `loadCharacters`'s entry is inspected
+- **THEN** its `behavior` field is `mixed`, and its `notes` field describes
+  the view-query-then-fallback-query structure that makes a plain
+  `swallow`/`rethrow` label insufficient
+
+### Requirement: Characterization tests pin current error-handling behavior
+The system SHALL include automated tests that pin the current, observable
+error-handling behavior of `storage.loadSpellById`, `storage.getMember`, and
+`storage.loadCharacters` without modifying `lib/storage.ts`. Tests SHALL
+mock the underlying database layer to force each method's error path(s) and
+assert against the method's actual current output, including cases where
+that output is ambiguous between a DB error and a legitimate not-found or
+empty result.
+
+#### Scenario: Swallowed error is indistinguishable from a real not-found
+- **WHEN** `storage.loadSpellById` is called once with a mocked DB error and
+  once with a mocked genuine not-found result
+- **THEN** both calls resolve to `null`, and a test asserts this equivalence
+  explicitly rather than only checking one of the two paths
+
+#### Scenario: Rethrown error propagates to the caller
+- **WHEN** `storage.getMember` is called with a mocked DB error
+- **THEN** the returned promise rejects with that same error, and a test
+  asserts the rejection (not a swallowed `null` return)
+
+#### Scenario: Fallback path is proven to actually run, not merely assumed
+- **WHEN** `storage.loadCharacters` is called with the `characters_active`
+  view query mocked to reject and the `characters` collection query mocked
+  to resolve with distinct, identifiable data
+- **THEN** a test asserts the returned data matches the `characters`
+  collection's mock specifically (not the view's), proving the fallback
+  path executed rather than the test passing vacuously
+
+#### Scenario: Double failure still resolves rather than throwing
+- **WHEN** `storage.loadCharacters` is called with both the view query and
+  the fallback query mocked to reject
+- **THEN** the method resolves to `[]` rather than rejecting, and a test
+  asserts this resolution
+
+### Requirement: No production behavior changes
+The system SHALL NOT modify any behavior in `lib/storage.ts` as part of this
+change. The inventory and characterization tests SHALL document and pin
+existing behavior only.
+
+#### Scenario: Storage source file is unchanged
+- **WHEN** this change's diff is reviewed
+- **THEN** `lib/storage.ts` has zero line changes

--- a/openspec/changes/storage-blast-radius-inventory/tasks.md
+++ b/openspec/changes/storage-blast-radius-inventory/tasks.md
@@ -1,0 +1,84 @@
+## 1. Inventory scaffolding
+
+- [ ] 1.1 Create `docs/storage-refactor/` directory
+- [ ] 1.2 Enumerate every method on `storage` in `lib/storage.ts`, including
+      the nested `storage.savedContent` sub-object, recording name, parent,
+      and source line number for each
+- [ ] 1.3 For each method, read its try/catch structure and classify
+      `behavior` as one of `swallow`, `rethrow`, `mixed`, `no-try`, and
+      record the `errorReturn` sentinel where applicable (`null`, `[]`,
+      `false`, `undefined`, etc.)
+- [ ] 1.4 For each method, grep its call sites across the 36 dependent files
+      and record `{file, fn, line}` entries in `callers`
+- [ ] 1.5 For each method, record any `existingTests` (search
+      `tests/unit/lib/storage*.test.ts`, `tests/unit/storage/storage.test.ts`,
+      and `tests/unit/lib/storage-shares.test.ts` for coverage) and leave
+      `characterizationTest` as `null` unless task group 3 adds one
+- [ ] 1.6 Write the complete result to `docs/storage-refactor/inventory.json`
+      per the schema in `design.md`, including `schemaVersion`,
+      `generatedFrom`, `generatedAt`, and `sourceLineCount`
+
+## 2. Narrative doc
+
+- [ ] 2.1 Write `docs/storage-refactor/plan.md`: purpose, the 4-value
+      taxonomy definition, how to read `inventory.json`, and an explicit
+      staleness warning that `#499` must re-verify (not blindly trust) the
+      inventory before designing `runStorageOp` against it
+- [ ] 2.2 Link `plan.md` and `inventory.json` from each other and reference
+      #499 and #500
+
+## 3. Characterization tests — loadSpellById (swallow)
+
+- [ ] 3.1 Add a `describe("storage.loadSpellById")` block (new file or
+      extend an existing `tests/unit/lib/storage*.test.ts` file, following
+      the `jest.mock("@/lib/db")` + per-collection mock pattern already used
+      in `tests/unit/lib/storage.characters.test.ts`)
+- [ ] 3.2 Test: mock `findOne` to reject; assert `loadSpellById` resolves to
+      `null` (not a rejection)
+- [ ] 3.3 Test: mock `findOne` to resolve `null` (genuine not-found); assert
+      `loadSpellById` also resolves to `null`
+- [ ] 3.4 Add a comment on the pair of tests above stating explicitly that
+      they pin the current DB-error/not-found ambiguity as a known
+      characteristic, not a design goal, with a reference to #499
+- [ ] 3.5 Update that method's `inventory.json` entry: set
+      `characterizationTest` to the new test file path
+
+## 4. Characterization tests — getMember (rethrow)
+
+- [ ] 4.1 Add a `describe("storage.getMember")` block using the same mocking
+      convention
+- [ ] 4.2 Test: mock `findOne` to reject; assert `storage.getMember(...)`
+      rejects with that same error (use `.rejects.toBe`/`.rejects.toThrow`
+      as appropriate, not a swallowed resolution)
+- [ ] 4.3 Update that method's `inventory.json` entry: set
+      `characterizationTest` to the new test file path
+
+## 5. Characterization tests — loadCharacters (mixed)
+
+- [ ] 5.1 Add a `describe("storage.loadCharacters")` block; mock
+      `db.collection` so `characters_active` and `characters` are
+      independently controllable (mock keyed by collection name argument,
+      not a single shared stub)
+- [ ] 5.2 Test: `characters_active` query resolves normally; assert the
+      returned data matches the view's mock data
+- [ ] 5.3 Test: `characters_active` query rejects, `characters` fallback
+      query resolves with data distinct from the view's mock; assert the
+      returned data matches the *fallback's* mock specifically, proving the
+      fallback path actually ran rather than the assertion passing
+      vacuously
+- [ ] 5.4 Test: both `characters_active` and `characters` queries reject;
+      assert `loadCharacters` resolves to `[]` rather than rejecting
+- [ ] 5.5 Update that method's `inventory.json` entry: set
+      `characterizationTest` to the new test file path, and confirm `notes`
+      describes the two-tier structure
+
+## 6. Verification
+
+- [ ] 6.1 Run the full test suite and confirm all new and existing tests
+      pass against `lib/storage.ts` unmodified
+- [ ] 6.2 Confirm `git diff` shows zero changes to `lib/storage.ts`
+- [ ] 6.3 Spot-check at least 10 of the ~61 non-test-covered
+      `inventory.json` entries against the actual source to catch
+      misclassification before treating the inventory as reliable
+- [ ] 6.4 Confirm `inventory.json` entry count matches the actual method
+      count on `storage` (flat + `savedContent`) in `lib/storage.ts`

--- a/openspec/changes/storage-blast-radius-inventory/tasks.md
+++ b/openspec/changes/storage-blast-radius-inventory/tasks.md
@@ -1,84 +1,84 @@
 ## 1. Inventory scaffolding
 
-- [ ] 1.1 Create `docs/storage-refactor/` directory
-- [ ] 1.2 Enumerate every method on `storage` in `lib/storage.ts`, including
+- [x] 1.1 Create `docs/storage-refactor/` directory
+- [x] 1.2 Enumerate every method on `storage` in `lib/storage.ts`, including
       the nested `storage.savedContent` sub-object, recording name, parent,
       and source line number for each
-- [ ] 1.3 For each method, read its try/catch structure and classify
+- [x] 1.3 For each method, read its try/catch structure and classify
       `behavior` as one of `swallow`, `rethrow`, `mixed`, `no-try`, and
       record the `errorReturn` sentinel where applicable (`null`, `[]`,
       `false`, `undefined`, etc.)
-- [ ] 1.4 For each method, grep its call sites across the 36 dependent files
+- [x] 1.4 For each method, grep its call sites across the 36 dependent files
       and record `{file, fn, line}` entries in `callers`
-- [ ] 1.5 For each method, record any `existingTests` (search
+- [x] 1.5 For each method, record any `existingTests` (search
       `tests/unit/lib/storage*.test.ts`, `tests/unit/storage/storage.test.ts`,
       and `tests/unit/lib/storage-shares.test.ts` for coverage) and leave
       `characterizationTest` as `null` unless task group 3 adds one
-- [ ] 1.6 Write the complete result to `docs/storage-refactor/inventory.json`
+- [x] 1.6 Write the complete result to `docs/storage-refactor/inventory.json`
       per the schema in `design.md`, including `schemaVersion`,
       `generatedFrom`, `generatedAt`, and `sourceLineCount`
 
 ## 2. Narrative doc
 
-- [ ] 2.1 Write `docs/storage-refactor/plan.md`: purpose, the 4-value
+- [x] 2.1 Write `docs/storage-refactor/plan.md`: purpose, the 4-value
       taxonomy definition, how to read `inventory.json`, and an explicit
       staleness warning that `#499` must re-verify (not blindly trust) the
       inventory before designing `runStorageOp` against it
-- [ ] 2.2 Link `plan.md` and `inventory.json` from each other and reference
+- [x] 2.2 Link `plan.md` and `inventory.json` from each other and reference
       #499 and #500
 
 ## 3. Characterization tests — loadSpellById (swallow)
 
-- [ ] 3.1 Add a `describe("storage.loadSpellById")` block (new file or
+- [x] 3.1 Add a `describe("storage.loadSpellById")` block (new file or
       extend an existing `tests/unit/lib/storage*.test.ts` file, following
       the `jest.mock("@/lib/db")` + per-collection mock pattern already used
       in `tests/unit/lib/storage.characters.test.ts`)
-- [ ] 3.2 Test: mock `findOne` to reject; assert `loadSpellById` resolves to
+- [x] 3.2 Test: mock `findOne` to reject; assert `loadSpellById` resolves to
       `null` (not a rejection)
-- [ ] 3.3 Test: mock `findOne` to resolve `null` (genuine not-found); assert
+- [x] 3.3 Test: mock `findOne` to resolve `null` (genuine not-found); assert
       `loadSpellById` also resolves to `null`
-- [ ] 3.4 Add a comment on the pair of tests above stating explicitly that
+- [x] 3.4 Add a comment on the pair of tests above stating explicitly that
       they pin the current DB-error/not-found ambiguity as a known
       characteristic, not a design goal, with a reference to #499
-- [ ] 3.5 Update that method's `inventory.json` entry: set
+- [x] 3.5 Update that method's `inventory.json` entry: set
       `characterizationTest` to the new test file path
 
 ## 4. Characterization tests — getMember (rethrow)
 
-- [ ] 4.1 Add a `describe("storage.getMember")` block using the same mocking
+- [x] 4.1 Add a `describe("storage.getMember")` block using the same mocking
       convention
-- [ ] 4.2 Test: mock `findOne` to reject; assert `storage.getMember(...)`
+- [x] 4.2 Test: mock `findOne` to reject; assert `storage.getMember(...)`
       rejects with that same error (use `.rejects.toBe`/`.rejects.toThrow`
       as appropriate, not a swallowed resolution)
-- [ ] 4.3 Update that method's `inventory.json` entry: set
+- [x] 4.3 Update that method's `inventory.json` entry: set
       `characterizationTest` to the new test file path
 
 ## 5. Characterization tests — loadCharacters (mixed)
 
-- [ ] 5.1 Add a `describe("storage.loadCharacters")` block; mock
+- [x] 5.1 Add a `describe("storage.loadCharacters")` block; mock
       `db.collection` so `characters_active` and `characters` are
       independently controllable (mock keyed by collection name argument,
       not a single shared stub)
-- [ ] 5.2 Test: `characters_active` query resolves normally; assert the
+- [x] 5.2 Test: `characters_active` query resolves normally; assert the
       returned data matches the view's mock data
-- [ ] 5.3 Test: `characters_active` query rejects, `characters` fallback
+- [x] 5.3 Test: `characters_active` query rejects, `characters` fallback
       query resolves with data distinct from the view's mock; assert the
       returned data matches the *fallback's* mock specifically, proving the
       fallback path actually ran rather than the assertion passing
       vacuously
-- [ ] 5.4 Test: both `characters_active` and `characters` queries reject;
+- [x] 5.4 Test: both `characters_active` and `characters` queries reject;
       assert `loadCharacters` resolves to `[]` rather than rejecting
-- [ ] 5.5 Update that method's `inventory.json` entry: set
+- [x] 5.5 Update that method's `inventory.json` entry: set
       `characterizationTest` to the new test file path, and confirm `notes`
       describes the two-tier structure
 
 ## 6. Verification
 
-- [ ] 6.1 Run the full test suite and confirm all new and existing tests
+- [x] 6.1 Run the full test suite and confirm all new and existing tests
       pass against `lib/storage.ts` unmodified
-- [ ] 6.2 Confirm `git diff` shows zero changes to `lib/storage.ts`
-- [ ] 6.3 Spot-check at least 10 of the ~61 non-test-covered
+- [x] 6.2 Confirm `git diff` shows zero changes to `lib/storage.ts`
+- [x] 6.3 Spot-check at least 10 of the ~61 non-test-covered
       `inventory.json` entries against the actual source to catch
       misclassification before treating the inventory as reliable
-- [ ] 6.4 Confirm `inventory.json` entry count matches the actual method
+- [x] 6.4 Confirm `inventory.json` entry count matches the actual method
       count on `storage` (flat + `savedContent`) in `lib/storage.ts`

--- a/tests/unit/lib/storage.characterization.test.ts
+++ b/tests/unit/lib/storage.characterization.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ *
+ * Characterization tests pinning current, observable error-handling behavior
+ * for three `storage.*` methods identified in #500 as inconsistent-by-design:
+ * `loadSpellById` (swallow), `getMember` (rethrow), and `loadCharacters`
+ * (mixed, two-tier view+fallback). See docs/storage-refactor/plan.md and
+ * docs/storage-refactor/inventory.json for the full taxonomy and inventory
+ * these tests support.
+ *
+ * IMPORTANT: these tests pin CURRENT behavior, including known
+ * inconsistencies (e.g. loadSpellById's DB-error/not-found ambiguity). They
+ * are not an assertion that this behavior is correct or desirable. #499's
+ * `runStorageOp` milestone is where that behavior may be intentionally
+ * changed — do not "fix" these tests without updating that epic's scope.
+ */
+import { storage } from "@/lib/storage";
+
+jest.mock("@/lib/db", () => ({
+  getDatabase: jest.fn(),
+}));
+
+import { getDatabase } from "@/lib/db";
+
+const mockedGetDatabase = jest.mocked(getDatabase);
+
+function makeMockCollection() {
+  const toArray = jest.fn();
+  const find = jest.fn(() => ({ toArray }));
+  const findOne = jest.fn();
+  return { find, toArray, findOne };
+}
+
+describe("storage.loadSpellById (behavior: swallow)", () => {
+  let mockCollection: ReturnType<typeof makeMockCollection>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection = makeMockCollection();
+    mockDb = { collection: jest.fn(() => mockCollection) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  // These two tests pin the current DB-error/not-found ambiguity as a known
+  // characteristic of loadSpellById, not a design goal: a rejected findOne
+  // (DB error) and a resolved-null findOne (genuine not-found) are currently
+  // indistinguishable to callers, both producing `null`. See #499, which is
+  // where this ambiguity may eventually be resolved by giving these two
+  // cases distinct observable outcomes.
+  it("resolves to null when the underlying DB call rejects", async () => {
+    mockCollection.findOne.mockRejectedValue(new Error("connection reset"));
+
+    await expect(storage.loadSpellById("spell-123")).resolves.toBeNull();
+  });
+
+  it("resolves to null when the underlying DB call finds no matching document", async () => {
+    mockCollection.findOne.mockResolvedValue(null);
+
+    await expect(storage.loadSpellById("spell-123")).resolves.toBeNull();
+  });
+});
+
+describe("storage.getMember (behavior: rethrow)", () => {
+  let mockCollection: ReturnType<typeof makeMockCollection>;
+  let mockDb: { collection: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection = makeMockCollection();
+    mockDb = { collection: jest.fn(() => mockCollection) };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  it("rejects with the original error when the underlying DB call rejects", async () => {
+    const dbError = new Error("connection reset");
+    mockCollection.findOne.mockRejectedValue(dbError);
+
+    await expect(storage.getMember("camp-1", "user-1")).rejects.toBe(dbError);
+  });
+});
+
+describe("storage.loadCharacters (behavior: mixed)", () => {
+  let mockActiveCollection: ReturnType<typeof makeMockCollection>;
+  let mockFallbackCollection: ReturnType<typeof makeMockCollection>;
+  let mockDb: { collection: jest.Mock };
+
+  const VIEW_RESULT = [{ id: "char-view", userId: "user-1", name: "From view" }];
+  const FALLBACK_RESULT = [{ id: "char-fallback", userId: "user-1", name: "From fallback" }];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActiveCollection = makeMockCollection();
+    mockFallbackCollection = makeMockCollection();
+    mockDb = {
+      collection: jest.fn((name: string) => {
+        if (name === "characters_active") return mockActiveCollection;
+        if (name === "characters") return mockFallbackCollection;
+        throw new Error(`unexpected collection name: ${name}`);
+      }),
+    };
+    mockedGetDatabase.mockResolvedValue(mockDb as never);
+  });
+
+  it("returns the view's results when the characters_active view query succeeds", async () => {
+    mockActiveCollection.toArray.mockResolvedValue(VIEW_RESULT);
+
+    const result = await storage.loadCharacters("user-1");
+
+    expect(result.map((c) => c.id)).toEqual(["char-view"]);
+    expect(mockFallbackCollection.find).not.toHaveBeenCalled();
+  });
+
+  // Proves the fallback path actually runs (not just that some result came
+  // back) by asserting the returned data matches the fallback collection's
+  // distinct mock data, not the view's.
+  it("falls back to the characters collection when the view query rejects", async () => {
+    mockActiveCollection.toArray.mockRejectedValue(new Error("view unavailable"));
+    mockFallbackCollection.toArray.mockResolvedValue(FALLBACK_RESULT);
+
+    const result = await storage.loadCharacters("user-1");
+
+    expect(result.map((c) => c.id)).toEqual(["char-fallback"]);
+    expect(mockFallbackCollection.find).toHaveBeenCalledWith({
+      userId: "user-1",
+      deletedAt: null,
+    });
+  });
+
+  // Proves the outer swallow catches the fallback's failure too, not just
+  // the view's — the double-failure case resolves to [] rather than
+  // rejecting.
+  it("resolves to [] when both the view query and the fallback query reject", async () => {
+    mockActiveCollection.toArray.mockRejectedValue(new Error("view unavailable"));
+    mockFallbackCollection.toArray.mockRejectedValue(new Error("fallback also unavailable"));
+
+    await expect(storage.loadCharacters("user-1")).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description
First milestone of the `#499` storage-decomposition epic. Adds a machine-readable inventory of every `storage.*` method's current error-handling behavior (swallow/rethrow/mixed/no-try), plus characterization tests pinning that behavior — including known inconsistencies — for the three methods #500 requires (`loadSpellById`, `getMember`, `loadCharacters`). No production code changes.

## Type of Change
- [x] Documentation update
- [x] Refactoring (no functional changes) — test/doc-only, `lib/storage.ts` is byte-for-byte unchanged

## Testing Approach
Added `tests/unit/lib/storage.characterization.test.ts` mocking the MongoDB driver via the existing `jest.mock("@/lib/db")` pattern to force each method's error path(s). Full unit suite (2740 tests) passes; `git diff` confirms zero changes to `lib/storage.ts`.

### Integration Tests Consideration
- [x] I am using mocks instead of integration tests

**If using mocks, please explain why integration tests were not appropriate:**
These are characterization tests pinning existing error-handling *code paths* (catch/rethrow/swallow branches), which requires forcing specific DB failure modes deterministically — not feasible with a real MongoDB instance. This follows the repo's existing convention for `lib/storage.ts` coverage (see `tests/unit/lib/storage.test.ts`, `storage.characters.test.ts`).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues
Part of #499. Closes #500.

## Additional Notes
- `docs/storage-refactor/inventory.json` is a point-in-time snapshot (tied to `sourceLineCount`/`generatedAt`); `docs/storage-refactor/plan.md` explicitly states `#499` must re-verify it before designing `runStorageOp` against it.
- Only 3 of 68 methods have characterization tests (`characterizationTest: null` elsewhere), per #500's explicit minimum scope — the inventory makes that gap visible for a follow-up change.
- OpenSpec change: `openspec/changes/storage-blast-radius-inventory` (all 25 tasks complete).
