### PR TITLE
Replace immediate-click dice strip with staged multi-die pool pop-out

### DIFF
--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -290,11 +290,7 @@ interface DicePoolPortalProps {
 
 function DicePoolPortal({ triggerRef, popoutRef, children }: DicePoolPortalProps) {
   const [position, setPosition] = useState<{ bottom: number; left: number } | null>(null)
-  const [root, setRoot] = useState<HTMLElement | null>(null)
-
-  useEffect(() => {
-    setRoot(getDiceOverlayRoot())
-  }, [])
+  const [root] = useState<HTMLElement | null>(() => getDiceOverlayRoot())
 
   useEffect(() => {
     function updatePosition() {

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useReducer, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { LocalStore } from '@/lib/offline/LocalStore'
 import { useCampaignStream } from '@/lib/hooks/useCampaignStream'
 import { useAuth } from '@/lib/hooks/useAuth'
-import { rollDie } from '@/lib/utils/dice'
+import { rollDicePool } from '@/lib/utils/dice'
 import { SceneComposer } from '@/lib/components/SceneComposer'
 import { SceneFeedItem } from '@/lib/components/SceneFeedItem'
 import type { CampaignMessage, CampaignRoll, CampaignStreamEvent, MessageVisibility, RollVisibility } from '@/lib/types'
@@ -253,41 +254,149 @@ function ChatComposer({
 }
 
 const DIE_SIDES = [4, 6, 8, 10, 12, 20] as const
+const EMPTY_POOL: Record<number, number> = { 4: 0, 6: 0, 8: 0, 10: 0, 12: 0, 20: 0 }
+const DICE_OVERLAY_ROOT_ID = 'dice-pool-overlay-root'
 
-interface RollEntryStripProps {
+function isBrowserEnv(): boolean {
+  return typeof document !== 'undefined'
+}
+
+function getDiceOverlayRoot(): HTMLElement | null {
+  if (!isBrowserEnv()) return null
+  let root = document.getElementById(DICE_OVERLAY_ROOT_ID)
+  if (!root) {
+    root = document.createElement('div')
+    root.id = DICE_OVERLAY_ROOT_ID
+    document.body.appendChild(root)
+  }
+  return root
+}
+
+function getActiveDiceGroups(pool: Record<number, number>): { sides: number; count: number }[] {
+  return DIE_SIDES.filter(sides => pool[sides] > 0).map(sides => ({ sides, count: pool[sides] }))
+}
+
+function buildPoolFormula(groups: { sides: number; count: number }[], modifier: number): string {
+  let formula = groups.map(({ sides, count }) => `${count}d${sides}`).join('+')
+  if (modifier !== 0) formula += modifier > 0 ? `+${modifier}` : `${modifier}`
+  return formula
+}
+
+interface DicePoolPortalProps {
+  triggerRef: React.RefObject<HTMLElement | null>
+  popoutRef: React.RefObject<HTMLDivElement | null>
+  children: React.ReactNode
+}
+
+function DicePoolPortal({ triggerRef, popoutRef, children }: DicePoolPortalProps) {
+  const [position, setPosition] = useState<{ bottom: number; left: number } | null>(null)
+  const [root, setRoot] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setRoot(getDiceOverlayRoot())
+  }, [])
+
+  useEffect(() => {
+    function updatePosition() {
+      const rect = triggerRef.current?.getBoundingClientRect()
+      if (!rect) return
+      setPosition({ bottom: window.innerHeight - rect.top + 8, left: rect.left })
+    }
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [triggerRef])
+
+  if (!root || !position) return null
+
+  return createPortal(
+    <div
+      ref={popoutRef}
+      aria-label="Dice pool"
+      className="fixed z-50 bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-3 w-64"
+      style={{ bottom: position.bottom, left: position.left }}
+    >
+      {children}
+    </div>,
+    root
+  )
+}
+
+interface DicePoolTriggerProps {
   campaignId: string
   activeSessionId: string | null
   streamStatus: 'connecting' | 'open' | 'error'
   onRollPosted: (roll: CampaignRoll) => void
 }
 
-function RollEntryStrip({ campaignId, activeSessionId, streamStatus, onRollPosted }: RollEntryStripProps) {
+function DicePoolTrigger({ campaignId, activeSessionId, streamStatus, onRollPosted }: DicePoolTriggerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [pool, setPool] = useState<Record<number, number>>(EMPTY_POOL)
   const [modifierText, setModifierText] = useState('0')
   const modifier = modifierText === '' || modifierText === '-' ? 0 : (parseInt(modifierText, 10) || 0)
   const [visibility, setVisibility] = useState<RollVisibility>({ scope: 'group' })
   const [isRolling, setIsRolling] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popoutRef = useRef<HTMLDivElement>(null)
 
-  const isDisabled = activeSessionId !== null ? streamStatus !== 'open' || isRolling : true
+  const isTriggerDisabled = activeSessionId !== null ? streamStatus !== 'open' : true
+  const poolTotal = DIE_SIDES.reduce((sum, sides) => sum + pool[sides], 0)
 
-  async function handleDieClick(sides: number) {
-    if (isDisabled) return
-    const [result] = rollDie(sides, 1)
-    const total = result + modifier
-    const formula = modifier !== 0
-      ? `1d${sides}${modifier > 0 ? '+' : ''}${modifier}`
-      : `1d${sides}`
+  useEffect(() => {
+    if (activeSessionId === null) setIsOpen(false)
+  }, [activeSessionId])
+
+  useEffect(() => {
+    if (!isOpen) return
+    function handlePointerDown(e: MouseEvent) {
+      const target = e.target as Node
+      if (popoutRef.current?.contains(target)) return
+      if (triggerRef.current?.contains(target)) return
+      setIsOpen(false)
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen])
+
+  function handleAdd(sides: number) {
+    setPool(prev => ({ ...prev, [sides]: prev[sides] + 1 }))
+  }
+
+  function handleRemove(sides: number) {
+    setPool(prev => ({ ...prev, [sides]: Math.max(0, prev[sides] - 1) }))
+  }
+
+  async function handleRoll() {
+    if (poolTotal === 0 || isRolling) return
+    const groups = getActiveDiceGroups(pool)
+    const formula = buildPoolFormula(groups, modifier)
+    const rolls = rollDicePool(groups).map(r => r.value)
+    const total = rolls.reduce((sum, v) => sum + v, 0) + modifier
     setIsRolling(true)
     setError(null)
     try {
       const res = await fetch(`/api/campaigns/${campaignId}/rolls`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ formula, rolls: [result], total, visibility }),
+        body: JSON.stringify({ formula, rolls, total, visibility }),
       })
       if (res.status === 201) {
         const roll: CampaignRoll = await res.json()
         onRollPosted(roll)
+        setPool(EMPTY_POOL)
+        setModifierText('0')
       } else if (res.status === 409) {
         setError('No active session')
       } else {
@@ -301,47 +410,84 @@ function RollEntryStrip({ campaignId, activeSessionId, streamStatus, onRollPoste
   }
 
   return (
-    <div className="border-t border-gray-700 p-2 flex-shrink-0">
+    <div className="border-t border-gray-700 p-2 flex-shrink-0 flex items-center justify-between">
       {activeSessionId === null && (
-        <p className="text-xs text-gray-500 mb-1">No active session</p>
+        <p className="text-xs text-gray-500">No active session</p>
       )}
-      <div className="flex flex-wrap gap-1 items-center">
-        {DIE_SIDES.map(sides => (
-          <button
-            key={sides}
-            type="button"
-            onClick={() => handleDieClick(sides)}
-            disabled={isDisabled}
-            aria-label={`d${sides}`}
-            className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white px-2 py-1 rounded"
-          >
-            d{sides}
-          </button>
-        ))}
-        <input
-          type="text"
-          inputMode="numeric"
-          value={modifierText}
-          onChange={e => {
-            const v = e.target.value
-            if (v === '' || v === '-' || /^-?\d+$/.test(v)) setModifierText(v)
-          }}
-          disabled={isDisabled}
-          aria-label="Modifier"
-          className="w-14 text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
-        />
-        <select
-          value={visibility.scope}
-          onChange={e => setVisibility({ scope: e.target.value as RollVisibility['scope'] })}
-          disabled={isDisabled}
-          aria-label="Roll visibility"
-          className="text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
-        >
-          <option value="group">Group</option>
-          <option value="dm-only">DM-only</option>
-        </select>
-      </div>
-      {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setIsOpen(o => !o)}
+        disabled={isTriggerDisabled}
+        aria-label="Roll dice"
+        aria-expanded={isOpen}
+        className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-full flex items-center gap-1"
+      >
+        d20
+      </button>
+      {isOpen && (
+        <DicePoolPortal triggerRef={triggerRef} popoutRef={popoutRef}>
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-1 items-center">
+              {DIE_SIDES.map(sides => (
+                <div key={sides} className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(sides)}
+                    disabled={isRolling}
+                    aria-label={`Remove d${sides}`}
+                    className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white w-5 h-5 rounded"
+                  >
+                    −
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleAdd(sides)}
+                    disabled={isRolling}
+                    aria-label={`Add d${sides}`}
+                    className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white px-2 py-1 rounded"
+                  >
+                    d{sides} ×{pool[sides]}
+                  </button>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-1 items-center">
+              <input
+                type="text"
+                inputMode="numeric"
+                value={modifierText}
+                onChange={e => {
+                  const v = e.target.value
+                  if (v === '' || v === '-' || /^-?\d+$/.test(v)) setModifierText(v)
+                }}
+                disabled={isRolling}
+                aria-label="Modifier"
+                className="w-14 text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
+              />
+              <select
+                value={visibility.scope}
+                onChange={e => setVisibility({ scope: e.target.value as RollVisibility['scope'] })}
+                disabled={isRolling}
+                aria-label="Roll visibility"
+                className="text-xs bg-gray-700 border border-gray-600 text-white rounded px-1 py-0.5 disabled:opacity-50"
+              >
+                <option value="group">Group</option>
+                <option value="dm-only">DM-only</option>
+              </select>
+            </div>
+            <button
+              type="button"
+              onClick={handleRoll}
+              disabled={poolTotal === 0 || isRolling}
+              className="text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white px-3 py-1 rounded"
+            >
+              Roll
+            </button>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+          </div>
+        </DicePoolPortal>
+      )}
     </div>
   )
 }
@@ -850,7 +996,7 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
         onMentionSelect={handleMentionSelect}
         textareaRef={textareaRef}
       />
-      <RollEntryStrip
+      <DicePoolTrigger
         campaignId={campaignId}
         activeSessionId={activeSessionId}
         streamStatus={streamStatus}

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -380,13 +380,13 @@ function DicePoolTrigger({ campaignId, activeSessionId, streamStatus, onRollPost
 
   async function handleRoll() {
     if (poolTotal === 0 || isRolling) return
-    const groups = getActiveDiceGroups(pool)
-    const formula = buildPoolFormula(groups, modifier)
-    const rolls = rollDicePool(groups).map(r => r.value)
-    const total = rolls.reduce((sum, v) => sum + v, 0) + modifier
     setIsRolling(true)
     setError(null)
     try {
+      const groups = getActiveDiceGroups(pool)
+      const formula = buildPoolFormula(groups, modifier)
+      const rolls = rollDicePool(groups).map(r => r.value)
+      const total = rolls.reduce((sum, v) => sum + v, 0) + modifier
       const res = await fetch(`/api/campaigns/${campaignId}/rolls`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/lib/utils/dice.ts
+++ b/lib/utils/dice.ts
@@ -52,3 +52,39 @@ export function rollDie(sides: number, count = 1): number[] {
   }
   return results;
 }
+
+/**
+ * Roll a mixed pool of dice across multiple die sizes using cryptographically
+ * secure randomness. Each group is validated the same way `rollDie` validates
+ * its `sides`/`count` arguments; if any group is invalid, no dice are rolled.
+ *
+ * @param groups - Array of `{ sides, count }` groups to roll
+ * @returns Flat array of `{ sides, value }` results, one entry per individual
+ *   die, in the same group order the groups were supplied in
+ * @throws Error if any group's sides is not a supported value or count is invalid
+ */
+export function rollDicePool(
+  groups: { sides: number; count: number }[]
+): { sides: number; value: number }[] {
+  for (const { sides, count } of groups) {
+    if (!SUPPORTED_SIDES.includes(sides as SupportedSides)) {
+      throw new Error(
+        `Unsupported die size: ${sides}. Must be one of ${SUPPORTED_SIDES.join(", ")}.`
+      );
+    }
+    if (!Number.isInteger(count) || count < 1) {
+      throw new Error(`Invalid count: ${count}. Must be a positive integer.`);
+    }
+  }
+
+  if (groups.length === 0) return [];
+
+  const cryptoObj = getCrypto();
+  const results: { sides: number; value: number }[] = [];
+  for (const { sides, count } of groups) {
+    for (let i = 0; i < count; i++) {
+      results.push({ sides, value: rollOneDie(sides as SupportedSides, cryptoObj) });
+    }
+  }
+  return results;
+}

--- a/openspec/changes/multi-dice-pool-popout/.openspec.yaml
+++ b/openspec/changes/multi-dice-pool-popout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: sdd-with-feedback-loop
+created: 2026-08-19

--- a/openspec/changes/multi-dice-pool-popout/design.md
+++ b/openspec/changes/multi-dice-pool-popout/design.md
@@ -1,0 +1,151 @@
+## Context
+
+- Relevant architecture: `lib/components/CampaignChat.tsx` hosts the chat dock (its own `isExpanded`/`isPinned`/`isLarge`/`customHeight` dock-shell state machine, see `campaign-chat-dock` spec) and, inside it, `RollEntryStrip` (lines ~255-347) and `RollFeedItem` (lines ~91-109). `lib/utils/dice.ts` exports `rollDie(sides, count = 1): number[]` using rejection-sampled `crypto.getRandomValues`. `app/api/campaigns/[id]/rolls/route.ts` validates and persists `{ formula: string, rolls: number[], total: number, visibility, ... }` — generic, formula-agnostic.
+- Dependencies: none new (no new npm packages — `createPortal` is part of `react-dom`, already a project dependency).
+- Interfaces/contracts touched:
+  - `lib/utils/dice.ts` — additive export only, `rollDie` untouched.
+  - `lib/components/CampaignChat.tsx` — `RollEntryStrip` removed and replaced; `RollFeedItem`, dock-shell state, SSE handling, and all other sub-components untouched.
+  - No changes to `lib/types.ts`, `app/api/campaigns/[id]/rolls/route.ts`, or `lib/utils/campaignRolls.ts`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Let a player stage a mix of any supported die sizes (4/6/8/10/12/20/100) plus a modifier, then commit them as one combined roll.
+- Return staged/committed results as `{ sides, value }[]` so per-die identity survives the roll (groundwork for later animation), while still posting the existing flat `formula`/`rolls`/`total` shape to the unchanged API.
+- Move the dice UI out of the chat dock's permanent footprint into a floating, portaled pop-out triggered by a small persistent d20 icon.
+
+### Non-Goals
+
+- Visual dice animation (tumble/roll effects) — deferred; only the data shape is prepared.
+- Cross-viewer replay of per-die breakdown — deferred; `CampaignRoll`/API/`RollFeedItem` unchanged.
+- Any change to `rollDie`, its callers, or the chat dock's own shell state machine.
+
+## Decisions
+
+### Decision 1: New multi-group roll function, `rollDicePool`, added alongside `rollDie`
+
+- Chosen: Add `rollDicePool(groups: { sides: number; count: number }[]): { sides: number; value: number }[]` to `lib/utils/dice.ts`. Internally it validates each group's `sides` against the same `SUPPORTED_SIDES` list and calls the existing `rollOneDie` helper per die (reusing the exact rejection-sampling logic `rollDie` uses today), just tagging each result with its source `sides`.
+- Alternatives considered:
+  1. Change `rollDie`'s return type to `{sides, value}[]`. Rejected — breaks `InitiativeEntry`/`lib/utils/combat.ts`, which expect a flat `number[]`; out of scope per the proposal's explicit constraint.
+  2. Have the UI call `rollDie` once per die-size group and zip in the `sides` tag client-side, with no new `dice.ts` export. Rejected — this would duplicate the "loop count times, tag with sides" logic in the component instead of the utility layer, and the `dice-rolling` capability is specifically meant to own all dice-roll logic centrally (see its existing Purpose statement: "one shared implementation instead of ad-hoc local dice logic").
+- Rationale: Keeps `dice-rolling`'s "single centralized dice-rolling utility" principle intact, keeps `rollDie`'s existing, spec-locked contract untouched, and gives the UI layer exactly the `{sides, value}[]` shape the proposal requires.
+- Trade-offs: One more exported function to maintain in `dice.ts`; acceptable given it's a thin, ~10-line wrapper around already-tested primitives.
+
+### Decision 2: Staging pool represented as `Record<number, number>` (sides → count), not a flat list of staged die instances
+
+- Chosen: Client component state is a map of die size to count, e.g. `{ 6: 2, 8: 2 }`, edited via per-size increment/decrement controls (mirrors today's die-button row, now with a count badge instead of firing an immediate roll).
+- Alternatives considered: A flat array of individually-addressable staged dice (`{id, sides}[]`) with per-line remove buttons. Rejected as the default — for the common case (multiple dice of the *same* size), a per-line list adds visual noise and scroll risk with no benefit, since individual same-size dice are interchangeable before rolling. This remains open per the proposal's Open Questions; grouped counters are the default pending confirmation.
+- Rationale: Matches the existing die-button row's visual language most closely (least surprising evolution of current UI), trivially serializes to both the `rollDicePool` group input and a `"NdX"`-per-group formula string, and needs no list-key/virtualization handling.
+- Trade-offs: If the requester confirms they want a flat per-instance list instead (e.g. to remove exactly one specific staged d6 while a 2nd d6 is retried differently — not meaningfully different pre-roll), this decision is revisited; the counter model can't express "these two d6 are different" because pre-roll they aren't.
+
+### Decision 3: Formula and breakdown strings are built from the staged state, never parsed from free text
+
+- Chosen: `formula` is composed as `Nd<sides>` per non-zero group, joined with `+`, with the modifier appended (`+M`/`-M`, omitted at 0) — same convention `RollEntryStrip` already uses for the modifier sign. `rolls: number[]` is `rollDicePool(...).map(r => r.value)` in staged-group order.
+- Alternatives considered: A free-text formula input (`"2d6+2d8+3"`) parsed client-side. Rejected — parsing/validating arbitrary dice-notation text is materially more surface area (ambiguous syntax, injection-adjacent input handling) for no benefit over structured staging controls, and wasn't requested.
+- Rationale: No parser needed; the wire format the server already validates (`formula` non-empty string, `rolls` finite-number array, `total` finite number) is satisfied trivially by construction.
+- Trade-offs: None significant — this is strictly simpler than the alternative.
+
+### Decision 4: Pop-out renders via `createPortal` to a dedicated overlay root appended to `document.body`, `fixed`-positioned from the trigger's `getBoundingClientRect()`
+
+- Chosen: A small `DicePoolPortal` wrapper creates (once, lazily, guarded by `typeof document !== 'undefined'` for SSR safety — same `isBrowser()` convention `LocalStore` already uses) a dedicated `<div id="dice-pool-overlay-root">` under `document.body` if one doesn't exist, and portals the pop-out contents into it. Position is computed from the trigger button's bounding rect on open and on window resize/scroll, anchored above-right of the trigger (mirroring the existing chat-dock pill's `fixed bottom-4 right-4` corner convention). `z-index` is set explicitly higher than the chat dock's `z-40`.
+- Alternatives considered:
+  1. `position: fixed` nested directly in the DOM tree without a portal, relying on the dock not having `overflow: hidden`/`transform` ancestors that would trap it. Rejected — proposal explicitly requires floating outside the chat frame, and the chat drawer's existing height-constrained, resizable box is exactly the kind of container `fixed` positioning can get trapped inside if any ancestor establishes a containing block; a portal sidesteps that entirely and is the standard React solution for this problem.
+  2. CSS-only `position: fixed` at the top of the React tree (sibling of `CampaignChat`, not a portal). Rejected — would require lifting the pop-out's mount point up to wherever `CampaignChat` itself is rendered (`app/campaigns/[id]/layout.tsx`), coupling two independent components' render trees for a purely visual/z-order concern that `createPortal` solves locally.
+- Rationale: This is the standard, idiomatic React pattern for "float above everything, ignore ancestor clipping/stacking context" — introducing it here (as the first portal in the codebase) is lower-risk than the workarounds.
+- Trade-offs: First portal usage means no existing test-harness precedent in this repo for asserting portaled content (e.g. RTL's `screen` queries against `document.body` generally still work fine since portals still attach to the DOM, but this should be explicitly verified in the first test written against it — see Testability below).
+
+### Decision 5: Pop-out open/close is local, independent React state — not wired into the chat dock's `dockReducer`
+
+- Chosen: A single `isDicePoolOpen` boolean (plus staged-pool state) lives in a new sub-component, siblings with `RollFeedItem`/etc. inside `CampaignChat`, entirely separate from `dockReducer`'s `isExpanded`/`isPinned`/`isLarge`/`customHeight`.
+- Alternatives considered: Extend `dockReducer` with pop-out state. Rejected — proposal explicitly scopes the chat dock's own shell state machine as untouched; the pop-out is a sibling floating panel with independent lifecycle (it can open/close regardless of whether the chat drawer itself is expanded, as long as an active session exists).
+- Rationale: Keeps the two concerns (chat drawer visibility vs. dice pop-out visibility) decoupled, avoids growing `dockReducer`'s action surface for an unrelated feature, and matches the proposal's explicit non-goal.
+- Trade-offs: None significant.
+
+## Proposal to Design Mapping
+
+- Proposal element: New multi-group roll operation returning `{sides, value}[]`
+  - Design decision: Decision 1
+  - Validation approach: Unit tests in `tests/unit/lib/dice.test.ts` (extended) covering mixed-group input, per-group validation errors, and result tagging.
+- Proposal element: Staging pool (add/remove dice of any size, shared modifier, explicit "Roll" commit)
+  - Design decision: Decision 2, Decision 3
+  - Validation approach: Component tests asserting pool state changes on increment/decrement, formula/rolls/total composed correctly at commit, and no POST fires before commit.
+- Proposal element: Floating pop-out outside the chat dock frame, triggered by a d20 icon
+  - Design decision: Decision 4
+  - Validation approach: Component test asserting the pop-out's DOM node is a descendant of the overlay root (not the chat dock's drawer container), plus a manual/visual verification task on desktop and narrow viewports (per proposal Risk 1).
+- Proposal element: No change to `CampaignRoll`/rolls API; flatten to existing POST shape at commit
+  - Design decision: Decision 3
+  - Validation approach: Existing `tests/unit/api/campaigns/[id]/rolls.route.test.ts` requires zero changes; a new component-level test asserts the POST body shape matches today's contract for a mixed-group roll.
+- Proposal element: Pop-out has independent open/close state, not part of `dockReducer`
+  - Design decision: Decision 5
+  - Validation approach: Component test asserting the pop-out can be opened/closed independently of the chat drawer's expand/collapse state.
+
+## Functional Requirements Mapping
+
+- Requirement: Staging pool accumulates dice across multiple sizes before any roll occurs
+  - Design element: Decision 2 (`Record<number, number>` pool state)
+  - Acceptance criteria reference: `roll-share-ui` delta spec, "ADDED Dice staging pool"
+  - Testability notes: Assert pool state after N increment clicks across multiple die sizes; assert zero network calls until commit.
+
+- Requirement: Commit posts one combined roll matching today's API contract
+  - Design element: Decision 3 (formula/rolls composition)
+  - Acceptance criteria reference: `roll-share-ui` delta spec, "MODIFIED Roll-entry mechanism now stages then commits"
+  - Testability notes: Assert POST body `formula`, `rolls`, `total` for a known pool + modifier + mocked `rollDicePool` result.
+
+- Requirement: New `rollDicePool` operation validates and tags results by die size
+  - Design element: Decision 1
+  - Acceptance criteria reference: `dice-rolling` delta spec, "ADDED Multi-group dice roll operation"
+  - Testability notes: Unit test each supported size, an unsupported size (rejection), zero/negative counts (rejection), and result ordering/tagging.
+
+- Requirement: Pop-out floats outside the chat dock frame
+  - Design element: Decision 4
+  - Acceptance criteria reference: `roll-share-ui` delta spec, "ADDED Floating dice pop-out"
+  - Testability notes: DOM structure assertion (portal target is a sibling of, not nested in, the chat dock drawer); no clipping under a constrained-height/`overflow:hidden` container in a test harness that simulates one.
+
+## Non-Functional Requirements Mapping
+
+- Requirement category: Reliability
+  - Requirement: Pop-out portal target creation is SSR-safe (no `document` access during server render)
+  - Design element: Decision 4 (`isBrowser()`-guarded lazy creation)
+  - Acceptance criteria reference: `roll-share-ui` delta spec, NFAC "Reliability — SSR safety"
+  - Testability notes: Mirrors the existing SSR-safety test pattern already used for `LocalStore`/`campaign-chat-dock` (`No localStorage access during server render`); add an analogous "no `document` access during server render for the dice pop-out" test.
+
+- Requirement category: Security
+  - Requirement: No new user-supplied input parsing (formula is constructed, never parsed) avoids introducing an injection/parsing surface
+  - Design element: Decision 3
+  - Acceptance criteria reference: See functional scenario "Commit posts one combined roll matching today's API contract" — no distinct NFAC scenario needed (per this project's rule against duplicating functional coverage in NFAC).
+
+- Requirement category: Operability
+  - Requirement: First-ever portal pattern in the codebase should not require ongoing bespoke handling by future components
+  - Design element: Decision 4 (`DicePoolPortal` wrapper is a small, reusable-shaped component, not inlined ad hoc)
+  - Acceptance criteria reference: N/A (implementation-quality guidance, not a testable scenario)
+  - Testability notes: Code review checklist item during `openspec-review-code` pass in tasks.md.
+
+## Risks / Trade-offs
+
+- Risk/trade-off: Grouped-counter staging model (Decision 2) can't express "these two same-size dice are individually distinct" pre-roll.
+  - Impact: If the requester's real intent was a flat per-instance list, this is a UI rework after the fact.
+  - Mitigation: Explicitly flagged in proposal Open Questions as non-blocking-but-pending; cheap to revisit since it's isolated to one sub-component's internal state shape, not the `rollDicePool` contract or the API.
+- Risk/trade-off: First portal usage (Decision 4) has no precedent test pattern in this repo.
+  - Impact: Slightly higher chance of an RTL/jsdom-specific gotcha (e.g. `document.body` cleanup between tests) surfacing during implementation.
+  - Mitigation: Write the portal-structure test early (per Functional Requirements Mapping) so any jsdom/RTL friction is caught before the rest of the pop-out is built on top of it.
+
+## Rollback / Mitigation
+
+- Rollback trigger: Pop-out positioning/z-index breaks on a real viewport in a way visual verification (Risk 1 in proposal) can't catch pre-merge, or the staging interaction is confirmed unwanted post-merge.
+- Rollback steps: Revert the `CampaignChat.tsx` changes to restore `RollEntryStrip` (git revert of the single implementation commit/PR); `rollDicePool` in `dice.ts` can be left in place harmlessly (unused, additive) or reverted alongside — no data/schema to roll back since `CampaignRoll`/API are untouched.
+- Data migration considerations: None — no persisted schema changes.
+- Verification after rollback: Existing `roll-share-ui`/`CampaignChat` test suites (pre-change baseline) pass unmodified, confirming the old strip's behavior is fully restored.
+
+## Operational Blocking Policy
+
+- If CI checks fail: Diagnose and fix per this project's tasks.md rules (mandatory pre-commit `openspec-review-code` pass, then `pr-review-toolkit:review-pr` gate loop) before enabling auto-merge; never force-merge.
+- If security checks fail: Treat as blocking; since this change introduces no new server-side input parsing or auth surface (Decision 3 explicitly avoids formula parsing), no security-specific exception is anticipated, but any finding must be resolved, not suppressed.
+- If required reviews are blocked/stale: Follow tasks.md's stall policy — after three or more review-fix-push iterations with no progress, report the stall to the user with remaining findings listed and wait for guidance, per `openspec/config.yaml`'s tasks rules.
+- Escalation path and timeout: Same as above — no distinct timeout beyond the "three-plus iterations with no progress" trigger already codified project-wide.
+
+## Open Questions
+
+- (Carried from proposal.md, both non-blocking for apply, defaults chosen above pending confirmation)
+  - Grouped per-size counters vs. flat per-instance staged list for the pool UI (Decision 2).
+  - Exact pop-out anchor/animation beyond "above-right of the trigger, matching the dock pill's corner convention, simple fade/scale" (Decision 4).

--- a/openspec/changes/multi-dice-pool-popout/proposal.md
+++ b/openspec/changes/multi-dice-pool-popout/proposal.md
@@ -1,0 +1,86 @@
+## GitHub Issues
+
+- dougis-org/session-combat#509
+
+## Why
+
+- Problem statement: The dice roller only supports rolling one die size at a time (`RollEntryStrip` in `lib/components/CampaignChat.tsx`). A player who needs a mixed roll — e.g. `2d6 + 2d8` for a multi-die damage formula — has to roll each die size separately and add totals by hand, and each click posts an individual roll to the chat feed instead of one combined result.
+- Why now: Filed by the campaign owner as issue #509; the always-visible strip also crowds the chat dock footer, and the issue explicitly asks for it to become a pop-out so it stops competing for space with the chat composer.
+- Business/user impact: Faster, less error-prone rolling for multi-die formulas (common in D&D damage/attack rolls); a cleaner chat dock footer (a single d20 trigger icon instead of a permanent row of six die buttons + modifier + visibility select).
+
+## Problem Space
+
+- Current behavior: `RollEntryStrip` renders six always-visible die buttons (d4–d20). Clicking any button immediately rolls one die of that size via `rollDie(sides, 1)`, adds the shared modifier, and POSTs a single-die-type formula (e.g. `"1d20+3"`) to `/api/campaigns/[id]/rolls`. There is no concept of combining multiple die sizes into one roll, and no staging step — every click is a commit.
+- Desired behavior: A d20 icon anchored at the bottom of the chat panel opens a floating pop-out, positioned outside the chat dock's own box (not clipped by it). Inside the pop-out, the user builds up a pool of dice across any mix of sizes (e.g. 2×d6, 2×d8) plus a modifier, then explicitly commits with a single "Roll" action. Nothing rolls until that commit — including a pool of exactly one die. The commit posts one combined roll (e.g. `formula: "2d6+2d8+3"`) to the existing rolls API, unchanged.
+- Constraints:
+  - The rolls API and `CampaignRoll` type (`lib/types.ts`, `app/api/campaigns/[id]/rolls/route.ts`) are not part of this change — the POST body shape (`formula: string`, `rolls: number[]`, `total: number`, `visibility`) stays exactly as today.
+  - `dice-rolling`'s existing `rollDie(sides, count = 1): number[]` contract must not change — other callers (`InitiativeEntry`, `lib/utils/combat.ts`) depend on its current single-die-type, flat-array shape.
+  - This repo has no existing React portal usage anywhere in `lib/components` — this is the first component to render outside its parent's DOM subtree via `createPortal`.
+- Assumptions:
+  - "Float outside the existing chat frame" means the pop-out is portaled to `document.body` (or a shared overlay root) and `fixed`-positioned relative to the viewport/trigger, not constrained by the chat dock's own layout/overflow.
+  - The per-die `{sides, value}` result shape is needed now (even though animation itself is deferred) so the staging/roll code path doesn't need a second breaking rework when animation is added later.
+  - Cross-viewer animated replay of a mixed roll (other campaign members watching the dice land) is a separate, later change — see Non-Goals.
+- Edge cases considered:
+  - Empty pool: "Roll" must be disabled/no-op with nothing staged.
+  - Removing all staged dice after adding some: pool returns to empty state, not an error state.
+  - No active session (`activeSessionId === null`): pop-out trigger/contents must be disabled the same way `RollEntryStrip` is disabled today, with the same "No active session" messaging.
+  - Same 409 race today's strip handles (session ends between staging and commit) must still surface an inline error without silently dropping the roll or double-posting.
+  - Large pools (e.g. 20 dice of one size): no artificial cap is introduced by this change; the existing `rollDie` per-call behavior and `SUPPORTED_SIDES` validation in `lib/utils/dice.ts` already bound individual die-size validity.
+
+## Scope
+
+### In Scope
+
+- A new multi-group dice-roll operation in `lib/utils/dice.ts` (additive, alongside unchanged `rollDie`) that accepts a mixed set of `{sides, count}` groups and returns `{sides, value}[]` per individual die.
+- A staging-pool UI: add/remove dice of any supported size to a pool, edit a shared modifier, then commit with one "Roll" action. Replaces the always-visible, click-to-roll `RollEntryStrip`.
+- A floating pop-out, rendered via a new React portal, triggered by a d20 icon anchored at the bottom of the chat dock — the first portal-based component in this codebase.
+- Flattening the staged `{sides, value}[]` + modifier into the existing formula-string/`rolls: number[]`/`total` POST shape at commit time (client-side only), so the existing `/api/campaigns/[id]/rolls` endpoint and `CampaignRoll` type require zero changes.
+- Updated delta specs for the `roll-share-ui` and `dice-rolling` capabilities.
+
+### Out of Scope
+
+- Animating individual dice (visually) as they roll — explicitly deferred; this change only produces the `{sides, value}[]` data groundwork for it.
+- Persisting/broadcasting per-die breakdown to other campaign members for cross-viewer animated replay — `CampaignRoll`, the rolls API, and `RollFeedItem`'s rendering (`lib/components/CampaignChat.tsx` ~L91-109) are unchanged; the feed still shows the flat `formula → [rolls] = total` breakdown it shows today.
+- Any change to `campaign-chat-dock`'s own dock shell (collapse/pin/drag/resize state machine) — the dice pop-out is a sibling floating panel with its own independent open/close state, not a mode of the chat dock.
+- Changing `rollDie`'s existing signature/contract or any of its current callers (`InitiativeEntry`, `lib/utils/combat.ts`).
+
+## What Changes
+
+- `lib/utils/dice.ts`: add a new multi-group roll operation (name TBD in design, e.g. `rollDicePool`) returning `{ sides: number; value: number }[]`; `rollDie` is untouched.
+- `lib/components/CampaignChat.tsx`: remove the always-visible `RollEntryStrip`; add a d20 trigger button anchored at the dock's bottom, plus a new pop-out component (staging pool + modifier + visibility + commit) rendered through a portal.
+- New portal-rendering pattern introduced for the pop-out (first use of `createPortal` in `lib/components`).
+- `openspec/specs/roll-share-ui/spec.md`: MODIFIED — "Roll-entry strip in the chat dock" requirement's immediate-click scenarios are superseded by staging + explicit-commit scenarios; ADDED requirements for the staging pool and the floating pop-out. "Roll feed item rendering" requirement is explicitly left unchanged.
+- `openspec/specs/dice-rolling/spec.md`: ADDED requirement for the new multi-group roll operation; existing `rollDie` requirements are explicitly left unchanged.
+
+## Risks
+
+- Risk: First-ever portal usage in this codebase could interact awkwardly with existing global styles/z-index stacking (the chat dock pill/drawer already uses `fixed` positioning with `z-40`).
+  - Impact: Pop-out could render behind the chat dock or other fixed UI, or clip on small viewports.
+  - Mitigation: Pick a portal root/z-index explicitly higher than the chat dock's, and verify visually on both desktop and narrow viewports before merge; add this as an explicit test/verification task.
+- Risk: Changing the interaction model from immediate-click to stage-then-commit is a behavior change for existing muscle memory (today, clicking `d20` rolls instantly).
+  - Impact: Users accustomed to one-click rolls may find the extra "Roll" commit step slower for the common single-die case.
+  - Mitigation: This was an explicit, deliberate decision from the requester (see Non-Goals/Problem Space) — no mitigation beyond clear UI affordance (an obviously-enabled "Roll" button showing the current pool) is planned in this change.
+- Risk: Flattening `{sides, value}[]` to `rolls: number[]` at commit time discards per-die grouping before it reaches the server, meaning the groundwork laid now is inert until the deferred animation/broadcast work lands.
+  - Impact: None to current users; a documented deferred-work dependency for whoever picks up the animation feature later.
+  - Mitigation: Explicitly noted in Non-Goals and cross-referenced in the `dice-rolling` delta spec so the next change can find the `{sides, value}[]` shape it needs already in place.
+
+## Open Questions
+
+- Question: What is the exact staged-pool UI shape — a running list of individual staged dice with per-line remove buttons, or grouped counters per die size (e.g. a stepper next to each of d4–d20 showing "×2")?
+  - Needed from: requester (design-level preference; either satisfies the "stage before roll" requirement)
+  - Blocker for apply: no — design.md will propose grouped per-size counters (matches the existing die-button row layout most closely and needs no per-line list virtualization) as the default; flagged for confirmation before/at apply.
+- Question: Exact placement, sizing, and open/close animation of the pop-out beyond "d20 icon at the bottom of the chat panel, floating outside the frame."
+  - Needed from: requester (visual/UX preference)
+  - Blocker for apply: no — design.md will propose anchoring the pop-out above-right of the trigger icon (same corner convention as the existing chat dock pill) with a simple fade/scale transition; flagged for confirmation before/at apply.
+
+## Non-Goals
+
+- Dice animation (visual roll/tumble of individual dice).
+- Cross-viewer broadcast/replay of per-die breakdown to other campaign members.
+- Any change to the `rolls-api` or `CampaignRoll` schema.
+- Any change to `campaign-chat-dock`'s own shell/state machine.
+
+## Change Control
+
+If scope changes after proposal approval, update `proposal.md`, `design.md`,
+`specs/**/*.md`, and `tasks.md` before implementation starts.

--- a/openspec/changes/multi-dice-pool-popout/specs/dice-rolling/spec.md
+++ b/openspec/changes/multi-dice-pool-popout/specs/dice-rolling/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Backend supports multi-group dice-pool rolls
+
+The system SHALL expose a backend dice-pool operation `rollDicePool(groups)` that accepts an array of `{ sides: number; count: number }` groups and returns a single flat array of `{ sides: number; value: number }` results — one entry per individual die across all groups, preserving each result's source die size.
+
+#### Scenario: Single-group pool returns tagged results
+
+- **Given** a caller requests `rollDicePool([{ sides: 6, count: 2 }])`
+- **Then** the backend returns an array of exactly two entries, each `{ sides: 6, value: <1-6> }`
+
+#### Scenario: Mixed-group pool returns results tagged by their own group's sides
+
+- **Given** a caller requests `rollDicePool([{ sides: 6, count: 2 }, { sides: 8, count: 2 }])`
+- **Then** the backend returns an array of exactly four entries: two with `sides: 6` and a `value` between 1 and 6, and two with `sides: 8` and a `value` between 1 and 8
+- **AND** the entries appear in the same group order the groups were supplied in
+
+#### Scenario: Empty group list returns an empty array
+
+- **Given** a caller requests `rollDicePool([])`
+- **Then** the backend returns an empty array without error
+
+### Requirement: Dice-pool rolls reuse the same secure randomness and validation as single-die rolls
+
+The system SHALL validate every group's `sides` against the same supported die sizes as `rollDie`, and SHALL use the same rejection-sampled secure random generation for each individual die.
+
+#### Scenario: Unsupported die size in any group is rejected
+
+- **Given** a caller requests `rollDicePool([{ sides: 6, count: 1 }, { sides: 7, count: 1 }])`
+- **Then** the backend rejects the request with a validation error and rolls no dice from any group
+
+#### Scenario: Invalid count in any group is rejected
+
+- **Given** a caller requests `rollDicePool([{ sides: 6, count: 0 }])`
+- **Then** the backend rejects the request with a validation error
+
+#### Scenario: Each die within a pool uses unbiased secure randomness
+
+- **Given** the backend generates results for any group within a pool
+- **Then** each face of that group's die size has an equal probability of being returned, using the same rejection-sampling approach `rollDie` uses
+
+## MODIFIED Requirements
+
+None. `rollDie(sides, count = 1): number[]` and its existing requirements ("Backend supports centralized dice rolls", "Roll contract is array only", "Dice rolls remain unbiased and validated", "Legacy d20-only helper is removed from the public dice API") are unchanged by this capability addition. Existing callers (`InitiativeEntry`, `lib/utils/combat.ts`) continue to use `rollDie` unmodified.
+
+## REMOVED Requirements
+
+None.
+
+## Traceability
+
+- Proposal element "New multi-group roll operation returning `{sides, value}[]`" → Requirement: ADDED Backend supports multi-group dice-pool rolls
+- Design decision 1 (`rollDicePool` added alongside `rollDie`, reusing `rollOneDie`) → Requirement: ADDED Backend supports multi-group dice-pool rolls; Requirement: Dice-pool rolls reuse the same secure randomness and validation
+- Requirements → Tasks: see `tasks.md`, task for `lib/utils/dice.ts` changes and `tests/unit/lib/dice.test.ts` extension
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: Partial-group failure does not roll any dice
+
+- **Given** a `rollDicePool` request contains one valid group and one group with an unsupported die size
+- **When** the request is processed
+- **Then** validation fails before any random values are generated for any group (no partial roll state is produced)
+
+### Requirement: Security
+
+No new input surface: `rollDicePool`'s `groups` parameter is validated identically to `rollDie`'s existing `sides`/`count` parameters (see functional scenarios "Unsupported die size in any group is rejected", "Invalid count in any group is rejected"). No distinct security scenario is needed.

--- a/openspec/changes/multi-dice-pool-popout/specs/roll-share-ui/spec.md
+++ b/openspec/changes/multi-dice-pool-popout/specs/roll-share-ui/spec.md
@@ -1,0 +1,211 @@
+## ADDED Requirements
+
+This document details *changes* to requirements and is additive to the [`design.md`](../../design.md) document, not a replacement.
+
+### Requirement: ADDED Dice pop-out trigger anchored to the chat dock
+
+The system SHALL display a persistent d20 trigger icon/button anchored at the bottom of the chat dock, which opens/closes the dice pop-out on click.
+
+#### Scenario: Trigger renders and is enabled when a session is active
+
+- **Given** a campaign page where `activeSessionId` is a non-null string
+- **When** the chat dock renders
+- **Then** a button with accessible name matching `/roll|dice/i` is visible and enabled at the bottom of the chat dock
+
+#### Scenario: Trigger is disabled when no active session
+
+- **Given** a campaign page where `activeSessionId` is null
+- **When** the chat dock renders
+- **Then** the dice pop-out trigger button is disabled and, if opened previously, the pop-out is closed
+
+#### Scenario: Clicking the trigger opens the pop-out
+
+- **Given** the trigger is enabled and the pop-out is closed
+- **When** the user clicks the trigger
+- **Then** the dice pop-out becomes visible in the document
+
+#### Scenario: Clicking the trigger again closes the pop-out
+
+- **Given** the pop-out is open
+- **When** the user clicks the trigger again
+- **Then** the dice pop-out is removed from the document
+
+---
+
+### Requirement: ADDED Floating dice pop-out renders outside the chat dock's DOM subtree
+
+The system SHALL render the dice pop-out via a React portal to a dedicated overlay root under `document.body`, positioned with `fixed` coordinates derived from the trigger button, independent of the chat dock's own layout and overflow constraints.
+
+#### Scenario: Pop-out DOM node is not a descendant of the chat dock drawer
+
+- **Given** the dice pop-out is open
+- **When** the DOM is queried
+- **Then** the pop-out's root element is found under a dedicated overlay container attached to `document.body`, and is NOT a descendant of the chat dock's `role="complementary"` drawer element
+
+#### Scenario: Pop-out is not clipped by a constrained-height ancestor
+
+- **Given** the chat dock drawer has a fixed height and `overflow` constraint (as it does today via `customHeight`/dock sizing)
+- **When** the dice pop-out is open
+- **Then** the pop-out renders fully visible, unclipped by the chat dock's height/overflow
+
+#### Scenario: Pop-out closes on outside click
+
+- **Given** the pop-out is open
+- **When** the user clicks outside both the pop-out and the trigger
+- **Then** the pop-out closes
+
+#### Scenario: Pop-out closes on Escape
+
+- **Given** the pop-out is open
+- **When** the user presses Escape
+- **Then** the pop-out closes
+
+---
+
+### Requirement: ADDED Dice staging pool
+
+The system SHALL let the user add and remove dice of any supported size (d4, d6, d8, d10, d12, d20) to a staging pool within the pop-out, and edit a shared modifier, without issuing any roll or network request until the user explicitly commits.
+
+#### Scenario: Adding a die increments its staged count
+
+- **Given** the pop-out is open and the pool is empty
+- **When** the user adds a d6 twice and a d8 twice
+- **Then** the pool shows a staged count of 2 for d6 and 2 for d8, and 0 for all other sizes
+- **AND** no network request has been made
+
+#### Scenario: Removing a die decrements its staged count
+
+- **Given** the pool has a staged count of 2 for d6
+- **When** the user removes one d6
+- **Then** the pool shows a staged count of 1 for d6
+
+#### Scenario: Staged count cannot go below zero
+
+- **Given** the pool has a staged count of 0 for d10
+- **When** the user attempts to remove a d10
+- **Then** the staged count for d10 remains 0 and no error is raised
+
+#### Scenario: Modifier is editable independent of staged dice
+
+- **Given** the pool is empty
+- **When** the user sets the modifier to -2
+- **Then** the modifier value is -2 and no die counts change
+
+---
+
+### Requirement: ADDED Commit rolls the entire staged pool as one combined roll
+
+The system SHALL, on explicit commit ("Roll"), roll every staged die across all sizes plus the modifier as a single combined roll, and POST one request to `/api/campaigns/[id]/rolls` matching the existing API contract unchanged.
+
+#### Scenario: Commit posts one combined formula, rolls, and total
+
+- **Given** the pool has 2 staged d6, 2 staged d8, and modifier 3
+- **When** the user clicks "Roll"
+- **Then** exactly one POST to `/api/campaigns/[id]/rolls` is made with `formula: "2d6+2d8+3"`, `rolls` containing exactly 4 numeric values (each within its die's 1..sides range), `total` equal to the sum of `rolls` plus 3, and `visibility` matching the pop-out's current visibility selection
+
+#### Scenario: Commit with zero modifier omits the modifier from formula
+
+- **Given** the pool has 1 staged d20 and modifier is empty or 0
+- **When** the user clicks "Roll"
+- **Then** the POST is made with `formula: "1d20"` (no `+0` suffix)
+
+#### Scenario: Commit with a single staged die still requires explicit commit
+
+- **Given** the pool has exactly 1 staged d20 and no other dice
+- **When** the user adds the d20 to the pool
+- **Then** no roll occurs and no POST is made
+- **And when** the user then clicks "Roll"
+- **Then** exactly one POST is made for that single die
+
+#### Scenario: Roll button is disabled when the pool is empty
+
+- **Given** the pool has zero staged dice of any size
+- **When** the pop-out renders
+- **Then** the "Roll" commit control is disabled
+
+#### Scenario: Roll button is disabled while a commit is in flight
+
+- **Given** a roll POST is pending (awaiting server response)
+- **When** the pop-out re-renders
+- **Then** the "Roll" control and all pool add/remove controls are disabled until the POST resolves or rejects
+
+#### Scenario: Successful commit clears the staged pool
+
+- **Given** a commit POST resolves with status 201
+- **When** the response is handled
+- **Then** the staged pool returns to empty (all counts 0, modifier reset to 0) and the resulting roll is passed to the feed exactly as `RollFeedItem` renders rolls today
+
+#### Scenario: 409 response (no active session race) shows inline error and preserves the staged pool
+
+- **Given** the pop-out appears enabled (an active session existed when opened) but the server returns 409 on commit
+- **When** the POST resolves with status 409
+- **Then** an inline error message "No active session" is shown in the pop-out, no roll is added to the feed, and the staged pool is NOT cleared (the user can retry once a session is active again)
+
+---
+
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Roll-entry strip is replaced by the dice pop-out trigger and pool
+
+The always-visible `RollEntryStrip` (six immediate-click die buttons, a modifier input, and a visibility selector, permanently rendered below the chat composer) SHALL be removed from the chat dock's default layout and replaced by the pop-out trigger (see "ADDED Dice pop-out trigger anchored to the chat dock"). The modifier input and visibility selector remain, relocated into the pop-out.
+
+#### Scenario: No always-visible die buttons remain in the chat dock body
+
+- **Given** a campaign page where the chat dock is expanded and `activeSessionId` is non-null
+- **When** the dock content renders
+- **Then** no permanently-visible d4/d6/d8/d10/d12/d20 buttons are present in the chat dock's body outside of the (closed-by-default) pop-out
+
+#### Scenario: Visibility selector defaults to group, now inside the pop-out
+
+- **Given** the pop-out is first opened
+- **When** no user interaction with the visibility control has occurred
+- **Then** the visibility selector inside the pop-out shows "Group" as the selected value
+
+#### Scenario: DM-only visibility sends correct scope
+
+- **Given** the user has selected "DM-only" in the pop-out's visibility selector
+- **When** the user commits a roll
+- **Then** the POST body includes `visibility: { scope: "dm-only" }`
+
+---
+
+## REMOVED Requirements
+
+### Requirement: REMOVED Immediate-click-to-roll behavior
+
+Reason for removal: Superseded by the stage-then-commit model. The prior requirement ("Clicking a die button posts a roll with correct formula and total" — a single click immediately rolls and posts) is replaced by "ADDED Dice staging pool" and "ADDED Commit rolls the entire staged pool as one combined roll," which require an explicit "Roll" commit for every roll, including a pool of exactly one die.
+
+---
+
+## Traceability
+
+- Proposal element "Staging pool (add/remove dice of any size, shared modifier, explicit Roll commit)" → Requirements: ADDED Dice staging pool; ADDED Commit rolls the entire staged pool as one combined roll
+- Proposal element "Floating pop-out outside the chat dock frame, triggered by a d20 icon" → Requirements: ADDED Dice pop-out trigger anchored to the chat dock; ADDED Floating dice pop-out renders outside the chat dock's DOM subtree
+- Proposal element "No change to CampaignRoll/rolls API; flatten to existing POST shape at commit" → Requirement: ADDED Commit rolls the entire staged pool as one combined roll (POST shape scenarios)
+- Proposal element "RollEntryStrip removed" → Requirement: MODIFIED Roll-entry strip is replaced by the dice pop-out trigger and pool; REMOVED Immediate-click-to-roll behavior
+- Design decision 1 (`rollDicePool`) → Requirement: ADDED Commit rolls the entire staged pool as one combined roll (rolls values scenario)
+- Design decision 2 (grouped counter pool state) → Requirement: ADDED Dice staging pool
+- Design decision 3 (formula/rolls composed, not parsed) → Requirement: ADDED Commit rolls the entire staged pool as one combined roll (formula scenarios)
+- Design decision 4 (portal, fixed-positioned, SSR-safe) → Requirement: ADDED Floating dice pop-out renders outside the chat dock's DOM subtree
+- Design decision 5 (independent open/close state, not in `dockReducer`) → Requirement: ADDED Dice pop-out trigger anchored to the chat dock (open/close scenarios)
+- Requirements → Tasks: all requirements map to the `CampaignChat.tsx` pop-out/trigger/staging-pool tasks and the portal-root task — see `tasks.md`
+
+**Note:** The existing "Roll feed item rendering" and "Interleaved feed of messages and rolls" requirements in `openspec/specs/roll-share-ui/spec.md` are unaffected by this change and are not restated here — `RollFeedItem` continues to render `formula → [flat rolls] = total` exactly as today (see proposal Non-Goals).
+
+## Non-Functional Acceptance Criteria
+
+### Requirement: Reliability
+
+#### Scenario: No `document` access during server render for the dice pop-out
+
+- **Given** the chat dock (including the dice pop-out trigger) is rendered in a Node.js (non-browser) environment
+- **When** the module is imported and the component tree is server-rendered
+- **Then** no `document`/overlay-root creation is attempted (guarded the same way `LocalStore`'s `isBrowser()` guards chat dock persistence)
+
+#### Scenario: Duplicate commit clicks do not double-post
+
+See functional scenario: "Roll button is disabled while a commit is in flight." No distinct scenario needed.
+
+### Requirement: Security
+
+No new input-parsing surface is introduced: the formula sent to `/api/campaigns/[id]/rolls` is constructed from staged counts, never parsed from free text (see functional scenarios under "ADDED Commit rolls the entire staged pool as one combined roll"). Visibility enforcement remains server-owned via `canSeeRoll`/`emitFiltered`, unchanged by this capability. No distinct security scenario is needed.

--- a/openspec/changes/multi-dice-pool-popout/tasks.md
+++ b/openspec/changes/multi-dice-pool-popout/tasks.md
@@ -1,0 +1,143 @@
+# Tasks
+
+## Preparation
+
+- [x] **Step 1 — Sync default branch:** done during proposal (`git fetch origin main`, worktree branched from `origin/main`)
+- [x] **Step 2 — Create and publish working branch:** done during proposal — `.worktrees/multi-dice-pool-popout` on branch `multi-dice-pool-popout`, pushed to `origin/multi-dice-pool-popout`
+
+## Preflight
+
+- [x] **Verify `pr-review-toolkit:review-pr` is available** — confirmed present in the available skills list (`pr-review-toolkit:review-pr`). No halt needed.
+
+## Execution
+
+- [ ] **Step 1 — Issue lifecycle: mark in-progress**: `gh issue edit 509 --repo dougis-org/session-combat --add-label "in-progress"`. Discover the linked GitHub Project (`gh project list --owner dougis-org --format json`), resolve the status field option matching "In Progress" (`gh project field-list <project-number> --owner dougis-org --format json`), and move the item via `gh project item-edit`. If no project item is found, log a warning and continue. If the `gh` token lacks the `project` scope, instruct the user to run `gh auth refresh -s project` and skip the project-item update (issue label update still proceeds).
+
+- [ ] **Step 2 — `lib/utils/dice.ts`: add `rollDicePool`**
+  - Add `rollDicePool(groups: { sides: number; count: number }[]): { sides: number; value: number }[]`, validating every group's `sides` against the existing `SUPPORTED_SIDES` and every group's `count` the same way `rollDie` validates `count`, before rolling any dice (fail closed — no partial rolls on validation failure).
+  - Reuse the existing `rollOneDie`/`getCrypto` helpers; do not duplicate rejection-sampling logic.
+  - `rollDie` itself is untouched — verify with a diff review that no existing export's signature or behavior changed.
+  - Acceptance criteria: `dice-rolling` delta spec — "ADDED Backend supports multi-group dice-pool rolls", "Dice-pool rolls reuse the same secure randomness and validation as single-die rolls".
+
+- [ ] **Step 3 — `tests/unit/lib/dice.test.ts`: extend for `rollDicePool`** (write tests before/alongside the implementation per BDD/TDD)
+  - Single-group pool returns correctly-tagged results.
+  - Mixed-group pool returns results tagged by their own group's sides, in group order.
+  - Empty group list returns `[]`.
+  - Unsupported die size in any group rejects the whole call, no partial rolls.
+  - Invalid count in any group rejects the whole call.
+  - Run: `npm run test:unit -- tests/unit/lib/dice.test.ts`
+
+- [ ] **Step 4 — New `DicePoolPortal` overlay-root component**
+  - Lazily create/reuse a `<div id="dice-pool-overlay-root">` under `document.body`, guarded by an `isBrowser()`-style check (mirror `LocalStore`'s existing SSR-safety convention) so no `document` access happens during server render.
+  - Renders children via `createPortal`, `fixed`-positioned from the trigger's `getBoundingClientRect()`, recomputed on open/resize/scroll, `z-index` explicitly above the chat dock's `z-40`.
+  - Acceptance criteria: `roll-share-ui` delta spec — "ADDED Floating dice pop-out renders outside the chat dock's DOM subtree"; NFAC "No `document` access during server render for the dice pop-out".
+
+- [ ] **Step 5 — New dice pop-out trigger + staging pool component in `lib/components/CampaignChat.tsx`**
+  - Remove `RollEntryStrip` and its render call.
+  - Add a persistent d20 trigger button anchored at the bottom of the chat dock; enabled iff `activeSessionId !== null` (same gating `RollEntryStrip` used); disabling it while open also closes the pop-out.
+  - Add the pop-out itself (rendered through `DicePoolPortal` when open): grouped per-size counters (d4–d20) with add/remove controls, a modifier input, and the visibility selector (Group/DM-only) relocated from the old strip.
+  - Wire outside-click and Escape-to-close handling.
+  - Keep pop-out open/close state local to this new component tree — do not add it to `dockReducer`.
+  - Acceptance criteria: `roll-share-ui` delta spec — "ADDED Dice pop-out trigger anchored to the chat dock", "ADDED Dice staging pool", "MODIFIED Roll-entry strip is replaced by the dice pop-out trigger and pool", "REMOVED Immediate-click-to-roll behavior".
+
+- [ ] **Step 6 — Commit ("Roll") handler**
+  - Build `formula` from non-zero staged groups (`Nd<sides>` joined by `+`) plus modifier (`+M`/`-M`, omitted at 0), matching the existing sign convention from the old strip.
+  - Call `rollDicePool` with the staged groups; flatten results to `rolls: number[]` in staged-group order; compute `total` as the sum plus modifier.
+  - POST to `/api/campaigns/[id]/rolls` with the same body shape as today (`formula`, `rolls`, `total`, `visibility`) — no changes to the endpoint or `CampaignRoll` type.
+  - Disable the "Roll" control and all pool controls while the POST is in flight; disable "Roll" when the pool is empty.
+  - On `201`: pass the returned roll to the feed exactly as today (`onRollPosted`), then clear the staged pool and reset the modifier.
+  - On `409`: show the existing "No active session" inline error, do not clear the staged pool, do not add anything to the feed.
+  - Acceptance criteria: `roll-share-ui` delta spec — "ADDED Commit rolls the entire staged pool as one combined roll" (all scenarios).
+
+- [ ] **Step 7 — Component tests for the new pop-out/pool/trigger** (write/extend alongside implementation)
+  - Trigger renders/enabled/disabled per `activeSessionId`; open/close on click, outside-click, and Escape.
+  - Pop-out DOM node is a descendant of the overlay root, not the chat dock drawer (`role="complementary"` element) — validates Decision 4's portal structure.
+  - Pool add/remove/modifier interactions with zero network calls until commit.
+  - Commit POST body shape (formula/rolls/total/visibility) for a mixed-group pool, a single-die pool, and a zero-modifier pool.
+  - Roll button disabled states: empty pool, in-flight commit.
+  - Successful commit clears pool; 409 preserves pool and shows inline error.
+  - No always-visible die buttons remain outside the (closed-by-default) pop-out.
+  - Run: `npm run test:unit -- tests/unit/components/CampaignChat`
+
+- [ ] **Step 8 — Manual/visual verification** (per proposal Risk 1 and design Decision 4 trade-off)
+  - Run the app locally (`npm run dev`), open a campaign with an active session, verify the pop-out positions correctly above-right of the trigger, is not clipped by the chat dock, and stacks above other fixed UI, on both a desktop-width and a narrow (mobile-width) viewport.
+  - Confirm the two proposal Open Questions' chosen defaults (grouped counters; above-right anchor with fade/scale) render reasonably; note any visual issue for follow-up but do not block on aesthetic polish beyond "not broken/clipped."
+
+- [ ] Look for existing tooling or functions in the codebase that can be reused or extended before writing new logic from scratch — confirmed: reused `rollOneDie`/`getCrypto` (Step 2), `isBrowser()`-style SSR guard convention from `LocalStore` (Step 4), existing formula-sign convention and 409/visibility handling from the old `RollEntryStrip` (Steps 5-6).
+- [ ] Confirm acceptance criteria are covered — cross-check every scenario in `openspec/changes/multi-dice-pool-popout/specs/dice-rolling/spec.md` and `openspec/changes/multi-dice-pool-popout/specs/roll-share-ui/spec.md` has a corresponding test from Steps 3 and 7.
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Automatically apply all clearly-correct findings directly to the code — without stopping, without presenting the findings list to the user, and without asking for confirmation. Apply fixes, re-run tests to confirm they pass, then proceed to commit.
+
+## Validation
+
+- [ ] Run unit/integration tests: `npm run test:unit`
+- [ ] Run E2E tests (if applicable to dice/chat flows): `npm run test:e2e` (or project's documented E2E command)
+- [ ] Run type checks: `npm run typecheck` (or project's documented command)
+- [ ] Run build: `npm run build`
+- [ ] Run security/code quality checks required by project standards (Codacy, per project skills)
+- [ ] All completed tasks marked as complete
+- [ ] All steps in [Remote push validation]
+
+## Remote push validation
+
+Before running, determine whether the current change is **docs-only**: run `git diff --name-only HEAD` (or compare the working branch against `main`) and check whether every changed file ends in `.md`. This change touches `lib/utils/dice.ts`, `lib/components/CampaignChat.tsx`, and test files — the **full path** applies.
+
+**Full path:**
+
+- **Unit tests** — `npm run test:unit`; all tests must pass
+- **Integration tests** — project's integration test command; all tests must pass
+- **Regression / E2E tests** — project's E2E/regression command; all tests must pass
+- **Build** — `npm run build`; build must succeed with no errors
+
+If **ANY** required step fails, iterate and fix before pushing.
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `multi-dice-pool-popout` to `main`. PR body MUST include `Closes #509`.
+- [ ] **Issue lifecycle: mark in-review**: `gh issue edit 509 --repo dougis-org/session-combat --add-label "in-review" --remove-label "in-progress"`. Move the project item to the status column matching "In Review" via `gh project item-edit` (same discovery pattern as the in-progress step; warn and skip if not found).
+- [ ] Wait 60 seconds for CI to start
+- [ ] Spawn a sub-agent to run `pr-review-toolkit:review-pr`; address all findings (commit, push, re-run) until zero findings remain. If findings persist after three or more iterations with no progress, report the stall with remaining findings listed and wait for human guidance before continuing.
+- [ ] **Enable auto-merge only after the review gate passes (zero findings):** `gh pr merge <PR-URL> --auto --merge` (NEVER use `--admin` to force the merge)
+- [ ] **Iterate until merged** — repeat the following priority loop continuously until `gh pr view <PR-URL> --json state` returns `MERGED`; if `CLOSED`, exit and notify the user — never wait for a human to report the merge; never force-merge:
+  1. **Build and tests** — run all steps in [Remote push validation]; fix any failures, commit, and push before doing anything else in this iteration
+  2. **PR comments** — poll `gh pr view <PR-URL> --json reviewThreads`; for every unresolved thread, address the feedback, commit fixes, run [Remote push validation], push, wait 180 seconds; continue until all threads are resolved
+  3. **CI check failures** — only after all comments are resolved, poll `gh pr checks <PR-URL> --json isRequired,state`; fix any failing required checks, commit, run [Remote push validation], push, wait 180 seconds; then restart this loop from step 1
+
+After every push, restart at step 1. Never skip the build/test gate before pushing any fix.
+
+Ownership metadata:
+
+- Implementer: agent (this change)
+- Reviewer(s): `pr-review-toolkit:review-pr` (automated gate) + human maintainer (dougis) on request
+- Required approvals: zero outstanding `review-pr` findings before auto-merge is enabled; human approval not required to enable auto-merge per this project's schema rules, but PR remains open for human comment until merged
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only` (from the primary checkout, not the worktree)
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (none anticipated beyond the specs themselves — no README/CLAUDE.md changes expected)
+- [ ] Sync approved spec deltas into `openspec/specs/`:
+  - Copy `openspec/changes/multi-dice-pool-popout/specs/dice-rolling/spec.md` content into `openspec/specs/dice-rolling/spec.md` (merge as ADDED requirements alongside existing content)
+  - Copy `openspec/changes/multi-dice-pool-popout/specs/roll-share-ui/spec.md` content into `openspec/specs/roll-share-ui/spec.md` (merge ADDED/MODIFIED/REMOVED into the existing capability spec, replacing the superseded immediate-click requirement)
+  - Update relative links that pointed into the change directory so they resolve from the archive location — replace `../../design.md` with `../../changes/archive/YYYY-MM-DD-multi-dice-pool-popout/design.md`, and similarly for `../../tasks.md`
+- [ ] Archive the change: move `openspec/changes/multi-dice-pool-popout/` to `openspec/changes/archive/YYYY-MM-DD-multi-dice-pool-popout/` **and stage both the new location and the deletion of the old location in a single commit**
+- [ ] Confirm `openspec/changes/archive/YYYY-MM-DD-multi-dice-pool-popout/` exists and `openspec/changes/multi-dice-pool-popout/` is gone
+- [ ] **Create a doc branch**: `git checkout -b doc/archive-YYYY-MM-DD-multi-dice-pool-popout` then `git push -u origin doc/archive-YYYY-MM-DD-multi-dice-pool-popout`
+- [ ] Open a PR from `doc/archive-YYYY-MM-DD-multi-dice-pool-popout` to `main` with title `docs: archive multi-dice-pool-popout (YYYY-MM-DD)` — do NOT push directly to `main`
+- [ ] **IMMEDIATELY** enable auto-merge on the doc PR: `gh pr merge <DOC-PR-URL> --auto --merge` (NEVER use `--admin`)
+- [ ] Monitor the doc PR until it merges (same loop as the implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and `git branch -D multi-dice-pool-popout doc/archive-YYYY-MM-DD-multi-dice-pool-popout`
+- [ ] Remove the change's dedicated worktree: `git worktree remove .worktrees/multi-dice-pool-popout`
+
+Required cleanup after archive: `git fetch --prune` and `git branch -D multi-dice-pool-popout doc/archive-YYYY-MM-DD-multi-dice-pool-popout`

--- a/openspec/changes/multi-dice-pool-popout/tests.md
+++ b/openspec/changes/multi-dice-pool-popout/tests.md
@@ -1,0 +1,74 @@
+---
+name: tests
+description: Tests for the change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `multi-dice-pool-popout` change. All work follows a strict TDD (Test-Driven Development) process: write a failing test for each scenario below before implementing the corresponding behavior in `tasks.md`, then implement the simplest code to pass it, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1.  **Write a failing test:** Before writing any implementation code, write a test that captures the requirements of the task. Run the test and ensure it fails.
+2.  **Write code to pass the test:** Write the simplest possible code to make the test pass.
+3.  **Refactor:** Improve the code quality and structure while ensuring the test still passes.
+
+## Test Cases
+
+### Task 2 — `lib/utils/dice.ts`: `rollDicePool` (`tests/unit/lib/dice.test.ts`)
+
+- [ ] Single-group pool: `rollDicePool([{ sides: 6, count: 2 }])` returns an array of exactly 2 entries, each `{ sides: 6, value }` with `value` in `1..6` — maps to `dice-rolling` spec scenario "Single-group pool returns tagged results"
+- [ ] Mixed-group pool: `rollDicePool([{ sides: 6, count: 2 }, { sides: 8, count: 2 }])` returns 4 entries, 2 tagged `sides: 6` (value `1..6`), 2 tagged `sides: 8` (value `1..8`), in group order — maps to "Mixed-group pool returns results tagged by their own group's sides"
+- [ ] Empty groups: `rollDicePool([])` returns `[]` without error — maps to "Empty group list returns an empty array"
+- [ ] Unsupported die size in any group (e.g. `sides: 7`) rejects the whole call, no dice rolled from either group — maps to "Unsupported die size in any group is rejected"
+- [ ] Invalid count (e.g. `count: 0`) in any group rejects the whole call — maps to "Invalid count in any group is rejected"
+- [ ] Statistical/rejection-sampling smoke check: large-sample roll of one group produces values across the full `1..sides` range with no out-of-range values — maps to "Each die within a pool uses unbiased secure randomness"
+- [ ] Regression: existing `rollDie` test suite passes unmodified — confirms `rollDie`'s contract is untouched (design Decision 1)
+
+### Task 4 — `DicePoolPortal` overlay-root component (`tests/unit/components/CampaignChat/` or a new colocated test file)
+
+- [ ] Portal creates (or reuses) a single `<div id="dice-pool-overlay-root">` under `document.body` — maps to `roll-share-ui` spec scenario "Pop-out DOM node is not a descendant of the chat dock drawer"
+- [ ] Rendering the portal wrapper in a simulated server (non-browser/no-`document`) environment does not throw and does not attempt `document` access — maps to NFAC "No `document` access during server render for the dice pop-out"
+- [ ] Portal content position updates on a simulated window resize/scroll event — supports design Decision 4's fixed-position recompute behavior
+
+### Task 5 — Trigger + staging pool component (`tests/unit/components/CampaignChat/`)
+
+- [ ] Trigger button with accessible name `/roll|dice/i` is visible and enabled when `activeSessionId` is a non-null string — maps to "Trigger renders and is enabled when a session is active"
+- [ ] Trigger button is disabled when `activeSessionId` is null; an already-open pop-out closes when `activeSessionId` transitions to null — maps to "Trigger is disabled when no active session"
+- [ ] Clicking the trigger opens the pop-out (pop-out content becomes present in the document) — maps to "Clicking the trigger opens the pop-out"
+- [ ] Clicking the trigger again closes the pop-out (pop-out content removed from the document) — maps to "Clicking the trigger again closes the pop-out"
+- [ ] Clicking outside the pop-out and trigger closes the pop-out — maps to "Pop-out closes on outside click"
+- [ ] Pressing Escape while the pop-out is open closes it — maps to "Pop-out closes on Escape"
+- [ ] No permanently-visible d4/d6/d8/d10/d12/d20 buttons exist in the chat dock body outside the closed-by-default pop-out — maps to "No always-visible die buttons remain in the chat dock body"
+- [ ] Pop-out's DOM node renders under the overlay root, not nested inside the chat dock's `role="complementary"` element, even when the chat dock drawer has a constrained height/overflow style applied in the test harness — maps to "Pop-out is not clipped by a constrained-height ancestor"
+- [ ] Adding a d6 twice and a d8 twice sets staged counts to `{6: 2, 8: 2}` with all other sizes at 0, and issues zero network requests — maps to "Adding a die increments its staged count"
+- [ ] Removing one d6 from a staged count of 2 decrements it to 1 — maps to "Removing a die decrements its staged count"
+- [ ] Attempting to remove a die from a staged count of 0 leaves it at 0 with no error — maps to "Staged count cannot go below zero"
+- [ ] Setting the modifier to -2 with an empty pool updates only the modifier, no die counts change — maps to "Modifier is editable independent of staged dice"
+- [ ] Pop-out first render shows "Group" selected in the visibility selector — maps to "Visibility selector defaults to group, now inside the pop-out"
+
+### Task 6 — Commit ("Roll") handler (`tests/unit/components/CampaignChat/`)
+
+- [ ] Committing a pool of 2 staged d6 + 2 staged d8 + modifier 3 issues exactly one POST to `/api/campaigns/[id]/rolls` with `formula: "2d6+2d8+3"`, `rolls` containing exactly 4 values each within its own die's range, `total` equal to the sum plus 3, and `visibility` matching the current selection — maps to "Commit posts one combined formula, rolls, and total"
+- [ ] Committing 1 staged d20 with modifier 0/empty sends `formula: "1d20"` (no `+0` suffix) — maps to "Commit with zero modifier omits the modifier from formula"
+- [ ] Adding a single d20 to the pool issues no POST; only clicking "Roll" afterward issues exactly one POST — maps to "Commit with a single staged die still requires explicit commit"
+- [ ] "Roll" control is disabled when the pool has zero staged dice of any size — maps to "Roll button is disabled when the pool is empty"
+- [ ] "Roll" control and all pool add/remove controls are disabled while a commit POST is pending, re-enabled after it resolves/rejects — maps to "Roll button is disabled while a commit is in flight"
+- [ ] On a `201` response, the staged pool resets to empty and modifier resets to 0, and the returned roll is passed through to the feed exactly as `RollFeedItem` renders today — maps to "Successful commit clears the staged pool"
+- [ ] On a `409` response, an inline "No active session" error is shown, no roll is added to the feed, and staged pool/modifier are unchanged — maps to "409 response (no active session race) shows inline error and preserves the staged pool"
+- [ ] Selecting "DM-only" in the visibility selector before commit sends `visibility: { scope: "dm-only" }` — maps to "DM-only visibility sends correct scope"
+- [ ] Regression: existing `RollFeedItem` rendering tests pass unmodified (flat `formula → [rolls] = total` breakdown) — confirms proposal Non-Goal (no `RollFeedItem` changes) is respected
+- [ ] Regression: existing `tests/unit/api/campaigns/[id]/rolls.route.test.ts` passes unmodified — confirms zero API/type changes
+
+### Task 8 — Manual/visual verification (not automated; tracked as a checklist item, not a test file)
+
+- [ ] Desktop-width viewport: pop-out renders fully visible above-right of the trigger, not clipped by the chat dock, stacks above other fixed UI (chat dock pill/drawer)
+- [ ] Narrow/mobile-width viewport: same checks, confirming no overflow off-screen
+
+## Traceability Summary
+
+Every `dice-rolling` and `roll-share-ui` delta-spec scenario listed in `openspec/changes/multi-dice-pool-popout/specs/**/spec.md` has at least one corresponding test case above. NFAC scenarios ("No `document` access during server render", "Duplicate commit clicks do not double-post" (covered by the in-flight-disabled test), "no distinct security scenario") are covered by the Task 4 and Task 6 test groups respectively.

--- a/tests/unit/components/CampaignChat.roll.test.tsx
+++ b/tests/unit/components/CampaignChat.roll.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, act, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { CampaignChat } from '@/lib/components/CampaignChat'
 import type { CampaignRoll, CampaignStreamEvent } from '@/lib/types'
@@ -7,10 +7,6 @@ import type { CampaignRoll, CampaignStreamEvent } from '@/lib/types'
 
 jest.mock('@/lib/offline/LocalStore', () => ({
   LocalStore: { get: jest.fn().mockReturnValue(null), set: jest.fn(), remove: jest.fn() },
-}))
-
-jest.mock('@/lib/utils/dice', () => ({
-  rollDie: jest.fn().mockReturnValue([15]),
 }))
 
 let capturedOnEvent: ((e: CampaignStreamEvent) => void) | null = null
@@ -253,147 +249,8 @@ it('roll item displays dice indicator emoji', async () => {
   expect(screen.getByText('🎲')).toBeInTheDocument()
 })
 
-// ── T4 — RollEntryStrip ───────────────────────────────────────────
-
-// T4.1
-it('roll strip disabled with "No active session" when activeSessionId is null', async () => {
-  await openDock(null)
-  expect(screen.getByText('No active session')).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: 'd20' })).toBeDisabled()
-  expect(screen.getByLabelText('Modifier')).toBeDisabled()
-  expect(screen.getByLabelText('Roll visibility')).toBeDisabled()
-})
-
-// T4.2
-it('roll strip enabled when activeSessionId is non-null and stream is open', async () => {
-  await openDock('session-1')
-  expect(screen.queryByText('No active session')).not.toBeInTheDocument()
-  expect(screen.getByRole('button', { name: 'd20' })).not.toBeDisabled()
-  expect(screen.getByLabelText('Modifier')).not.toBeDisabled()
-  expect(screen.getByLabelText('Roll visibility')).not.toBeDisabled()
-})
-
-// T4.3
-it('clicking d20 with modifier=3 posts correct formula and total', async () => {
-  const { rollDie } = await import('@/lib/utils/dice')
-  ;(rollDie as jest.Mock).mockReturnValue([15])
-  const user = await openDock('session-1')
-  const modifierInput = screen.getByLabelText('Modifier')
-  await user.clear(modifierInput)
-  await user.type(modifierInput, '3')
-  await user.click(screen.getByRole('button', { name: 'd20' }))
-  await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      '/api/campaigns/test-campaign/rolls',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ formula: '1d20+3', rolls: [15], total: 18, visibility: { scope: 'group' } }),
-      }),
-    )
-  })
-})
-
-// T4.4
-it('clicking d6 with modifier=0 sends formula without +0', async () => {
-  const { rollDie } = await import('@/lib/utils/dice')
-  ;(rollDie as jest.Mock).mockReturnValue([4])
-  await openDock('session-1')
-  await userEvent.click(screen.getByRole('button', { name: 'd6' }))
-  await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      '/api/campaigns/test-campaign/rolls',
-      expect.objectContaining({
-        body: JSON.stringify({ formula: '1d6', rolls: [4], total: 4, visibility: { scope: 'group' } }),
-      }),
-    )
-  })
-})
-
-// T4.5
-it('clicking d8 with modifier=-2 sends formula with minus sign', async () => {
-  const { rollDie } = await import('@/lib/utils/dice')
-  ;(rollDie as jest.Mock).mockReturnValue([5])
-  const user = await openDock('session-1')
-  const modifierInput = screen.getByLabelText('Modifier')
-  fireEvent.change(modifierInput, { target: { value: '-2' } })
-  await user.click(screen.getByRole('button', { name: 'd8' }))
-  await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      '/api/campaigns/test-campaign/rolls',
-      expect.objectContaining({
-        body: JSON.stringify({ formula: '1d8-2', rolls: [5], total: 3, visibility: { scope: 'group' } }),
-      }),
-    )
-  })
-})
-
-// T4.6
-it('visibility selector defaults to group on first render', async () => {
-  await openDock('session-1')
-  expect(screen.getByLabelText('Roll visibility')).toHaveValue('group')
-})
-
-// T4.7
-it('selecting DM-only sends correct scope', async () => {
-  const { rollDie } = await import('@/lib/utils/dice')
-  ;(rollDie as jest.Mock).mockReturnValue([10])
-  const user = await openDock('session-1')
-  await user.selectOptions(screen.getByLabelText('Roll visibility'), 'dm-only')
-  await user.click(screen.getByRole('button', { name: 'd6' }))
-  await waitFor(() => {
-    expect(fetchSpy).toHaveBeenCalledWith(
-      '/api/campaigns/test-campaign/rolls',
-      expect.objectContaining({
-        body: expect.stringContaining('"scope":"dm-only"'),
-      }),
-    )
-  })
-})
-
-// T4.8 — buttons disabled while roll is in flight
-it('all die buttons are disabled while a roll POST is in flight', async () => {
-  let resolvePost: (value: unknown) => void
-  fetchSpy.mockImplementation((url: string, init?: RequestInit) => {
-    if (url.includes('/rolls') && init?.method === 'POST') {
-      return new Promise(resolve => { resolvePost = resolve })
-    }
-    if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
-    if (url.includes('/messages')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
-    if (url.includes('/rolls')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ rolls: [] }) })
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
-  })
-  await openDock('session-1')
-  // Click a die button — POST hangs
-  userEvent.click(screen.getByRole('button', { name: 'd6' }))
-  // While in flight, all die buttons should be disabled
-  await waitFor(() => {
-    expect(screen.getByRole('button', { name: 'd6' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'd20' })).toBeDisabled()
-  })
-  // Resolve the POST to clean up
-  resolvePost!({ ok: true, status: 201, json: () => Promise.resolve(makeRoll()) })
-})
-
-// T4.9
-it('409 response shows inline "No active session" error', async () => {
-  setupFetchMock({ rollPostStatus: 409 })
-  await openDock('session-1')
-  await userEvent.click(screen.getByRole('button', { name: 'd20' }))
-  await waitFor(() => {
-    expect(screen.getByText('No active session')).toBeInTheDocument()
-  })
-})
-
-// T4.10
-it('successful 201 response calls onRollPosted (roll appears in feed)', async () => {
-  const returnedRoll = makeRoll({ id: 'roll-from-server', formula: '1d20', rolls: [15], total: 15 })
-  setupFetchMock({ rollPostBody: returnedRoll, rollPostStatus: 201 })
-  await openDock('session-1')
-  await userEvent.click(screen.getByRole('button', { name: 'd20' }))
-  await waitFor(() => {
-    expect(screen.getByText(/1d20/)).toBeInTheDocument()
-  })
-})
+// T4 — RollEntryStrip (immediate-click roll UI) is superseded by the dice
+// pool trigger/pop-out; see CampaignChat.dicePool.test.tsx.
 
 // ── T5 — Roll history fetch on expand ────────────────────────────
 

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.ssr.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.ssr.test.tsx
@@ -1,0 +1,25 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/offline/LocalStore', () => ({
+  LocalStore: { get: jest.fn(), set: jest.fn(), remove: jest.fn() },
+}))
+
+jest.mock('@/lib/hooks/useCampaignStream', () => ({
+  useCampaignStream: jest.fn(() => ({ status: 'connecting' })),
+}))
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: jest.fn(() => ({ user: null, loading: true })),
+}))
+
+describe('CampaignChat dice pop-out — SSR safety', () => {
+  test('server-rendering the chat dock does not access document', async () => {
+    const { renderToString } = await import('react-dom/server')
+    const React = await import('react')
+    const { CampaignChat } = await import('@/lib/components/CampaignChat')
+
+    expect(() =>
+      renderToString(React.createElement(CampaignChat, { campaignId: 'campaign-1' }))
+    ).not.toThrow()
+  })
+})

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
@@ -1,0 +1,371 @@
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CampaignChat } from '@/lib/components/CampaignChat'
+import { rollDicePool } from '@/lib/utils/dice'
+import { CAMPAIGN_ID, sharedTestState, setupFetchMock, restoreFetch } from './helpers'
+
+jest.mock('@/lib/offline/LocalStore', () => ({
+  LocalStore: {
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    remove: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/hooks/useCampaignStream', () => ({
+  useCampaignStream: jest.fn((_, onEvent) => {
+    const { sharedTestState: state } = require('./helpers')
+    state.capturedOnEvent = onEvent
+    return { status: 'open' }
+  }),
+}))
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: jest.fn(() => ({
+    user: { userId: 'user-1', email: 'test@example.com', username: 'tester' },
+    loading: false,
+  })),
+}))
+
+jest.mock('@/lib/utils/dice', () => ({
+  rollDicePool: jest.fn(),
+}))
+
+const mockedRollDicePool = rollDicePool as jest.Mock
+
+async function openDockWithSession(activeSessionId: string | null = 'session-1') {
+  const user = userEvent.setup()
+  const { rerender } = render(<CampaignChat campaignId={CAMPAIGN_ID} activeSessionId={activeSessionId} />)
+  await user.click(screen.getByRole('button', { name: /chat/i }))
+  return { user, rerender }
+}
+
+describe('CampaignChat — dice pool trigger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    sharedTestState.capturedOnEvent = null
+    setupFetchMock()
+    mockedRollDicePool.mockReturnValue([])
+    document.getElementById('dice-pool-overlay-root')?.remove()
+  })
+
+  afterEach(() => {
+    restoreFetch()
+  })
+
+  it('trigger renders and is enabled when a session is active', async () => {
+    await openDockWithSession('session-1')
+    expect(screen.getByRole('button', { name: /roll|dice/i })).toBeEnabled()
+  })
+
+  it('trigger is disabled when no active session', async () => {
+    await openDockWithSession(null)
+    expect(screen.getByRole('button', { name: /roll|dice/i })).toBeDisabled()
+  })
+
+  it('an already-open pop-out closes when activeSessionId transitions to null', async () => {
+    const { user, rerender } = await openDockWithSession('session-1')
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    expect(screen.getByRole('button', { name: 'Roll' })).toBeInTheDocument()
+    rerender(<CampaignChat campaignId={CAMPAIGN_ID} activeSessionId={null} />)
+    expect(screen.queryByRole('button', { name: 'Roll' })).not.toBeInTheDocument()
+  })
+
+  it('clicking the trigger opens the pop-out', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    expect(screen.getByRole('button', { name: 'Roll' })).toBeInTheDocument()
+  })
+
+  it('clicking the trigger again closes the pop-out', async () => {
+    const { user } = await openDockWithSession()
+    const trigger = screen.getByRole('button', { name: /roll|dice/i })
+    await user.click(trigger)
+    await user.click(trigger)
+    expect(screen.queryByRole('button', { name: 'Roll' })).not.toBeInTheDocument()
+  })
+
+  it('closes on outside click', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    expect(screen.getByRole('button', { name: 'Roll' })).toBeInTheDocument()
+    await user.click(document.body)
+    expect(screen.queryByRole('button', { name: 'Roll' })).not.toBeInTheDocument()
+  })
+
+  it('closes on Escape', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    expect(screen.getByRole('button', { name: 'Roll' })).toBeInTheDocument()
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(screen.queryByRole('button', { name: 'Roll' })).not.toBeInTheDocument()
+  })
+
+  it('no always-visible die buttons remain in the chat dock body', async () => {
+    await openDockWithSession()
+    expect(screen.queryByRole('button', { name: 'Add d6' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Add d20' })).not.toBeInTheDocument()
+  })
+
+  it("pop-out is not nested inside the chat dock's role=complementary element", async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    const rollButton = screen.getByRole('button', { name: 'Roll' })
+    const drawer = screen.getByRole('complementary')
+    expect(drawer.contains(rollButton)).toBe(false)
+  })
+
+  it('adding a d6 twice and a d8 twice sets staged counts and issues zero network requests', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d6' }))
+    await user.click(screen.getByRole('button', { name: 'Add d6' }))
+    await user.click(screen.getByRole('button', { name: 'Add d8' }))
+    await user.click(screen.getByRole('button', { name: 'Add d8' }))
+    expect(screen.getByRole('button', { name: 'Add d6' })).toHaveTextContent('d6 ×2')
+    expect(screen.getByRole('button', { name: 'Add d8' })).toHaveTextContent('d8 ×2')
+    expect(screen.getByRole('button', { name: 'Add d4' })).toHaveTextContent('d4 ×0')
+    expect(sharedTestState.fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('/rolls'), expect.anything())
+  })
+
+  it('removing one d6 from a staged count of 2 decrements it to 1', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d6' }))
+    await user.click(screen.getByRole('button', { name: 'Add d6' }))
+    await user.click(screen.getByRole('button', { name: 'Remove d6' }))
+    expect(screen.getByRole('button', { name: 'Add d6' })).toHaveTextContent('d6 ×1')
+  })
+
+  it('staged count cannot go below zero', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Remove d10' }))
+    expect(screen.getByRole('button', { name: 'Add d10' })).toHaveTextContent('d10 ×0')
+  })
+
+  it('modifier is editable independent of staged dice', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    const modifierInput = screen.getByRole('textbox', { name: 'Modifier' })
+    await user.clear(modifierInput)
+    await user.type(modifierInput, '-2')
+    expect(modifierInput).toHaveValue('-2')
+    expect(screen.getByRole('button', { name: 'Add d6' })).toHaveTextContent('d6 ×0')
+  })
+
+  it('visibility selector defaults to group', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    expect(screen.getByRole('combobox', { name: 'Roll visibility' })).toHaveValue('group')
+  })
+})
+
+describe('CampaignChat — dice pool commit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    sharedTestState.capturedOnEvent = null
+    setupFetchMock()
+    document.getElementById('dice-pool-overlay-root')?.remove()
+  })
+
+  afterEach(() => {
+    restoreFetch()
+  })
+
+  it('commits a mixed pool as one combined roll', async () => {
+    mockedRollDicePool.mockReturnValue([
+      { sides: 6, value: 3 }, { sides: 6, value: 5 },
+      { sides: 8, value: 2 }, { sides: 8, value: 7 },
+    ])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-1', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '2d6+2d8+3', rolls: [3, 5, 2, 7], total: 20,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d6' }))
+    await user.click(screen.getByRole('button', { name: 'Add d6' }))
+    await user.click(screen.getByRole('button', { name: 'Add d8' }))
+    await user.click(screen.getByRole('button', { name: 'Add d8' }))
+    const modifierInput = screen.getByRole('textbox', { name: 'Modifier' })
+    await user.clear(modifierInput)
+    await user.type(modifierInput, '3')
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => {
+      const call = sharedTestState.fetchSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as string).includes('/rolls') && (c[1] as RequestInit)?.method === 'POST'
+      )
+      expect(call).toBeDefined()
+      const body = JSON.parse((call![1] as RequestInit).body as string)
+      expect(body.formula).toBe('2d6+2d8+3')
+      expect(body.rolls).toEqual([3, 5, 2, 7])
+      expect(body.total).toBe(20)
+      expect(body.visibility).toEqual({ scope: 'group' })
+    })
+  })
+
+  it('commit with zero modifier omits the modifier from formula', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 15 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-2', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [15], total: 15,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => {
+      const call = sharedTestState.fetchSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as string).includes('/rolls') && (c[1] as RequestInit)?.method === 'POST'
+      )
+      const body = JSON.parse((call![1] as RequestInit).body as string)
+      expect(body.formula).toBe('1d20')
+    })
+  })
+
+  it('adding a single die issues no POST; only Roll issues exactly one POST', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-3', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    expect(
+      sharedTestState.fetchSpy.mock.calls.filter(
+        (c: unknown[]) => (c[0] as string).includes('/rolls') && (c[1] as RequestInit)?.method === 'POST'
+      )
+    ).toHaveLength(0)
+
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+    await waitFor(() => {
+      expect(
+        sharedTestState.fetchSpy.mock.calls.filter(
+          (c: unknown[]) => (c[0] as string).includes('/rolls') && (c[1] as RequestInit)?.method === 'POST'
+        )
+      ).toHaveLength(1)
+    })
+  })
+
+  it('Roll button is disabled when the pool is empty', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    expect(screen.getByRole('button', { name: 'Roll' })).toBeDisabled()
+  })
+
+  it('successful commit clears the staged pool', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-4', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add d20' })).toHaveTextContent('d20 ×0'))
+    expect(screen.getByRole('button', { name: 'Roll' })).toBeDisabled()
+  })
+
+  it('409 response shows inline error and preserves the staged pool', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({}) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => expect(screen.getByText('No active session')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Add d20' })).toHaveTextContent('d20 ×1')
+  })
+
+  it('DM-only visibility sends correct scope', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-5', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'dm-only' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Roll visibility' }), 'dm-only')
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => {
+      const call = sharedTestState.fetchSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as string).includes('/rolls') && (c[1] as RequestInit)?.method === 'POST'
+      )
+      const body = JSON.parse((call![1] as RequestInit).body as string)
+      expect(body.visibility).toEqual({ scope: 'dm-only' })
+    })
+  })
+})

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
@@ -331,10 +331,16 @@ describe('CampaignChat — dice pool commit', () => {
     const { user } = await openDockWithSession()
     await user.click(screen.getByRole('button', { name: /roll|dice/i }))
     await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    const modifierInput = screen.getByRole('textbox', { name: 'Modifier' })
+    await user.clear(modifierInput)
+    await user.type(modifierInput, '5')
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Roll visibility' }), 'dm-only')
     await user.click(screen.getByRole('button', { name: 'Roll' }))
 
     await waitFor(() => expect(screen.getByText('No active session')).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Add d20' })).toHaveTextContent('d20 ×1')
+    expect(modifierInput).toHaveValue('5')
+    expect(screen.getByRole('combobox', { name: 'Roll visibility' })).toHaveValue('dm-only')
   })
 
   it('Roll and pool controls are disabled while a commit is in flight, re-enabled after', async () => {

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
@@ -337,6 +337,75 @@ describe('CampaignChat — dice pool commit', () => {
     expect(screen.getByRole('button', { name: 'Add d20' })).toHaveTextContent('d20 ×1')
   })
 
+  it('Roll and pool controls are disabled while a commit is in flight, re-enabled after', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    let resolvePost: (value: unknown) => void
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return new Promise(resolve => { resolvePost = resolve })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Roll' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Add d20' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Remove d20' })).toBeDisabled()
+    })
+
+    resolvePost!({
+      ok: true, status: 201,
+      json: () => Promise.resolve({
+        id: 'roll-6', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+        formula: '1d20', rolls: [10], total: 10,
+        visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+      }),
+    })
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add d20' })).not.toBeDisabled())
+  })
+
+  it('non-409 failure (e.g. 500) shows inline error and preserves the staged pool', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => expect(screen.getByText('Roll failed, try again')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Add d20' })).toHaveTextContent('d20 ×1')
+  })
+
+  it('a thrown rollDicePool error is caught and shows inline error instead of crashing', async () => {
+    mockedRollDicePool.mockImplementation(() => { throw new Error('boom') })
+    sharedTestState.fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => expect(screen.getByText('Roll failed, try again')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Roll' })).not.toBeDisabled()
+  })
+
   it('DM-only visibility sends correct scope', async () => {
     mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
     sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {

--- a/tests/unit/lib/dice.test.ts
+++ b/tests/unit/lib/dice.test.ts
@@ -1,4 +1,4 @@
-import { rollDie } from "@/lib/utils/dice";
+import { rollDie, rollDicePool } from "@/lib/utils/dice";
 
 // ---------------------------------------------------------------------------
 // Supported die sizes and default count behaviour
@@ -126,5 +126,73 @@ describe("rollDie – crypto unavailable", () => {
         configurable: true,
       });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rollDicePool – multi-group dice pool
+// ---------------------------------------------------------------------------
+describe("rollDicePool – single-group pool", () => {
+  it("returns tagged results for a single group", () => {
+    const result = rollDicePool([{ sides: 6, count: 2 }]);
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(entry.sides).toBe(6);
+      expect(entry.value).toBeGreaterThanOrEqual(1);
+      expect(entry.value).toBeLessThanOrEqual(6);
+    }
+  });
+});
+
+describe("rollDicePool – mixed-group pool", () => {
+  it("returns results tagged by their own group's sides, in group order", () => {
+    const result = rollDicePool([
+      { sides: 6, count: 2 },
+      { sides: 8, count: 2 },
+    ]);
+    expect(result).toHaveLength(4);
+    expect(result[0].sides).toBe(6);
+    expect(result[1].sides).toBe(6);
+    expect(result[2].sides).toBe(8);
+    expect(result[3].sides).toBe(8);
+    expect(result[0].value).toBeGreaterThanOrEqual(1);
+    expect(result[0].value).toBeLessThanOrEqual(6);
+    expect(result[2].value).toBeGreaterThanOrEqual(1);
+    expect(result[2].value).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("rollDicePool – empty group list", () => {
+  it("returns an empty array without error", () => {
+    expect(rollDicePool([])).toEqual([]);
+  });
+});
+
+describe("rollDicePool – validation", () => {
+  it("rejects the whole call when any group has an unsupported die size", () => {
+    expect(() =>
+      rollDicePool([
+        { sides: 6, count: 1 },
+        { sides: 7, count: 1 },
+      ])
+    ).toThrow("Unsupported die size");
+  });
+
+  it("rejects the whole call when any group has an invalid count", () => {
+    expect(() => rollDicePool([{ sides: 6, count: 0 }])).toThrow("Invalid count");
+  });
+});
+
+describe("rollDicePool – unbiased randomness smoke check", () => {
+  it("produces values across the full 1..sides range with no out-of-range values", () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 200; i++) {
+      const [{ sides, value }] = rollDicePool([{ sides: 6, count: 1 }]);
+      expect(sides).toBe(6);
+      expect(value).toBeGreaterThanOrEqual(1);
+      expect(value).toBeLessThanOrEqual(6);
+      seen.add(value);
+    }
+    expect(seen.size).toBe(6);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `rollDicePool(groups)` to `lib/utils/dice.ts` — rolls a mixed set of `{sides, count}` groups and returns `{sides, value}[]` per individual die, reusing the existing `rollOneDie`/`getCrypto` secure-randomness helpers. `rollDie` and its callers (`InitiativeEntry`, `lib/utils/combat.ts`) are unchanged.
- Replaces the always-visible `RollEntryStrip` in `lib/components/CampaignChat.tsx` with a `DicePoolTrigger` (d20 button) that opens a `DicePoolPortal` — the first React portal in this codebase — rendered to a lazily-created overlay root under `document.body`, `fixed`-positioned from the trigger and recomputed on resize/scroll.
- The pop-out lets a player stage any mix of d4–d20 plus a modifier; nothing rolls or posts until an explicit "Roll" commit, including a pool of exactly one die.
- Commit flattens the staged pool into the existing `/api/campaigns/[id]/rolls` POST shape (`formula`, `rolls`, `total`, `visibility`) — zero changes to the API or `CampaignRoll` type.

## Testing

- `npm run test:unit` — 214 suites / 2758 tests pass
- `npm run typecheck` — clean
- `npm run build` — succeeds

Closes #509