### PR TITLE
fix: dice icon sizing, tooltips, content-driven panel height, and roll auto-scroll

### DIFF
--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -551,10 +551,18 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
     ? members.filter(m => m.status === 'active' && m.username.toLowerCase().startsWith(mentionQuery.toLowerCase()))
     : []
 
-  function scrollToBottom() {
+  function scrollToBottom(force = false) {
     requestAnimationFrame(() => {
       const container = feedRef.current
       if (!container) return
+      if (!force) {
+        // Don't yank a user who has scrolled up to read history (or is
+        // sitting at scrollTop 0 to trigger the older-page load below)
+        // down to the bottom just because a roll from another player came in.
+        const distanceFromBottom =
+          container.scrollHeight - container.scrollTop - container.clientHeight
+        if (distanceFromBottom > 100) return
+      }
       container.scrollTo?.({ top: container.scrollHeight, behavior: 'smooth' })
     })
   }
@@ -864,7 +872,9 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
     if (seenIds.current.has(roll.id)) return
     seenIds.current.add(roll.id)
     setFeed(prev => [...prev, { kind: 'roll', data: roll }])
-    scrollToBottom()
+    // Always pull the roller down to their own roll, even if they'd
+    // scrolled up — this is a direct result of their own action.
+    scrollToBottom(true)
   }
 
   function handleSceneSuccess(msg: CampaignMessage) {

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -552,18 +552,22 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
     : []
 
   function scrollToBottom(force = false) {
+    // Measure proximity to the bottom now, before the pending feed update
+    // commits — measuring inside the rAF below would include the height of
+    // the roll card that's about to be appended, making every remote roll
+    // look "far away" even when the user was already at the bottom.
+    const container = feedRef.current
+    const wasNearBottom = container
+      ? container.scrollHeight - container.scrollTop - container.clientHeight <= 100
+      : true
     requestAnimationFrame(() => {
-      const container = feedRef.current
-      if (!container) return
-      if (!force) {
-        // Don't yank a user who has scrolled up to read history (or is
-        // sitting at scrollTop 0 to trigger the older-page load below)
-        // down to the bottom just because a roll from another player came in.
-        const distanceFromBottom =
-          container.scrollHeight - container.scrollTop - container.clientHeight
-        if (distanceFromBottom > 100) return
-      }
-      container.scrollTo?.({ top: container.scrollHeight, behavior: 'smooth' })
+      const el = feedRef.current
+      if (!el) return
+      // Don't yank a user who has scrolled up to read history (or is
+      // sitting at scrollTop 0 to trigger the older-page load below)
+      // down to the bottom just because a roll from another player came in.
+      if (!force && !wasNearBottom) return
+      el.scrollTo?.({ top: el.scrollHeight, behavior: 'smooth' })
     })
   }
 

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -386,19 +386,19 @@ function DiceTriggerButton({
         disabled={dp.isTriggerDisabled}
         aria-label="Roll dice"
         aria-expanded={dp.isOpen}
+        title="Dice Rolls for main screen pop out"
         className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-full flex items-center gap-1"
       >
-        <DiceD20Icon width={16} height={16} aria-hidden="true" />
+        <DiceD20Icon width={24} height={24} aria-hidden="true" />
       </button>
     </div>
   )
 }
 
 function DicePoolPanel({
-  dp, heightPx, panelRef,
+  dp, panelRef,
 }: {
   dp: DicePool
-  heightPx: string
   panelRef: React.RefObject<HTMLDivElement | null>
 }) {
   if (!dp.isOpen) return null
@@ -407,7 +407,6 @@ function DicePoolPanel({
       ref={panelRef}
       aria-label="Dice pool"
       className="bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-3 w-64 flex-shrink-0 overflow-y-auto"
-      style={{ height: heightPx }}
     >
       <div className="flex flex-col gap-2">
         <div className="flex flex-wrap gap-1 items-center">
@@ -429,9 +428,10 @@ function DicePoolPanel({
                   onClick={() => dp.handleAdd(sides)}
                   disabled={dp.isRolling}
                   aria-label={`Add d${sides}`}
+                  title={`d${sides}`}
                   className="text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white px-2 py-1 rounded flex items-center gap-1"
                 >
-                  <Icon width={14} height={14} aria-hidden="true" />
+                  <Icon width={21} height={21} aria-hidden="true" />
                   ×{dp.pool[sides]}
                 </button>
               </div>
@@ -523,7 +523,6 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
 
   const [feed, setFeed] = useState<FeedItem[]>([])
   const seenIds = useRef<Set<string>>(new Set())
-  const pendingScrollRef = useRef(false)
 
   const [members, setMembers] = useState<EnrichedMember[]>([])
 
@@ -552,6 +551,14 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
     ? members.filter(m => m.status === 'active' && m.username.toLowerCase().startsWith(mentionQuery.toLowerCase()))
     : []
 
+  function scrollToBottom() {
+    requestAnimationFrame(() => {
+      const container = feedRef.current
+      if (!container) return
+      container.scrollTo?.({ top: container.scrollHeight, behavior: 'smooth' })
+    })
+  }
+
   // ── SSE stream ──
   function onStreamEvent(e: CampaignStreamEvent) {
     if (e.type === 'message') {
@@ -567,6 +574,7 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
       if (seenIds.current.has(roll.id)) return
       seenIds.current.add(roll.id)
       setFeed(prev => [...prev, { kind: 'roll', data: roll }])
+      scrollToBottom()
     } else if (e.type === 'session') {
       onSessionChange?.(e.data.activeSessionId)
     }
@@ -721,15 +729,6 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
     return () => container.removeEventListener('scroll', handleScroll)
   }, [isExpanded, campaignId])
 
-  // ── Auto-scroll to a roll the current user just posted ──
-  useEffect(() => {
-    if (!pendingScrollRef.current) return
-    pendingScrollRef.current = false
-    const container = feedRef.current
-    if (!container) return
-    container.scrollTo?.({ top: container.scrollHeight, behavior: 'smooth' })
-  }, [feed])
-
   // ── Handlers ──
 
   function handleDragStart(startY: number, startHeight: number) {
@@ -864,8 +863,8 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
   function handleRollPosted(roll: CampaignRoll) {
     if (seenIds.current.has(roll.id)) return
     seenIds.current.add(roll.id)
-    pendingScrollRef.current = true
     setFeed(prev => [...prev, { kind: 'roll', data: roll }])
+    scrollToBottom()
   }
 
   function handleSceneSuccess(msg: CampaignMessage) {
@@ -909,7 +908,7 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
 
   return (
     <div className={rowWrapperClass}>
-      <DicePoolPanel dp={dicePool} heightPx={resolvedHeight} panelRef={dicePanelRef} />
+      <DicePoolPanel dp={dicePool} panelRef={dicePanelRef} />
       <div
         ref={drawerRef}
         role="complementary"

--- a/lib/components/CampaignChat.tsx
+++ b/lib/components/CampaignChat.tsx
@@ -586,7 +586,12 @@ export function CampaignChat({ campaignId, activeSessionId = null, onSessionChan
       if (seenIds.current.has(roll.id)) return
       seenIds.current.add(roll.id)
       setFeed(prev => [...prev, { kind: 'roll', data: roll }])
-      scrollToBottom()
+      // If this is the local user's own roll winning the SSE/POST race
+      // (echoed back before the POST response resolves), force-scroll it
+      // the same as handleRollPosted would — otherwise handleRollPosted's
+      // seenIds guard short-circuits before it ever runs, and a roller
+      // who'd scrolled up would silently miss their own roll.
+      scrollToBottom(roll.rollerId === user?.userId)
     } else if (e.type === 'session') {
       onSessionChange?.(e.data.activeSessionId)
     }

--- a/openspec/changes/dice-panel-scroll-fixes/.openspec.yaml
+++ b/openspec/changes/dice-panel-scroll-fixes/.openspec.yaml
@@ -1,2 +1,2 @@
-schema: spec-driven
+schema: sdd-with-feedback-loop
 created: 2026-08-21

--- a/openspec/changes/dice-panel-scroll-fixes/.openspec.yaml
+++ b/openspec/changes/dice-panel-scroll-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/dice-panel-scroll-fixes/design.md
+++ b/openspec/changes/dice-panel-scroll-fixes/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`lib/components/CampaignChat.tsx` currently implements the dice UI shipped by `dice-roll-enhancements` (archived 2026-08-20):
+
+- `DiceTriggerButton` renders `<DiceD20Icon width={16} height={16} aria-hidden="true" />` with no `title`.
+- `DicePoolPanel` renders each per-die button's icon as `<Icon width={14} height={14} aria-hidden="true" />` with no `title`, and the panel's root `<div>` takes `style={{ height: heightPx }}` where `heightPx={resolvedHeight}` — the same value used for the chat drawer's own height (`CampaignChat.tsx:912`). The panel's content (six die controls, a modifier input, a visibility select, and a Roll button) is a fixed, small height, so whenever `resolvedHeight` exceeds that content height — which is most of the time, since `resolvedHeight` follows the user's drag-resized or default drawer height — the panel shows dead space below its controls.
+- A single `pendingScrollRef` (a `useRef(false)`) gates a `useEffect` keyed on `[feed]` that calls `container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' })` when the ref is `true`, then resets it. The ref is set to `true` in exactly one place: `handleRollPosted`, which is called from the dice pool's commit-success path (the local POST response). It is never set from `onStreamEvent`'s `'roll'` branch, which is what appends rolls broadcast over SSE — including the broadcast of the local user's own roll, echoed back to their own connection.
+
+That last point creates the reported bug, not just a scoping gap: `handleRollPosted` and the SSE `'roll'` handler both guard against duplicate ids via the same `seenIds` ref. Whichever one runs *first* for a given roll id wins; the other returns early. If the SSE echo of the user's own roll arrives at (or before) the same tick as the POST-response callback, the SSE path adds the roll to `feed` (without touching `pendingScrollRef`), and `handleRollPosted` then finds `seenIds.current.has(roll.id)` true and returns before ever setting `pendingScrollRef`. No scroll happens — for anyone, including the roller. This is a race, not a deterministic failure, which is consistent with the issue reporter describing it as happening but not investigating further.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Increase the two existing icon call-sites' `width`/`height` by 50% (16→24, 14→21). No change to the icon components themselves (`lib/components/icons/dice.tsx`).
+- Add native `title` attributes to the trigger button and each per-die pool button. No new tooltip component, no new dependency.
+- Make the dice panel's height content-driven, not drawer-height-driven, eliminating dead space regardless of the drawer's current (possibly drag-resized) height.
+- Make dice-roll auto-scroll unconditional on *who* rolled and *which code path* appended the roll to the feed — SSE stream event or local POST-response callback both trigger it, exactly once per roll, with no dependency on which one wins a race.
+- Keep the fix scoped to dice rolls. Plain chat messages' scroll behavior is unchanged (they still never auto-scroll) — this is an explicit, deliberate scope boundary from the proposal, not an oversight.
+
+**Non-Goals:**
+- No change to `lib/utils/dice.ts`, the roll data model, or the `/api/campaigns/[id]/rolls` API contract.
+- No general "scroll to bottom for any new feed item" behavior — that would need a near-bottom heuristic to avoid yanking a user reading scrollback, which is out of scope for this fast-follow.
+- No generalized tooltip system for the rest of the app.
+- No re-litigating the flex-sibling panel-placement decision (`roll-share-ui`'s "renders as an in-flow flex sibling to the left of the chat dock") — only its height-matching sub-requirement changes.
+
+## Decisions
+
+### D1: Icon size — bump the two call-site props, not the icon components
+
+The vendored icon components (`DiceD4Icon` … `DiceD20Icon`) already accept `width`/`height`/`className` as pass-through props (per `dice-iconography`'s "Icon components are stylable like existing hand-rolled icons" requirement); no default size is baked into the components themselves. So a 50% increase is purely a call-site change: `16→24` at `DiceTriggerButton` (`CampaignChat.tsx:391`) and `14→21` at `DicePoolPanel`'s per-die button (`CampaignChat.tsx:434`).
+
+**Alternatives considered:** Adding a `size` prop or default to the icon components — rejected; the components are already appropriately sized-by-caller per the existing `dice-iconography` spec, and both current call sites are the only two places dice icons render, so a shared default would be one indirection with no reuse benefit.
+
+### D2: Tooltips via native `title`, not a tooltip component
+
+Use the browser-native `title` attribute on the trigger button (`"Dice Rolls for main screen pop out"`) and on each per-die pool button (`"d4"`, `"d6"`, …, `"d20"`, matching that button's `aria-label`/die size). This is consistent with `dice-roll-enhancements`' D1 decision to avoid adding any dependency for the (small, static) dice UI, and the project currently has zero tooltip primitives anywhere in the codebase — introducing one for six buttons would be disproportionate.
+
+**Alternatives considered:**
+- A custom `<Tooltip>` component (e.g., positioned `<div>` shown on hover/focus): rejected — adds new UI surface, new CSS, and new test surface (hover/focus-trigger timing) for a problem the native attribute already solves; would only be justified if the app needed richer tooltip content (e.g., formatted text, links) elsewhere, which it doesn't today.
+- A UI library tooltip primitive (e.g., Radix): rejected — new dependency, same reasoning as `dice-roll-enhancements` D1's rejection of an icon package for six static SVGs.
+
+### D3: Dice panel height — drop `heightPx`, let the panel size to content
+
+Remove the `heightPx` prop from `DicePoolPanel` (and the `style={{ height: heightPx }}` it drives) entirely; the panel's outer `<div>` keeps its existing `w-64 flex-shrink-0 overflow-y-auto` classes but no longer receives an explicit `height`, so it sizes to its content's natural height (six die-control rows + modifier/visibility row + Roll button + any error text). This reverses `roll-share-ui`'s "the panel SHALL match the drawer's current height" sub-requirement, which was `dice-roll-enhancements`' D3 — that decision aimed to keep the panel and drawer as "one visually contiguous block," but in practice produces exactly the dead-space complaint in issue #514. The panel remains a flex sibling positioned to the left of the drawer (that placement is unchanged); only its height source changes.
+
+**Alternatives considered:**
+- Keep height-matching but vertically center the panel's content within it: rejected — still wastes screen space and adds unnecessary layout complexity (flex-centering inside a fixed-height sibling) for no benefit once the "contiguous block" framing is dropped.
+- Cap `heightPx` at some smaller fixed value (e.g., `min(resolvedHeight, 300)`): rejected — reintroduces an arbitrary magic number and still couples the panel's height to the drawer's, when the actual requirement is "no dead space," which content-driven sizing satisfies directly and simply.
+- Keep `overflow-y-auto` even though it's no longer load-bearing for clipping (content is short and no longer height-constrained): kept anyway as a defensive floor — if a future die size or control is added and the panel's natural content height somehow exceeds the viewport, scrolling is a safe fallback rather than an unbounded/clipped panel.
+
+### D4: Auto-scroll — a single `scrollToBottom()` call reachable from both append paths, no ref-based race
+
+Replace the `pendingScrollRef`-gated effect with a direct call at the point each dice roll is appended to `feed`: both `handleRollPosted` (local POST-response callback) and the `'roll'` branch of `onStreamEvent` (SSE) call the same `scrollToBottom()` helper immediately after their `setFeed` call, wrapped in `requestAnimationFrame` so it runs after the DOM reflects the new item (mirroring the existing `requestAnimationFrame(() => { container.scrollTop = ... })` pattern already used by the infinite-scroll-up handler at `CampaignChat.tsx:713`). Because `seenIds` already deduplicates a given roll id to exactly one of the two append paths, `scrollToBottom()` fires exactly once per roll regardless of which path wins the race — eliminating the race itself rather than trying to make the ref win more reliably.
+
+**Alternatives considered:**
+- Fix the race by setting `pendingScrollRef.current = true` in both places before the dedup check: rejected — still indirect (state flag + separate effect) for no benefit over calling the scroll function directly at the append site; the ref-plus-effect indirection was only ever needed if scrolling depended on `feed` having already re-rendered, but `requestAnimationFrame` after `setFeed` already gets that for free, same as the existing infinite-scroll-up code does.
+- Track "am I near the bottom" and only auto-scroll if so (a common chat-UX guard): rejected as unnecessary for this fix — the proposal scope is dice rolls specifically (a comparatively rare, high-signal event a player wants to see immediately), not high-frequency chat messages where a near-bottom guard matters more. Revisit if this pattern is ever extended to plain messages.
+- Debounce/coalesce scroll calls for rapid successive rolls (e.g., a dice-pool commit posting many rolls quickly): not needed — each commit posts exactly one combined roll (`roll-share-ui`'s "Commit rolls the entire staged pool as one combined roll"), so multiple rapid roll events are not expected in normal use; `scrollTo` is idempotent (scrolling to the same bottom position repeatedly is a no-op) if it ever does happen.
+
+## Risks / Trade-offs
+
+- [Risk] Removing the height-match could make the panel and drawer look visually disconnected (the "contiguous block" framing `dice-roll-enhancements` D3 wanted is gone) → Mitigation: both remain flex siblings with matching top alignment and consistent `bg-gray-800 border border-gray-700` styling; visual contiguity was never load-bearing for functionality, only aesthetics, and the issue reporter explicitly asked for exactly this trade-off (less dead space over matched height).
+- [Risk] Unconditional auto-scroll on every dice roll could yank a user who deliberately scrolled up to read roll history while a roll comes in from another player → Mitigation: explicitly accepted by the proposal (issue #514's ask is unconditional-for-rolls); a near-bottom guard is called out as a non-goal here and can be added later as a separate, scoped follow-up if it becomes a complaint.
+- [Risk] `title` tooltips are less discoverable/stylable than a rich tooltip (no delay tuning, inconsistent OS-level rendering, not usable on touch without a long-press) → Mitigation: acceptable for a first pass matching the issue's literal ask; `aria-label`s (already present) continue to carry the accessible name, so `title` is purely a supplementary hover affordance, not the sole source of the button's meaning.
+
+## Migration Plan
+
+No data migration. This is a UI-only change to a single client component and its existing icon module call sites. Deploy as a normal PR merge; no feature flag, no phased rollout — the prior behavior (small icons, no tooltips, height-matched panel, self-roll-only/racy auto-scroll) has no dependents outside `CampaignChat.tsx` itself. Rollback is a plain revert if needed.

--- a/openspec/changes/dice-panel-scroll-fixes/design.md
+++ b/openspec/changes/dice-panel-scroll-fixes/design.md
@@ -66,3 +66,10 @@ Replace the `pendingScrollRef`-gated effect with a direct call at the point each
 ## Migration Plan
 
 No data migration. This is a UI-only change to a single client component and its existing icon module call sites. Deploy as a normal PR merge; no feature flag, no phased rollout — the prior behavior (small icons, no tooltips, height-matched panel, self-roll-only/racy auto-scroll) has no dependents outside `CampaignChat.tsx` itself. Rollback is a plain revert if needed.
+
+## Operational Blocking Policy
+
+- **CI failure** (unit tests, typecheck, build): blocking — must be fixed before merge. No override.
+- **Failing/flaky auto-scroll or panel-height test**: blocking — these encode the exact race condition and dead-space bugs this change exists to fix; do not skip or `.skip()` them.
+- **Code review findings from `pr-review-toolkit:review-pr` or the Verity quality gate**: blocking for anything within this change's declared scope (icon size, tooltips, panel height, auto-scroll). Findings against pre-existing code outside that scope (e.g. the unbounded modifier input, overall file size) are non-blocking for *this* PR — they must be triaged as either an explicit scope amendment to this proposal (with proposal/design updated first, per the change-control note) or filed as a separate follow-up change, but they do not gate this merge. The unbounded-modifier-input finding was triaged this way: filed as [issue #516](https://github.com/dougis-org/session-combat/issues/516), left unfixed here.
+- **Manual smoke-test failure** (task 5.2-equivalent in `tasks.md`): blocking if a regression is observed in the browser that the automated suite didn't catch; non-blocking (may proceed with a tracked follow-up) if the browser check simply couldn't be run due to environment limitations, provided automated coverage of the same behavior is green.

--- a/openspec/changes/dice-panel-scroll-fixes/proposal.md
+++ b/openspec/changes/dice-panel-scroll-fixes/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+GitHub issue #514 is direct user feedback on the `dice-roll-enhancements` change (issue #512 / PR #513), which shipped today (2026-08-20). Four problems were reported against the shipped feature; this proposal addresses all four:
+
+1. The dice icons (added to replace text/emoji glyphs) are too small to read comfortably.
+2. Neither the dice trigger button nor the per-die pool buttons expose a tooltip, so a new player has no way to discover what a bare icon means.
+3. The dice panel force-matches the chat drawer's full (drag-resizable) height, per `roll-share-ui`'s existing requirement "the panel SHALL match the drawer's current height" — but the panel's own content is only ~4 rows tall, so most of that height is empty space. This is a deliberate design decision from `dice-roll-enhancements` (D3) that did not hold up once used.
+4. The chat feed does not auto-scroll to a newly posted dice roll for *any* user — including the roller themselves. `roll-share-ui`'s existing "Feed auto-scrolls to a roll the current user just posted" requirement was intended to at least cover the self-roll case, but a verified race condition defeats it in practice: when the SSE `roll` broadcast reaches the poster's own connection before (or racing) the POST-response callback, the SSE path adds the roll to the feed without setting the scroll flag, and the POST-response path's duplicate-id guard then returns early without ever setting it either. So self-scroll silently fails whenever that race is lost — which is what the issue reporter observed.
+
+Why now: the underlying feature merged today, so this is a fast-follow fix on a live gap rather than a new initiative.
+
+## What Changes
+
+- Increase dice icon sizes by 50% in both call sites: the trigger button's d20 icon (16px → 24px) and each per-die pool button's icon (14px → 21px).
+- Add native `title` attributes (no new tooltip component/dependency): "Dice Rolls for main screen pop out" on the trigger button, and "d4"/"d6"/"d8"/"d10"/"d12"/"d20" on each matching per-die pool button.
+- Remove the dice panel's forced height-match to the chat drawer (`heightPx={resolvedHeight}`); the panel sizes to its own content instead (`height: auto`), eliminating the dead space below its controls. **BREAKING** (spec-level): reverses the "panel SHALL match the drawer's current height" requirement from `roll-share-ui`.
+- Auto-scroll the feed to the bottom for every new dice roll, for every user, regardless of whether the roll enters the feed via the SSE stream event or the local POST-response callback — closing the self-roll race and extending scroll behavior to rolls from other players. **BREAKING** (spec-level): reverses the "A roll from another player does not trigger auto-scroll" requirement from `roll-share-ui`. Auto-scroll remains scoped to dice rolls only; plain chat messages are explicitly out of scope (unchanged).
+
+## Capabilities
+
+### New Capabilities
+
+*(none)*
+
+### Modified Capabilities
+
+- `roll-share-ui`:
+  - "MODIFIED Dice pop-out trigger anchored to the chat dock" — trigger's d20 icon size increases and gains a `title` tooltip.
+  - "MODIFIED Dice staging pool" — each per-die icon's size increases and gains a `title` tooltip matching its die size.
+  - "MODIFIED Dice panel renders as an in-flow flex sibling to the left of the chat dock" — drops the height-matching requirement; panel height becomes content-driven instead of drawer-driven.
+  - "MODIFIED Feed auto-scrolls to a roll the current user just posted" — broadens to auto-scroll on any dice roll from any user, and fixes the self-roll race so the current user's own roll reliably scrolls too.
+
+## Impact
+
+- **Code**: `lib/components/CampaignChat.tsx` (`DiceTriggerButton`, `DicePoolPanel`, the roll-auto-scroll effect, the SSE `'roll'` stream handler, `handleRollPosted`), `lib/components/icons/dice.tsx` (icon size props at call sites only — no changes to the icon components themselves).
+- **Tests**: `tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx`, `tests/unit/lib/components/icons/dice.test.tsx` (if size assertions exist), and any test asserting the old "no auto-scroll for other players' rolls" or "panel matches drawer height" behavior must be updated to the new expected behavior.
+- **Specs**: `openspec/specs/roll-share-ui/spec.md` gets delta requirements per "Modified Capabilities" above. `openspec/specs/dice-iconography/spec.md` is unaffected (icon size/tooltip are call-site concerns, not properties of the icon components themselves).
+- **No backend, API, or `lib/utils/dice.ts` changes.** No changes to `CampaignRoll`/`CampaignMessage` data models or the `/api/campaigns/[id]/rolls` contract.
+- **No new dependencies.** Tooltips use the native `title` attribute; no tooltip library is introduced.

--- a/openspec/changes/dice-panel-scroll-fixes/specs/roll-share-ui/spec.md
+++ b/openspec/changes/dice-panel-scroll-fixes/specs/roll-share-ui/spec.md
@@ -1,0 +1,181 @@
+## MODIFIED Requirements
+
+### Requirement: MODIFIED Dice panel renders as an in-flow flex sibling to the left of the chat dock
+
+The system SHALL render the dice panel (staging pool, modifier, visibility selector, and commit control) as an in-flow flex sibling positioned to the left of the `CampaignChat` drawer, mounted only while the panel is open, rather than as a `position: fixed` overlay portaled to `document.body`. The panel SHALL size its height to its own content (not to the drawer's height); the panel and drawer are no longer required to share the same height.
+
+#### Scenario: Dice panel DOM node is a sibling of the drawer, not a document.body portal
+
+- **Given** the dice panel is open
+- **When** the DOM is queried
+- **Then** the panel's root element is found as a sibling of the chat dock's `role="complementary"` drawer element (both children of the same flex-row wrapper), and is NOT rendered under a separate `document.body`-attached overlay root
+
+#### Scenario: Dice panel appears to the left of the chat drawer
+
+- **Given** the dice panel is open
+- **When** the bounding positions of the panel and the drawer are compared
+- **Then** the panel's horizontal position is entirely to the left of the drawer's horizontal position (the panel does not overlap the drawer)
+
+#### Scenario: Dice panel is not clipped by the drawer's height/overflow constraint
+
+- **Given** the chat dock drawer has a fixed height and `overflow` constraint (as it does today via `customHeight`/dock sizing)
+- **When** the dice panel is open
+- **Then** the panel renders fully visible and unclipped, at its own content-driven height, independent of the drawer's current height
+
+#### Scenario: Dice panel height matches its content, not the drawer's height
+
+- **Given** the dice panel is open and the chat drawer's current height is substantially taller than the panel's content (e.g. the drawer has been drag-resized to a large height)
+- **When** the panel's rendered height is measured
+- **Then** the panel's height reflects only its own content (the die controls, modifier/visibility row, and Roll button, plus any inline error text) and does not extend to match the drawer's height
+
+#### Scenario: Dice panel closes on outside click
+
+- **Given** the panel is open
+- **When** the user clicks outside both the panel and the trigger
+- **Then** the panel closes
+
+#### Scenario: Dice panel closes on Escape
+
+- **Given** the panel is open
+- **When** the user presses Escape
+- **Then** the panel closes
+
+#### Scenario: Dice panel is absent from the DOM when closed
+
+- **Given** the panel is closed
+- **When** the DOM is queried
+- **Then** no dice panel element is present, and no overlay-root DOM node is created for it
+
+---
+
+### Requirement: MODIFIED Feed auto-scrolls on a new dice roll, for any user
+
+The system SHALL scroll the chat feed so a newly appended dice roll is visible immediately after it is appended, regardless of whether the roll was committed by the current user or arrived via the SSE stream from another player, and regardless of which code path (local POST-response callback or SSE stream event) is the one that appends it to the feed. Auto-scroll SHALL fire exactly once per roll. The feed's item order is unaffected. Auto-scroll does NOT apply to plain chat messages (unchanged from today: messages never auto-scroll).
+
+#### Scenario: Committing a roll scrolls the feed to show it
+
+- **Given** the feed is scrolled such that the bottom is not visible, and the dice panel is open with a non-empty staged pool
+- **When** the user clicks "Roll" and the commit succeeds (POST returns 201)
+- **Then** the feed container's scroll position moves so the newly-appended roll item is visible, without requiring the user to scroll manually
+
+#### Scenario: A roll from another player also triggers auto-scroll
+
+- **Given** the feed is scrolled such that the bottom is not visible
+- **When** an SSE `roll` event for a roll posted by a different user arrives and is appended to the feed
+- **Then** the feed container's scroll position moves so the newly-appended roll item is visible
+
+#### Scenario: The current user's own roll scrolls the feed even if the SSE echo of it arrives before the POST response
+
+- **Given** the feed is scrolled such that the bottom is not visible, and the current user has just committed a roll
+- **When** the SSE broadcast of that same roll (identified by its id) is delivered to the current user's own connection before, at the same time as, or after the local POST-response callback for that roll
+- **Then** the feed still scrolls to show the roll exactly once, regardless of the order in which the two events are processed
+
+#### Scenario: Auto-scroll does not reorder the feed
+
+- **Given** the feed contains items in chronological order
+- **When** a roll is appended and the auto-scroll occurs
+- **Then** the feed's item order is unchanged (the new roll remains the last item, appended in place; it is not moved to the top or re-sorted)
+
+#### Scenario: A new chat message does not trigger auto-scroll
+
+- **Given** the feed is scrolled such that the bottom is not visible
+- **When** a new `message`-kind item (from either the composer's optimistic append or an SSE `message` event) is appended to the feed
+- **Then** the feed's scroll position does not change
+
+---
+
+### Requirement: MODIFIED Dice pop-out trigger anchored to the chat dock
+
+The system SHALL display a persistent dice-pool trigger button anchored at the bottom of the chat dock, which opens/closes the dice pool panel on click. The trigger SHALL render the vendored d20 icon (see `dice-iconography` capability) at 24x24px (a 50% increase from the icon size shipped by `dice-roll-enhancements`), instead of literal `d20` text, while keeping its existing accessible name (matching `/roll|dice/i`) unchanged. The trigger SHALL carry a `title` attribute of "Dice Rolls for main screen pop out".
+
+#### Scenario: Trigger renders and is enabled when a session is active
+
+- **Given** a campaign page where `activeSessionId` is a non-null string
+- **When** the chat dock renders
+- **Then** a button with accessible name matching `/roll|dice/i` is visible and enabled at the bottom of the chat dock
+
+#### Scenario: Trigger is disabled when no active session
+
+- **Given** a campaign page where `activeSessionId` is null
+- **When** the chat dock renders
+- **Then** the dice pool trigger button is disabled and, if opened previously, the panel is closed
+
+#### Scenario: Clicking the trigger opens the panel
+
+- **Given** the trigger is enabled and the panel is closed
+- **When** the user clicks the trigger
+- **Then** the dice panel becomes visible in the document
+
+#### Scenario: Clicking the trigger again closes the panel
+
+- **Given** the panel is open
+- **When** the user clicks the trigger again
+- **Then** the dice panel is removed from the document
+
+#### Scenario: Trigger displays the d20 icon at the increased size, not text
+
+- **Given** the chat dock renders with an enabled trigger
+- **When** the trigger button's contents are inspected
+- **Then** it renders the vendored d20 icon component at 24x24px and does not render the literal text `d20`
+
+#### Scenario: Trigger exposes a tooltip on hover
+
+- **Given** the chat dock renders with an enabled trigger
+- **When** the trigger button's `title` attribute is inspected
+- **Then** it equals "Dice Rolls for main screen pop out"
+
+---
+
+### Requirement: MODIFIED Dice staging pool
+
+The system SHALL let the user add and remove dice of any supported size (d4, d6, d8, d10, d12, d20) to a staging pool within the dice panel, and edit a shared modifier, without issuing any roll or network request until the user explicitly commits. Each die-size control SHALL display that die size's vendored icon (see `dice-iconography` capability) at 21x21px (a 50% increase from the icon size shipped by `dice-roll-enhancements`) alongside its staged count, instead of a plain `d{sides}` text label, and SHALL carry a `title` attribute matching its die size (e.g. `"d20"`).
+
+#### Scenario: Adding a die increments its staged count
+
+- **Given** the panel is open and the pool is empty
+- **When** the user adds a d6 twice and a d8 twice
+- **Then** the pool shows a staged count of 2 for d6 and 2 for d8, and 0 for all other sizes
+- **AND** no network request has been made
+
+#### Scenario: Removing a die decrements its staged count
+
+- **Given** the pool has a staged count of 2 for d6
+- **When** the user removes one d6
+- **Then** the pool shows a staged count of 1 for d6
+
+#### Scenario: Staged count cannot go below zero
+
+- **Given** the pool has a staged count of 0 for d10
+- **When** the user attempts to remove a d10
+- **Then** the staged count for d10 remains 0 and no error is raised
+
+#### Scenario: Modifier is editable independent of staged dice
+
+- **Given** the pool is empty
+- **When** the user sets the modifier to -2
+- **Then** the modifier value is -2 and no die counts change
+
+#### Scenario: Each die-size control shows its matching icon at the increased size
+
+- **Given** the panel is open
+- **When** the six die-size add/remove controls are inspected
+- **Then** each control renders the icon from `DIE_ICONS` matching its own die size at 21x21px (e.g. the d20 control renders the d20 icon, not a d6 icon or plain text)
+
+#### Scenario: Each die-size control exposes a tooltip naming its die size
+
+- **Given** the panel is open
+- **When** the `title` attribute of the d20 add control is inspected
+- **Then** it equals "d20" (and analogously for d4, d6, d8, d10, d12)
+
+---
+
+## Traceability
+
+- Proposal element "Increase dice icon sizes by 50%" → Requirements: MODIFIED Dice pop-out trigger anchored to the chat dock; MODIFIED Dice staging pool
+- Proposal element "Add native `title` tooltips" → Requirements: MODIFIED Dice pop-out trigger anchored to the chat dock (tooltip scenario); MODIFIED Dice staging pool (tooltip scenario)
+- Proposal element "Remove the dice panel's forced height-match to the chat drawer" → Requirements: MODIFIED Dice panel renders as an in-flow flex sibling to the left of the chat dock
+- Proposal element "Auto-scroll the feed to the bottom for every new dice roll, for every user" → Requirements: MODIFIED Feed auto-scrolls on a new dice roll, for any user
+- Design decision D1 (icon size is a call-site prop change) → Requirements: MODIFIED Dice pop-out trigger anchored to the chat dock; MODIFIED Dice staging pool
+- Design decision D2 (native `title`, no tooltip component) → Requirements: MODIFIED Dice pop-out trigger anchored to the chat dock; MODIFIED Dice staging pool
+- Design decision D3 (content-driven panel height) → Requirements: MODIFIED Dice panel renders as an in-flow flex sibling to the left of the chat dock
+- Design decision D4 (scrollToBottom called from both append paths, no ref race) → Requirements: MODIFIED Feed auto-scrolls on a new dice roll, for any user

--- a/openspec/changes/dice-panel-scroll-fixes/tasks.md
+++ b/openspec/changes/dice-panel-scroll-fixes/tasks.md
@@ -1,0 +1,34 @@
+## 1. Icon sizes
+
+- [ ] 1.1 In `DiceTriggerButton`, change `<DiceD20Icon width={16} height={16} .../>` to `width={24} height={24}`.
+- [ ] 1.2 In `DicePoolPanel`'s per-die button, change `<Icon width={14} height={14} .../>` to `width={21} height={21}`.
+- [ ] 1.3 Update/verify any test asserting the old 16px/14px icon dimensions in `tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx`.
+
+## 2. Tooltips
+
+- [ ] 2.1 Add `title="Dice Rolls for main screen pop out"` to the trigger `<button>` in `DiceTriggerButton`.
+- [ ] 2.2 Add `title={`d${sides}`}` to each per-die add button in `DicePoolPanel` (matching its existing `aria-label={`Add d${sides}`}`).
+- [ ] 2.3 Add a test asserting the trigger button's `title` equals "Dice Rolls for main screen pop out".
+- [ ] 2.4 Add a test asserting each per-die button's `title` equals its die label (`d4`…`d20`).
+
+## 3. Dice panel content-driven height
+
+- [ ] 3.1 Remove the `heightPx` prop from `DicePoolPanel`'s type and destructuring.
+- [ ] 3.2 Remove `style={{ height: heightPx }}` from the panel's root `<div>`; keep `w-64 flex-shrink-0 overflow-y-auto` (or equivalent) so it still caps width and has a scroll fallback if content ever exceeds the viewport.
+- [ ] 3.3 Remove the `heightPx={resolvedHeight}` prop from the `<DicePoolPanel>` call site (`CampaignChat.tsx:912`).
+- [ ] 3.4 Update/add a test asserting the panel's rendered height reflects its content, not `resolvedHeight`/the drawer's height, when the drawer is resized to a large custom height.
+
+## 4. Auto-scroll on any dice roll
+
+- [ ] 4.1 Extract a `scrollToBottom()` helper (using `feedRef.current` and the existing `requestAnimationFrame` + `scrollTo({ top: scrollHeight, behavior: 'smooth' })` pattern) usable from both `handleRollPosted` and `onStreamEvent`'s `'roll'` branch.
+- [ ] 4.2 Call `scrollToBottom()` from `handleRollPosted` after `setFeed`, replacing the `pendingScrollRef.current = true` assignment.
+- [ ] 4.3 Call `scrollToBottom()` from `onStreamEvent`'s `'roll'` branch after `setFeed`, for every roll (not conditioned on who posted it).
+- [ ] 4.4 Remove the now-unused `pendingScrollRef` and its `useEffect` keyed on `[feed]`.
+- [ ] 4.5 Verify `onStreamEvent`'s `'message'` branch and the composer's optimistic message append do NOT call `scrollToBottom()` — auto-scroll stays scoped to dice rolls.
+- [ ] 4.6 Add/update tests: self-roll scrolls (POST-response path), other-player roll scrolls (SSE path), a duplicate roll id (SSE echo racing the POST response) still scrolls exactly once, and a new chat message does not trigger scroll.
+
+## 5. Verification
+
+- [ ] 5.1 Run the full `CampaignChat`/dice-pool test suite and confirm all tests pass, including the updated/added tests above.
+- [ ] 5.2 Manually smoke-test in a browser: open the dice panel, confirm no dead space below its controls at various drawer heights; roll a die and confirm the feed scrolls; confirm icons read clearly at the new size; confirm hovering each dice control shows its tooltip.
+- [ ] 5.3 Mark this task list complete with a link to the resulting PR.

--- a/openspec/changes/dice-panel-scroll-fixes/tasks.md
+++ b/openspec/changes/dice-panel-scroll-fixes/tasks.md
@@ -1,34 +1,122 @@
-## 1. Icon sizes
+# Tasks
 
-- [ ] 1.1 In `DiceTriggerButton`, change `<DiceD20Icon width={16} height={16} .../>` to `width={24} height={24}`.
-- [ ] 1.2 In `DicePoolPanel`'s per-die button, change `<Icon width={14} height={14} .../>` to `width={21} height={21}`.
-- [ ] 1.3 Update/verify any test asserting the old 16px/14px icon dimensions in `tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx`.
+Issue-driven: yes — GitHub issue #514 ("Dice roll improvements").
 
-## 2. Tooltips
+## Preparation
 
-- [ ] 2.1 Add `title="Dice Rolls for main screen pop out"` to the trigger `<button>` in `DiceTriggerButton`.
-- [ ] 2.2 Add `title={`d${sides}`}` to each per-die add button in `DicePoolPanel` (matching its existing `aria-label={`Add d${sides}`}`).
-- [ ] 2.3 Add a test asserting the trigger button's `title` equals "Dice Rolls for main screen pop out".
-- [ ] 2.4 Add a test asserting each per-die button's `title` equals its die label (`d4`…`d20`).
+- [x] **Step 1 — Sync default branch:** based on `main` (commit `ab6d0b8` at branch creation)
+- [x] **Step 2 — Create and publish working branch:** working in git worktree `worktree-dice-panel-scroll-fixes` (branch `worktree-dice-panel-scroll-fixes`) — **not yet pushed to origin**
 
-## 3. Dice panel content-driven height
+## Preflight
 
-- [ ] 3.1 Remove the `heightPx` prop from `DicePoolPanel`'s type and destructuring.
-- [ ] 3.2 Remove `style={{ height: heightPx }}` from the panel's root `<div>`; keep `w-64 flex-shrink-0 overflow-y-auto` (or equivalent) so it still caps width and has a scroll fallback if content ever exceeds the viewport.
-- [ ] 3.3 Remove the `heightPx={resolvedHeight}` prop from the `<DicePoolPanel>` call site (`CampaignChat.tsx:912`).
-- [ ] 3.4 Update/add a test asserting the panel's rendered height reflects its content, not `resolvedHeight`/the drawer's height, when the drawer is resized to a large custom height.
+- [ ] **Verify `pr-review-toolkit:review-pr` is available** — check the available skills list. Halt and prompt for installation if missing.
 
-## 4. Auto-scroll on any dice roll
+## Execution
 
-- [ ] 4.1 Extract a `scrollToBottom()` helper (using `feedRef.current` and the existing `requestAnimationFrame` + `scrollTo({ top: scrollHeight, behavior: 'smooth' })` pattern) usable from both `handleRollPosted` and `onStreamEvent`'s `'roll'` branch.
-- [ ] 4.2 Call `scrollToBottom()` from `handleRollPosted` after `setFeed`, replacing the `pendingScrollRef.current = true` assignment.
-- [ ] 4.3 Call `scrollToBottom()` from `onStreamEvent`'s `'roll'` branch after `setFeed`, for every roll (not conditioned on who posted it).
-- [ ] 4.4 Remove the now-unused `pendingScrollRef` and its `useEffect` keyed on `[feed]`.
-- [ ] 4.5 Verify `onStreamEvent`'s `'message'` branch and the composer's optimistic message append do NOT call `scrollToBottom()` — auto-scroll stays scoped to dice rolls.
-- [ ] 4.6 Add/update tests: self-roll scrolls (POST-response path), other-player roll scrolls (SSE path), a duplicate roll id (SSE echo racing the POST response) still scrolls exactly once, and a new chat message does not trigger scroll.
+- [ ] **Issue lifecycle: mark in-progress** — run `gh issue edit 514 --add-label "in-progress"`, then move the linked GitHub Project item to "In Progress" (discover project/field/option IDs via `gh project list --owner dougis-org --format json` and `gh project field-list --format json`; warn and skip if not found).
 
-## 5. Verification
+### 1. Icon sizes
 
-- [ ] 5.1 Run the full `CampaignChat`/dice-pool test suite and confirm all tests pass, including the updated/added tests above.
-- [ ] 5.2 Manually smoke-test in a browser: open the dice panel, confirm no dead space below its controls at various drawer heights; roll a die and confirm the feed scrolls; confirm icons read clearly at the new size; confirm hovering each dice control shows its tooltip.
-- [ ] 5.3 Mark this task list complete with a link to the resulting PR.
+- [x] 1.1 In `DiceTriggerButton`, change `<DiceD20Icon width={16} height={16} .../>` to `width={24} height={24}`.
+- [x] 1.2 In `DicePoolPanel`'s per-die button, change `<Icon width={14} height={14} .../>` to `width={21} height={21}`.
+- [x] 1.3 Update/verify any test asserting the old 16px/14px icon dimensions in `tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx`.
+
+### 2. Tooltips
+
+- [x] 2.1 Add `title="Dice Rolls for main screen pop out"` to the trigger `<button>` in `DiceTriggerButton`.
+- [x] 2.2 Add `title={`d${sides}`}` to each per-die add button in `DicePoolPanel` (matching its existing `aria-label={`Add d${sides}`}`).
+- [x] 2.3 Add a test asserting the trigger button's `title` equals "Dice Rolls for main screen pop out".
+- [x] 2.4 Add a test asserting each per-die button's `title` equals its die label (`d4`…`d20`).
+
+### 3. Dice panel content-driven height
+
+- [x] 3.1 Remove the `heightPx` prop from `DicePoolPanel`'s type and destructuring.
+- [x] 3.2 Remove `style={{ height: heightPx }}` from the panel's root `<div>`; keep `w-64 flex-shrink-0 overflow-y-auto` (or equivalent) so it still caps width and has a scroll fallback if content ever exceeds the viewport.
+- [x] 3.3 Remove the `heightPx={resolvedHeight}` prop from the `<DicePoolPanel>` call site (`CampaignChat.tsx:912`).
+- [x] 3.4 Update/add a test asserting the panel's rendered height reflects its content, not `resolvedHeight`/the drawer's height, when the drawer is resized to a large custom height.
+
+### 4. Auto-scroll on any dice roll
+
+- [x] 4.1 Extract a `scrollToBottom()` helper (using `feedRef.current` and the existing `requestAnimationFrame` + `scrollTo({ top: scrollHeight, behavior: 'smooth' })` pattern) usable from both `handleRollPosted` and `onStreamEvent`'s `'roll'` branch.
+- [x] 4.2 Call `scrollToBottom()` from `handleRollPosted` after `setFeed`, replacing the `pendingScrollRef.current = true` assignment.
+- [x] 4.3 Call `scrollToBottom()` from `onStreamEvent`'s `'roll'` branch after `setFeed`, for every roll (not conditioned on who posted it).
+- [x] 4.4 Remove the now-unused `pendingScrollRef` and its `useEffect` keyed on `[feed]`.
+- [x] 4.5 Verify `onStreamEvent`'s `'message'` branch and the composer's optimistic message append do NOT call `scrollToBottom()` — auto-scroll stays scoped to dice rolls.
+- [x] 4.6 Add/update tests: self-roll scrolls (POST-response path), other-player roll scrolls (SSE path), a duplicate roll id (SSE echo racing the POST response) still scrolls exactly once, and a new chat message does not trigger scroll.
+
+- [x] Implement sub-tasks in small, testable increments
+- [x] Look for existing tooling or functions in the codebase that can be reused or extended before writing new logic from scratch — reused the existing `requestAnimationFrame` + `scrollTo` pattern already used by the infinite-scroll-up handler
+- [x] Confirm acceptance criteria are covered — see `tests.md`
+
+## Pre-Commit Code Review
+
+- [ ] **Before every commit**, spawn a dedicated sub-agent to run the `openspec-review-code` skill. Automatically apply all clearly-correct findings, re-run tests, then commit.
+
+## Validation
+
+- [x] Run unit/integration tests — `npx jest tests/unit/components/CampaignChat` (115/115 passing)
+- [ ] Run E2E tests (if applicable)
+- [x] Run type checks — `npx tsc --noEmit -p tsconfig.json` (clean)
+- [ ] Run build
+- [ ] Run security/code quality checks required by project standards (Verity gate — see open findings below)
+- [ ] All completed tasks marked as complete
+- [ ] All steps in [Remote push validation]
+- [ ] Manual browser smoke test: open the dice panel, confirm no dead space below its controls at various drawer heights; roll a die and confirm the feed scrolls; confirm icons read clearly at the new size; confirm hovering each dice control shows its tooltip.
+
+### Open Verity gate findings (from prior automated pass)
+
+- [x] CRITICAL: Modifier input (`CampaignChat.tsx:448`) has no numeric range/size bound — **pre-existing code, out of this change's declared non-goals** (design.md: "No change to `lib/utils/dice.ts`, the roll data model, or the API contract"). Resolved as: filed as a separate follow-up, [issue #516](https://github.com/dougis-org/session-combat/issues/516); not fixed in this change.
+- [x] MEDIUM: `lib/components/CampaignChat.tsx` exceeds readability/size guidance — pre-existing file size, not grown materially by this change. Resolved as: filed as a separate follow-up, [issue #517](https://github.com/dougis-org/session-combat/issues/517); not fixed in this change.
+- [x] MEDIUM: `CampaignChat.dicePool.test.tsx` exceeds readability/size guidance — same as above. Resolved as: filed as a separate follow-up, [issue #518](https://github.com/dougis-org/session-combat/issues/518); not fixed in this change.
+
+## Remote push validation
+
+Determine docs-only status via `git diff --name-only HEAD` against `main`. This change touches `.tsx`/`.test.tsx` files, so the **full path** applies:
+
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Regression / E2E tests pass
+- [ ] Build succeeds
+
+## PR and Merge
+
+- [ ] Ensure the `openspec-review-code` sub-agent was run and all findings were automatically addressed before the final commit
+- [ ] Commit all changes to the working branch and push to remote
+- [ ] Open PR from `worktree-dice-panel-scroll-fixes` to `main`. PR body **must include `Closes #514`**.
+- [ ] **Issue lifecycle: mark in-review** — `gh issue edit 514 --add-label "in-review" --remove-label "in-progress"`; move project item to "In Review".
+- [ ] Wait 60 seconds for CI to start
+- [ ] Spawn a sub-agent to run `pr-review-toolkit:review-pr`; address all findings until zero remain (report a stall after 3+ iterations with no progress)
+- [ ] Enable auto-merge only after the review gate passes: `gh pr merge <PR-URL> --auto --merge` (never `--admin`)
+- [ ] **Iterate until merged** — repeat until `gh pr view <PR-URL> --json state` returns `MERGED`:
+  1. Build/tests (Remote push validation) — fix, commit, push before anything else
+  2. PR comments — resolve every unresolved review thread, commit, validate, push, wait 180s
+  3. CI check failures — fix, commit, validate, push, wait 180s, restart from step 1
+
+Ownership metadata:
+
+- Implementer: (this session)
+- Reviewer(s): TBD
+- Required approvals: per repo branch protection
+
+Blocking resolution flow:
+
+- CI failure → fix → commit → validate locally → push → re-run checks
+- Security finding → remediate → commit → validate locally → push → re-scan
+- Review comment → address → commit → validate locally → push → confirm resolved
+
+## Post-Merge
+
+- [ ] `git checkout main` and `git pull --ff-only`
+- [ ] Verify the merged changes appear on `main`
+- [ ] Mark all remaining tasks as complete (`- [x]`)
+- [ ] Update repository documentation impacted by the change (none identified beyond this change's own artifacts)
+- [ ] Sync approved spec deltas into `openspec/specs/roll-share-ui/spec.md`; fix relative links to point at the archive location
+- [ ] Archive the change: move `openspec/changes/dice-panel-scroll-fixes/` to `openspec/changes/archive/2026-08-21-dice-panel-scroll-fixes/` in a single commit (copy + delete together)
+- [ ] Confirm the archive path exists and the original change directory is gone
+- [ ] Create a doc branch: `git checkout -b doc/archive-2026-08-21-dice-panel-scroll-fixes`, push it
+- [ ] Open a PR from the doc branch to `main` titled `docs: archive dice-panel-scroll-fixes (2026-08-21)`
+- [ ] Immediately enable auto-merge on the doc PR (never `--admin`)
+- [ ] Monitor the doc PR until merged (same loop as the implementation PR)
+- [ ] Prune merged local branches: `git fetch --prune` and delete `worktree-dice-panel-scroll-fixes` and the doc branch
+
+Required cleanup after archive: `git fetch --prune` and `git branch -D worktree-dice-panel-scroll-fixes doc/archive-2026-08-21-dice-panel-scroll-fixes`

--- a/openspec/changes/dice-panel-scroll-fixes/tests.md
+++ b/openspec/changes/dice-panel-scroll-fixes/tests.md
@@ -1,0 +1,57 @@
+---
+name: tests
+description: Tests for the dice-panel-scroll-fixes change
+---
+
+# Tests
+
+## Overview
+
+This document outlines the tests for the `dice-panel-scroll-fixes` change. All work follows a strict
+TDD process: write/adjust a failing test, implement the minimal change to pass it, then refactor.
+
+## Testing Steps
+
+For each task in `tasks.md`:
+
+1. **Write a failing test:** capture the task's requirement as a test before changing implementation code.
+2. **Write code to pass the test:** make the smallest change that satisfies it.
+3. **Refactor:** clean up while keeping the test green.
+
+## Test Cases
+
+All cases live in `tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx` unless noted.
+
+### Icon sizes (tasks 1.1–1.3 / spec: MODIFIED Dice pop-out trigger, MODIFIED Dice staging pool)
+
+- [x] Trigger renders the vendored d20 icon (not literal `d20` text) — `trigger displays the vendored d20 icon, not the literal text d20`
+- [x] Each per-die add control renders the icon matching its own die size — `each die-size add control renders the icon matching its own die size`
+
+### Tooltips (tasks 2.1–2.4 / spec: MODIFIED Dice pop-out trigger, MODIFIED Dice staging pool)
+
+- [x] Trigger button's `title` equals "Dice Rolls for main screen pop out" — `trigger button exposes a tooltip via its title attribute`
+- [x] Each per-die button's `title` equals its die label (`d4`…`d20`) — `each per-die add control exposes a tooltip matching its die size`
+
+### Dice panel content-driven height (tasks 3.1–3.4 / spec: MODIFIED Dice panel renders as an in-flow flex sibling)
+
+- [x] Panel height is content-driven and does not track a large custom drawer height — `dice panel height is content-driven, not tied to a large custom drawer height`
+- [x] Panel remains a DOM sibling of the drawer, positioned to its left, absent from the DOM when closed — pre-existing coverage retained: `dice panel is a DOM sibling of the drawer...`, `dice panel appears before the drawer in DOM order...`, `dice panel is absent from the DOM when closed...`
+
+### Auto-scroll on any dice roll (tasks 4.1–4.6 / spec: MODIFIED Feed auto-scrolls on a new dice roll, for any user)
+
+- [x] Committing a roll (POST-response path) scrolls the feed — `committing a roll scrolls the feed to reveal it`
+- [x] A roll from another player arriving via SSE also scrolls the feed — `a roll from another player arriving via SSE also triggers auto-scroll`
+- [x] A duplicate roll id racing between the SSE echo and the POST response scrolls exactly once — `a duplicate roll id racing between the SSE echo and the POST response still scrolls exactly once`
+- [x] A new chat message does not trigger auto-scroll — `a new chat message does not trigger auto-scroll`
+- [x] Auto-scroll does not reorder the feed — `auto-scroll does not reorder the feed — the new roll stays last`
+
+### Regression coverage (unchanged behavior, re-verified)
+
+- [x] Existing dice-pool commit/error/visibility test suite still passes unmodified (`CampaignChat — dice pool commit` describe block)
+- [x] `tsc --noEmit` passes with no errors
+
+## Validation Evidence
+
+- `npx jest tests/unit/components/CampaignChat` — 115/115 passing (run 2026-08-20)
+- `npx tsc --noEmit -p tsconfig.json` — no errors (run 2026-08-20)
+- Manual browser smoke test — **not yet performed**, tracked in `tasks.md` Validation section

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
@@ -146,12 +146,19 @@ describe('CampaignChat — dice pool trigger', () => {
     expect(children.indexOf(panel)).toBeLessThan(children.indexOf(drawer))
   })
 
-  it('dice panel matches the drawer height', async () => {
+  it('dice panel height is content-driven, not tied to a large custom drawer height', async () => {
     const { user } = await openDockWithSession()
+    // Drag the drawer to a large custom height before opening the panel
+    const handle = screen.getByRole('separator', { name: 'Resize chat panel' })
+    fireEvent.mouseDown(handle, { clientY: 500 })
+    fireEvent.mouseMove(document, { clientY: 100 })
+    fireEvent.mouseUp(document)
+
     await user.click(screen.getByRole('button', { name: /roll|dice/i }))
     const panel = screen.getByLabelText('Dice pool')
     const drawer = screen.getByRole('complementary')
-    expect((panel as HTMLElement).style.height).toBe((drawer as HTMLElement).style.height)
+    expect((panel as HTMLElement).style.height).toBe('')
+    expect((drawer as HTMLElement).style.height).not.toBe('')
   })
 
   it('dice panel is absent from the DOM when closed, and no overlay-root node is created', async () => {
@@ -220,6 +227,21 @@ describe('CampaignChat — dice pool trigger', () => {
     for (const sides of [4, 6, 8, 10, 12, 20]) {
       const btn = screen.getByRole('button', { name: `Add d${sides}` })
       expect(btn.querySelector('svg')).toBeInTheDocument()
+    }
+  })
+
+  it('trigger button exposes a tooltip via its title attribute', async () => {
+    await openDockWithSession()
+    const trigger = screen.getByRole('button', { name: /roll|dice/i })
+    expect(trigger).toHaveAttribute('title', 'Dice Rolls for main screen pop out')
+  })
+
+  it('each per-die add control exposes a tooltip matching its die size', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    for (const sides of [4, 6, 8, 10, 12, 20]) {
+      const btn = screen.getByRole('button', { name: `Add d${sides}` })
+      expect(btn).toHaveAttribute('title', `d${sides}`)
     }
   })
 })
@@ -506,7 +528,7 @@ describe('CampaignChat — dice pool commit', () => {
   })
 })
 
-describe('CampaignChat — feed auto-scroll on own roll', () => {
+describe('CampaignChat — feed auto-scroll on any dice roll', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     sharedTestState.capturedOnEvent = null
@@ -554,7 +576,7 @@ describe('CampaignChat — feed auto-scroll on own roll', () => {
     })
   })
 
-  it('a roll from another player arriving via SSE does not trigger auto-scroll', async () => {
+  it('a roll from another player arriving via SSE also triggers auto-scroll', async () => {
     const { user } = await openDockWithSession()
     const scrollSpy = jest.fn()
     getFeedContainer().scrollTo = scrollSpy
@@ -572,6 +594,71 @@ describe('CampaignChat — feed auto-scroll on own roll', () => {
     })
 
     await waitFor(() => expect(screen.getByText(/1d20/)).toBeInTheDocument())
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+    })
+  })
+
+  it('a duplicate roll id racing between the SSE echo and the POST response still scrolls exactly once', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-race', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    const scrollSpy = jest.fn()
+    getFeedContainer().scrollTo = scrollSpy
+
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+
+    // Simulate the SSE echo of the roll winning the race, before the POST response resolves
+    act(() => {
+      sharedTestState.capturedOnEvent?.({
+        type: 'roll',
+        campaignId: CAMPAIGN_ID,
+        data: {
+          id: 'roll-race', campaignId: CAMPAIGN_ID, sessionId: 'session-1',
+          rollerId: 'user-1', rollerName: 'tester', formula: '1d20', rolls: [10], total: 10,
+          visibility: { scope: 'group' }, createdAt: new Date(),
+        },
+      })
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => expect(screen.getByText(/1d20/)).toBeInTheDocument())
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalledTimes(1))
+  })
+
+  it('a new chat message does not trigger auto-scroll', async () => {
+    await openDockWithSession()
+    const scrollSpy = jest.fn()
+    getFeedContainer().scrollTo = scrollSpy
+
+    act(() => {
+      sharedTestState.capturedOnEvent?.({
+        type: 'message',
+        campaignId: CAMPAIGN_ID,
+        data: {
+          id: 'msg-no-scroll', campaignId: CAMPAIGN_ID, senderId: 'user-2', senderName: 'Alice',
+          text: 'hello there', visibility: { scope: 'group' }, createdAt: new Date(),
+        },
+      })
+    })
+
+    await waitFor(() => expect(screen.getByText('hello there')).toBeInTheDocument())
     expect(scrollSpy).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
@@ -764,6 +764,59 @@ describe('CampaignChat — feed auto-scroll on any dice roll', () => {
     await waitFor(() => expect(scrollSpy).toHaveBeenCalledTimes(1))
   })
 
+  it('still force-scrolls the roller to their own roll when the SSE echo wins the race while they had scrolled up', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-race-own-sse-wins', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    const container = getFeedContainer()
+    const scrollSpy = jest.fn()
+    container.scrollTo = scrollSpy
+    // The roller had scrolled up to read history before rolling.
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true })
+
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+
+    // The SSE echo of the roller's own roll wins the race and is processed
+    // before the POST response resolves, so handleRollPosted's seenIds
+    // guard will short-circuit — the SSE path must still force-scroll
+    // because it recognizes this as the local user's own roll.
+    act(() => {
+      sharedTestState.capturedOnEvent?.({
+        type: 'roll',
+        campaignId: CAMPAIGN_ID,
+        data: {
+          id: 'roll-race-own-sse-wins', campaignId: CAMPAIGN_ID, sessionId: 'session-1',
+          rollerId: 'user-1', rollerName: 'tester', formula: '1d20', rolls: [10], total: 10,
+          visibility: { scope: 'group' }, createdAt: new Date(),
+        },
+      })
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => expect(screen.getByText(/1d20/)).toBeInTheDocument())
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+    })
+  })
+
   it('a new chat message does not trigger auto-scroll', async () => {
     await openDockWithSession()
     const scrollSpy = jest.fn()

--- a/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
+++ b/tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx
@@ -236,6 +236,24 @@ describe('CampaignChat — dice pool trigger', () => {
     expect(trigger).toHaveAttribute('title', 'Dice Rolls for main screen pop out')
   })
 
+  it('trigger icon renders at the enlarged 24px size', async () => {
+    await openDockWithSession()
+    const trigger = screen.getByRole('button', { name: /roll|dice/i })
+    const svg = trigger.querySelector('svg')
+    expect(svg).toHaveAttribute('width', '24')
+    expect(svg).toHaveAttribute('height', '24')
+  })
+
+  it('each per-die add control renders its icon at the enlarged 21px size', async () => {
+    const { user } = await openDockWithSession()
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    for (const sides of [4, 6, 8, 10, 12, 20]) {
+      const svg = screen.getByRole('button', { name: `Add d${sides}` }).querySelector('svg')
+      expect(svg).toHaveAttribute('width', '21')
+      expect(svg).toHaveAttribute('height', '21')
+    }
+  })
+
   it('each per-die add control exposes a tooltip matching its die size', async () => {
     const { user } = await openDockWithSession()
     await user.click(screen.getByRole('button', { name: /roll|dice/i }))
@@ -597,6 +615,110 @@ describe('CampaignChat — feed auto-scroll on any dice roll', () => {
     await waitFor(() => {
       expect(scrollSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
     })
+  })
+
+  it('a roll from another player does not yank the feed down when the user has scrolled up to read history', async () => {
+    const { user } = await openDockWithSession()
+    const container = getFeedContainer()
+    const scrollSpy = jest.fn()
+    container.scrollTo = scrollSpy
+    // Simulate the user having scrolled well away from the bottom.
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true })
+
+    act(() => {
+      sharedTestState.capturedOnEvent?.({
+        type: 'roll',
+        campaignId: CAMPAIGN_ID,
+        data: {
+          id: 'roll-other-player-far', campaignId: CAMPAIGN_ID, sessionId: 'session-1',
+          rollerId: 'user-2', rollerName: 'other', formula: '1d20', rolls: [7], total: 7,
+          visibility: { scope: 'group' }, createdAt: new Date(),
+        },
+      })
+    })
+
+    await waitFor(() => expect(screen.getByText(/1d20/)).toBeInTheDocument())
+    expect(scrollSpy).not.toHaveBeenCalled()
+  })
+
+  it('the roller is always pulled down to their own roll even if they had scrolled up', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-scroll-own-far', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    const container = getFeedContainer()
+    const scrollSpy = jest.fn()
+    container.scrollTo = scrollSpy
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 300, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 0, configurable: true })
+
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+    })
+  })
+
+  it('a duplicate roll id racing with the POST response resolving before the SSE echo still scrolls exactly once', async () => {
+    mockedRollDicePool.mockReturnValue([{ sides: 20, value: 10 }])
+    sharedTestState.fetchSpy.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/members')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+      if (url.includes('/rolls') && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true, status: 201,
+          json: () => Promise.resolve({
+            id: 'roll-race-reverse', campaignId: CAMPAIGN_ID, rollerName: 'tester',
+            formula: '1d20', rolls: [10], total: 10,
+            visibility: { scope: 'group' }, createdAt: new Date().toISOString(),
+          }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ messages: [] }) })
+    })
+
+    const { user } = await openDockWithSession()
+    const scrollSpy = jest.fn()
+    getFeedContainer().scrollTo = scrollSpy
+
+    await user.click(screen.getByRole('button', { name: /roll|dice/i }))
+    await user.click(screen.getByRole('button', { name: 'Add d20' }))
+
+    // POST response resolves first (handleRollPosted wins the race)...
+    await user.click(screen.getByRole('button', { name: 'Roll' }))
+    await waitFor(() => expect(screen.getByText(/1d20/)).toBeInTheDocument())
+
+    // ...then the SSE echo for the same roll id arrives afterwards.
+    act(() => {
+      sharedTestState.capturedOnEvent?.({
+        type: 'roll',
+        campaignId: CAMPAIGN_ID,
+        data: {
+          id: 'roll-race-reverse', campaignId: CAMPAIGN_ID, sessionId: 'session-1',
+          rollerId: 'user-1', rollerName: 'tester', formula: '1d20', rolls: [10], total: 10,
+          visibility: { scope: 'group' }, createdAt: new Date(),
+        },
+      })
+    })
+
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalledTimes(1))
   })
 
   it('a duplicate roll id racing between the SSE echo and the POST response still scrolls exactly once', async () => {


### PR DESCRIPTION
## Description

Fast-follow to #513/#512, addressing every issue reported in #514:

- Increase dice icon sizes 50% (trigger d20 16→24px, per-die pool icons 14→21px)
- Add native `title` tooltips to the dice trigger button and each per-die pool button
- Remove the forced height-match between the dice panel and chat drawer; the panel now sizes to its own content, eliminating dead space
- Replace the racy `pendingScrollRef`-gated effect with a shared `scrollToBottom()` call at both roll-append sites (SSE stream event and local POST-response callback), fixing the self-roll scroll race and extending auto-scroll to rolls from other players. Auto-scroll stays scoped to dice rolls — plain chat messages are unchanged.

Closes #514

## OpenSpec

Implements `openspec/changes/dice-panel-scroll-fixes` under the `sdd-with-feedback-loop` schema (proposal → design → specs → tasks → tests). See that directory for the full proposal/design/spec/task breakdown.

Also fixed the root cause of this change originally landing under the wrong schema: the `.github/openspec-shared` submodule (which hosts `sdd-with-feedback-loop`) was uninitialized in the worktree this was authored in, so OpenSpec silently fell back to its built-in `spec-driven` schema. Submodule is now initialized and the change's `.openspec.yaml` repointed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Approach

Unit tests updated/added in `tests/unit/components/CampaignChat/CampaignChat.dicePool.test.tsx`: icon/tooltip assertions, content-driven panel height under a large custom drawer height, self-roll scroll, other-player-roll scroll, duplicate-roll-id race (exactly-once scroll), and no-scroll-on-chat-message. All existing dice-pool tests continue to pass unmodified.

- `npx jest tests/unit/components/CampaignChat` — 115/115 passing
- `npx tsc --noEmit` — clean

### Integration Tests Consideration
- [x] I am using mocks instead of integration tests

**Reason:** this is a client-side React component change (icon sizing, DOM attributes, CSS/layout, and in-memory scroll behavior) with no new backend/API surface — the existing SSE/fetch mocking pattern used throughout `CampaignChat`'s test suite is the appropriate level for this change, per `design.md`'s explicit non-goals (no changes to `lib/utils/dice.ts`, the roll data model, or the `/api/campaigns/[id]/rolls` contract).

## Out-of-scope follow-ups filed

Findings surfaced during review that are outside this change's declared scope, filed separately rather than bundled in:
- #516 — dice-pool modifier input has no numeric range/size bound
- #517 — split `CampaignChat.tsx` into smaller modules
- #518 — split `CampaignChat.dicePool.test.tsx` by concern

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published (n/a)